### PR TITLE
Add support for time tag channels

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## v0.3.0 | In development
 
 * TIFF scan exports now default to using 32bit floats
+* Support for photon time tag data has been added (Bluelake version 1.5.0 and higher, HDF5 file format version 2)
 
 ## v0.2.0 | 2018-07-27
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -8,14 +8,14 @@ class Slice:
     """A lazily evaluated slice of a timeline/HDF5 channel
 
     Users will only ever get these as a result of slicing a timeline/HDF5
-    channel or slicing another slice (via this classes `__getitem__`), i.e.
+    channel or slicing another slice (via this class' `__getitem__`), i.e.
     the `__init__` method will never be invoked by users.
 
     Parameters
     ----------
     data_source : Any
-        A slice data source. Can be `Continuous`, `TimeSeries` or any other source
-        which conforms to the same interface.
+        A slice data source. Can be `Continuous`, `TimeSeries`,
+        or any other source which conforms to the same interface.
     labels : Dict[str, str]
         Plot labels: "x", "y", "title".
     """
@@ -132,6 +132,13 @@ class Continuous:
     def __len__(self):
         return len(self._src_data)
 
+    @staticmethod
+    def from_dataset(dset, y_label="y"):
+        start = dset.attrs["Start time (ns)"]
+        dt = int(1e9 / dset.attrs["Sample rate (Hz)"])
+        return Slice(Continuous(dset.value, start, dt),
+                     labels={"title": dset.name.strip("/"), "y": y_label})
+
     @property
     def data(self):
         if self._cached_data is None:
@@ -156,7 +163,7 @@ class Continuous:
                               start=self.start + self.dt * (factor - 1) // 2, dt=self.dt * factor)
 
 
-class Timeseries:
+class TimeSeries:
     """A source of time series data for a timeline slice
 
     Parameters
@@ -174,6 +181,11 @@ class Timeseries:
 
     def __len__(self):
         return len(self.data)
+
+    @staticmethod
+    def from_dataset(dset, y_label="y"):
+        return Slice(TimeSeries(dset["Value"], dset["Timestamp"]),
+                     labels={"title": dset.name.strip("/"), "y": y_label})
 
     @property
     def start(self):
@@ -194,7 +206,7 @@ class Timeseries:
 class Empty:
     """A lightweight source of no data
 
-    Both `Continuous` and `Timeseries` can be empty, but this is a lighter
+    Both `Continuous` and `TimeSeries` can be empty, but this is a lighter
     class which can be returned an empty slice from properties.
     """
     def __len__(self):
@@ -212,20 +224,10 @@ class Empty:
 empty_slice = Slice(Empty())
 
 
-def is_continuous_channel(dset):
-    """Continuous channels consist of simple (non-compound) types"""
-    return dset.dtype.fields is None
+def channel_class(dset):
+    if dset.dtype.fields is None:
+        return Continuous
+    else:
+        return TimeSeries
 
 
-def make_continuous_channel(dset, y_label="y"):
-    """Generate timestamps based on start/stop time and the sample rate"""
-    start = dset.attrs["Start time (ns)"]
-    dt = int(1e9 / dset.attrs["Sample rate (Hz)"])
-    return Slice(Continuous(dset.value, start, dt),
-                 labels={"title": dset.name.strip("/"), "y": y_label})
-
-
-def make_timeseries_channel(dset, y_label="y"):
-    """Just real all the data"""
-    return Slice(Timeseries(dset["Value"], dset["Timestamp"]),
-                 labels={"title": dset.name.strip("/"), "y": y_label})

--- a/lumicks/pylake/detail/mixin.py
+++ b/lumicks/pylake/detail/mixin.py
@@ -129,3 +129,21 @@ class PhotonCounts:
     @property
     def blue_photon_count(self) -> Slice:
         return _try_get_or_empty(self._get_photon_count, "Blue")
+
+
+class PhotonTimeTags:
+    """Red, green, and blue photon time tag channels"""
+    def _get_photon_time_tags(self, name):
+        raise NotImplementedError
+
+    @property
+    def red_photon_time_tags(self) -> Slice:
+        return _try_get_or_empty(self._get_photon_time_tags, "Red")
+
+    @property
+    def green_photon_time_tags(self) -> Slice:
+        return _try_get_or_empty(self._get_photon_time_tags, "Green")
+
+    @property
+    def blue_photon_time_tags(self) -> Slice:
+        return _try_get_or_empty(self._get_photon_time_tags, "Blue")

--- a/lumicks/pylake/fdcurve.py
+++ b/lumicks/pylake/fdcurve.py
@@ -1,6 +1,6 @@
 import numpy as np
 from copy import copy
-from .channel import Slice, Timeseries
+from .channel import Slice, TimeSeries
 from .detail.mixin import DownsampledFD
 
 
@@ -67,8 +67,8 @@ class FDCurve(DownsampledFD):
         new_force = force - interpolated_baseline_force(distance)
 
         new_fd = copy(self)
-        new_fd._force_cache = Slice(Timeseries(new_force, timestamps), self.f.labels)
-        new_fd._distance_cache = Slice(Timeseries(distance, timestamps), self.d.labels)
+        new_fd._force_cache = Slice(TimeSeries(new_force, timestamps), self.f.labels)
+        new_fd._distance_cache = Slice(TimeSeries(distance, timestamps), self.d.labels)
         return new_fd
 
     def _get_downsampled_force(self, n, xy):

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -2,8 +2,8 @@ import h5py
 import numpy as np
 from typing import Dict
 
-from .channel import Slice, Continuous, TimeSeries, TimeTags
-from .detail.mixin import Force, DownsampledFD, PhotonCounts
+from .channel import Slice, Continuous, TimeSeries, TimeTags, channel_class
+from .detail.mixin import Force, DownsampledFD, PhotonCounts, PhotonTimeTags
 from .fdcurve import FDCurve
 from .group import Group
 from .kymo import Kymo
@@ -13,7 +13,7 @@ from .scan import Scan
 __all__ = ["File"]
 
 
-class File(Group, Force, DownsampledFD, PhotonCounts):
+class File(Group, Force, DownsampledFD, PhotonCounts, PhotonTimeTags):
     """A convenient HDF5 file wrapper for reading data exported from Bluelake
 
     Parameters
