### PR TITLE
Support for downsampling continuous channel slices

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## v0.2.0 | In development
 
+* Channel slices can be downsampled: `lf_force = hf_force.downsampled_by(20)`.
 * `h5py` >= v2.8 is now required.
 
 ## v0.1.0 | 2018-06-20

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -62,6 +62,14 @@ class Slice:
         """Absolute timestamps (since epoch) which correspond to the channel data"""
         return self._src.timestamps
 
+    @property
+    def sample_rate(self) -> int:
+        """The data frequency for continuous data sources or `None` if it's variable"""
+        try:
+            return self._src.sample_rate
+        except AttributeError:
+            return None
+
     def downsampled_by(self, factor, reduce=np.mean):
         """Return a copy of this slice which is downsampled by `factor`
 
@@ -127,6 +135,10 @@ class Continuous:
     @property
     def timestamps(self):
         return np.arange(self.start, self.stop, self.dt)
+
+    @property
+    def sample_rate(self):
+        return int(1e9 / self.dt)
 
     def slice(self, start, stop):
         # TODO: should be lazily evaluated

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -25,12 +25,6 @@ class Slice:
         self.timestamps = np.asarray(timestamps)
         self.labels = labels or {}
 
-    def __array__(self):
-        """Coerce this slice into an `np.ndarray` of data values (no timestamps)"""
-        # TODO: Currently, this just returns pre-formed data array, but it should eventually
-        #       do lazy evaluation by only loading timeline data here on demand.
-        return self.data
-
     def __len__(self):
         return len(self.data)
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -4,56 +4,61 @@ from .detail.timeindex import to_timestamp
 
 
 class Slice:
-    """A lazily evaluated* slice of a timeline channel
+    """A lazily evaluated slice of a timeline/HDF5 channel
 
-    *Not actually lazy, yet.
+    Users will only ever get these as a result of slicing a timeline/HDF5
+    channel or slicing another slice (via this classes `__getitem__`), i.e.
+    the `__init__` method will never be invoked by users.
 
-    Users will only ever get these as a result of slicing a timeline channel
-    or slicing another slice (via this classes `__getitem__`).
-
-    Attributes
+    Parameters
     ----------
-    data : array_like
-        Channel data from the timeline.
-    timestamps : array_like
-        Timestamps in nanoseconds for each data point.
+    data_source : Any
+        A slice data source. Can be `Continuous`, `TimeSeries` or any other source
+        which conforms to the same interface.
+    labels : Dict[str, str]
+        Plot labels: "x", "y", "title".
     """
-
-    def __init__(self, data, timestamps, labels=None):
-        assert len(data) == len(timestamps)
-        self.data = np.asarray(data)
-        self.timestamps = np.asarray(timestamps)
+    def __init__(self, data_source, labels=None):
+        self._src = data_source
         self.labels = labels or {}
 
     def __len__(self):
-        return len(self.data)
+        return len(self._src)
 
     def __getitem__(self, item):
         """All indexing is in timestamp units (ns)"""
+        if not isinstance(item, slice):
+            raise IndexError("Scalar indexing is not supported, only slicing")
+        if item.step is not None:
+            raise IndexError("Slice steps are not supported")
+
         if len(self) == 0:
-            return Slice([], [], self.labels)
+            return self
 
-        first = self.timestamps[0]
-        after_last = self.timestamps[-1] + 1
+        src_start = self._src.start
+        src_stop = self._src.stop
 
-        if isinstance(item, slice):
-            if item.step is not None:
-                raise IndexError("Slice steps are not supported")
+        start, stop = item.start, item.stop
+        if start is None:
+            start = src_start
+        if stop is None:
+            stop = src_stop
+        start, stop = (to_timestamp(v, src_start, src_stop) for v in (start, stop))
 
-            start, stop = item.start, item.stop
-            if start is None:
-                start = first
-            if stop is None:
-                stop = after_last
-            start, stop = (to_timestamp(v, first, after_last) for v in (start, stop))
+        return self.__class__(self._src.slice(start, stop), self.labels)
 
