### PR TITLE
Ng 987 - Export pixel size and dwell time to TIFF

### DIFF
--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -124,4 +124,5 @@ def save_tiff(image, filename, dtype, clip=False, pixel_size=1.0, pixel_time=1.0
     pixel_time = pixel_time * 1e-3              # ms => s
 
     tifffile.imsave(filename, image.astype(dtype), resolution=(1/pixel_size, 1/pixel_size, "CENTIMETER"),
-                    metadata={'PixelTime': pixel_time})
+                    metadata={'PixelTime': pixel_time, 'PixelTimeUnit': 's'})
+

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -3,7 +3,7 @@ import math
 import numpy as np
 
 
-class ImageMetaData:
+class ImageMetadata:
     """Image metadata
 
     Parameters
@@ -25,34 +25,31 @@ class ImageMetaData:
             self._pixel_size_y = pixel_size_x
 
     @staticmethod
-    def from_dataset(json=None):
+    def from_dataset(json):
         """
         Fetch metadata from json structure
 
         Parameters
         ----------
-        json : json structure containing kymograph metadata
+        json : dict
+            json structure containing kymograph metadata
         """
         if json:
             pixel_size = json["scan volume"]["scan axes"][0]["pixel size (nm)"]
             pixel_time = json["scan volume"]["pixel time (ms)"]
-            return ImageMetaData(pixel_size_x=pixel_size, pixel_time=pixel_time)
+            return ImageMetadata(pixel_size_x=pixel_size, pixel_time=pixel_time)
         else:
-            return ImageMetaData()
+            return ImageMetadata()
 
     @property
     def resolution(self):
-        """
-        :return: X, Y resolution in pixels per cm followed by unit specification accepted by Tifffile
-        """
+        """X, Y resolution in pixels per cm followed by unit specification accepted by Tifffile"""
         # TIFF only supports centimeters and inches as valid units, hence we convert from nm => cm
         return 1e7 / self._pixel_size_x, 1e7 / self._pixel_size_y, "CENTIMETER"
 
     @property
     def metadata(self):
-        """
-        :return: Dictionary with metadata
-        """
+        """Dictionary with metadata"""
         pixel_time = self._pixel_time * 1e-3  # ms => s
         return {'PixelTime': pixel_time, 'PixelTimeUnit': 's'}
 
@@ -144,7 +141,7 @@ def reconstruct_image(data, infowave, pixels_per_line, lines_per_frame=None, red
         return pixels.reshape(-1, lines_per_frame, pixels_per_line).squeeze()
 
 
-def save_tiff(image, filename, dtype, clip=False, metadata=ImageMetaData()):
+def save_tiff(image, filename, dtype, clip=False, metadata=ImageMetadata()):
     """Save an RGB `image` to TIFF
 
     This is a thin wrapper around `tifffile` with additional safety checks
@@ -160,7 +157,7 @@ def save_tiff(image, filename, dtype, clip=False, metadata=ImageMetaData()):
     clip : bool
         If enabled, the photon count data will be clipped to fit into the desired `dtype`.
         This option is disabled by default: an error will be raise if the data does not fit.
-    metadata : ImageMetaData
+    metadata : ImageMetadata
     """
     import tifffile
 

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -90,29 +90,38 @@ def reconstruct_image(data, infowave, pixels_per_line, lines_per_frame=None, red
         return pixels.reshape(-1, lines_per_frame, pixels_per_line).squeeze()
 
 
-def save_tiff(image, filename, dtype, clip=False):
-        """Save an RGB `image` to TIFF
+def save_tiff(image, filename, dtype, clip=False, pixel_size=0.0, pixel_time=0.0):
+    """Save an RGB `image` to TIFF
 
-        This is a thin wrapper around `tifffile` with additional safety checks
+    This is a thin wrapper around `tifffile` with additional safety checks
 
-        Parameters
-        ----------
-        image : np.array
-            Image data. An RGB image is expected to have `shape == (w, h, 3)`.
-        filename : str
-            The name of the TIFF file where the image will be saved.
-        dtype : np.dtype
-            The data type of a single color channel in the resulting image.
-        clip : bool
-            If enabled, the photon count data will be clipped to fit into the desired `dtype`.
-            This option is disabled by default: an error will be raise if the data does not fit.
-        """
-        import tifffile
+    Parameters
+    ----------
+    image : np.array
+        Image data. An RGB image is expected to have `shape == (w, h, 3)`.
+    filename : str
+        The name of the TIFF file where the image will be saved.
+    dtype : np.dtype
+        The data type of a single color channel in the resulting image.
+    clip : bool
+        If enabled, the photon count data will be clipped to fit into the desired `dtype`.
+        This option is disabled by default: an error will be raise if the data does not fit.
+    pixel_size : float
+        Pixel size [nm]
+    pixel_time: float
+        How long does pixel acquisition take [ms]
+    """
+    import tifffile
 
-        info = np.finfo(dtype) if np.dtype(dtype).kind == "f" else np.iinfo(dtype)
-        if not clip and (np.min(image) < info.min or np.max(image) > info.max):
-            raise RuntimeError(f"Can't safely export image with `dtype={dtype.__name__}` channels."
-                               f" Switch to a larger `dtype` in order to safely store everything"
-                               f" or pass `force=True` to clip the data.")
+    info = np.finfo(dtype) if np.dtype(dtype).kind == "f" else np.iinfo(dtype)
+    if not clip and (np.min(image) < info.min or np.max(image) > info.max):
+        raise RuntimeError(f"Can't safely export image with `dtype={dtype.__name__}` channels."
+                           f" Switch to a larger `dtype` in order to safely store everything"
+                           f" or pass `force=True` to clip the data.")
 
-        tifffile.imsave(filename, image.astype(dtype))
+    # TIFF only supports centimeters and inches as valid units
+    pixel_size = float(pixel_size) * 1e-7       # nm => cm
+    pixel_time = pixel_time * 1e-3              # ms => s
+
+    tifffile.imsave(filename, image.astype(dtype), resolution=(1/pixel_size, 1/pixel_size, "CENTIMETER"),
+                    metadata={'PixelTime': pixel_time})

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -90,7 +90,7 @@ def reconstruct_image(data, infowave, pixels_per_line, lines_per_frame=None, red
         return pixels.reshape(-1, lines_per_frame, pixels_per_line).squeeze()
 
 
-def save_tiff(image, filename, dtype, clip=False, pixel_size=0.0, pixel_time=0.0):
+def save_tiff(image, filename, dtype, clip=False, pixel_size=1.0, pixel_time=1.0):
     """Save an RGB `image` to TIFF
 
     This is a thin wrapper around `tifffile` with additional safety checks

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -171,4 +171,7 @@ class Kymo(PhotonCounts):
             If enabled, the photon count data will be clipped to fit into the desired `dtype`.
             This option is disabled by default: an error will be raise if the data does not fit.
         """
-        save_tiff(self.rgb_image, filename, dtype, clip)
+        pixel_size = self.json["scan volume"]["scan axes"][0]["pixel size (nm)"]
+        pixel_time = self.json["scan volume"]["pixel time (ms)"]
+
+        save_tiff(self.rgb_image, filename, dtype, clip, pixel_size, pixel_time)

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -2,7 +2,7 @@ import json
 import numpy as np
 
 from .detail.mixin import PhotonCounts
-from .detail.image import reconstruct_image, save_tiff
+from .detail.image import reconstruct_image, save_tiff, ImageMetaData
 
 
 class Kymo(PhotonCounts):
@@ -171,7 +171,6 @@ class Kymo(PhotonCounts):
             If enabled, the photon count data will be clipped to fit into the desired `dtype`.
             This option is disabled by default: an error will be raise if the data does not fit.
         """
