### PR TITLE
Improve performance of confocal image reconstruction

### DIFF
--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -154,9 +154,14 @@ class Continuous:
         return int(1e9 / self.dt)
 
     def slice(self, start, stop):
-        # TODO: should be lazily evaluated
-        idx = np.logical_and(start <= self.timestamps, self.timestamps < stop)
-        return self.__class__(self.data[idx], max(start, self.start), self.dt)
+        def to_index(t):
+            """Convert a timestamp into a continuous channel index (assumes t >= self.start)"""
+            return (t - self.start + self.dt - 1) // self.dt
+
+        start = max(start, self.start)
+        start_idx = to_index(start)
+        stop_idx = to_index(stop)
+        return self.__class__(self.data[start_idx:stop_idx], start, self.dt)
 
     def downsampled_by(self, factor, reduce):
         return self.__class__(_downsample(self.data, factor, reduce),

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -3,6 +3,37 @@ import math
 import numpy as np
 
 
+class InfowaveCode(enum.IntEnum):
+    discard = 0  # this data sample does not contain useful information
+    use = 1  # useful data to be used to form a pixel
+    pixel_boundary = 2  # useful data and marks the last data sample in a pixel
+
+
+def reconstruct_num_frames(infowave, pixels_per_line, lines_per_frame):
+    """Reconstruct the number of frames in a continuous scan
+
+    Unfortunately, continuous scans do not store the number of frames as part of their
+    metadata (instead the number is zero) so we must reconstruct this number based on
+    the infowave.
+
+    Parameters
+    ----------
+    infowave : array_like
+        The famous infowave.
+    pixels_per_line : int
+        The number of pixels on the fast axis of the scan.
+    lines_per_frame : int
+        The number of pixels on the slow axis of the scan. Only needed for multi-frame scans.
+
+    Returns
+    -------
+    int
+    """
+    num_pixels = np.count_nonzero(infowave == InfowaveCode.pixel_boundary)
+    pixels_per_frames = pixels_per_line * lines_per_frame
+    return math.ceil(num_pixels / pixels_per_frames)
+
+
 def reconstruct_image(data, infowave, pixels_per_line, lines_per_frame=None, reduce=np.sum):
     """Reconstruct a scan or kymograph image from raw data
 
@@ -26,23 +57,18 @@ def reconstruct_image(data, infowave, pixels_per_line, lines_per_frame=None, red
     """
     assert data.size == infowave.size
 
-    class Code(enum.IntEnum):
-        discard = 0
-        use = 1
-        pixel_boundary = 2
-
     # Example infowave:
     #  1 0 0 1 0 1 2 0 1 0 0 1 0 1 0 1 0 0 1 0 2 0 1 0 1 0 0 1 0 1 0 1 2 1 0 0 1
     #              ^ <-----------------------> ^                       ^
     #                       one pixel
-    valid_idx = infowave != Code.discard
+    valid_idx = infowave != InfowaveCode.discard
     infowave = infowave[valid_idx]
 
     # After discard:
     #  1 1 1 2 1 1 1 1 1 2 1 1 1 1 1 2 1 1 1
     #        ^ <-------> ^           ^
     #         pixel_size (i.e. data samples per pixel)
-    pixel_sizes = np.diff(np.flatnonzero(infowave == Code.pixel_boundary))
+    pixel_sizes = np.diff(np.flatnonzero(infowave == InfowaveCode.pixel_boundary))
     pixel_size = pixel_sizes[0]
     # For now we assume that every pixel consists of the same number of samples
     assert np.all(pixel_sizes == pixel_size)

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -68,10 +68,10 @@ def reconstruct_image(data, infowave, pixels_per_line, lines_per_frame=None, red
     #  1 1 1 2 1 1 1 1 1 2 1 1 1 1 1 2 1 1 1
     #        ^ <-------> ^           ^
     #         pixel_size (i.e. data samples per pixel)
-    pixel_sizes = np.diff(np.flatnonzero(infowave == InfowaveCode.pixel_boundary))
-    pixel_size = pixel_sizes[0]
-    # For now we assume that every pixel consists of the same number of samples
-    assert np.all(pixel_sizes == pixel_size)
+    # This should be:
+    #   pixel_sizes = np.diff(np.flatnonzero(infowave == InfowaveCode.pixel_boundary))
+    # But for now we assume that every pixel consists of the same number of samples
+    pixel_size = np.argmax(infowave) + 1
 
     def round_up(size, n):
         """Round up `size` to the nearest multiple of `n`"""

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -21,6 +21,7 @@ class Kymo(PhotonCounts):
         self.name = h5py_dset.name.split("/")[-1]
         self.json = json.loads(h5py_dset[()])["value0"]
         self.file = file
+        self._cache = {}
 
     def __repr__(self):
         name = self.__class__.__name__
@@ -46,8 +47,11 @@ class Kymo(PhotonCounts):
         return self.json["scan volume"]["scan axes"][0]["num of pixels"]
 
     def _image(self, color):
-        return reconstruct_image(getattr(self, f"{color}_photon_count").data, self.infowave.data,
-                                 self.pixels_per_line).T
+        if color not in self._cache:
+            photon_counts = getattr(self, f"{color}_photon_count").data
+            self._cache[color] = reconstruct_image(photon_counts, self.infowave.data,
+                                                   self.pixels_per_line).T
+        return self._cache[color]
 
     def _timestamps(self, sample_timestamps):
         return reconstruct_image(sample_timestamps, self.infowave.data,

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -17,6 +17,8 @@ class Scan(Kymo):
     def __init__(self, h5py_dset, file):
         super().__init__(h5py_dset, file)
         self._num_frames = self.json["scan count"]
+        if len(self.json["scan volume"]["scan axes"]) > 2:
+            raise RuntimeError("3D scans are not supported")
 
     def __repr__(self):
         name = self.__class__.__name__

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .kymo import Kymo
-from .detail.image import reconstruct_image
+from .detail.image import reconstruct_image, reconstruct_num_frames
 
 
 class Scan(Kymo):
@@ -16,15 +16,18 @@ class Scan(Kymo):
     """
     def __init__(self, h5py_dset, file):
         super().__init__(h5py_dset, file)
-        self.num_frames = self.json["scan count"]
-        if self.num_frames == 0:
-            # For continuous scans this number is dynamic
-            # TODO: this is not an efficient way to determine the total number of frames
-            self.num_frames = self._image("red").shape[0]
+        self._num_frames = self.json["scan count"]
 
     def __repr__(self):
         name = self.__class__.__name__
         return f"{name}(pixels=({self.pixels_per_line}, {self.lines_per_frame}))"
+
+    @property
+    def num_frames(self):
+        if self._num_frames == 0:
+            self._num_frames = reconstruct_num_frames(self.infowave.data, self.pixels_per_line,
+                                                      self.lines_per_frame)
+        return self._num_frames
 
     @property
     def lines_per_frame(self):

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -34,8 +34,11 @@ class Scan(Kymo):
         return self.json["scan volume"]["scan axes"][1]["num of pixels"]
 
     def _image(self, color):
-        return reconstruct_image(getattr(self, f"{color}_photon_count").data, self.infowave.data,
-                                 self.pixels_per_line, self.lines_per_frame)
+        if color not in self._cache:
+            photon_counts = getattr(self, f"{color}_photon_count").data
+            self._cache[color] = reconstruct_image(photon_counts, self.infowave.data,
+                                                   self.pixels_per_line, self.lines_per_frame)
+        return self._cache[color]
 
     def _timestamps(self, sample_timestamps):
         return reconstruct_image(sample_timestamps, self.infowave.data, self.pixels_per_line,

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from lumicks.pylake.detail.image import reconstruct_image, save_tiff
+from lumicks.pylake.detail.image import reconstruct_image, reconstruct_num_frames, save_tiff
 
 
 def test_reconstruct():
@@ -29,6 +29,10 @@ def test_reconstruct_multiframe():
     assert reconstruct_image(the_data, infowave, 2, 2).shape == (3, 2, 2)
     assert reconstruct_image(the_data, infowave, 2, 3).shape == (2, 3, 2)
     assert reconstruct_image(the_data, infowave, 2, 5).shape == (5, 2)
+
+    assert reconstruct_num_frames(infowave, 2, 2) == 3
+    assert reconstruct_num_frames(infowave, 2, 3) == 2
+    assert reconstruct_num_frames(infowave, 2, 5) == 1
 
 
 def test_int_tiff(tmpdir):

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -20,7 +20,7 @@ def test_reconstruct():
 def test_reconstruct_multiframe():
     size = 100
     infowave = np.ones(size)
-    infowave[::10] = 2
+    infowave[9::10] = 2
     the_data = np.arange(size)
 
     assert reconstruct_image(the_data, infowave, 5).shape == (2, 5)


### PR DESCRIPTION
Should mostly resolve NG-1472.

Benchmarked with a 2 GiB HDF5 file containing a continuous scan with 212 frames:
```
|            | before (ms) | after (ms) | speedup |
|------------|-------------|------------|---------|
| load       |   1353.3    |     1.1    |    ∞    |
| rgb image  |   3906.6    |   863.9    |   4.5x  |
| num_frames |   0.003     |    19.7    |    ∞    |
|------------|-------------|------------|---------|
|  total     |   5259.9    |   884.7    |  5.95x  |
```

* `load` is just listing the scan using `file.scans`. This was previously very slow for continuous scans because the the number of frames needed to be calculated and this was being done in the constructor. This is now done lazily, but the calculation is also faster. See below.
* `rgb image` indicates the time needed to reconstruct the full RGB image with all the frames. This got a massive speedup thanks to a more efficient way of slicing continuous channels and a faster way of calculating the number of samples per pixel.
* `num_frames` is the time needed to look up the number of frames in a continuous scan. This was previously instant becaues it was calculated up front. This is now done lazily and it uses a dedicated algorithms which only looks at the infowave instead of reconstructing the entire image to get number of frames.

In total, the speedup is quite significant and should also reduce RAM usage.