### PR TITLE
Ng 1812 - Images reconstructed in pylake can have the axes inverted

### DIFF
--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -1,7 +1,6 @@
 
 def first(iterable, condition=lambda x: True):
-    """
-    Returns the first item in the `iterable` that satisfies the `condition`.
+    """Return the first item in the `iterable` that satisfies the `condition`.
 
     If the condition is not given, returns the first item of the iterable.
 

--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -1,0 +1,17 @@
+
+def first(iterable, condition=lambda x: True):
+    """
+    Returns the first item in the `iterable` that satisfies the `condition`.
+
+    If the condition is not given, returns the first item of the iterable.
+
+    Raises `StopIteration` if no item satisfying the condition is found.
+
+    Parameters
+    ----------
+    iterable : iterable
+    condition : callable
+        callable which returns true when the element is eligible as return value
+    """
+
+    return next(x for x in iterable if condition(x))

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -68,6 +68,13 @@ class Kymo(PhotonCounts):
     def _get_photon_count(self, name):
         return getattr(self.file, f"{name}_photon_count".lower())[self.start:self.stop]
 
+    def _get_axis_metadata(self, axis=0):
+        for cur_axis in self.json["scan volume"]["scan axes"]:
+            if cur_axis["axis"] == axis:
+                return cur_axis
+        else:
+            raise RuntimeError(f"Invalid axis {axis} specified")
+
     @property
     def has_fluorescence(self) -> bool:
         return self.json["fluorescence"]
@@ -82,7 +89,7 @@ class Kymo(PhotonCounts):
 
     @property
     def pixels_per_line(self):
-        return self.json["scan volume"]["scan axes"][0]["num of pixels"]
+        return self._get_axis_metadata(0)["num of pixels"]
 
     def _image(self, color):
         if color not in self._cache:
@@ -129,7 +136,7 @@ class Kymo(PhotonCounts):
     def _plot(self, image, **kwargs):
         import matplotlib.pyplot as plt
 
-        width_um = self.json["scan volume"]["scan axes"][0]["scan width (um)"]
+        width_um = self._get_axis_metadata(0)["scan width (um)"]
         duration = (self.stop - self.start) / 1e9
 
         default_kwargs = dict(

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -4,6 +4,7 @@ import numpy as np
 from .detail.mixin import PhotonCounts
 from .detail.image import reconstruct_image, save_tiff, ImageMetadata, line_timestamps_image
 from .detail.timeindex import to_timestamp
+from .detail.utilities import first
 
 
 class Kymo(PhotonCounts):
@@ -69,8 +70,7 @@ class Kymo(PhotonCounts):
         return getattr(self.file, f"{name}_photon_count".lower())[self.start:self.stop]
 
     def _get_axis_metadata(self, axis=0):
-        [return_axis] = (cur_axis for cur_axis in self.json["scan volume"]["scan axes"] if cur_axis["axis"] == axis)
-        return return_axis
+        return first(self.json["scan volume"]["scan axes"], lambda x: x["axis"] == axis)
 
     @property
     def has_fluorescence(self) -> bool:

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -69,11 +69,8 @@ class Kymo(PhotonCounts):
         return getattr(self.file, f"{name}_photon_count".lower())[self.start:self.stop]
 
     def _get_axis_metadata(self, axis=0):
-        for cur_axis in self.json["scan volume"]["scan axes"]:
-            if cur_axis["axis"] == axis:
-                return cur_axis
-        else:
-            raise RuntimeError(f"Invalid axis {axis} specified")
+        [return_axis] = (cur_axis for cur_axis in self.json["scan volume"]["scan axes"] if cur_axis["axis"] == axis)
+        return return_axis
 
     @property
     def has_fluorescence(self) -> bool:

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -43,7 +43,7 @@ class Scan(Kymo):
 
     @property
     def lines_per_frame(self):
-        return self.json["scan volume"]["scan axes"][1]["num of pixels"]
+        return self._get_axis_metadata(1)["num of pixels"]
 
     def _image(self, color):
         if color not in self._cache:
@@ -63,8 +63,8 @@ class Scan(Kymo):
         if self.num_frames != 1:
             image = image[frame - 1]
 
-        x_um = self.json["scan volume"]["scan axes"][0]["scan width (um)"]
-        y_um = self.json["scan volume"]["scan axes"][1]["scan width (um)"]
+        x_um = self._get_axis_metadata(0)["scan width (um)"]
+        y_um = self._get_axis_metadata(1)["scan width (um)"]
         default_kwargs = dict(
             extent=[0, x_um, 0, y_um],
             aspect=(image.shape[0] / image.shape[1]) * (x_um / y_um)

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -192,17 +192,17 @@ def h5_file(tmpdir_factory, request):
                     "pixel time (ms)": 0.2,
                     "scan axes": [
                         {
-                            "axis": 0,
+                            "axis": 1,
                             "cereal_class_version": 1,
-                            "num of pixels": 5,
+                            "num of pixels": 4,
                             "pixel size (nm)": 10,
                             "scan time (ms)": 0,
                             "scan width (um)": 36.07468112612217
                         },
                         {
-                            "axis": 1,
+                            "axis": 0,
                             "cereal_class_version": 1,
-                            "num of pixels": 4,
+                            "num of pixels": 5,
                             "pixel size (nm)": 10,
                             "scan time (ms)": 0,
                             "scan width (um)": 36.07468112612217

--- a/lumicks/pylake/tests/test_utilities.py
+++ b/lumicks/pylake/tests/test_utilities.py
@@ -1,0 +1,12 @@
+from lumicks.pylake.detail.utilities import first
+import pytest
+
+
+def test_first():
+    assert(first((1, 2, 3), condition=lambda x: x % 2 == 0) == 2)
+    assert(first(range(3, 100)) == 3)
+
+    with pytest.raises(StopIteration):
+        first((1, 2, 3), condition=lambda x: x % 5 == 0)
+    with pytest.raises(StopIteration):
+        first(())


### PR DESCRIPTION
This fixes a bug where image reconstruction fails when the image axes in the json are switched.