-        pixel_size = self.json["scan volume"]["scan axes"][0]["pixel size (nm)"]
-        pixel_time = self.json["scan volume"]["pixel time (ms)"]
+        metadata = ImageMetaData.from_dataset(self.json)
 
-        save_tiff(self.rgb_image, filename, dtype, clip, pixel_size, pixel_time)
+        save_tiff(self.rgb_image, filename, dtype, clip, metadata)

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -2,7 +2,7 @@ import json
 import numpy as np
 
 from .detail.mixin import PhotonCounts
-from .detail.image import reconstruct_image, save_tiff, ImageMetaData
+from .detail.image import reconstruct_image, save_tiff, ImageMetadata
 
 
 class Kymo(PhotonCounts):
@@ -171,6 +171,5 @@ class Kymo(PhotonCounts):
             If enabled, the photon count data will be clipped to fit into the desired `dtype`.
             This option is disabled by default: an error will be raise if the data does not fit.
         """
-        metadata = ImageMetaData.from_dataset(self.json)
 
-        save_tiff(self.rgb_image, filename, dtype, clip, metadata)
+        save_tiff(self.rgb_image, filename, dtype, clip, ImageMetadata.from_dataset(self.json))

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from lumicks.pylake.detail.image import reconstruct_image, reconstruct_num_frames, save_tiff, ImageMetaData
+from lumicks.pylake.detail.image import reconstruct_image, reconstruct_num_frames, save_tiff, ImageMetadata
 
 def test_metadata_from_json():
     json = { 'cereal_class_version': 1,
@@ -20,7 +20,7 @@ def test_metadata_from_json():
                                             'scan time (ms)': 0,
                                             'scan width (um)': 36.07468112612217}]}}
 
-    image_metadata = ImageMetaData.from_dataset(json)
+    image_metadata = ImageMetadata.from_dataset(json)
 
     res = image_metadata.resolution
     assert np.isclose(res[0], 1e7 / 150)
@@ -79,8 +79,8 @@ def test_int_tiff(tmpdir):
             return tiff_tags
 
     image16 = np.ones(shape=(10, 10, 3)) * np.iinfo(np.uint16).max
-    save_tiff(image16, str(tmpdir.join("1")), dtype=np.uint16, metadata=ImageMetaData(pixel_size_x=1.0, pixel_time=1.0))
-    save_tiff(image16, str(tmpdir.join("2")), dtype=np.float32, metadata=ImageMetaData(pixel_size_x=5.0, pixel_time=5.0))
+    save_tiff(image16, str(tmpdir.join("1")), dtype=np.uint16, metadata=ImageMetadata(pixel_size_x=1.0, pixel_time=1.0))
+    save_tiff(image16, str(tmpdir.join("2")), dtype=np.float32, metadata=ImageMetadata(pixel_size_x=5.0, pixel_time=5.0))
     save_tiff(image16, str(tmpdir.join("3")), dtype=np.uint8, clip=True)
 
     with pytest.raises(RuntimeError) as excinfo:


### PR DESCRIPTION
- Adds dwell time / pixel time as metadata to exported TIFF file.

- Adds resolution to exported TIFF file (resolution is verified to be correctly recognized in ImageJ).

- Add tests for resolution and pixel time export.