### PR TITLE
Baseline subtraction for FD curves

### DIFF
--- a/lumicks/pylake/fdcurve.py
+++ b/lumicks/pylake/fdcurve.py
@@ -1,3 +1,4 @@
+from copy import copy
 from .detail.mixin import DownsampledFD
 
 
@@ -8,21 +9,39 @@ class FDCurve(DownsampledFD):
     and `distance1`. Alternatives can be selected using `FDCurve.with_channels()`.
     Note that it does not modify the FD curve in place but returns a copy.
 
-    Parameters
+    Attributes
     ----------
-    h5py_dset : h5py.Dataset
-        The original HDF5 dataset containing FD curve information
     file : lumicks.pylake.File
-        The parent file. Used to loop up channel data.
+        The parent file. Used to look up channel data.
+    start, stop : int
+        The time range (ns) of this FD curve within the file.
+    name : str
+        The name of this FD curve as it appeared in the timeline.
     """
-    def __init__(self, h5py_dset, file, force="2", distance="1"):
-        self.dset = h5py_dset
-        self.start = h5py_dset.attrs["Start time (ns)"]
-        self.stop = h5py_dset.attrs["Stop time (ns)"]
-        self.name = h5py_dset.name.split("/")[-1]
+    def __init__(self, file, start, stop, name, force="2", distance="1"):
         self.file = file
+        self.start = start
+        self.stop = stop
+        self.name = name
         self._primary_force_channel = force
         self._primary_distance_channel = distance
+        self._force_cache = None
+        self._distance_cache = None
+
+    @classmethod
+    def from_dset(cls, h5py_dset, file, **kwargs):
+        return cls(file=file, start=h5py_dset.attrs["Start time (ns)"],
+                   stop=h5py_dset.attrs["Stop time (ns)"], name=h5py_dset.name.split("/")[-1],
+                   **kwargs)
+
+    def __copy__(self):
+        """Custom implementation of copy because the caches need to be cleared"""
+        cls = self.__class__
+        new_copy = cls.__new__(cls)
+        new_copy.__dict__.update(self.__dict__)
+        new_copy._force_cache = None
+        new_copy._distance_cache = None
+        return new_copy
 
     def _get_downsampled_force(self, n, xy):
         return getattr(self.file, f"downsampled_force{n}{xy}")[self.start:self.stop]
@@ -33,16 +52,23 @@ class FDCurve(DownsampledFD):
     @property
     def f(self):
         """The primary force channel associated with this FD curve"""
-        return getattr(self, f"downsampled_force{self._primary_force_channel}")
+        if self._force_cache is None:
+            self._force_cache = getattr(self, f"downsampled_force{self._primary_force_channel}")
+        return self._force_cache
 
     @property
     def d(self):
         """The primary distance channel associated with this FD curve"""
-        return getattr(self, f"distance{self._primary_distance_channel}")
+        if self._distance_cache is None:
+            self._distance_cache = getattr(self, f"distance{self._primary_distance_channel}")
+        return self._distance_cache
 
     def with_channels(self, force, distance):
         """Return a copy of this FD curve with difference primary force and distance channels"""
-        return FDCurve(self.dset, self.file, force, distance)
+        new_fd = copy(self)
+        new_fd._primary_force_channel = force
+        new_fd._primary_distance_channel = distance
+        return new_fd
 
     def plot_scatter(self, **kwargs):
         """Plot the FD curve points
@@ -57,3 +83,4 @@ class FDCurve(DownsampledFD):
         plt.scatter(self.d.data, self.f.data, **{"s": 8, **kwargs})
         plt.xlabel(self.d.labels.get("y", "distance"))
         plt.ylabel(self.f.labels.get("y", "force"))
+        plt.title(self.name)

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -149,4 +149,4 @@ class File(Group, Force, DownsampledFD, PhotonCounts):
 
     @property
     def fdcurves(self) -> Dict[str, FDCurve]:
-        return {name: FDCurve(dset, self) for name, dset in self.h5["FD Curve"].items()}
+        return {name: FDCurve.from_dset(dset, self) for name, dset in self.h5["FD Curve"].items()}

--- a/lumicks/pylake/tests/test_dfcurve.py
+++ b/lumicks/pylake/tests/test_dfcurve.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from lumicks.pylake.fdcurve import FDCurve
+from lumicks.pylake.channel import Slice, Timeseries
+
+
+def make_mock_fd(force, distance, start=0):
+    """Mock FD curve which is not attached to an actual file, timestamps start at `start`"""
+    assert len(force) == len(distance)
+    fd = FDCurve(file=None, start=None, stop=None, name="")
+    timestamps = np.arange(len(force)) + start
+    fd._force_cache = Slice(Timeseries(force, timestamps))
+    fd._distance_cache = Slice(Timeseries(distance, timestamps))
+    return fd
+
+
+def test_subtraction():
+    fd1 = make_mock_fd(force=[1, 2, 3], distance=[0, 1, 2], start=0)
+    fd2 = make_mock_fd(force=[2, 2, 2], distance=[0, 1, 2], start=100)
+    assert np.allclose((fd1 - fd2).f.data, [-1, 0, 1])
+    assert np.allclose((fd2 - fd1).f.data, [1, 0, -1])
+
+    fd1 = make_mock_fd(force=[1, 2, 3], distance=[0, 1, 2], start=0)
+    fd2 = make_mock_fd(force=[2, 2, 2], distance=[1, 2, 3], start=100)
+    assert np.allclose((fd1 - fd2).f.data, [0, 1])
+    assert np.allclose((fd2 - fd1).f.data, [0, -1])
+
+    fd1 = make_mock_fd(force=[1, 2, 3], distance=[0, 1, 2], start=0)
+    fd2 = make_mock_fd(force=[1, 1, 1], distance=[5, 6, 7], start=100)
+    assert np.allclose((fd1 - fd2).f.data, [])
+    assert np.allclose((fd2 - fd1).f.data, [])

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,12 @@ plt.plot(force.timestamps, force.data)
 
 # By default `f` is `downsampled_force2` and `d` is `distance1`
 altenative_fd = fd.with_channels(force='1x', distance='2')
+
+# Baseline subtraction
+fd_baseline = h5file.fdcurves["Baseline"]
+fd_measured = h5file.fdcurves["Measurement"]
+fd = fd_measured - fd_baseline
+fd.plot_scatter()
 ```
 
 ### Force vs. time

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ setup(
     packages=PEP420PackageFinder.find(include=["lumicks.*"]),
     python_requires='>=3.6',
     install_requires=['pytest>=3.5, <4.0', 'h5py>=2.8, <3.0', 'numpy>=1.14, <2',
-                      'matplotlib>=2.2, <3'],
+                      'scipy>=1.1, <2', 'matplotlib>=2.2, <3'],
     zip_safe=False,
 )


### PR DESCRIPTION
Usage is very simple:
```python
fd_baseline = h5file.fdcurves["Baseline"]
fd_measured = h5file.fdcurves["Measurement"]
fd = fd_measured - fd_baseline
fd.plot_scatter()
```

The implementation is also reasonably simple, based on `scipy.interpolate.interp1d()`.