### PR TITLE
Ng 1929 - As a user, I would like to be able to see the keys in a group when printing either the group, or requesting its keys via keys()

### DIFF
--- a/lumicks/pylake/group.py
+++ b/lumicks/pylake/group.py
@@ -12,7 +12,6 @@ class Group:
     """
     def __init__(self, h5py_group):
         self.h5 = h5py_group
-        self._idx = -1
 
     def __getitem__(self, item):
         """Return a subgroup or a bluelake timeline channel"""
@@ -25,22 +24,15 @@ class Group:
 
     def keys(self):
         """Return group names at this level"""
-        return list(self.h5.keys())
+        return self.h5.keys()
 
     def __iter__(self):
-        self._idx = -1
-        return self
+        return self.h5.__iter__()
 
     def __next__(self):
-        """Return key names for the iterator analogously to HDF5"""
-        if self._idx >= len(self.keys()) - 1:
-            raise StopIteration
-
-        self._idx += 1
-        return self.keys()[self._idx]
+        return self.h5.__next__()
 
     def __repr__(self):
-        """Return type name and members of the group"""
-        name = self.__class__.__name__
-        members = ''.join(f"{e}, " for e in self.keys())
-        return f"{name} (members: {members[:-2]})"
+        """Return formatted representation of group keys"""
+        group_keys = ", ".join(f"'{k}'" for k in self.keys())
+        return f"{{{group_keys}}}"

--- a/lumicks/pylake/group.py
+++ b/lumicks/pylake/group.py
@@ -43,7 +43,4 @@ class Group:
         """Return type name and members of the group"""
         name = self.__class__.__name__
         members = ''.join(f"{e}, " for e in self.keys())
-        if members:
-            return f"{name} (members: {members[:-2]})"
-        else:
-            return f"{name}"
+        return f"{name} (members: {members[:-2]})"

--- a/lumicks/pylake/group.py
+++ b/lumicks/pylake/group.py
@@ -22,10 +22,6 @@ class Group:
             cls = channel_class(thing)
             return cls.from_dataset(thing)
 
-    def keys(self):
-        """Return group names at this level"""
-        return self.h5.keys()
-
     def __iter__(self):
         return self.h5.__iter__()
 
@@ -34,5 +30,5 @@ class Group:
 
     def __repr__(self):
         """Return formatted representation of group keys"""
-        group_keys = ", ".join(f"'{k}'" for k in self.keys())
+        group_keys = ", ".join(f"'{k}'" for k in self.h5)
         return f"{{{group_keys}}}"

--- a/lumicks/pylake/group.py
+++ b/lumicks/pylake/group.py
@@ -12,6 +12,7 @@ class Group:
     """
     def __init__(self, h5py_group):
         self.h5 = h5py_group
+        self._idx = -1
 
     def __getitem__(self, item):
         """Return a subgroup or a bluelake timeline channel"""
@@ -21,3 +22,28 @@ class Group:
         else:
             cls = channel_class(thing)
             return cls.from_dataset(thing)
+
+    def keys(self):
+        """Return group names at this level"""
+        return list(self.h5.keys())
+
+    def __iter__(self):
+        self._idx = -1
+        return self
+
+    def __next__(self):
+        """Return key names for the iterator analogously to HDF5"""
+        if self._idx >= len(self.keys()) - 1:
+            raise StopIteration
+
+        self._idx += 1
+        return self.keys()[self._idx]
+
+    def __repr__(self):
+        """Return type name and members of the group"""
+        name = self.__class__.__name__
+        members = ''.join(f"{e}, " for e in self.keys())
+        if members:
+            return f"{name} (members: {members[:-2]})"
+        else:
+            return f"{name}"

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -93,10 +93,17 @@ def test_groups(h5_file):
         assert set(f.keys()) == set(f.h5.keys())
         assert str(f["Force HF"]) == "Group (members: Force 1x, Force 1y)"
 
-        t = []
-        for name in f.keys():
-            t.append(name)
-        assert set(t) == set(f.keys())
+        for x in range(0, 1):
+            t = []
+            for name in f:
+                t.append(name)
+            assert set(t) == set(f.keys())
+
+        for x in range(0, 1):
+            t = []
+            for name in f["Force HF"]:
+                t.append(name)
+            assert set(t) == set(["Force 1x", "Force 1y"])
 
 
 def test_repr_and_str(h5_file):

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -90,12 +90,11 @@ def test_properties(h5_file):
 def test_groups(h5_file):
     f = pylake.File.from_h5py(h5_file)
     if f.format_version == 1:
-        assert set(f.keys()) == set(f.h5.keys())
         assert str(f["Force HF"]) == "{'Force 1x', 'Force 1y'}"
 
         for x in range(0, 2):
             t = [name for name in f]
-            assert set(t) == set(f.keys())
+            assert set(t) == set(f)
 
         for x in range(0, 2):
             t = [name for name in f["Force HF"]]

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -91,18 +91,14 @@ def test_groups(h5_file):
     f = pylake.File.from_h5py(h5_file)
     if f.format_version == 1:
         assert set(f.keys()) == set(f.h5.keys())
-        assert str(f["Force HF"]) == "Group (members: Force 1x, Force 1y)"
+        assert str(f["Force HF"]) == "{'Force 1x', 'Force 1y'}"
 
         for x in range(0, 2):
-            t = []
-            for name in f:
-                t.append(name)
+            t = [name for name in f]
             assert set(t) == set(f.keys())
 
         for x in range(0, 2):
-            t = []
-            for name in f["Force HF"]:
-                t.append(name)
+            t = [name for name in f["Force HF"]]
             assert set(t) == set(["Force 1x", "Force 1y"])
 
 

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -93,13 +93,13 @@ def test_groups(h5_file):
         assert set(f.keys()) == set(f.h5.keys())
         assert str(f["Force HF"]) == "Group (members: Force 1x, Force 1y)"
 
-        for x in range(0, 1):
+        for x in range(0, 2):
             t = []
             for name in f:
                 t.append(name)
             assert set(t) == set(f.keys())
 
-        for x in range(0, 1):
+        for x in range(0, 2):
             t = []
             for name in f["Force HF"]:
                 t.append(name)

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -87,6 +87,18 @@ def test_properties(h5_file):
     assert f.fdcurves == {}
 
 
+def test_groups(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+    if f.format_version == 1:
+        assert set(f.keys()) == set(f.h5.keys())
+        assert str(f["Force HF"]) == "Group (members: Force 1x, Force 1y)"
+
+        t = []
+        for name in f.keys():
+            t.append(name)
+        assert set(t) == set(f.keys())
+
+
 def test_repr_and_str(h5_file):
     f = pylake.File.from_h5py(h5_file)
 


### PR DESCRIPTION
- Adds more informative __repr__ for groups (shows the members and makes navigation of the h5 tree easier).

- Adds keys() for Group.

- Adds iterator for Group.

- Adds tests for above functionality (full coverage).

Note that the tests are failing because of an actual error in the tests that was fixed in #17 . Rebasing after that PR is accepted should fix this.
