### PR TITLE
NG-1936: Bugfix for scan constructor failing due to changes in base class Kymo.

### DIFF
--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -176,7 +176,7 @@ class File(Group, Force, DownsampledFD, PhotonCounts, PhotonTimeTags):
     def scans(self) -> Dict[str, Scan]:
         if "Scan" not in self.h5:
             return dict()
-        return {name: Scan(dset, self) for name, dset in self.h5["Scan"].items()}
+        return {name: Scan.from_dataset(dset, self) for name, dset in self.h5["Scan"].items()}
 
     @property
     def fdcurves(self) -> Dict[str, FDCurve]:

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -221,8 +221,8 @@ class Kymo(PhotonCounts):
         else:
             raise RuntimeError("Can't export TIFF if there are no pixels")
 
-    @staticmethod
-    def from_dataset(h5py_dset, file):
+    @classmethod
+    def from_dataset(cls, h5py_dset, file):
         """
         Construct Kymograph class from dataset.
 
@@ -237,7 +237,7 @@ class Kymo(PhotonCounts):
         stop = h5py_dset.attrs["Stop time (ns)"]
         name = h5py_dset.name.split("/")[-1]
         json_data = json.loads(h5py_dset[()])["value0"]
-        return Kymo(name, file, start, stop, json_data)
+        return cls(name, file, start, stop, json_data)
 
 
 class EmptyKymo(Kymo):

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -137,17 +137,10 @@ class Kymo(PhotonCounts):
             aspect=(image.shape[0] / image.shape[1]) * (duration / width_um)
         )
 
-        x_lims, y_lims = [kwargs.pop(f, None) for f in ("xlim", "ylim")]
-
         plt.imshow(image, **{**default_kwargs, **kwargs})
         plt.xlabel("time (s)")
         plt.ylabel(r"position ($\mu$m)")
         plt.title(self.name)
-
-        if x_lims:
-            plt.gca().set_xlim(x_lims)
-        if y_lims:
-            plt.gca().set_ylim(y_lims)
 
     def _plot_color(self, color, **kwargs):
         from matplotlib.colors import LinearSegmentedColormap

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -10,15 +10,21 @@ class Scan(Kymo):
 
     Parameters
     ----------
-    h5py_dset : h5py.Dataset
-        The original HDF5 dataset containing kymo information
+    name : str
+        Kymograph name
     file : lumicks.pylake.File
-        The parent file. Used to loop up channel data
+        Parent file. Contains the channel data.
+    start : int
+        Start point in the relevant info wave.
+    stop : int
+        End point in the relevant info wave.
+    json : dict
+        Dictionary containing kymograph-specific metadata.
     """
-    def __init__(self, name, file, start, stop, metadata):
-        super().__init__( name, file, start, stop, metadata)
-        self._num_frames = self.metadata["scan count"]
-        if len(self.metadata["scan volume"]["scan axes"]) > 2:
+    def __init__(self, name, file, start, stop, json):
+        super().__init__( name, file, start, stop, json)
+        self._num_frames = self.json["scan count"]
+        if len(self.json["scan volume"]["scan axes"]) > 2:
             raise RuntimeError("3D scans are not supported")
 
     def __repr__(self):
@@ -37,7 +43,7 @@ class Scan(Kymo):
 
     @property
     def lines_per_frame(self):
-        return self.metadata["scan volume"]["scan axes"][1]["num of pixels"]
+        return self.json["scan volume"]["scan axes"][1]["num of pixels"]
 
     def _image(self, color):
         if color not in self._cache:
@@ -57,8 +63,8 @@ class Scan(Kymo):
         if self.num_frames != 1:
             image = image[frame - 1]
 
