### PR TITLE
reconstruct_image: make a copy when in-place resize fails

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.2 | t.b.d.
+* Fixed an issue which prevented images from being reconstructed when a debugger is attached. Problem resided in `reconstruct_image` which threw an exception when attempting to resize a `numpy` array while the debugger was holding a reference to it.
+
 ## v0.4.1 | 2020-03-23
 * Drop `matplotlib` < 3 requirement.
 * Add functionality which redirects users to the API when accessing particular fields, e.g. accessing `file["FD curve"]` will throw an error and redirect users to use `file.fdcurves`.

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -146,17 +146,18 @@ def reconstruct_image(data, infowave, pixels_per_line, lines_per_frame=None, red
         """Round up `size` to the nearest multiple of `n`"""
         return int(math.ceil(size / n)) * n
 
-    data = data[valid_idx]
-    data.resize(round_up(data.size, pixel_size))
-
-    pixels = reduce(data.reshape(-1, pixel_size), axis=1)
+    resized_data = np.zeros(round_up(infowave.size, pixel_size))
+    resized_data[:infowave.size] = data[valid_idx]
+    pixels = reduce(resized_data.reshape(-1, pixel_size), axis=1)
 
     if lines_per_frame is None:
-        pixels.resize(round_up(pixels.size, pixels_per_line))
-        return pixels.reshape(-1, pixels_per_line)
+        resized_pixels = np.zeros(round_up(pixels.size, pixels_per_line))
+        resized_pixels[:pixels.size] = pixels
+        return resized_pixels.reshape(-1, pixels_per_line)
     else:
-        pixels.resize(round_up(pixels.size, pixels_per_line * lines_per_frame))
-        return pixels.reshape(-1, lines_per_frame, pixels_per_line).squeeze()
+        resized_pixels = np.zeros(round_up(pixels.size, pixels_per_line * lines_per_frame))
+        resized_pixels[:pixels.size] = pixels
+        return resized_pixels.reshape(-1, lines_per_frame, pixels_per_line).squeeze()
 
 
 def save_tiff(image, filename, dtype, clip=False, metadata=ImageMetadata()):


### PR DESCRIPTION
Three try catches :(.

I could try to put this in a function, but then we wouldn't be able to use try/catch, since passing the reference into the function would bump the reference count by one. There isn't an equivalent of move semantics, is there? :)

We could consider switching to concatenate altogether (since it doesn't seem to have a huge performance impact), but I'm not sure how much memory it takes compared to an in-place resize.

Time measurement (performed in randomized sequential order):
In place: 1.5232401490211487 +- 0.050069897091749985 (N=20)
Concatenate: 1.6158243656158446 +- 0.0414880556443715 (N=20)
np.resize: 2.3809279084205626 +- 0.06063061274418485 (N=20)