@@ -135,6 +135,9 @@ class File(Group, Force, DownsampledFD, PhotonCounts):
 
     def _get_photon_count(self, name):
         return Continuous.from_dataset(self.h5["Photon count"][name], "Photon count")
+
+    def _get_photon_time_tags(self, name):
+        return TimeTags.from_dataset(self.h5["Photon Time Tags"][name], "Photon time tags")
 
     @property
     def kymos(self) -> Dict[str, Kymo]:

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -2,7 +2,7 @@ import h5py
 import numpy as np
 from typing import Dict
 
-from .channel import Slice, Continuous, TimeSeries
+from .channel import Slice, Continuous, TimeSeries, TimeTags
 from .detail.mixin import Force, DownsampledFD, PhotonCounts
 from .fdcurve import FDCurve
 from .group import Group

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -39,7 +39,7 @@ class File(Group, Force, DownsampledFD, PhotonCounts, PhotonTimeTags):
     def from_h5py(cls, h5py_file):
         """Directly load an existing `h5py.File`"""
         new_file = cls.__new__(cls)
-        super(cls, new_file).__init__(h5py_file)
+        new_file.h5 = h5py_file
         return new_file
 
     @property

--- a/lumicks/pylake/group.py
+++ b/lumicks/pylake/group.py
@@ -1,5 +1,5 @@
 import h5py
-from .channel import is_continuous_channel, make_continuous_channel, make_timeseries_channel
+from .channel import channel_class
 
 
 class Group:
@@ -19,7 +19,5 @@ class Group:
         if type(thing) is h5py.Group:
             return Group(thing)
         else:
-            if is_continuous_channel(thing):
-                return make_continuous_channel(thing)
-            else:
-                return make_timeseries_channel(thing)
+            cls = channel_class(thing)
+            return cls.from_dataset(thing)

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -83,4 +83,9 @@ def h5_file(tmpdir_factory, request):
     mock_file.make_timeseries_channel("Force LF", "Force 1x", [(1, 1.1), (2, 2.1)])
     mock_file.make_timeseries_channel("Force LF", "Force 1y", [(1, 1.2), (2, 2.2)])
 
+    if mock_class == MockDataFile_v2:
+        mock_file.make_timetags_channel(
+            "Photon Time Tags", "Red",
+            np.arange(10, 100, step=10, dtype=np.int64))
+
     return mock_file.file

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -89,3 +89,15 @@ def h5_file(tmpdir_factory, request):
             np.arange(10, 100, step=10, dtype=np.int64))
 
     return mock_file.file
