### PR TITLE
Deal with unrecognized fields

### DIFF
--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -354,7 +354,14 @@ def channel_class(dset):
         else:
             raise RuntimeError("Unknown channel kind " + str(kind))
     elif dset.dtype.fields is None:
-        # For compatibility with Bluelake HDF5 files v1
-        return Continuous
+        # Version 1 Bluelake HDF5 files do not have a kind field which indicates the type of data they store. These
+        # older files typically contain either Continuous or TimeSeries channel data. Continuous channel data contains
+        # the attribute "Sample rate (Hz)". Newer Bluelake HDF5 files also have fields which do not have the kind
+        # attribute, but which are not Continuous data. Direct access to these fields is not supported as they are
+        # typically accessed through dedicated API classes.
+        if "Sample rate (Hz)" in dset.attrs.keys():
+            return Continuous
+        else:
+            raise IndexError("Direct access to this field is not supported.")
     else:
         return TimeSeries

--- a/lumicks/pylake/fdcurve.py
+++ b/lumicks/pylake/fdcurve.py
@@ -31,7 +31,7 @@ class FDCurve(DownsampledFD):
         self._distance_cache = None
 
     @classmethod
-    def from_dset(cls, h5py_dset, file, **kwargs):
+    def from_dataset(cls, h5py_dset, file, **kwargs):
         return cls(file=file, start=h5py_dset.attrs["Start time (ns)"],
                    stop=h5py_dset.attrs["Stop time (ns)"], name=h5py_dset.name.split("/")[-1],
                    **kwargs)

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -10,6 +10,7 @@ from .group import Group
 from .kymo import Kymo
 from .point_scan import PointScan
 from .scan import Scan
+from .marker import Marker
 
 __all__ = ["File"]
 
@@ -182,3 +183,7 @@ class File(Group, Force, DownsampledFD, PhotonCounts, PhotonTimeTags):
     @property
     def fdcurves(self) -> Dict[str, FDCurve]:
         return self._get_object_dictionary("FD Curve", FDCurve)
+
+    @property
+    def markers(self) -> Dict[str, Marker]:
+        return self._get_object_dictionary("Marker", Marker)

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -160,17 +160,18 @@ class File(Group, Force, DownsampledFD, PhotonCounts, PhotonTimeTags):
     def _get_photon_time_tags(self, name):
         return TimeTags.from_dataset(self.h5["Photon Time Tags"][name], "Photon time tags")
 
+    def _get_object_dictionary(self, field, cls):
+        if field not in self.h5:
+            return dict()
+        return {name: cls.from_dataset(dset, self) for name, dset in self.h5[field].items()}
+
     @property
     def kymos(self) -> Dict[str, Kymo]:
-        if "Kymograph" not in self.h5:
-            return dict()
-        return {name: Kymo.from_dataset(dset, self) for name, dset in self.h5["Kymograph"].items()}
+        return self._get_object_dictionary("Kymograph", Kymo)
 
     @property
     def point_scans(self) -> Dict[str, Scan]:
-        if "Point Scan" not in self.h5:
-            return dict()
-        return {name: PointScan(dset, self) for name, dset in self.h5["Point Scan"].items()}
+        return self._get_object_dictionary("Point Scan", PointScan)
 
     @property
     def scans(self) -> Dict[str, Scan]:
@@ -180,6 +181,4 @@ class File(Group, Force, DownsampledFD, PhotonCounts, PhotonTimeTags):
 
     @property
     def fdcurves(self) -> Dict[str, FDCurve]:
-        if "FD Curve" not in self.h5:
-            return dict()
-        return {name: FDCurve.from_dset(dset, self) for name, dset in self.h5["FD Curve"].items()}
+        return self._get_object_dictionary("FD Curve", FDCurve)