-        x_um = self.metadata["scan volume"]["scan axes"][0]["scan width (um)"]
-        y_um = self.metadata["scan volume"]["scan axes"][1]["scan width (um)"]
+        x_um = self.json["scan volume"]["scan axes"][0]["scan width (um)"]
+        y_um = self.json["scan volume"]["scan axes"][1]["scan width (um)"]
         default_kwargs = dict(
             extent=[0, x_um, 0, y_um],
             aspect=(image.shape[0] / image.shape[1]) * (x_um / y_um)

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -10,7 +10,7 @@ import json
 class MockDataFile_v1:
 
     def __init__(self, file):
-        self.file = h5py.File(file)
+        self.file = h5py.File(file, 'w')
 
     def get_file_format_version(self):
         return 1
@@ -223,7 +223,7 @@ def h5_file(tmpdir_factory, request):
 def h5_file_invalid_version(tmpdir_factory):
     tmpdir = tmpdir_factory.mktemp("pylake")
 
-    mock_file = h5py.File(tmpdir.join("invalid.h5"))
+    mock_file = h5py.File(tmpdir.join("invalid.h5"), 'w')
     mock_file.attrs["Bluelake version"] = "unknown"
     mock_file.attrs["File format version"] = 254
 

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -4,6 +4,14 @@ import pytest
 from textwrap import dedent
 
 
+def test_scans(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+    if f.format_version == 2:
+        scan = f.scans["Scan1"]
+        assert scan.pixels_per_line == 5
+        assert np.allclose(scan.red_image, [[2, 0, 0, 0, 2], [0, 0, 0, 0, 0], [1, 0, 0, 0, 1], [0, 1, 1, 1, 0]])
+
+
 def test_kymos(h5_file):
     f = pylake.File.from_h5py(h5_file)
     if f.format_version == 2:
@@ -71,7 +79,10 @@ def test_properties(h5_file):
         assert f.kymos == {}
     else:
         assert len(f.kymos) == 1
-    assert f.scans == {}
+    if f.format_version == 1:
+        assert f.scans == {}
+    else:
+        assert len(f.scans) == 1
     assert f.point_scans == {}
     assert f.fdcurves == {}
 

--- a/lumicks/pylake/tests/test_scan.py
+++ b/lumicks/pylake/tests/test_scan.py
@@ -1,0 +1,32 @@
+import numpy as np
+from lumicks import pylake
+import pytest
+
+
+def test_scans(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+    if f.format_version == 2:
+        scan = f.scans["Scan1"]
+
+        assert repr(scan) == "Scan(pixels=(5, 4))"
+
+        reference_timestamps = [[2.006250e+10, 2.109375e+10, 2.206250e+10, 2.309375e+10],
+                                [2.025000e+10, 2.128125e+10, 2.225000e+10, 2.328125e+10],
+                                [2.043750e+10, 2.146875e+10, 2.243750e+10, 2.346875e+10],
+                                [2.062500e+10, 2.165625e+10, 2.262500e+10, 2.365625e+10],
+                                [2.084375e+10, 2.187500e+10, 2.284375e+10, 2.387500e+10]]
+
+        assert np.allclose(scan.timestamps, np.transpose(reference_timestamps))
+        assert scan.num_frames == 1
+        assert scan.has_fluorescence
+        assert not scan.has_force
+        assert scan.pixels_per_line == 5
+        assert scan.lines_per_frame == 4
+        assert len(scan.infowave) == 64
+        assert scan.rgb_image.shape == (4, 5, 3)
+        assert scan.red_image.shape == (4, 5)
+        assert scan.blue_image.shape == (4, 5)
+        assert scan.green_image.shape == (4, 5)
+
+        with pytest.raises(NotImplementedError):
+            scan["1s":"2s"]


### PR DESCRIPTION
- Fixes a regression in Scan which prevented the constructor from being called correctly upon file loading. Reason for the bug was inheritance on Kymo and no testing for Scan itself.

- Reverts the field name metadata back to json for backward compatibility.

- It also adds tests to prevent this from happening in the future.

- Removes convenience plot limit flags.

- Fixes test failures due to file open mode not being indicated in tests (deprecated in the h5py used on travis).