+
+
+@pytest.fixture(scope="session")
+def h5_file_invalid_version(tmpdir_factory):
+    tmpdir = tmpdir_factory.mktemp("pylake")
+
+    mock_file = h5py.File(tmpdir.join("invalid.h5"))
+    mock_file.attrs["Bluelake version"] = "unknown"
+    mock_file.attrs["File format version"] = 254
+
+    return mock_file
+

--- a/lumicks/pylake/tests/test_dfcurve.py
+++ b/lumicks/pylake/tests/test_dfcurve.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from lumicks.pylake.fdcurve import FDCurve
-from lumicks.pylake.channel import Slice, Timeseries
+from lumicks.pylake.channel import Slice, TimeSeries
 
 
 def make_mock_fd(force, distance, start=0):
@@ -9,8 +9,8 @@ def make_mock_fd(force, distance, start=0):
     assert len(force) == len(distance)
     fd = FDCurve(file=None, start=None, stop=None, name="")
     timestamps = np.arange(len(force)) + start
-    fd._force_cache = Slice(Timeseries(force, timestamps))
-    fd._distance_cache = Slice(Timeseries(distance, timestamps))
+    fd._force_cache = Slice(TimeSeries(force, timestamps))
+    fd._distance_cache = Slice(TimeSeries(distance, timestamps))
     return fd
 
 

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -1,5 +1,6 @@
 import numpy as np
 from lumicks import pylake
+import pytest
 from textwrap import dedent
 
 
@@ -66,3 +67,8 @@ def test_repr_and_str(h5_file):
               - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
               - Size: 2
         """)
+
+
+def test_invalid_file_format(h5_file_invalid_version):
+    with pytest.raises(Exception):
+        f = pylake.File.from_h5py(h5_file_invalid_version)

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -7,7 +7,7 @@ def test_attributes(h5_file):
     f = pylake.File.from_h5py(h5_file)
 
     assert type(f.bluelake_version) is str
-    assert f.format_version == 1
+    assert f.format_version in [1, 2]
     assert type(f.experiment) is str
     assert type(f.description) is str
     assert type(f.guid) is str
@@ -41,27 +41,28 @@ def test_repr_and_str(h5_file):
     f = pylake.File.from_h5py(h5_file)
 
     assert repr(f) == f"lumicks.pylake.File('{h5_file.filename}')"
-    assert str(f) == dedent("""\
-        File root metadata:
-        - Bluelake version: unknown
-        - File format version: 1
-        - Experiment: 
-        - Description: 
-        - GUID: 
-        - Export time (ns): -1
-    
-        Force HF:
-          Force 1x:
-          - Data type: float64
-          - Size: 5
-          Force 1y:
-          - Data type: float64
-          - Size: 5
-        Force LF:
-          Force 1x:
-          - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
-          - Size: 2
-          Force 1y:
-          - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
-          - Size: 2
-    """)
+    if f.format_version == 1:
+        assert str(f) == dedent("""\
+            File root metadata:
+            - Bluelake version: unknown
+            - File format version: 1
+            - Experiment: 
+            - Description: 
+            - GUID: 
+            - Export time (ns): -1
+        
+            Force HF:
+              Force 1x:
+              - Data type: float64
+              - Size: 5
+              Force 1y:
+              - Data type: float64
+              - Size: 5
+            Force LF:
+              Force 1x:
+              - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
+              - Size: 2
+              Force 1y:
+              - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
+              - Size: 2
+        """)


### PR DESCRIPTION
This is the _pylake_ companion to the Bluelake implementation of photon time tagging (NG-1392 and friends).

* Channel source classes in `pylake.channel` have been refactored to make room for a new `TimeTags` source.
* Explicit checking of different file format versions is now in place in `pylake.File`. Right now, an exception is thrown upon encountering an unknown file format. 
  **Open question**: Is that the right behavior? Would it be better to issue a warning instead, and risk messing up the data if the file format has undergone major changes? Or play it safe, and force people to upgrade their _pylake_ if needed?
* Adds unit tests for the new channel types and file format versions, including some infrastructure for testing different file format versions.

### Checklist

- [x] Add unit tests for time tag data.
- [x] Update release notes.