### PR TITLE
Simplify time-based slicing of data channels

### DIFF
--- a/lumicks/hdf5/detail/timeindex.py
+++ b/lumicks/hdf5/detail/timeindex.py
@@ -1,0 +1,78 @@
+import re
+
+__all__ = ["Timeindex", "to_timestamp"]
+
+# It's impossible to see, but this regex matches a floating point number and suffix
+regex_template = "((?P<{suffix}>\d*\.?\d+)\s*{suffix})?"
+
+# Day, hour, minute, second, millisecond, microsecond, nanosecond
+units = ["d", "h", "m", "s", "ms", "us", "ns"]
+
+# Matches strings like "1s 216ms", "-1m 30s", "-1.4s", "2.7h"
+regex = re.compile(
+    "^(?P<sign>-?)" + "\s*".join(regex_template.format(suffix=u) for u in units) + "$"
+)
+
+ns = 1
+us = 1000 * ns
+ms = 1000 * us
+s = 1000 * ms
+m = 60 * s
+h = 60 * m
+d = 24 * h
+
+# Ratio of nanosecond to `unit`
+ratios = {unit: globals()[unit] for unit in units}
+
+
+class Timeindex:
+    """A helper class for indexing in time units
+
+    It translates strings like "1.4s", "-2s 36ms", "1h 7m" to nanosecond timestamps.
+
+    Parameters
+    ----------
+    timestring : str
+
+    """
+    def __init__(self, timestring):
+        match = regex.match(timestring)
+        if not match:
+            raise RuntimeError(f"Invalid time string '{timestring}'")
+
+        self.sign = -1 if match.group("sign") else 1
+
+        self.d = 0
+        self.h = 0
+        self.m = 0
+        self.s = 0
+        self.ms = 0
+        self.us = 0
+        self.ns = 0
+        unit_matches = {unit: match.group(unit) for unit in units}
+        self.__dict__.update({unit: float(value) for unit, value in unit_matches.items() if value})
+
+        self.total_ns = self.sign * sum(int(self.__dict__[unit] * ratios[unit]) for unit in units)
+
+    def __int__(self):
+        return self.total_ns
+
+
+def to_timestamp(value, first, after_last):
+    """Convert `value` to a timestamp (ns) or return it unchanged if it's already a timestamp
+
+    Parameters
+    ----------
+    value : Union[str, int]
+        Either a timestring to be processed by `Timeindex` or a nanosecond timestamp
+    first, after_last : int
+        Nanosecond timestamps of the first and past-the-end elements of a range
+    """
+    try:
+        idx = Timeindex(value).total_ns
+        if idx >= 0:
+            return first + idx
+        else:
+            return after_last + idx
+    except TypeError:
+        return value

--- a/lumicks/hdf5/tests/test_timeindex.py
+++ b/lumicks/hdf5/tests/test_timeindex.py
@@ -1,0 +1,66 @@
+import pytest
+import re
+
+from lumicks.hdf5.detail.timeindex import regex_template, regex, Timeindex
+
+
+def test_regex_template():
+    r = re.compile("^" + regex_template.format(suffix="foo") + "$")
+
+    assert r.match("1.2foo").group("foo") == "1.2"
+    assert r.match("1 foo").group("foo") == "1"
+    assert r.match(".2foo").group("foo") == ".2"
+    assert r.match("").group("foo") is None
+
+    assert not r.match("foo")
+    assert not r.match("4. foo")
+
+
+def test_regex():
+    groups = regex.match("1.2s 50ms 4.0us 3 ns")
+    assert groups["s"] == "1.2"
+    assert groups["ms"] == "50"
+    assert groups["us"] == "4.0"
+    assert groups["ns"] == "3"
+
+
+def test_timeindex():
+    t = Timeindex("1s2ms 3us")
+    assert t.sign == 1
+    assert t.s == 1
+    assert t.ms == 2
+    assert t.us == 3
+    assert t.ns == 0
+    assert t.total_ns == 1_002_003_000
+
+    t = Timeindex("-1d 2h3m   6ns")
+    assert t.sign == -1
+    assert t.d == 1
+    assert t.h == 2
+    assert t.m == 3
+    assert t.ns == 6
+    assert t.total_ns == -93_780_000_000_006
+
+    t = Timeindex("1.51s 3.3ns")
+    assert t.sign == 1
+    assert t.s == 1.51
+    assert t.ns == 3.3
+    assert t.total_ns == 1_510_000_003
+
+    with pytest.raises(RuntimeError):
+        Timeindex("bad")
+
+    with pytest.raises(RuntimeError):
+        Timeindex("ms")
+
+    with pytest.raises(RuntimeError):
+        Timeindex("ms 1ns")
+
+    with pytest.raises(RuntimeError):
+        Timeindex("1ns 1us")  # wrong order
+
+    with pytest.raises(RuntimeError):
+        Timeindex("1")
+
+    with pytest.raises(TypeError):
+        Timeindex(1)

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,29 @@ f1x_timestamps = h5file.force1x.timestamps
 plt.plot(f1x_timestamps, f1x_data)
 ```
 
+### Slicing data channels
+
+```python
+# Take the entire channel
+everything = h5file.force1x
+everything.plot()
+
+# Get the data between 1 and 1.5 seconds
+part = h5file.force1x['1s':'1.5s']
+part.plot()
+# Or manually
+f1x_data = part.data
+f1x_timestamps = part.timestamps
+plt.plot(f1x_timestamps, f1x_data)
+
+# More slicing examples
+a = h5file.force1x[:'-5s']  # everything except the last 5 seconds
+b = h5file.force1x['-1m':]  # take the last minute
+c = h5file.force1x['-1m':'-500ms']  # last minute except the last 0.5 seconds
+d = h5file.force1x['1.2s':'-4s']  # between 1.2 seconds and 4 seconds from the end
+e = h5file.force1x['5.7m':'1h 40m']  # 5.7 minutes to an hour and 40 minutes
+```
+
 ### Scans and kymographs
 
 The following code uses kymographs as an example. 


### PR DESCRIPTION
I'm pretty happy with the way this turned out. It should make it much easier to slice the data channels using understandable time units instead of raw nanosecond timestamps.

```python
# Take the entire channel
everything = h5file.force1x
everything.plot()

# Get the data between 1 and 1.5 seconds
part = h5file.force1x['1s':'1.5s']
part.plot()

# More slicing examples
a = h5file.force1x[:'-5s']  # everything except the last 5 seconds
b = h5file.force1x['-1m':]  # take the last minute
c = h5file.force1x['-1m':'-500ms']  # last minute except the last 0.5 seconds
d = h5file.force1x['1.2s':'-4s']  # between 1.2 seconds and 4 seconds from the end
e = h5file.force1x['5.7m':'1h 40m']  # 5.7 minutes to an hour and 40 minutes
```

The spec is pretty simple. The possible time units are: `'d', 'h', 'm', 's', 'ms', 'us', 'ns'`. The values can be integers or floats. The strings get parsed and converted to integers and everything still follows the usual indexing rules in Python.