-            idx = np.logical_and(start <= self.timestamps, self.timestamps < stop)
-            return Slice(self.data[idx], self.timestamps[idx], self.labels)
-        else:
-            idx = np.argwhere(self.timestamps == to_timestamp(item, first, after_last))
-            return Slice(self.data[idx], self.timestamps[idx], self.labels)
+    @property
+    def data(self):
+        """The primary values of this channel slice"""
+        return self._src.data
+
+    @property
+    def timestamps(self):
+        """Absolute timestamps (since epoch) which correspond to the channel data"""
+        return self._src.timestamps
 
     def plot(self, **kwargs):
+        """A simple line plot to visualize the data over time"""
         import matplotlib.pyplot as plt
 
         seconds = (self.timestamps - self.timestamps[0]) / 1e9
@@ -61,6 +66,97 @@ class Slice:
         plt.xlabel(self.labels.get("x", "Time") + " (s)")
         plt.ylabel(self.labels.get("y", "y"))
         plt.title(self.labels.get("title", "title"))
+
+
+class Continuous:
+    """A source of continuous data for a timeline slice
+
+    Parameters
+    ----------
+    data : array_like
+        Anything that's convertible to an `np.ndarray`.
+    start : int
+        Timestamp of the first data point.
+    dt : int
+        Delta between two timestamps. Constant for the entire data range.
+    """
+    def __init__(self, data, start, dt):
+        self._src_data = data
+        self._cached_data = None
+        self.start = start
+        self.stop = start + len(data) * dt
+        self.dt = dt
+
+    def __len__(self):
+        return len(self._src_data)
+
+    @property
+    def data(self):
+        if self._cached_data is None:
+            self._cached_data = np.asarray(self._src_data)
+        return self._cached_data
+
+    @property
+    def timestamps(self):
+        return np.arange(self.start, self.stop, self.dt)
+
+    def slice(self, start, stop):
+        # TODO: should be lazily evaluated
+        idx = np.logical_and(start <= self.timestamps, self.timestamps < stop)
+        return self.__class__(self.data[idx], max(start, self.start), self.dt)
+
+
+class Timeseries:
+    """A source of time series data for a timeline slice
+
+    Parameters
+    ----------
+    data : array_like
+        Anything that's convertible to an `np.ndarray`.
+    timestamps : array_like
+        An array of integer timestamps.
+    """
+    def __init__(self, data, timestamps):
+        assert len(data) == len(timestamps)
+        # TODO: should be lazily evaluated
+        self.data = np.asarray(data)
+        self.timestamps = np.asarray(timestamps)
+
+    def __len__(self):
+        return len(self.data)
+
+    @property
+    def start(self):
+        return self.timestamps[0]
+
+    @property
+    def stop(self):
+        return self.timestamps[-1] + 1
+
+    def slice(self, start, stop):
+        idx = np.logical_and(start <= self.timestamps, self.timestamps < stop)
+        return self.__class__(self.data[idx], self.timestamps[idx])
+
+
+class Empty:
+    """A lightweight source of no data
+
+    Both `Continuous` and `Timeseries` can be empty, but this is a lighter
+    class which can be returned an empty slice from properties.
+    """
+    def __len__(self):
+        return 0
+
+    @property
+    def data(self):
+        return np.empty(0)
+
+    @property
+    def timestamps(self):
+        return np.empty(0)
+
+
+empty_slice = Slice(Empty())
 
 
 def is_continuous_channel(dset):
@@ -71,13 +167,12 @@ def is_continuous_channel(dset):
 def make_continuous_channel(dset, y_label="y"):
     """Generate timestamps based on start/stop time and the sample rate"""
     start = dset.attrs["Start time (ns)"]
-    stop = dset.attrs["Stop time (ns)"]
     dt = int(1e9 / dset.attrs["Sample rate (Hz)"])
