### PR TITLE
Preparation for release v.0.4.1 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.1 | 2020-03-23
+* Drop `matplotlib` < 3 requirement.
+* Add functionality which redirects users to API when accessing particular fields, e.g. accessing `file["FD curve"]` will throw an error and redirect users to use `file.fdcurves`.
+* Add API for markers, i.e. `file.markers` returns a dictionary of markers (see docs tutorials section: Files and Channels).
+* Bugfix `CorrelatedStack.plot()` which resulted in the function throwing an error rather than showing a single frame.
+
 ## v0.4.0 | 2020-01-21
 
 * Add calibration data as attribute of force channels (see docs tutorials section: Files and Channels).
@@ -27,7 +33,7 @@
 ## v0.2.0 | 2018-07-27
 
 * Channel slices can be downsampled: `lf_force = hf_force.downsampled_by(factor=20)`
-* `FDCurve`s now support subtraction, e.g. `fd = f.fdcurves["measured"] - f.fdcurves["basline"]`
+* `FDCurve`s now support subtraction, e.g. `fd = f.fdcurves["measured"] - f.fdcurves["baseline"]`
 * Scans and kymos now have a `.timestamps` property with per-pixel timestamps with the same shape as the image arrays
 * Added Matlab compatibility examples to the repository in `examples/matlab`
 * `h5py` >= v2.8 is now required

--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,10 @@
 
 ## v0.4.1 | 2020-03-23
 * Drop `matplotlib` < 3 requirement.
-* Add functionality which redirects users to API when accessing particular fields, e.g. accessing `file["FD curve"]` will throw an error and redirect users to use `file.fdcurves`.
+* Add functionality which redirects users to the API when accessing particular fields, e.g. accessing `file["FD curve"]` will throw an error and redirect users to use `file.fdcurves`.
 * Add API for markers, i.e. `file.markers` returns a dictionary of markers (see docs tutorials section: Files and Channels).
 * Bugfix `CorrelatedStack.plot()` which resulted in the function throwing an error rather than showing a single frame.
+* Add canvas draw call to `CorrelatedStack.plot_correlated()` to make sure the plot is also interactive when it is not run from an interactive notebook.
 
 ## v0.4.0 | 2020-01-21
 

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -25,15 +25,6 @@ To see a textual representation of the contents of a file::
     - Export time (ns): 1531162366497820300
     - File format version: 1
 
-    Calibration:
-      1:
-        Force 1x
-        Force 1y
-        Force 2x
-        Force 2y
-        JSON:
-        - Data type: object
-        - Size: 1
     Force HF:
       Force 1x:
       - Data type: float64
@@ -51,10 +42,6 @@ To see a textual representation of the contents of a file::
       Info wave:
       - Data type: uint8
       - Size: 706251
-    Marker:
-      FRAP 3:
-      - Data type: object
-      - Size: 1
     Photon count:
       Blue:
       - Data type: uint32
@@ -65,16 +52,23 @@ To see a textual representation of the contents of a file::
       Red:
       - Data type: uint32
       - Size: 706251
-    Scan:
-      reference:
-      - Data type: object
-      - Size: 1
-      bleach:
-      - Data type: object
-      - Size: 1
-      imaging:
-      - Data type: object
-      - Size: 1
+
+    .scans
+      - reference
+      - bleach
+      - imaging
+
+    .markers:
+      - FRAP 3
+
+    .force1x
+      .calibration
+    .force1y
+      .calibration
+    .force2x
+      .calibration
+    .force2y
+      .calibration
 
 For a listing of more specific timeline items::
 
@@ -162,3 +156,24 @@ The actual values can be obtained from the list as follows, where the index refe
     0.0
 
 If we slice a force channel, we only obtain the calibrations relevant for the selected region.
+
+Markers
+-------
+
+We can see that the file also contains markers. These can be accessed from the markers attribute which returns a dictionary of markers.
+
+    >>> print(file.markers)
+    {'FRAP 3': <lumicks.pylake.marker.Marker at 0x2c6164bc910>}
+
+The actual markers can be obtained from the dictionary as follows::
+
+    >>> file.markers["FRAP 3"]
+    <lumicks.pylake.marker.Marker at 0x2c616bcf8b0>
+
+We can find the start and stop time with ``.start`` and ``.stop``.
+
+    >>> print(file.markers["FRAP 3"].start)
+    1573136459289265920
+
+    >>> print(file.markers["FRAP 3"].stop)
+    1573136602571107585

--- a/lumicks/pylake/__about__.py
+++ b/lumicks/pylake/__about__.py
@@ -1,5 +1,5 @@
 __title__ = "lumicks.pylake"
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __summary__ = "Bluelake data analysis tools"
 __url__ = "https://github.com/lumicks/pylake"
 

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -145,7 +145,7 @@ class CorrelatedStack:
             cmap='gray'
         )
 
-        image = self.get_frame(frame).data
+        image = self._get_frame(frame).data
         plt.imshow(image, **{**default_kwargs, **kwargs})
 
         if self.num_frames == 1:

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -224,6 +224,7 @@ class CorrelatedStack:
                         poly.remove()
                         image_object.set_data(current_frame.data)
                         poly = update_position(current_frame)
+                        fig.canvas.draw()
                         return
 
         fig.canvas.mpl_connect('button_press_event', select_frame)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
 
     packages=PEP420PackageFinder.find(include=["lumicks.*"]),
     python_requires='>=3.6',
-    install_requires=['pytest>=3.5, <4.0', 'h5py>=2.9, <3.0', 'numpy>=1.14, <2',
-                      'scipy>=1.1, <2', 'matplotlib>=2.2, <3', 'tifffile>=2018.11.6'],
+    install_requires=['pytest>=3.5', 'h5py>=2.9, <3.0', 'numpy>=1.14, <2',
+                      'scipy>=1.1, <2', 'matplotlib>=2.2', 'tifffile>=2018.11.6'],
     zip_safe=False,
 )


### PR DESCRIPTION
This PR aims to get pylake ready for release v0.4.1

- Removes matplotlib < 3 requirement. Despite conda-forge's recommendation to go with matplotlib-base, it seems more sensible to stick with matplotlib > 2.2, since matplotlib-base only starts at 3.0 and > 3.0 may be a harder constraint than base (leading to more difficult environment solving).
- Modifies the documentation to be in accordance with the current output of print.
- Updates the changelog.
- Implements a plotting bugfix on CorrelatedStack.