### PR TITLE
Return int64 for time from channel.downsampled_over

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## v0.4.2 | t.b.d.
 * Fixed an issue which prevented images from being reconstructed when a debugger is attached. Problem resided in `reconstruct_image` which threw an exception when attempting to resize a `numpy` array while the debugger was holding a reference to it.
+* Fixed bug that lead to timestamps becoming floating point values when using `channel.downsampled_over`.
 
 ## v0.4.1 | 2020-03-23
 * Drop `matplotlib` < 3 requirement.

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -121,7 +121,7 @@ class Slice:
         if where != 'center' and where != 'left':
             raise ValueError("Invalid argument for where. Valid options are center and left")
 
-        t = np.zeros(len(range_list))
+        t = np.zeros(len(range_list), dtype=self._src.timestamps.dtype)
         d = np.zeros(len(range_list))
         for i, time_range in enumerate(range_list):
             start, stop = time_range

--- a/lumicks/pylake/tests/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_correlated_stack.py
@@ -114,3 +114,8 @@ def test_correlation():
     assert (stack[1:3][0].raw.start == 20)
     assert (stack[1:3].raw[0].start == 20)
     assert (stack[1:3].raw[1].start == 30)
+
+    # Regression test downsampled_over losing precision due to reverting to double rather than int64.
+    cc = channel.Slice(channel.Continuous(np.arange(10, 80, 2), 1588267266006287100, 1000))
+    ch = cc.downsampled_over([(1588267266006287100, 2588267266006287100)], where='left')
+    assert int(ch.timestamps[0]) == 1588267266006287100


### PR DESCRIPTION
Timestamps returned from downsampled_over weren't defined as int64. This PR fixes that.