--- a/lumicks/pylake/group.py
+++ b/lumicks/pylake/group.py
@@ -12,9 +12,14 @@ class Group:
     """
     def __init__(self, h5py_group):
         self.h5 = h5py_group
+        self.redirect_list = {}
 
     def __getitem__(self, item):
         """Return a subgroup or a bluelake timeline channel"""
+        if item in self.redirect_list:
+            raise IndexError(f"Direct access to this field is not supported. Use file.{self.redirect_list[item]} "
+                             f"instead. In case raw access is needed, go through the fn.h5 directly.")
+
         thing = self.h5[item]
         if type(thing) is h5py.Group:
             return Group(thing)

--- a/lumicks/pylake/marker.py
+++ b/lumicks/pylake/marker.py
@@ -1,0 +1,19 @@
+class Marker:
+    def __init__(self, file, marker_data):
+        self.file = file
+        self.start = marker_data["Start time (ns)"]
+        self.stop = marker_data["Stop time (ns)"]
+
+    @staticmethod
+    def from_dataset(h5py_dset, file):
+        """
+        Construct Marker class from dataset.
+
+        Parameters
+        ----------
+        h5py_dset : h5py.Dataset
+            The original HDF5 dataset containing Marker information
+        file : lumicks.pylake.File
+            The parent file.
+        """
+        return Marker(file, h5py_dset.attrs)

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -1,5 +1,6 @@
 import numpy as np
 from lumicks import pylake
+from lumicks.pylake.marker import Marker
 import pytest
 from textwrap import dedent
 
@@ -71,6 +72,19 @@ def test_calibration(h5_file):
         assert len(f.force1x.calibration) == 2
         assert len(f.downsampled_force1.calibration) == 0
         assert len(f.downsampled_force1x.calibration) == 1
+
+
+def test_marker(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+
+    if f.format_version == 2:
+        with pytest.raises(IndexError):
+            f["Marker"]["test_marker"]
+
+        assert np.isclose(f.markers["test_marker"].start, 100)
+        assert np.isclose(f.markers["test_marker"].stop, 200)
+        assert np.isclose(f.markers["test_marker2"].start, 200)
+        assert np.isclose(f.markers["test_marker2"].stop, 300)
 
 
 def test_properties(h5_file):

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -135,3 +135,11 @@ def test_repr_and_str(h5_file):
 def test_invalid_file_format(h5_file_invalid_version):
     with pytest.raises(Exception):
         f = pylake.File.from_h5py(h5_file_invalid_version)
+
+
+def test_invalid_access(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+
+    if f.format_version == 2:
+        with pytest.raises(IndexError):
+            f["Kymograph"]["Kymo1"]

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -115,6 +115,24 @@ def test_groups(h5_file):
             assert set(t) == set(["Force 1x", "Force 1y"])
 
 
+def test_redirect_list(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+    with pytest.raises(IndexError):
+        f["Calibration"]
+
+    with pytest.raises(IndexError):
+        f["Marker"]
+
+    with pytest.raises(IndexError):
+        f["FD Curve"]
+
+    with pytest.raises(IndexError):
+        f["Kymograph"]
+
+    with pytest.raises(IndexError):
+        f["Scan"]
+
+
 def test_repr_and_str(h5_file):
     f = pylake.File.from_h5py(h5_file)
 
@@ -143,6 +161,67 @@ def test_repr_and_str(h5_file):
               Force 1y:
               - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
               - Size: 2
+            
+            .force1x
+            .force1y
+        """)
+    if f.format_version == 2:
+        assert str(f) == dedent("""\
+            File root metadata:
+            - Bluelake version: unknown
+            - Description: 
+            - Experiment: 
+            - Export time (ns): -1
+            - File format version: 2
+            - GUID: 
+            
+            Force HF:
+              Force 1x:
+              - Data type: float64
+              - Size: 5
+              Force 1y:
+              - Data type: float64
+              - Size: 5
+            Force LF:
+              Force 1x:
+              - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
+              - Size: 2
+              Force 1y:
+              - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
+              - Size: 2
+            Info wave:
+              Info wave:
+              - Data type: uint8
+              - Size: 64
+            Photon Time Tags:
+              Red:
+              - Data type: int64
+              - Size: 9
+            Photon count:
+              Blue:
+              - Data type: uint32
+              - Size: 64
+              Green:
+              - Data type: uint32
+              - Size: 64
+              Red:
+              - Data type: uint32
+              - Size: 64
+            
+            .markers
+              - test_marker
+              - test_marker2
+
+            .kymos
+              - Kymo1
+            
+            .scans
+              - Scan1
+            
+            .force1x
+              .calibration
+            .force1y
+              .calibration
         """)
 
 


### PR DESCRIPTION
In ```group.__getitem__```, we check what type of data we are actually trying to index. Modern bluelake files have a "kind" field for channel data, but there's a fallback for older versions which don't have this field, which returns Continuous.

Not all datasets are channel data however, and when it gets called on one of these, the construction of Continuous fails providing an error that to the user has little or nothing to do with what they were trying to do. Instead, we now throw an exception when the user accesses something pylake isn't built to understand.

In this PR:
- Provides API for markers.
- Allows printing property fields available in the h5 in human readable format.
- When data access is attempted through the fields directly (such as h5file["Calibration"]) the user is redirected to the appropriate API.