-    return Slice(dset, np.arange(start, stop, dt),
+    return Slice(Continuous(dset.value, start, dt),
                  labels={"title": dset.name.strip("/"), "y": y_label})
 
 
 def make_timeseries_channel(dset, y_label="y"):
     """Just real all the data"""
-    return Slice(dset["Value"], dset["Timestamp"],
+    return Slice(Timeseries(dset["Value"], dset["Timestamp"]),
                  labels={"title": dset.name.strip("/"), "y": y_label})

--- a/lumicks/pylake/detail/mixin.py
+++ b/lumicks/pylake/detail/mixin.py
@@ -1,5 +1,5 @@
 """Mixin class which add properties for predefined channels"""
-from ..channel import Slice
+from ..channel import Slice, empty_slice
 
 
 def _try_get_or_empty(f, *args, **kwargs):
@@ -7,7 +7,7 @@ def _try_get_or_empty(f, *args, **kwargs):
     try:
         return f(*args, **kwargs)
     except KeyError:
-        return Slice([], [])
+        return empty_slice
 
 
 class Force:

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -2,7 +2,7 @@ import h5py
 import numpy as np
 from typing import Dict
 
-from .channel import make_continuous_channel, make_timeseries_channel, Slice
+from .channel import make_continuous_channel, make_timeseries_channel, Slice, Timeseries
 from .detail.mixin import Force, DownsampledFD, PhotonCounts
 from .fdcurve import FDCurve
 from .group import Group
@@ -125,7 +125,7 @@ class File(Group, Force, DownsampledFD, PhotonCounts):
         # If it's completely missing, we can reconstruct it from the x and y components
         fx = make(f"Force {n}x")
         fy = make(f"Force {n}y")
-        return Slice(np.sqrt(fx.data**2 + fy.data**2), fx.timestamps,
+        return Slice(Timeseries(np.sqrt(fx.data**2 + fy.data**2), fx.timestamps),
                      labels={"title": f"Force LF/Force {n}", "y": "Force (pN)"})
 
     def _get_distance(self, n):

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -5,10 +5,13 @@ from lumicks.pylake import channel
 
 def test_slice_properties():
     size = 5
-    s = channel.Slice(np.random.rand(size), np.random.rand(size))
+    s = channel.Slice(channel.Timeseries(np.random.rand(size), np.random.rand(size)))
     assert len(s) == size
 
-    s = channel.Slice([], [])
+    s = channel.Slice(channel.Continuous(np.random.rand(size), 0, 1))
+    assert len(s) == size
+
+    s = channel.empty_slice
     assert len(s) == 0
 
 
@@ -16,66 +19,90 @@ def test_labels():
     """Slicing must preserve labels"""
     size = 5
     labels = {"x": "distance", "y": "force"}
-    s = channel.Slice(np.random.rand(size), np.random.rand(size), labels)
+    s = channel.Slice(channel.Timeseries(np.random.rand(size), np.random.rand(size)), labels)
     assert s.labels == labels
     assert s[:].labels == labels
     assert s[:0].labels == labels
     assert s[:10].labels == labels
 
-    s = channel.Slice([], [], labels)
+    s = channel.Slice(channel.Timeseries([], []), labels)
     assert len(s) == 0
     assert s.labels == labels
     assert s[:].labels == labels
 
 
-def test_indexing():
+def test_empty_slice():
+    s = channel.empty_slice
+    assert len(s[1:2].data) == 0
+    assert len(s[1:2].timestamps) == 0
+
+
+def test_timeseries_indexing():
     """The default integer indices are in timestamps (ns)"""
-    s = channel.Slice([14, 15, 16, 17], [4, 5, 6, 7])
+    s = channel.Slice(channel.Timeseries([14, 15, 16, 17], [4, 5, 6, 7]))
 
-    # Scalar access
-    assert s[4].data == 14
-    assert s[4].timestamps == 4
-    assert len(s[99]) == 0
-
-    # Slices
+    np.testing.assert_equal(s[0:5].data, [14])
+    np.testing.assert_equal(s[0:5].timestamps, [4])
     np.testing.assert_equal(s[4:5].data, [14])
     np.testing.assert_equal(s[4:5].timestamps, [4])
-
     np.testing.assert_equal(s[4:6].data, [14, 15])
     np.testing.assert_equal(s[4:6].timestamps, [4, 5])
-
     np.testing.assert_equal(s[4:10].data, [14, 15, 16, 17])
     np.testing.assert_equal(s[4:10].timestamps, [4, 5, 6, 7])
 
     with pytest.raises(IndexError) as exc:
+        assert s[1]
+    assert str(exc.value) == "Scalar indexing is not supported, only slicing"
+    with pytest.raises(IndexError) as exc:
         assert s[1:2:3]
     assert str(exc.value) == "Slice steps are not supported"
 
-    s = channel.Slice([], [])
-    assert len(s[0].data) == 0
-    assert len(s[0].timestamps) == 0
+    s = channel.Slice(channel.Timeseries([], []))
+    assert len(s[1:2].data) == 0
+    assert len(s[1:2].timestamps) == 0
+
+
+def test_continuous_idexing():
+    s = channel.Slice(channel.Continuous([14, 15, 16, 17], 4, 1))
+    np.testing.assert_equal(s[0:5].data, [14])
+    np.testing.assert_equal(s[0:5].timestamps, [4])
+    np.testing.assert_equal(s[4:5].data, [14])
+    np.testing.assert_equal(s[4:5].timestamps, [4])
+    np.testing.assert_equal(s[4:6].data, [14, 15])
+    np.testing.assert_equal(s[4:6].timestamps, [4, 5])
+    np.testing.assert_equal(s[4:10].data, [14, 15, 16, 17])
+    np.testing.assert_equal(s[4:10].timestamps, [4, 5, 6, 7])
+
+    s = channel.Slice(channel.Continuous([14, 15, 16, 17], 4, 2))
+    np.testing.assert_equal(s[0:5].data, [14])
+    np.testing.assert_equal(s[0:5].timestamps, [4])
+    np.testing.assert_equal(s[4:5].data, [14])
+    np.testing.assert_equal(s[4:5].timestamps, [4])
+    np.testing.assert_equal(s[4:8].data, [14, 15])
+    np.testing.assert_equal(s[4:8].timestamps, [4, 6])
+    np.testing.assert_equal(s[4:14].data, [14, 15, 16, 17])
+    np.testing.assert_equal(s[4:14].timestamps, [4, 6, 8, 10])
+
+    with pytest.raises(IndexError) as exc:
+        assert s[1]
+    assert str(exc.value) == "Scalar indexing is not supported, only slicing"
+    with pytest.raises(IndexError) as exc:
+        assert s[1:2:3]
+    assert str(exc.value) == "Slice steps are not supported"
+
+    s = channel.Slice(channel.Timeseries([], []))
     assert len(s[1:2].data) == 0
     assert len(s[1:2].timestamps) == 0
 
 
 def test_time_indexing():
     """String time-based indexing"""
-    s = channel.Slice([1, 2, 3, 4, 5], [1400, 2500, 16e6, 34e9, 122 * 1e9])
+    s = channel.Slice(channel.Timeseries([1, 2, 3, 4, 5], [1400, 2500, 16e6, 34e9, 122 * 1e9]))
     # --> in time indices: ['0ns', '1100ns', '15.9986ms', '33.99s', '2m 2s']
-
-    # Scalar access
-    assert s[1400].data == 1
-    assert s['0ns'].data == 1
-    assert s['1100ns'].data == 2
-    assert s['1.1us'].data == 2
-    assert s['1us 100ns'].data == 2
-    assert s['-1ns'].data == 5
-    assert len(s['1ns']) == 0
 
     def assert_equal(actual, expected):
         np.testing.assert_equal(actual.data, expected)
 
-    # Slices
     assert_equal(s['0ns':'1100ns'], [1])
     assert_equal(s['0ns':'1101ns'], [1, 2])
     assert_equal(s['1us':'1.1us'], [])
@@ -97,11 +124,13 @@ def test_time_indexing():
     assert_equal(s['-5m':], [1, 2, 3, 4, 5])
 
     with pytest.raises(IndexError) as exc:
+        assert s['1ns']
+    assert str(exc.value) == "Scalar indexing is not supported, only slicing"
+    with pytest.raises(IndexError) as exc:
         assert s['1ns':'2s':'3ms']
     assert str(exc.value) == "Slice steps are not supported"
 
-    s = channel.Slice([], [])
-    assert len(s['0ns'].data) == 0
+    s = channel.empty_slice
     assert len(s['1s':'2h'].data) == 0
 
 

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -7,12 +7,15 @@ def test_slice_properties():
     size = 5
     s = channel.Slice(channel.Timeseries(np.random.rand(size), np.random.rand(size)))
     assert len(s) == size
+    assert s.sample_rate is None
 
-    s = channel.Slice(channel.Continuous(np.random.rand(size), 0, 1))
+    s = channel.Slice(channel.Continuous(np.random.rand(size), start=0, dt=1))
     assert len(s) == size
+    assert s.sample_rate == 1e9
 
     s = channel.empty_slice
     assert len(s) == 0
+    assert s.sample_rate is None
 
 
 def test_labels():
@@ -151,22 +154,27 @@ def test_channel(h5_file):
 
 def test_downsampling():
     s = channel.Slice(channel.Continuous([14, 15, 16, 17], start=40, dt=10))
+    assert s.sample_rate == 1e8
 
     s2 = s.downsampled_by(2)
     np.testing.assert_allclose(s2.data, 14.5, 16.5)
     np.testing.assert_allclose(s2.timestamps, [45, 65])
+    assert s2.sample_rate == 0.5e8
 
     s4 = s.downsampled_by(4)
     np.testing.assert_allclose(s4.data, 15.5)
     np.testing.assert_allclose(s4.timestamps, [55])
+    assert s4.sample_rate == 0.25e8
 
     s3 = s.downsampled_by(3)
     np.testing.assert_allclose(s3.data, 15)
     np.testing.assert_allclose(s3.timestamps, [50])
+    assert s3.sample_rate == 33333333
 
     s22 = s2.downsampled_by(2)
     np.testing.assert_allclose(s22.data, 15.5)
     np.testing.assert_allclose(s22.timestamps, [55])
+    assert s22.sample_rate == 0.25e8
 
     with pytest.raises(ValueError):
         s.downsampled_by(-1)

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -147,3 +147,28 @@ def test_channel(h5_file):
     downsampled = channel.make_timeseries_channel(h5_file["Force LF"]["Force 1x"])
     assert np.allclose(downsampled.data, [1.1, 2.1])
     assert np.allclose(downsampled.timestamps, [1, 2])
+
+
+def test_downsampling():
+    s = channel.Slice(channel.Continuous([14, 15, 16, 17], start=40, dt=10))
+
+    s2 = s.downsampled_by(2)
+    np.testing.assert_allclose(s2.data, 14.5, 16.5)
+    np.testing.assert_allclose(s2.timestamps, [45, 65])
+
+    s4 = s.downsampled_by(4)
+    np.testing.assert_allclose(s4.data, 15.5)
+    np.testing.assert_allclose(s4.timestamps, [55])
+
+    s3 = s.downsampled_by(3)
+    np.testing.assert_allclose(s3.data, 15)
+    np.testing.assert_allclose(s3.timestamps, [50])
+
+    s22 = s2.downsampled_by(2)
+    np.testing.assert_allclose(s22.data, 15.5)
+    np.testing.assert_allclose(s22.timestamps, [55])
+
+    with pytest.raises(ValueError):
+        s.downsampled_by(-1)
+    with pytest.raises(TypeError):
+        s.downsampled_by(1.5)

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -105,14 +105,6 @@ def test_time_indexing():
     assert len(s['1s':'2h'].data) == 0
 
 
-def test_asarray():
-    """Slices can be given to numpy functions"""
-    s = channel.Slice([14, 15, 16, 17], [4, 5, 6, 7])
-
-    np.testing.assert_equal(np.asarray(s), s.data)
-    assert np.sum(s) == np.sum(s.data)
-
-
 def test_inspections(h5_file):
     assert channel.is_continuous_channel(h5_file["Force HF"]["Force 1x"]) is True
     assert channel.is_continuous_channel(h5_file["Force LF"]["Force 1x"]) is False


### PR DESCRIPTION
This only includes downsampling by a factor for continuous channels:
```python
lf_force = hf_force.downsampled_by(20)
```

Downsampling to a specific frequency is not implemented because the interface would be very misleading:
```python
assert hf.sample_rate == 78125
lf = hf.downsampled_to(77000)
assert lf.sample_rate == 77000  # FAILS!
assert lf.sample_rate == 39062  # what actually happens -> the factor must be an integer
```