### PR TITLE
FdFit 1.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## v0.4.2 | t.b.d.
+## v0.5.0 | 2020-06-08
+* Added F, d Fitting functionality (beta, see docs tutorial section `Fd Fitting` and examples `Twistable Worm-Like-Chain Fitting` and `RecA Fd Fitting`).
 * Fixed an issue which prevented images from being reconstructed when a debugger is attached. Problem resided in `reconstruct_image` which threw an exception when attempting to resize a `numpy` array while the debugger was holding a reference to it.
 * Fixed bug that lead to timestamps becoming floating point values when using `channel.downsampled_over`.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,3 +16,12 @@ If you are just looking to get started, read the :doc:`/tutorial/index` first.
     scan.Scan
     point_scan.PointScan
     correlated_stack.CorrelatedStack
+
+FD Fitting
+----------
+
+.. autosummary::
+    :toctree: _api
+
+    fitting.model.Model
+    FdFit

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,3 +25,19 @@ FD Fitting
 
     fitting.model.Model
     FdFit
+
+.. _fd_models:
+.. rubric:: Available models
+
+.. autosummary::
+    :toctree: _api
+
+    force_offset
+    distance_offset
+    marko_siggia_ewlc_force
+    marko_siggia_ewlc_distance
+    marko_siggia_simplified
+    odijk
+    inverted_odijk
+    freely_jointed_chain
+    inverted_freely_jointed_chain

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,6 +25,7 @@ FD Fitting
 
     fitting.model.Model
     FdFit
+    parameter_trace
 
 .. _fd_models:
 .. rubric:: Available models
@@ -41,3 +42,5 @@ FD Fitting
     inverted_odijk
     freely_jointed_chain
     inverted_freely_jointed_chain
+    twistable_wlc
+    inverted_twistable_wlc

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ plot_pre_code = """
 import numpy as np
 import matplotlib.pyplot as plt
 
-from lumicks import pylake
+import lumicks.pylake as lk
 """
 plot_rcparams = {}
 plot_apply_rcparams = False

--- a/docs/examples/cst/kinesin_closed_loop.rst
+++ b/docs/examples/cst/kinesin_closed_loop.rst
@@ -16,7 +16,7 @@ With the IRM, you can see unlabeled microtubules and the kinesin-coated bead on 
 
 Open the file::
 
-    file = pylake.File("20190215-142512 Marker force clamp.h5")
+    file = lk.File("20190215-142512 Marker force clamp.h5")
 
 Load the data::
 

--- a/docs/examples/cst/kinesin_open_loop.rst
+++ b/docs/examples/cst/kinesin_open_loop.rst
@@ -22,7 +22,7 @@ To see and characterize this behaviour, we need to have the following plots:
 
 Open the file::
 
-    file = pylake.File("20190215-170635 Marker Kinesin stepping open loop.h5")
+    file = lk.File("20190215-170635 Marker Kinesin stepping open loop.h5")
 
 Force versus Time
 -----------------

--- a/docs/examples/dna_rna_protein/force_kymograph.rst
+++ b/docs/examples/dna_rna_protein/force_kymograph.rst
@@ -17,7 +17,7 @@ This experiments perfectly demonstrates the correlative capabilities of the C-tr
 Open the file::
 
     # Sytox binding, unbinding, with decreased, than increased force
-    file = pylake.File("20181107-152940 Sytox kymograph 7.h5")
+    file = lk.File("20181107-152940 Sytox kymograph 7.h5")
 
 Make Kymographs
 ---------------

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -8,7 +8,7 @@ For all of the examples, it is assumed that the following lines precede any othe
     import numpy as np
     import matplotlib.pyplot as plt
 
-    from lumicks import pylake
+    import lumicks.pylake as lk
 
 .. toctree::
     :caption: Segments

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -18,4 +18,5 @@ For all of the examples, it is assumed that the following lines precede any othe
     cst/index
     dna_rna_protein/index
     twlc_fitting/twlc_fitting
+    reca_fitting/reca_fitting
 

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -17,4 +17,5 @@ For all of the examples, it is assumed that the following lines precede any othe
 
     cst/index
     dna_rna_protein/index
+    twlc_fitting/twlc_fitting
 

--- a/docs/examples/reca_fitting/output_10_1.png
+++ b/docs/examples/reca_fitting/output_10_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a863853a574b22345620bc66ffefe44fb82a21688b2e5b2f59e8b2faebf55f9d
+size 15767

--- a/docs/examples/reca_fitting/output_10_2.png
+++ b/docs/examples/reca_fitting/output_10_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aaa1b49132160454e4ea6c37badb61366713fedb1df68b2db55f24a59a592b6e
+size 19733

--- a/docs/examples/reca_fitting/output_10_3.png
+++ b/docs/examples/reca_fitting/output_10_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0b6a70c49907c76549c0f01f0dc8a1e723a1218889cfcb34a3eb88615e1951a
+size 13261

--- a/docs/examples/reca_fitting/output_10_5.png
+++ b/docs/examples/reca_fitting/output_10_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:972c38357f93c2b31d51200cee9fb339d9dba61e72b48ceb6a62b5135ca0bbff
+size 51002

--- a/docs/examples/reca_fitting/output_10_6.png
+++ b/docs/examples/reca_fitting/output_10_6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1118b93b7f49a912747ebd6df1380e30020f654c4ab14f06be06da168d04dd5
+size 10042

--- a/docs/examples/reca_fitting/output_10_7.png
+++ b/docs/examples/reca_fitting/output_10_7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3dc4f6c91c64abbb6c4b4ec03b0215b630f031d941fcdfa0a6e7c1954fe831db
+size 8229

--- a/docs/examples/reca_fitting/output_10_8.png
+++ b/docs/examples/reca_fitting/output_10_8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:841c29c540afb8462ab4e4f4bff8f01125a1b7e3b05e55f2e3e70dc653b3c95a
+size 16693

--- a/docs/examples/reca_fitting/reca_fitting.rst
+++ b/docs/examples/reca_fitting/reca_fitting.rst
@@ -1,0 +1,335 @@
+.. warning::
+    This is beta functionality. While usable, this has not yet been tested in a large
+    number of different scenarios. The API may also still be subject to change.
+
+RecA Fd Fitting
+===============
+
+.. only:: html
+
+    :nbexport:`Download this page as a Jupyter notebook <self>`
+
+
+RecA Fd Fitting
+---------------
+
+RecA is a protein that is involved in DNA repair. In this notebook, we analyze data acquired in the presence and
+absence of RecA. RecA forms nucleoprotein filaments on DNA and is able to mechanically modify the DNA structure.
+Here, we quantify these changes using the worm-like chain model.
+
+Let's first load our data and see which curves are present in these files::
+
+    >>> control_file = lk.File("RecA/20200430-192424 FD Curve FD_5_control_forw.h5")
+    >>> reca_file = lk.File("RecA/20200430-192432 FD Curve FD_5_3_RecA_forw.h5")
+
+    >>> print(control_file.fdcurves)
+    >>> print(reca_file.fdcurves)
+
+    {'FD_5_control_forw': <lumicks.pylake.fdcurve.FDCurve object at 0x0000022C8514E780>}
+    {'FD_5_3_RecA_forw_after_2_quick_manual_FD': <lumicks.pylake.fdcurve.FDCurve object at 0x0000022C8514E860>}
+
+Plot the data
+-------------
+
+We see that each of the files has just one Fd curve. We can access the Fd curves by invoking `control_file[curve_name]`,
+or alternatively, since there's only one, we can simply use `popitem`. Let's have a quick look at the data::
+
+    control_name, control_curve = control_file.fdcurves.popitem()
+    reca_name, reca_curve = reca_file.fdcurves.popitem()
+
+    control_curve.plot_scatter(s=1, c="k")
+    reca_curve.plot_scatter(s=1, c="r")
+
+.. image:: output_10_1.png
+
+Set up the model
+----------------
+
+For this we want to use an inverted worm-like chain model. We also include an estimated distance and force offset::
+
+    model = lk.inverted_odijk("DNA").subtract_independent_offset() + lk.force_offset("DNA")
+
+We would like to fit this model to some data. So let's make a `FdFit`::
+
+    fit = lk.FdFit(model)
+
+Let's have a look at the parameters in this model::
+
+    >>> print(model.parameter_names)
+
+    ['DNA/d_offset', 'DNA/Lp', 'DNA/Lc', 'DNA/St', 'kT', 'DNA/f_offset']
+
+Load the data
+-------------
+
+We have to be careful when loading the data, as the Odijk worm-like chain model is only valid for intermediate forces
+(0 - 30 pN). That means we'll have to crop out the section of the data that's outside this range. We can do this by
+creating a logical mask which is true for the data we wish to include and false for the data we wish to exclude.
+
+The data in an `FdCurve` can be referenced by invoking the f and d attribute for force and distance respectively. This
+returns `Slice` objects, from which we can extract the data by calling `.data`. Since we have to do this twice, let's
+make a little function that extracts the data from the `FdCurve` and filters it::
+
+    def extract_data(fdcurve, f_min, f_max):
+        f = fdcurve.f.data
+        d = fdcurve.d.data
+        mask = (f < f_max) & (f > f_min)
+        return f[mask], d[mask]
+
+    force_control, distance_control = extract_data(control_curve, 0, 30)
+    force_reca, distance_reca = extract_data(reca_curve, 0, 30)
+
+We can load data into the `FdFit` by using the function `add_data`::
+
+    fit.add_data("Control", force_control, distance_control)
+
+If parameters are expected to differ between conditions, we can rename them for a specific data set when adding data to
+the fit. For the second data set, we expect the contour length, persistence length and stiffness to be different, so
+let’s rename these. We can do this by passing an extra argument named `params`. This argument takes a dictionary. The
+keys of this dictionary have to be given by the original name of the parameter in the model. This name is typically
+given by the name of the model followed by a slash and then the model parameter name. The value of this dictionary
+should be set to the model name slash the new parameter name. Let's rename the contour length Lc, persistence length
+Lp and stretch modulus St for this data set::
+
+    fit.add_data("RecA", force_reca, distance_reca,
+                 params={"DNA/Lc": "DNA/Lc_RecA", "DNA/Lp": "DNA/Lp_RecA",
+                         "DNA/St": "DNA/St_RecA"})
+
+Set up the fit
+--------------
+
+Let's add some custom parameter bounds::
+
+    fit["DNA/Lp"].value = 50
+    fit["DNA/Lp"].lower_bound = 39
+    fit["DNA/Lp"].upper_bound = 80
+
+    fit["DNA/St"].value = 1200
+    fit["DNA/St"].lower_bound = 700
+    fit["DNA/St"].upper_bound = 2000
+
+Fit the model
+-------------
+
+Everything is set up now and we can proceed to fit the model::
+
+    >>> fit.fit()
+
+    Fit
+      - Model: DNA(x-d)_with_DNA
+      - Equation:
+          f(d) = argmin[f](norm(DNA.Lc * (1 - (1/2)*sqrt(kT/(f*DNA.Lp)) + f/DNA.St)-(d - DNA.d_offset))) + DNA.f_offset
+
+      - Data sets:
+        - FitData(Control, N=884)
+        - FitData(RecA, N=1030, Transformations: DNA/Lp → DNA/Lp_RecA, DNA/Lc → DNA/Lc_RecA, DNA/St → DNA/St_RecA)
+
+      - Fitted parameters:
+        Name                 Value  Unit      Fitted      Lower bound    Upper bound
+        ------------  ------------  --------  --------  -------------  -------------
+        DNA/d_offset    -0.0716458  [au]      True               -0.1            0.1
+        DNA/Lp          55.7977     [nm]      True               39             80
+        DNA/Lc           2.83342    [micron]  True                0            inf
+        DNA/St        1407.65       [pN]      True              700           2000
+        kT               4.11       [pN*nm]   False               0              8
+        DNA/f_offset     0.0697629  [pN]      True               -0.1            0.1
+        DNA/Lp_RecA     90.2603     [nm]      True                0            100
+        DNA/Lc_RecA      3.04193    [micron]  True                0            inf
+        DNA/St_RecA    846.33       [pN]      True                0            inf
+
+
+Plot the fit
+------------
+
+Calling the plot function on the `FdFit` (i.e. `fit.plot()`) plots the fit alongside the data::
+
+    fit.plot()
+    plt.ylabel("Force [pN]")
+    plt.xlabel("Distance [$\\mu$M]")
+
+.. image:: output_10_2.png
+
+We would like to compare the two modelled curves without the data. Since we named our data sets, we can simply plot them
+with their respective names. Instead this time, we specify `plot_data = False` to indicate that we do not wish to plot
+the data this time::
+
+    fit.plot("Control", "r--", np.arange(2.1, 5.0, 0.01), plot_data=False)
+    fit.plot("RecA", "r--", np.arange(2.1, 5.0, 0.01), plot_data=False)
+    plt.ylabel("Force [pN]")
+    plt.xlabel("Distance [$\\mu$M]")
+    plt.ylim([0, 30])
+    plt.xlim([2, 3.1])
+
+.. image:: output_10_3.png
+
+Let’s print the contour length difference due to RecA. We multiply by 1000 since we desire this value in nanometers::
+
+    >>> delta_lc = (fit["DNA/Lc_RecA"].value - fit["DNA/Lc"].value) * 1000.0
+    >>> print(f"Contour length difference: {delta_lc:.2f} [nm]")
+
+    Contour length difference: 208.51 [nm]
+
+Try another model
+-----------------
+
+There are more models in pylake. We can also try the Marko Siggia model for instance and see if it fits this data any
+differently::
+
+    ms_model = lk.marko_siggia_ewlc_force("DNA").subtract_independent_offset() + lk.force_offset("DNA")
+    ms_fit = lk.FdFit(ms_model)
+    ms_fit.add_data("Control", force_control, distance_control)
+    ms_fit.add_data("RecA", force_reca, distance_reca,
+                            params={"DNA/Lc": "DNA/Lc_RecA", "DNA/Lp": "DNA/Lp_RecA",
+                                    "DNA/St": "DNA/St_RecA"})
+    ms_fit.fit();
+
+Plot the competing models
+-------------------------
+
+Let's plot the models side by side, so we can get an idea of which model fits best::
+
+    plt.figure(figsize=(20,5))
+    plt.subplot(1, 2, 1)
+    fit.plot()
+    plt.title("Odijk")
+    plt.ylim([0,10])
+    plt.subplot(1, 2, 2)
+    ms_fit.plot()
+    plt.title("Marko-Siggia")
+    plt.ylim([0,10])
+
+.. image:: output_10_5.png
+
+At first glance, the model fits look very similar. Since we were interested in the contour length changes, let's have a
+look at what these models predict for the change in contour length::
+
+    >>> delta_lc = (fit["DNA/Lc_RecA"].value - fit["DNA/Lc"].value) * 1000.0
+    >>> print(f"Contour length difference Odijk: {delta_lc:.2f} [nm]")
+    >>> delta_lc = (ms_fit["DNA/Lc_RecA"].value - ms_fit["DNA/Lc"].value) * 1000.0
+    >>> print(f"Contour length difference Marko-Siggia: {delta_lc:.2f} [nm]")
+
+    Contour length difference Odijk: 208.51 [nm]
+    Contour length difference Marko-Siggia: 210.33 [nm]
+
+These results are very similar, increasing our confidence in the result.
+
+Which fit is statistically optimal
+----------------------------------
+
+We can also determine how well a model fits the data by looking at the corrected Akaike Information Criterion and
+Bayesian Information Criterion. Here, a low value indicates a better model.
+
+We can see here that both criteria seem to indicate that the Odijk model provides the best fit. Please note however,
+that it is always important to verify that the model produce sensible results. More freedom to fit parameters, will
+almost always lead to an improved fit, and this additional freedom can lead to fits that produce non-physical results.
+Information criteria tend to try and penalize unnecessary over-fitting, but they do not guard against unphysical
+parameter values.
+
+Generally, it is always a good idea to try multiple models, and multiple sets of bound constraints, to get a feel for
+how reliable the estimates are::
+
+    >>> print("Corrected Akaike Information Criterion")
+    >>> print(f"Odijk Model with force offset {fit.aicc}")
+    >>> print(f"Marko-Siggia Model with force offset {ms_fit.aicc}")
+    >>> print("Bayesian Information Criterion")
+    >>> print(f"Odijk Model with force offset {fit.bic}")
+    >>> print(f"Marko-Siggia Model with force offset {ms_fit.bic}")
+
+    Corrected Akaike Information Criterion
+    Odijk Model with force offset 266.0174147701515
+    Marko-Siggia Model with force offset 285.1340433325082
+    Bayesian Information Criterion
+    Odijk Model with force offset 310.3974287950736
+    Marko-Siggia Model with force offset 329.5140573574303
+
+We can also quickly compare parameter values::
+
+    >>> fit.params
+
+    Name                 Value  Unit      Fitted      Lower bound    Upper bound
+    ------------  ------------  --------  --------  -------------  -------------
+    DNA/d_offset    -0.0716458  [au]      True               -0.1            0.1
+    DNA/Lp          55.7977     [nm]      True               39             80
+    DNA/Lc           2.83342    [micron]  True                0            inf
+    DNA/St        1407.65       [pN]      True              700           2000
+    kT               4.11       [pN*nm]   False               0              8
+    DNA/f_offset     0.0697629  [pN]      True               -0.1            0.1
+    DNA/Lp_RecA     90.2603     [nm]      True                0            100
+    DNA/Lc_RecA      3.04193    [micron]  True                0            inf
+    DNA/St_RecA    846.33       [pN]      True                0            inf
+
+    >>> ms_fit.params
+
+    Name                 Value  Unit      Fitted      Lower bound    Upper bound
+    ------------  ------------  --------  --------  -------------  -------------
+    DNA/d_offset    -0.1        [au]      True               -0.1            0.1
+    DNA/Lp          58.377      [nm]      True                0            100
+    DNA/Lc           2.86002    [micron]  True                0            inf
+    DNA/St        1400.35       [pN]      True                0            inf
+    kT               4.11       [pN*nm]   False               0              8
+    DNA/f_offset     0.0468744  [pN]      True               -0.1            0.1
+    DNA/Lp_RecA     91.857      [nm]      True                0            100
+    DNA/Lc_RecA      3.07035    [micron]  True                0            inf
+    DNA/St_RecA    855.266      [pN]      True                0            inf
+
+Dynamic experiments
+-------------------
+
+We can see some differences in the estimates but nothing that would be a cause for immediate concern, so let's stick
+with the Odijk model for the rest of this analysis as it fits slightly better. One thing we noticed when acquiring the
+data was that some of the experiments showed some dynamics. It would be interesting to look at the contour length
+changes for these experiments. To this end, we take the model we just fitted and determine a contour length per data
+point of this model while keeping all other parameters the same.
+
+Let's load the data and have a look::
+
+    dynamic_file = lk.File("RecA/20200430-182304 FD Curve 40.h5")
+    dynamic_name, dynamic_curve = dynamic_file.fdcurves.popitem()
+    dynamic_curve.plot_scatter()
+
+.. image:: output_10_6.png
+
+Once again, we extract our data up to 25 pN. We can reuse the function we defined earlier::
+
+    force_dynamic, distance_dynamic = extract_data(dynamic_curve, 0, 25)
+
+A contour length per point
+--------------------------
+
+Now comes the more challenging part. Inverting the model for contour length. Luckily, this procedure has already been
+implemented in Pylake. The function `parameter_trace` inverts the model for a particular model parameter. Let's have
+a look at the parameters it needs. We can look this up in the documentation for :func:`~lumicks.pylake.parameter_trace`
+or invoke help::
+
+    help(lk.parameter_trace)
+
+Let's see if we have all these pieces of information. We stored the model in the variable `model`. We can extract
+the parameters for the RecA condition using the name we provided to the dataset before (i.e. `fit["RecA"]`).
+The parameter we wish to invert for is `DNA/Lc` and for the independent and dependent variables we simply
+pass the dataset::
+
+    Lcs = lk.parameter_trace(model, fit["RecA"], "DNA/Lc", distance_dynamic, force_dynamic)
+
+Let's plot it::
+
+    plt.plot(Lcs)
+    plt.ylabel("Contour lengths")
+    plt.xlabel("Time [s]")
+
+.. image:: output_10_7.png
+
+Looks like some of the estimates are way off early in the curve. Doing this inversion at very low distances is quite
+error prone, likely due to the non-linearity of the model. In addition, the Odijk model is known to not be reliable at
+low forces, so we would like to exclude this data anyway. Let's only look at the points where the distance is higher
+than 2.25 micrometers::
+
+    distance_mask = distance_dynamic > 2.2
+
+    plt.plot(distance_dynamic[distance_mask], Lcs[distance_mask])
+    plt.ylabel("Contour length [micron]")
+    plt.xlabel("Distance [micron]")
+
+.. image:: output_10_8.png
+
+Here we can see the different contour length transitions quite clearly. There seems to be one region
+of contour lengths around 3.2 before finally lengthening to 3.4 micrometers.

--- a/docs/examples/twlc_fitting/output_9_1.png
+++ b/docs/examples/twlc_fitting/output_9_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59910095d369d926ee1baed128846b0f6315bfd6ca478fe6a826a53afb20c647
+size 10756

--- a/docs/examples/twlc_fitting/output_9_2.png
+++ b/docs/examples/twlc_fitting/output_9_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:878a5cf23dbfa1a923f58b948541b45a36a0b086b9c60212d86cd754aad50de8
+size 14142

--- a/docs/examples/twlc_fitting/twlc_fitting.rst
+++ b/docs/examples/twlc_fitting/twlc_fitting.rst
@@ -1,0 +1,178 @@
+.. warning::
+    This is beta functionality. While usable, this has not yet been tested in a large
+    number of different scenarios. The API may also still be subject to change.
+
+Twistable Worm-Like-Chain Fitting
+=================================
+
+.. only:: html
+
+    :nbexport:`Download this page as a Jupyter notebook <self>`
+
+In this notebook, we analyze force extension data of DNA over its full range of structural transitions under mechanical
+stress (0 - 60 pN). The twistable worm-like chain model (tWLC) takes twisting deformations on the DNA double helix into
+account. Here we will use this model to describe the mechanical response of DNA at such high forces.
+
+Let's load and plot the data first::
+
+    file = lk.File("twlc_data//20200430-163932 FD Curve FD_1_control_forw.h5")
+    fd_curve = file.fdcurves["FD_1_control_forw"]
+    fd_curve.plot_scatter()
+
+.. image:: output_9_1.png
+
+Set up a basic model first
+--------------------------
+
+We clearly see that the force starts levelling out at high forces in the data. We'll need something rather complex in
+order to capture this behavior. The twistable worm-like chain (tWLC) model can describe the untwisting behavior of DNA
+that becomes apparent in the 30-60 pN force range. However, the model's complexity also incurs some challenges.
+
+Parameter estimation typically begins from an initial guess, and if this initial guess is bad, it can get stuck at an
+estimated set of parameters that are suboptimal, a so-called local optimum. One way to mitigate this, is to start with
+better initial values.
+
+In this notebook, we fit the region before the force begins levelling out (i.e. 30 pN) first with a regular worm-like
+chain model and then use those estimates as initial guesses to fit the tWLC model.
+
+Depending on your experiments, small offsets can be present in the data. For instance, the bead diameter may vary
+slightly from experiment to experiment, or the force may have experienced some drift. We incorporate an offset in
+both distance and force to compensate for small offsets that may exist in the data. Let's set up the Odijk worm-like
+chain model and create the fit::
+
+    m_odijk = lk.inverted_odijk("DNA").subtract_independent_offset() + lk.force_offset("DNA")
+    fit_odijk = lk.FdFit(m_odijk)
+
+Considering that this model only describes the force-extension behaviour at low forces (0.1 - 30 pN), we have to extract
+the data that is relevant to us. We can obtain this data from the force-distance curve as follows::
+
+    force = fd_curve.f.data
+    distance = fd_curve.d.data
+
+We only wish to use the forces below 30, so we filter the data according to this requirement::
+
+    mask = force < 30
+    distance = distance[mask]
+    force = force[mask]
+
+Now we are ready to add this data to the fit, but first, we must constrain the distance offset to help the fitting,
+as this provides a lot of additional freedom in the model::
+
+    fit_odijk.add_data("Inverted Odijk", force, distance)
+    fit_odijk["DNA/d_offset"].upper_bound = 0.01
+    fit_odijk["DNA/d_offset"].lower_bound = -0.01
+
+And fit the model::
+
+    >>> fit_odijk.fit()
+
+    Fit
+      - Model: DNA(x-d)_with_DNA
+      - Equation:
+          f(d) = argmin[f](norm(DNA.Lc * (1 - (1/2)*sqrt(kT/(f*DNA.Lp)) + f/DNA.St)-(d - DNA.d_offset))) + DNA.f_offset
+
+      - Data sets:
+        - FitData(Inverted Odijk, N=959)
+
+      - Fitted parameters:
+        Name                  Value  Unit      Fitted      Lower bound    Upper bound
+        ------------  -------------  --------  --------  -------------  -------------
+        DNA/d_offset    -0.00601252  [au]      True              -0.01           0.01
+        DNA/Lp          44.2558      [nm]      True               0            100
+        DNA/Lc           2.80085     [micron]  True               0            inf
+        DNA/St        1714.56        [pN]      True               0            inf
+        kT               4.11        [pN*nm]   False              0              8
+        DNA/f_offset     0.0392458   [pN]      True              -0.1            0.1
+
+Set up the twistable worm like chain model
+------------------------------------------
+
+By default, the `twistable_wlc` model provided with pylake outputs the distance as a function of force. However, we
+typically want to fit force as a function of distance. To achieve this, we can invert the model using its `invert`
+function at the cost of slowing down the fit. Alternatively, we have a faster way of achieving this in pylake, by
+using the dedicated `inverted_twistable_wlc` model::
+
+    m_dna = lk.inverted_twistable_wlc("DNA").subtract_independent_offset() + lk.force_offset("DNA")
+    fit_twlc = lk.FdFit(m_dna)
+
+Load the full data into the model
+---------------------------------
+
+In the plot showing the data, we could see that there is a small transition event at the end of the Fd curve. The model
+will not be able to capture this behaviour and therefore it is best to remove this section prior to fitting::
+
+    force = fd_curve.f.data
+    distance = fd_curve.d.data
+    mask = distance < 2.88
+    distance = distance[mask]
+    force = force[mask]
+
+Now we can load the data into the model::
+
+    fit_twlc.add_data("Twistable WLC", force, distance)
+
+We could add more datasets in a similar manner, but in this example, we only fit a single model. Let’s load the
+parameters from our previous fit to use them as initial guesses for this one. We also fix the twist rigidity and
+critical force to values from literature (analogous to Broekmans et al. "DNA twist stability changes with
+magnesium (2+) concentration." Physical Review Letters 116, 258102 (2016))::
+
+    fit_twlc.update_params(fit_odijk)
+
+    # Fix twist rigidity and critical force to literature values.
+    fit_twlc["DNA/C"].value = 440
+    fit_twlc["DNA/C"].fixed = True
+    fit_twlc["DNA/Fc"].value = 30.6
+    fit_twlc["DNA/Fc"].fixed = True
+
+Fit the model
+-------------
+
+Considering that the tWLC model is more difficult to evaluate, this may take a while. This is also
+why we choose to enable verbose output::
+
+    >>> fit_twlc.fit(verbose=2)
+    >>> plt.show()
+
+       Iteration     Total nfev        Cost      Cost reduction    Step norm     Optimality
+           0              1         2.4384e+02                                    2.81e+05
+           1              2         4.4649e+01      1.99e+02       6.84e+00       1.14e+04
+           2              3         4.3820e+01      8.29e-01       5.79e+01       4.67e+03
+           3              4         4.3756e+01      6.46e-02       1.36e+01       2.16e+02
+           4              5         4.3755e+01      8.30e-04       3.92e+00       9.48e+00
+           5              6         4.3755e+01      1.29e-06       7.15e-02       5.84e-02
+           6              7         4.3755e+01      5.81e-09       3.60e-02       1.86e-02
+    `ftol` termination condition is satisfied.
+    Function evaluations 7, initial cost 2.4384e+02, final cost 4.3755e+01, first-order optimality 1.86e-02.
+
+Plotting the results
+--------------------
+
+After fitting we can plot our results and print our parameters by invoking `fit.plot()` and `fit.params` respectively::
+
+    fit_twlc.plot()
+    plt.xlabel("Distance [$\\mu$m]")
+    plt.ylabel("Force [pN]");
+
+
+.. image:: output_9_2.png
+
+We can also show the parameters::
+
+    >>> fit_twlc.params
+
+    Name                  Value  Unit        Fitted      Lower bound    Upper bound
+    ------------  -------------  ----------  --------  -------------  -------------
+    DNA/d_offset    -0.00605829  [au]        True              -0.01           0.01
+    DNA/Lp          43.2315      [nm]        True               0            100
+    DNA/Lc           2.80289     [micron]    True               0            inf
+    DNA/St        1761.79        [pN]        True               0            inf
+    DNA/C          440           [pN*nm**2]  False              0           5000
+    DNA/g0        -579.909       [pN*nm]     True           -5000              0
+    DNA/g1          17.6625      [nm]        True               0           1000
+    DNA/Fc          30.6         [pN]        False              0             50
+    kT               4.11        [pN*nm]     False              0              8
+    DNA/f_offset     0.0295708   [pN]        True              -0.1            0.1
+
+These seem to agree well with what’s typically found for dsDNA.
+
+

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -8,7 +8,7 @@ Correlated stacks
 Bluelake has the ability to export videos from the camera's.
 These videos can be opened and sliced using `CorrelatedStack`::
 
-    stack = pylake.CorrelatedStack("example.tiff")  # Loading a stack.
+    stack = lk.CorrelatedStack("example.tiff")  # Loading a stack.
     stack_slice = stack[2:10]  # Grab frame 2 to 9
 
 Quite often, it is interesting to correlate events on the camera's to `channel` data.

--- a/docs/tutorial/fdcurves.rst
+++ b/docs/tutorial/fdcurves.rst
@@ -7,9 +7,9 @@ FD curves
 
 The following code loads an HDF5 file and lists all of the FD curves inside of it::
 
-    from lumicks import pylake
+    import lumicks.pylake as lk
 
-    file = pylake.File("example.h5")
+    file = lk.File("example.h5")
     list(file.fdcurves)  # e.g. shows: "['baseline', '1', '2']"
 
 To visualizes an FD curve, you can use the built-in `.plot_scatter()` function::

--- a/docs/tutorial/fdfitting.rst
+++ b/docs/tutorial/fdfitting.rst
@@ -1,0 +1,390 @@
+.. warning::
+    This is beta functionality. While usable, this has not yet been tested in a large
+    number of different scenarios. The API may also still be subject to change.
+
+Fd Fitting
+==========
+
+.. only:: html
+
+    :nbexport:`Download this page as a Jupyter notebook <self>`
+
+Pylake is capable of fitting force extension curves using various polymer models. This tutorial aims at being a gentle
+introduction to these fitting capabilities.
+
+Models
+------
+
+When fitting data, everything revolves around models. One of these models is the so-called extensible worm-like-chain
+model by Odijk et al. Let's have a look at it. We can construct this model using the supplied function `lk.odijk()`.
+
+Note that we also have to give it a name. This name will be prefixed to model specific parameters in this model::
+
+    >>> model = lk.odijk("DNA")
+
+Entering model prints the model equation and its default parameters::
+
+    >>> model
+
+    Model equation:
+
+    d(f) = DNA.Lc * (1 - (1/2)*sqrt(kT/(f*DNA.Lp)) + f/DNA.St)
+
+    Parameter defaults:
+
+    Name      Value  Unit      Fitted      Lower bound    Upper bound
+    ------  -------  --------  --------  -------------  -------------
+    DNA/Lp    40     [nm]      True                  0            inf
+    DNA/Lc    16     [micron]  True                  0            inf
+    DNA/St  1500     [pN]      True                  0            inf
+    kT         4.11  [pN*nm]   False                 0              8
+
+Note how most of the parameters listed have the model name prefixed. For example, the persistence length in this model
+is now named `DNA/Lp`. Here `DNA` refers to the name we gave to the model.
+
+One parameter stands out, which is kT as it doesn't have `DNA` prefixed. The reason for this is that this parameter is
+not model specific (in this case the parameter represents the Boltzmann constant times the temperature).
+
+We can also obtain the parameters as a list::
+
+    >>> print(model.parameter_names)
+
+    ['DNA/Lp', 'DNA/Lc', 'DNA/St', 'kT']
+
+As we can see from the model equation, the model is given as distance as a function of force.
+
+
+Model composition and inversion
+-------------------------------
+
+In practice, we would typically want to fit force as a function of distance however. For this we have the inverted
+Odijk model::
+
+    model = lk.inverted_odijk("DNA")
+
+We can have a quick look at what this model looks like and which parameters are in there::
+
+    >>> model
+
+    Model equation:
+
+    f(d) = argmin[f](norm(DNA.Lc * (1 - (1/2)*sqrt(kT/(f*DNA.Lp)) + f/DNA.St)-(d - DNA.d_offset))) + DNA.f_offset
+
+    Parameter defaults:
+
+    Name      Value  Unit      Fitted      Lower bound    Upper bound
+    ------  -------  --------  --------  -------------  -------------
+    DNA/Lp    40     [nm]      True                  0            inf
+    DNA/Lc    16     [micron]  True                  0            inf
+    DNA/St  1500     [pN]      True                  0            inf
+    kT         4.11  [pN*nm]   False                 0              8
+
+This seems to be what we want: force as a function of distance. Let's assume we have acquired data, but upon analysis
+we notice that the template matching wasn't completely optimal. In addition, we experienced some force drift, while
+forgetting to reset the force back to zero. In this case, we can incorporate offsets in our model. We can introduce an
+offset in the independent parameter, by calling `.subtract_independent_offset()` on our model::
+
+    >>> model = lk.inverted_odijk("DNA").subtract_independent_offset()
+    >>> model
+
+    Model: DNA(x-d)
+
+    Model equation:
+
+    f(d) = argmin[f](norm(DNA.Lc * (1 - (1/2)*sqrt(kT/(f*DNA.Lp)) + f/DNA.St)-(d - DNA.d_offset)))
+
+    Parameter defaults:
+
+    Name            Value  Unit      Fitted      Lower bound    Upper bound
+    ------------  -------  --------  --------  -------------  -------------
+    DNA/d_offset     0.01  [au]      True               -0.1            0.1
+    DNA/Lp          40     [nm]      True                0            100
+    DNA/Lc          16     [micron]  True                0            inf
+    DNA/St        1500     [pN]      True                0            inf
+    kT               4.11  [pN*nm]   False               0              8
+
+If we also expect an offset in the dependent parameter, we can simply add an offset model to our model::
+
+    >>> model = lk.inverted_odijk("DNA").subtract_independent_offset() + lk.force_offset("DNA")
+    >>> model
+
+    Model: DNA(x-d)_with_DNA
+
+    Model equation:
+
+    f(d) = argmin[f](norm(DNA.Lc * (1 - (1/2)*sqrt(kT/(f*DNA.Lp)) + f/DNA.St)-(d - DNA.d_offset))) + DNA.f_offset
+
+    Parameter defaults:
+
+    Name            Value  Unit      Fitted      Lower bound    Upper bound
+    ------------  -------  --------  --------  -------------  -------------
+    DNA/d_offset     0.01  [au]      True               -0.1            0.1
+    DNA/Lp          40     [nm]      True                0            100
+    DNA/Lc          16     [micron]  True                0            inf
+    DNA/St        1500     [pN]      True                0            inf
+    kT               4.11  [pN*nm]   False               0              8
+    DNA/f_offset     0.01  [pN]      True               -0.1            0.1
+
+From the above example, you can see how easy it is to composite models. Sometimes, models become more complicated. For
+instance, we may have two worm like chain models that we wish to add, and then invert. For the Odijk model, this can be
+done as follows::
+
+    model = lk.odijk("DNA") + lk.odijk("protein") + lk.distance_offset("offset")
+    model = model.invert()
+
+Note how we added three models and then inverted the composition of those models. Models inverted via `invert()` will
+typically be slower than the pre-inverted counterparts. This is because the inversion is done numerically rather than
+analytically. For more complex examples on how this inversion may be used, please see the examples.
+
+For a full list of models that are available, please refer to the documentation by invoking `help(lk.fitting.models)`
+or see :ref:`fd_models`.
+
+Fitting data
+------------
+
+To fit Fd models, we have to create an `FdFit`. This object will collect all the parameters involved in the models and
+data, and will allow you to interact with the model parameters and fit them. We construct it using `lk.FdFit` and
+pass it one or more models. In return, we get an object we can interact with, which in this case we store in `fit`::
+
+    fit = lk.FdFit(model)
+
+Adding data to the fit
+**********************
+
+To do a fit, we have to add data. Let's assume we have two data sets. One was acquired in the presence of a ligand, and
+another was measured without a ligand. We expect this ligand to only affect the contour length of our DNA. Let's add the
+first data set which we name `Control`. Adding it to the fit is simple::
+
+    fit.add_data("Control", force1, distance1)
+
+For the second data set, we want the contour length to be different. We can achieve this by renaming the parameter
+when loading the data::
+
+    fit.add_data("RecA", force2, distance2, params={"DNA/Lc": "DNA/Lc_RecA"})
+
+More specifically, we renamed the parameter `DNA/Lc` to `DNA/Lc_RecA`.
+
+Setting parameter bounds
+************************
+
+The parameters of the model can be accessed directly from `FdFit`. Note that by default, parameters tend to have
+reasonable initial guesses and bounds in pylake, but we can set our own as follows::
+
+    fit["DNA/Lp"].value = 50
+    fit["DNA/Lp"].lower_bound = 39
+    fit["DNA/Lp"].upper_bound = 80
+
+After this, the model is ready to be fitted. We can fit the model to the data by calling the function `.fit()`. This
+estimates the model parameters by minimizing the least squares differences between the model's dependent variable and
+the data in the fit::
+
+    fit.fit()
+
+After this call, the parameters will have new values that should bring the model closer to the data. Note that multiple
+models can be fit at once by supplying more than one model::
+
+    fit = lk.FdFit(model1, model2, model3)
+
+Frequently, global fits have better statistical properties than fitting the data separately as more information is
+available to infer parameters shared between the various models.
+
+
+Plotting the data
+-----------------
+
+A model can be plotted before it is fitted. This can be useful when the default parameter values don't seem to work
+very well. Parameter estimation is typically initiated from an initial guess. A poor initial guess can lead to a poor
+parameter estimate. Therefore, you might want to see what your initial model curve looks like and set some better
+initial guesses yourself when you run into trouble.
+
+
+Fits can be plotted using the built-in plot functionality::
+    
+    fit.plot()
+    plt.ylabel("Force [pN]")
+    plt.xlabel("Distance [$\\mu$M]");
+
+Sometimes, more fine grained control over the plots is required. Let's say we want to plot the model over a range of
+values (in this case values from 2.0 to 5.0) for the conditions corresponding to the `Control` and `RecA` data. We can
+do this by supplying different arguments to the plot function::
+
+    fit.plot("Control", "k--", np.arange(2.0, 5.0, 0.01))
+    fit.plot("RecA", "k--", np.arange(2.0, 5.0, 0.01))
+
+Or what if we really only want the model prediction, then we can do::
+
+    fit.plot("Control", "k--", np.arange(2.0, 5.0, 0.01), plot_data=False)
+
+It is also possible to obtain simulations from the model directly. We can do this by calling the model with values for
+the independent variable (here denoted as distance) and the parameters required to simulate the model. We obtain these
+parameters by grabbing them from our fit object using the data handles::
+
+    distance = np.arange(2.0, 5.0, 0.01)
+    simulation_result = model(distance, fit["Control"])
+
+Basically what happens here is that `fit["Control"]` grabs those parameters needed to simulate the condition
+corresponding to the dataset with the name `control`. By providing specifically those parameters to the model, we can
+simulate that condition.
+
+Incremental fitting
+-------------------
+
+Fits can also be done incrementally::
+
+    >>> model = lk.inverted_odijk("DNA")
+    >>> fit = lk.FdFit(model)
+    >>> print(fit.params)
+    No parameters
+
+We can see that there are no parameters to be fitted. The reason for this is that we did not add any data to the fit
+yet. Let's add some and fit this data::
+
+    >>> fit.add_data("Control", f1, d1)
+    >>> fit.fit()
+    >>> print(fit.params)
+    Name         Value  Unit      Fitted      Lower bound    Upper bound
+    ------  ----------  --------  --------  -------------  -------------
+    DNA/Lp    59.409    [nm]      True                  0            inf
+    DNA/Lc     2.81072  [micron]  True                  0            inf
+    DNA/St  1322.9      [pN]      True                  0            inf
+    kT         4.11     [pN*nm]   False                 0              8
+
+Let's add a second data set where we expect a different contour length and refit::
+
+    >>> fit.add_data("RecA", f2, d2, params={"DNA/Lc": "DNA/Lc_RecA"})
+    >>> print(fit.params)
+    Name              Value  Unit      Fitted      Lower bound    Upper bound
+    -----------  ----------  --------  --------  -------------  -------------
+    DNA/Lp         89.3347   [nm]      True                  0            inf
+    DNA/Lc          2.80061  [micron]  True                  0            inf
+    DNA/St       1597.68     [pN]      True                  0            inf
+    kT              4.11     [pN*nm]   False                 0              8
+    DNA/Lc_RecA     3.7758   [micron]  True                  0            inf
+    
+We see that indeed the second parameter now appears. We also note that the parameters from the first fit changed. If
+this was not intentional, we should have fixed these parameters after the first fit. For example, we can fix the
+parameter `DNA/Lp` by invoking::
+
+    >>> fit["DNA/Lp"].fixed = True
+    
+
+Calculating per point contour length
+------------------------------------
+
+Sometimes, one wishes to invert the model with respect to one parameter (i.e. re-estimate one parameter on a per data
+point basis). This can be used to obtain dynamic contour lengths for instance. In pylake, such an analysis can easily
+be performed. We first set up a model and fit it to some data. This is all analogous to what we've learned before::
+
+    # Define the model to be fitted
+    model = lk.inverted_odijk("model") + lk.force_offset("model")
+
+    # Fit the overall model first
+    fit = lk.FdFit(model)
+    fit.add_data("Control", force, distance)
+    fit.fit()
+
+Now, we wish to allow the contour length to vary on a per data point basis. For this, we use the function
+`parameter_trace`. Here we see a few things happening. The first argument specifies the model to use for the inversion.
+
+The second argument should contain the parameters to be used in this method. Note how we select them from the parameters
+in the `fit` using the same syntax as before (i.e. `fit[data_name]`). Next, we specify which parameter has to be fitted
+on a per data point basis. This is the parameter that we will re-estimate for every data point. Finally, we supply the
+data to use in this analysis. First the independent parameter is passed, followed by the dependent parameter::
+
+    lcs = lk.parameter_trace(model, fit["Control"], "model/Lc", distance, force)
+    plt.plot(lcs)
+
+The result of this analysis is an estimated contour length per data point, which can be used in subsequent analyses.
+
+Advanced usage
+--------------
+
+Adding many data sets
+*********************
+
+Sometimes, you may want to add a large number of data sets with different offsets. Consider two lists of distance and
+force vectors stored in `distances` and `forces`. In this case, it may make sense to load them in a loop and set such
+transformations programmatically. We can iterate over both lists at once by using `zip`. In addition, we wanted to have
+a different offset for each data set. This means that we'd need to give those new offsets a name. Let's just number
+them. By adding enumerate, we also obtain an iteration counter, which we store in `i`. The whole procedure can then
+succinctly be summarized in just two lines of code::
+
+    for i, (d, f) in enumerate(zip(distances, forces)):
+        fit.add_data(f"RecA {i}", f, d, params={"DNA/f_offset": f"DNA/f_offset_{i}"})
+
+The syntax `f"DNA/f_offset_{i}"` is parsed into `DNA/f_offset_0`, `DNA/f_offset_1` ... etc. For more information on
+how this works, read up on Python fantastic f-Strings.
+
+Global fits versus single fits
+******************************
+
+The `FdFit` object manages a fit. To illustrate its use, and how a global fit differs from a local fit, consider the
+following two examples::
+
+    model = lk.inverted_odijk("DNA")
+    fit = lk.FdFit(model)
+    for i, (distance, force) in enumerate(zip(distances, forces)):
+        fit.add_data(f"RecA {i}", f=force, d=distance)
+    fit.fit()
+    print(fit["DNA/Lc"])
+
+and::
+
+    for i, (distance, force) in enumerate(zip(distances, forces)):
+        model = lk.inverted_odijk("DNA")
+        fit = lk.FdFit(model)
+        fit.add_data(f"RecA {i}", f=force, d=distance)
+        fit.fit()
+        print(fit["DNA/Lc"])
+
+The first example is what we refer to as a global fit whereas the second example is an example of a local fit. The
+difference between these two is that the former sets up one model that has to fit all the data whereas the latter fits
+all the data sets independently. The former has one parameter set, whereas the latter has a parameter set per data set.
+Also note how in the second example a new `Model` and `FdFit` is created at every cycle of the for loop.
+
+Statistically, it is typically more optimal to fit data using global fitting (meaning you use one model to fit all the
+data, as opposed to recreating the model for each new set of data), as more information goes into estimates of
+parameters shared between different conditions. It's usually a good idea to think about which parameters you expect to
+be different between different experiments and only allow these parameters to be different in the fit. For example,
+if the only expected difference between the experiments is the contour length, then this can be achieved using::
+
+    model = lk.inverted_odijk("DNA")
+    fit = lk.FdFit(model)
+    for i, (distance, force) in enumerate(zip(distances, forces)):
+        fit.add_data(f"RecA {i}", force, distance, {"DNA/Lc": f"DNA/Lc_{i}"})
+    fit.fit()
+    print(fit.params)
+
+Note that this piece of code will lead to parameters `DNA/Lc_0`, `DNA/Lc_1` etc.
+
+Multiple models
+***************
+
+When working with multiple models, things can get a little more complicated. Let's say we have two models, `model1` and
+`model2` and we want to fit both in a global fit. Constructing the `FdFit` is easy::
+
+    model1 = lk.inverted_odijk("DNA")
+    model2 = (lk.odijk("DNA") + lk.odijk("protein")).invert()
+    fit = lk.FdFit(model1, model2)
+
+But then the question arises, how do we add data to each model? Well, the trick is in the assignments to `model1` and
+`model2`. We can use these now to add data to each model as follows::
+
+    fit[model1].add_data("data for model 1", forces_1, distances_1)
+    fit[model2].add_data("data for model 2", forces_2, distances_2)
+
+See how we used the model handles? They are used to let the `FdFit` know to which model each data set should be added.
+You can add as many data sets as you want to both models and fit it all at once.
+
+Plotting is straightforward in this setting. We can plot the data sets corresponding to model 1 and 2 as follows::
+
+    fit[model1].plot()
+    fit[model2].plot()
+
+Accessing the model parameters for a specific data set is a little more complicated in this setting. If we want to
+obtain the parameters for "data for model 1", we'd have to invoke::
+
+    params = fit[model1]["data for model 1"]
+
+Note how we are now forced to index the model first using the square brackets, and only then access the data set by
+name. An unfortunate necessity when it comes to multi-model curve fitting.

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -7,9 +7,9 @@ Files and channels
 
 Opening a Bluelake HDF5 file is very simple::
 
-    from lumicks import pylake
+    import lumicks.pylake as lk
 
-    file = pylake.File("example.h5")
+    file = lk.File("example.h5")
 
 Contents
 --------

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -9,9 +9,9 @@ The following code uses scans as an example.
 Kymographs work the same way -- just substitute `file.scans` with `file.kymos`.
 To load an HDF5 file and lists all of the scans inside of it, run::
 
-    from lumicks import pylake
+    import lumicks.pylake as lk
 
-    file = pylake.File("example.h5")
+    file = lk.File("example.h5")
     list(file.scans)  # e.g. shows: "['reference', 'bleach', 'imaging']"
 
 Once again, `.scans` is a regular Python dictionary so we can easily iterate over it::

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -10,7 +10,7 @@ It is assumed that the following lines precede any other code::
     import numpy as np
     import matplotlib.pyplot as plt
 
-    from lumicks import pylake
+    import lumicks.pylake as lk
 
 
 This uses the common scientific package aliases: `np` and `plt`.

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -27,3 +27,4 @@ These import conventions are used consistently in the tutorial.
     images
     kymographs
     correlatedstacks
+    fdfitting

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -7,9 +7,9 @@ Kymographs
 
 To load an HDF5 file and lists all of the kymographs inside of it, run::
 
-    from lumicks import pylake
+    import lumicks.pylake as lk
 
-    file = pylake.File("example.h5")
+    file = lk.File("example.h5")
     list(file.kymos)  # e.g. shows: "['reference', 'sytox']"
 
 Once again, `.kymos` is a regular Python dictionary so we can easily iterate over it::

--- a/lumicks/pylake/__about__.py
+++ b/lumicks/pylake/__about__.py
@@ -1,5 +1,5 @@
 __title__ = "lumicks.pylake"
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 __summary__ = "Bluelake data analysis tools"
 __url__ = "https://github.com/lumicks/pylake"
 

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -2,7 +2,10 @@ from .__about__ import (__author__, __copyright__, __doc__, __email__, __license
                         __title__, __url__, __version__)
 
 from .file import *
+from .fitting.models import *
 from .correlated_stack import CorrelatedStack
+from .fitting.fit import FdFit
+from lumicks.pylake.fitting.parameter_trace import parameter_trace
 
 
 def pytest(args=None, plugins=None):

--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -1,3 +1,7 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+
 
 def first(iterable, condition=lambda x: True):
     """Return the first item in the `iterable` that satisfies the `condition`.
@@ -14,3 +18,20 @@ def first(iterable, condition=lambda x: True):
     """
 
     return next(x for x in iterable if condition(x))
+
+
+def unique(input_list):
+    unique_list = []
+    [unique_list.append(x) for x in input_list if x not in unique_list]
+    return unique_list
+
+
+def get_color(i):
+    color_cycle = plt.rcParams['axes.prop_cycle'].by_key()['color']
+    return color_cycle[i % len(color_cycle)]
+
+
+def lighten_color(c, amount):
+    hsv = mpl.colors.rgb_to_hsv(mpl.colors.to_rgb(c))
+    hsv[2] = np.clip(hsv[2]+amount, 0.0, 1.0)
+    return mpl.colors.hsv_to_rgb(hsv)

--- a/lumicks/pylake/fitting/datasets.py
+++ b/lumicks/pylake/fitting/datasets.py
@@ -183,3 +183,40 @@ class Datasets:
             repr_text += f"- {d.__repr__()}\n"
 
         return repr_text
+
+
+class FdDatasets(Datasets):
+    def add_data(self, name, f, d, params={}):
+        """
+        Adds a data set to this fit.
+
+        Parameters
+        ----------
+        name : str
+            Name of this data set.
+        f : array_like
+            An array_like containing force data.
+        d : array_like
+            An array_like containing distance data.
+        params : dict of {str : str or int}
+            List of parameter transformations. These can be used to convert one parameter in the model, to a new
+            parameter name or constant for this specific data set (for more information, see the examples).
+
+        Examples
+        --------
+        ::
+
+            dna_model = pylake.inverted_odijk("DNA")  # Use an inverted Odijk eWLC model.
+            fit = pylake.FdFit(dna_model)
+
+            fit.add_data("Data1", force1, distance1)  # Load the first data set like that
+            fit.add_data("Data2", force2, distance2, params={"DNA/Lc": "DNA/Lc_RecA"})  # Different DNA/Lc
+        """
+        if self._model.independent == "f":
+            return self._add_data(name, f, d, params)
+        else:
+            return self._add_data(name, d, f, params)
+
+    @staticmethod
+    def dataset(model):
+        return FdDatasets(model)

--- a/lumicks/pylake/fitting/datasets.py
+++ b/lumicks/pylake/fitting/datasets.py
@@ -1,0 +1,185 @@
+from .detail.link_functions import generate_conditions
+from .detail.utilities import parse_transformation
+from .fitdata import FitData
+from copy import deepcopy
+from collections import OrderedDict
+import numpy as np
+
+
+class Datasets:
+    def __init__(self, model, fit):
+        """A collection of datasets to be fitted for a model.
+
+        Parameters
+        ----------
+        model : Model
+            The model these datasets are for.
+        fit : Fit
+            Fit this dataset is associated with.
+        """
+        self._model = model
+        self._fit = fit
+        self.data = OrderedDict()
+        self._conditions = []
+        self._data_link = []
+        self.built = False
+
+    def __getitem__(self, item):
+        return self._fit.params[self.data.__getitem__(item)]
+
+    def _link_data(self, parameter_lookup):
+        self._conditions, self._data_link = generate_conditions(self.data, parameter_lookup,
+                                                                self._model.parameter_names)
+        self.built = True
+
+    def conditions(self):
+        # We need to return a list of conditions; and a list which links which data is linked to which conditions
+        condition_iterator = self._conditions.__iter__()
+        data_link = self._data_link.__iter__()
+
+        while True:
+            try:
+                yield next(condition_iterator), next(data_link)
+            except StopIteration:
+                return
+
+    @property
+    def n_residuals(self):
+        """Number of data points loaded into this model."""
+        count = 0
+        for data in self.data.values():
+            count += len(data.independent)
+
+        return count
+
+    def _add_data(self, name, x, y, params={}):
+        """
+        Loads a data set.
+
+        Parameters
+        ----------
+        name : str
+            Name of this data set.
+        x : array_like
+            Independent variable. NaNs are silently dropped.
+        y : array_like
+            Dependent variable. NaNs are silently dropped.
+        params : dict of {str : str or int}
+            List of parameter transformations. These can be used to convert one parameter in the model, to a new
+            parameter name or constant for this specific data set (for more information, see the examples).
+
+        Examples
+        --------
+        ::
+            dna_model = pylake.inverted_odijk("DNA")  # Use an inverted Odijk eWLC model.
+            fit = pylake.FdFit(dna_model)
+
+            fit.add_data("Control", f1, d1)  # Load the first dataset like that
+            fit.add_data("RecA", f2, d2, params={"DNA/Lc": "DNA/Lc_RecA"})  # Different contour length Lc
+        """
+        if name in self.data:
+            raise KeyError("The name of the data set must be unique.")
+
+        x = np.asarray(x, dtype=np.float64)
+        y = np.asarray(y, dtype=np.float64)
+        assert x.ndim == 1, "Independent variable should be one dimension"
+        assert y.ndim == 1, "Dependent variable should be one dimension"
+        assert len(x) == len(y), "Every value for the independent variable should have a corresponding data point"
+
+        filter_nan = np.logical_not(np.logical_or(np.isnan(x), np.isnan(y)))
+        y = y[filter_nan]
+        x = x[filter_nan]
+
+        self.built = False
+        parameter_list = parse_transformation(self._model.parameter_names, params)
+        data = FitData(name, x, y, parameter_list)
+        self.data[name] = data
+
+        return data
+
+    def plot(self, data=None, fmt='', independent=None, legend=True, plot_data=True, overrides=None, **kwargs):
+        """Plot model and data
+
+        Parameters
+        ----------
+            data : str
+                Name of the data set to plot (optional, omission plots all for that model).
+            fmt : str
+                Format string, forwarded to :func:`matplotlib.pyplot.plot`.
+            independent : array_like
+                Array with values for the independent variable (used when plotting the model).
+            legend : bool
+                Show legend (default: True).
+            plot_data : bool
+                Show data (default: True).
+            overrides : dict
+                Parameter / value pairs which override parameter values in the current fit. Should be a dict of
+                {str: float} that provides values for parameters which should be set to particular values in the plot
+                (default: None);
+            ``**kwargs``
+                Forwarded to :func:`matplotlib.pyplot.plot`.
+
+        Examples
+        --------
+        ::
+            from lumicks import pylake
+
+            model = pylake.inverted_odijk("DNA")
+            fit = pylake.FdFit(model)
+            fit.add_data("Control", force, distance)
+            fit.fit()
+
+            # Basic plotting of one data set over a custom range can be done by just invoking plot.
+            fit.plot("Control", 'k--', np.arange(2.0, 5.0, 0.01))
+
+            # Have a quick look at what a stiffness of 5 would do to the fit.
+            fit.plot("Control", overrides={"DNA/St": 5})
+
+            # When dealing with multiple models in one fit, one has to select the model first when we want to plot.
+            model1 = pylake.odijk("DNA")
+            model2 = pylake.odijk("DNA") + pylake.odijk("protein")
+            fit[model1].add_data("Control", force1, distance2)
+            fit[model2].add_data("Control", force1, distance2)
+            fit.fit()
+
+            fit = pylake.FdFit(model1, model2)
+            fit[model1].plot("Control")  # Plots data set Control for model 1
+            fit[model2].plot("Control")  # Plots data set Control for model 2
+        """
+        self._fit._plot(self._model, data, fmt, overrides, independent, legend, plot_data, **kwargs)
+
+    @property
+    def names(self):
+        return [data.name for data in self.data.values()]
+
+    @property
+    def _transformed_params(self):
+        """Retrieves the full list of fitted parameters post-transformation used by these data sets."""
+        return [name for data in self.data.values() for name in data.parameter_names]
+
+    @property
+    def _defaults(self):
+        if self.data:
+            return [deepcopy(self._model.defaults[name]) for data in self.data.values() for name in
+                    data.source_parameter_names]
+        else:
+            return [deepcopy(self._model.defaults[name]) for name in self._model.parameter_names]
+
+    def _repr_html_(self):
+        repr_text = ''
+        for d in self.data.values():
+            repr_text += f"&ensp;&ensp;{d.__str__()}<br>\n"
+
+        return repr_text
+
+    def __repr__(self):
+        return (f"lumicks.pylake.{self.__class__.__name__}"
+                f"(datasets={{{', '.join([x.name for x in self.data.values()])}}}, "
+                f"N={self.n_residuals})")
+
+    def __str__(self):
+        repr_text = 'Data sets:\n'
+        for d in self.data.values():
+            repr_text += f"- {d.__repr__()}\n"
+
+        return repr_text

--- a/lumicks/pylake/fitting/detail/derivative_manipulation.py
+++ b/lumicks/pylake/fitting/detail/derivative_manipulation.py
@@ -1,0 +1,19 @@
+import warnings
+import numpy as np
+
+
+def numerical_diff(fn, x, dx=1e-6):
+    return (fn(x + dx) - fn(x - dx)) / (2.0 * dx)
+
+
+def numerical_jacobian(fn, parameter_vector, dx=1e-6):
+    finite_difference_jacobian = np.zeros((len(parameter_vector), len(fn(parameter_vector))))
+    for i in np.arange(len(parameter_vector)):
+        params = np.copy(parameter_vector)
+        params[i] = params[i] + dx
+        up = fn(params)
+        params[i] = params[i] - 2.0 * dx
+        down = fn(params)
+        finite_difference_jacobian[i, :] = (up - down) / (2.0*dx)
+
+    return finite_difference_jacobian

--- a/lumicks/pylake/fitting/detail/derivative_manipulation.py
+++ b/lumicks/pylake/fitting/detail/derivative_manipulation.py
@@ -1,5 +1,6 @@
 import warnings
 import numpy as np
+import scipy.optimize as optim
 
 
 def numerical_diff(fn, x, dx=1e-6):
@@ -17,3 +18,125 @@ def numerical_jacobian(fn, parameter_vector, dx=1e-6):
         finite_difference_jacobian[i, :] = (up - down) / (2.0*dx)
 
     return finite_difference_jacobian
+
+
+def inversion_functions(model_function, f_min, f_max, derivative_function, tol):
+    """This function generates two functions which allow for inverting models via optimization. These functions are used
+    by functions which require inversion of a model's dependent and independent variable"""
+
+    def fit_single(single_distance, initial_guess):
+        """Invert a single independent / dependent data point"""
+        jac = derivative_function if derivative_function else "2-point"
+        single_estimate = optim.least_squares(lambda f: model_function(f) - single_distance, initial_guess, jac=jac,
+                                              bounds=(f_min, f_max), method='trf', ftol=tol, xtol=tol, gtol=tol)
+
+        return single_estimate.x[0]
+
+    def manual_inversion(distances, initial_guess):
+        """Invert the dependent and independent variable for a list"""
+        return np.array([fit_single(distance, initial_guess) for distance in distances])
+
+    return manual_inversion, fit_single
+
+
+def invert_function(d, initial, f_min, f_max, model_function, derivative_function=None, tol=1e-8):
+    """This function inverts a function using a least squares optimizer. For models where this is required, this is the
+    most time consuming step.
+
+    Parameters
+    ----------
+    d : array_like
+        old independent parameter
+    initial : float
+        initial guess for the optimization procedure
+    f_min : float
+        minimum bound for inverted parameter
+    f_max : float
+        maximum bound for inverted parameter
+    model_function : callable
+        non-inverted model function
+    derivative_function : callable
+        model derivative with respect to the independent variable (returns an element per data point)
+    tol : float
+        optimization tolerances
+    """
+    manual_inversion, _ = inversion_functions(model_function, f_min, f_max, derivative_function, tol)
+
+    return manual_inversion(d, initial)
+
+
+def invert_jacobian(d, inverted_model_function, jacobian_function, derivative_function):
+    """This function computes the jacobian of the model when the model has been inverted with respect to the independent
+    variable.
+
+    The Jacobian of the function with one variable inverted is related to the original Jacobian. This transformation
+    can be derived from the implicit function:
+
+    G = F - f_inverse(f(F, p), p) = 0
+
+    Differentiation w.r.t. p_i yields:
+
+    0 = δG / δp_i + (δG / δf_inverse(f(F, p), p)) * (δf_inverse(f(F, p), p) / δp_i)
+
+    0 = (δG / δf_inverse(f(F, p), p)) * (δf_inverse(f(F, p), p) / δp_i)
+
+    0 = - δf_inverse(f(F, p), p) / δp_i
+      = (δf_inverse(f(F, p), p) / δf(F, p)) (δf(F, p) / δp_i) + δf_inverse(f(F, p), p) / δp_i
+      = (δf_inverse(dist, p) / δdist) (δf(F, p) / δp_i) + δf_inverse(dist, p) / δp_i
+
+    Hence:
+        δf_inverse(dist, p) / δp_i = - (δf_inverse(dist, p) / δdist) (δf(F, p) / δp_i)
+
+    Since (see invert_derivative)
+        δf_inverse(dist, p) / δdist = ( δf(F, p) / δF )^-1
+
+    We obtain:
+        δf_inverse(dist, p) / δp_i = - (δf(F, p) / δp_i) ( δf(F, p) / δF )^-1
+
+    Parameters
+    ----------
+    d : values for the old independent variable
+    inverted_model_function : callable
+        inverted model function (model with the dependent and independent variable exchanged)
+    jacobian_function : callable
+        derivatives of the non-inverted model
+    derivative_function : callable
+        derivative of the non-inverted model w.r.t. the independent variable
+    """
+    F = inverted_model_function(d)
+    jacobian = jacobian_function(F)
+    derivative = derivative_function(F)
+    inverse = 1.0/derivative
+    inverted_dyda = np.tile(inverse, (jacobian.shape[0], 1))
+    jacobian = -jacobian * inverted_dyda
+
+    return jacobian
+
+
+def invert_derivative(d, inverted_model_function, derivative_function):
+    """
+    Calculates the derivative of the inverted function.
+
+    F = f_inverse(f(F), p)
+
+    Derive both sides w.r.t. F gives:
+
+    1 = δf_inverse(f(F), p) / δF
+
+    or:
+
+    1 = ( δf_inverse(f(F), p) / δf(F) ) ( δf(F) / δF )
+
+    or:
+
+    δf_inverse(d, p) / δd = ( δf(F) / δF )^-1
+
+    Parameters
+    ----------
+    d : values for the old independent variable
+    inverted_model_function : callable
+        inverted model function (model with the dependent and independent variable exchanged)
+    derivative_function : callable
+        derivative of the non-inverted model w.r.t. the independent variable
+    """
+    return 1.0 / derivative_function(inverted_model_function(d))

--- a/lumicks/pylake/fitting/detail/link_functions.py
+++ b/lumicks/pylake/fitting/detail/link_functions.py
@@ -1,0 +1,47 @@
+from ..fitdata import Condition
+from .utilities import unique_idx
+import numpy as np
+
+
+def generate_conditions(data_sets, parameter_lookup, model_params):
+    """
+    This function builds a list of unique conditions from a list of data sets and a list of references pointing to the
+    data that belongs to each condition.
+
+    Parameters
+    ----------
+    data_sets : list of Data
+        References to data
+    parameter_lookup : OrderedDict[str, int]
+        Lookup table for looking up parameter indices by name
+    model_params : list of str
+        Base model parameter names
+    """
+    # Quickly concatenate the parameter transformations corresponding to this condition
+    str_conditions = []
+    for data_set in data_sets.values():
+        str_conditions.append(data_set.condition_string)
+
+        assert set(data_set.transformations.keys()) == set(model_params), \
+            "Source parameters in data parameter transformations are incompatible with the specified model parameters."
+
+        target_params = [x for x in data_set.transformations.values() if isinstance(x, str)]
+        assert set(target_params).issubset(parameter_lookup.keys()), \
+            "Parameter transformations contain transformed parameter names that are not in the combined parameter list."
+
+    # Determine unique parameter conditions and the indices to get the appropriate unique condition from data index.
+    unique_condition_strings, indices = unique_idx(str_conditions)
+    indices = np.asarray(indices)
+
+    data_link = []
+    keys = list(data_sets.keys())
+    for condition_idx in np.arange(len(unique_condition_strings)):
+        data_indices, = np.nonzero(np.equal(indices, condition_idx))
+        data_link.append([data_sets[keys[x]] for x in data_indices])
+
+    conditions = []
+    for data_sets in data_link:
+        transformations = data_sets[0].transformations
+        conditions.append(Condition(transformations, parameter_lookup))
+
+    return conditions, data_link

--- a/lumicks/pylake/fitting/detail/model_implementation.py
+++ b/lumicks/pylake/fitting/detail/model_implementation.py
@@ -1,0 +1,646 @@
+from ..parameters import Parameter
+from .derivative_manipulation import invert_function
+from .utilities import latex_frac, solve_formatter, solve_formatter_tex
+import numpy as np
+
+
+class Defaults:
+    kT = Parameter(value=4.11, lower_bound=0.0, upper_bound=8.0, fixed=True, shared=True, unit="pN*nm")
+    Lp = Parameter(value=40.0, lower_bound=0.0, upper_bound=100, unit="nm")
+    Lc = Parameter(value=16.0, lower_bound=0.0, upper_bound=np.inf, unit="micron")
+    St = Parameter(value=1500.0, lower_bound=0.0, upper_bound=np.inf, unit="pN")
+    offset = Parameter(value=0.0, lower_bound=-0.1, upper_bound=0.1, unit="pN")
+
+
+def offset_equation(x, offset):
+    return offset
+
+
+def offset_equation_tex(x, offset):
+    return offset
+
+
+def distance_offset_model(f, d_offset):
+    """Offset on the the model output."""
+    return d_offset * np.ones(f.shape)
+
+
+def force_offset_model(d, f_offset):
+    """Offset on the the model output."""
+    return f_offset * np.ones(d.shape)
+
+
+def offset_model_jac(x, offset):
+    """Offset on the model output."""
+    return np.ones((1, len(x)))
+
+
+def offset_model_derivative(x, offset):
+    """Offset on the model output."""
+    return np.zeros(len(x))
+
+
+def Marko_Siggia_equation(d, Lp, Lc, kT):
+    return f"({kT}/{Lp}) * ((1/4) * (1-({d}/{Lc}))**(-2) + ({d}/{Lc}) - (1/4))"
+
+
+def Marko_Siggia_equation_tex(d, Lp, Lc, kT):
+    return (f"\\frac{{{kT}}}{{{Lp}}} \\left(\\frac{{1}}{{4}} \\left(1-\\frac{{{d}}}{{{Lc}}}\\right)^{{-2}} + "
+                f"\\frac{{{d}}}{{{Lc}}} - \\frac{{1}}{{4}}\\right)")
+
+
+def Marko_Siggia(d, Lp, Lc, kT):
+    """Markov Siggia's Worm-like Chain model based on only entropic contributions. Valid for F < 10 pN).
+
+    References:
+        1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
+        8759-8770 (1995).
+    """
+    d_div_Lc = d / Lc
+    return (kT/Lp) * (.25 * (1.0-d_div_Lc)**(-2) + d_div_Lc - .25)
+
+
+def Marko_Siggia_jac(d, Lp, Lc, kT):
+    return np.vstack((-0.25*Lc**2*kT/(Lp**2*(Lc - d)**2) + 0.25*kT/Lp**2 - d*kT/(Lc*Lp**2),
+                     -0.5*Lc*d*kT/(Lp*(Lc - d)**3) - d*kT/(Lc**2*Lp),
+                     0.25*Lc**2/(Lp*(Lc - d)**2) - 0.25/Lp + d/(Lc*Lp)))
+
+
+def Marko_Siggia_derivative(d, Lp, Lc, kT):
+    return 0.5*Lc**2*kT/(Lp*(Lc - d)**3) + kT/(Lc*Lp)
+
+
+def WLC_equation(f, Lp, Lc, St, kT = 4.11):
+    return f"{Lc} * (1 - (1/2)*sqrt({kT}/({f}*{Lp})) + {f}/{St})"
+
+
+def WLC_equation_tex(f, Lp, Lc, St, kT = 4.11):
+    return f"{Lc} \\left(1 - \\frac{1}{2}\\sqrt{{\\frac{{{kT}}}{{{f} {Lp}}}}} + \\frac{{{f}}}{{{St}}}\\right)"
+
+
+def WLC(f, Lp, Lc, St, kT = 4.11):
+    """Odijk's Extensible Worm-like Chain model
+
+    References:
+      1. T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules
+         28, 7016-7018 (1995).
+      2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
+         DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+
+    Parameters
+    ----------
+    f : array_like
+        force [pN]
+    Lp : float
+        persistence length [nm]
+    Lc : float
+        contour length [um]
+    St : float
+        stretching modulus [pN]
+    kT : float
+        Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
+    """
+    return Lc * (1.0 - 1.0/2.0*np.sqrt(kT/(f*Lp)) + f/St)
+
+
+def WLC_jac(f, Lp, Lc, St, kT=4.11):
+    sqrt_term = np.sqrt(kT / (f * Lp))
+    return np.vstack((0.25 * Lc * sqrt_term / Lp,
+                     f / St - 0.5 * sqrt_term + 1.0,
+                     -f * Lc / (St * St),
+                     -0.25 * Lc * sqrt_term / kT))
+
+
+def coth(x):
+    sol = np.ones(x.shape)
+    mask = abs(x) < 500
+    sol[mask] = np.cosh(x[mask]) / np.sinh(x[mask])  # Crude overflow protection, this limit approaches 1.0
+    mask = abs(x) < -500
+    sol[mask] = -1.0  # Crude overflow protection, this limit approaches -1.0
+    return sol
+
+
+def FJC_equation(f, Lp, Lc, St, kT=4.11):
+    return f"{Lc} * (coth(2.0 * {f} * {Lp} / {kT}) - {kT} / (2 * {f} * {Lp})) * (1 + {f}/{St})"
+
+
+def FJC_equation_tex(f, Lp, Lc, St, kT=4.11):
+    frac1 = latex_frac(f"{f} {Lp}", kT)
+    frac2 = latex_frac(kT, f"2 {f} {Lp}")
+    frac3 = latex_frac(f, St)
+
+    return f"{Lc} \\left(coth\\left(2 {frac1}\\right) - {frac2}\\right) \\left(1 + {frac3}\\right)"
+
+
+def FJC(f, Lp, Lc, St, kT=4.11):
+    """Freely-Jointed Chain
+
+    References:
+       1. S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The
+          Elastic Response of Individual Double-Stranded and Single-Stranded
+          DNA Molecules, Science 271, 795-799 (1996).
+       2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
+          DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+
+    Parameters
+    ----------
+    F : array_like
+        force [pN]
+    Lp : float
+        persistence length [nm]
+    Lc : float
+        contour length [um]
+    St : float
+        elastic modulus [pN]
+    kT : float
+        Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
+    """
+    return Lc * (coth(2.0 * f * Lp / kT) - kT / (2.0 * f * Lp)) * (1.0 + f/St)
+
+
+def FJC_jac(f, Lp, Lc, St, kT=4.11):
+    x0 = 0.5 / f
+    x1 = 2.0 * f / kT
+    x2 = Lp * x1
+    x3 = np.zeros(x2.shape)
+    x3[abs(x2) < 300] = np.sinh(x2[abs(x2) < 300]) ** (-2)
+    x4 = f / St + 1.0
+    x5 = Lc * x4
+    x6 = x0 / Lp
+    x7 = -kT * x6 + coth(x2)
+    return np.vstack((x5 * (-x1 * x3 + kT * x0 / (Lp * Lp)),
+                      x4 * x7,
+                      -f * Lc * x7 / (St*St),
+                      x5 * (2.0 * f * Lp * x3 / (kT*kT) - x6)))
+
+
+def solve_cubic_wlc(a, b, c, selected_root):
+    # Convert the equation to a depressed cubic for p and q, which'll allow us to greatly simplify the equations
+    p = b - a * a / 3.0
+    q = 2 * a * a * a / 27.0 - a * b / 3.0 + c
+    det = q*q/4.0 + p*p*p/27.0
+
+    # The model changes behaviours when the discriminant equates to zero. From this point we need a different root
+    # resolution mechanism.
+    sol = np.zeros(det.shape)
+    mask = det >= 0
+
+    sqrt_det = np.sqrt(det[mask])
+    t1 = -q[mask]*0.5 + sqrt_det
+    t2 = -q[mask]*0.5 - sqrt_det
+    sol[mask] = np.cbrt(t1) + np.cbrt(t2)
+
+    sqrt_minus_p = np.sqrt(-p[np.logical_not(mask)])
+    q_masked = q[np.logical_not(mask)]
+
+    asin_argument = 3.0 * np.sqrt(3.0) * q_masked / (2.0 * sqrt_minus_p ** 3)
+    asin_argument = np.clip(asin_argument, -1.0, 1.0)
+
+    if selected_root == 0:
+        sol[np.logical_not(mask)] = 2.0 / np.sqrt(3.0) * sqrt_minus_p * \
+            np.sin((1.0 / 3.0) * np.arcsin(asin_argument))
+    elif selected_root == 1:
+        sol[np.logical_not(mask)] = - 2.0 / np.sqrt(3.0) * sqrt_minus_p * \
+            np.sin((1.0 / 3.0) * np.arcsin(asin_argument) + np.pi/3.0)
+    elif selected_root == 2:
+        sol[np.logical_not(mask)] = 2.0 / np.sqrt(3.0) * sqrt_minus_p * \
+            np.cos((1.0/3.0) * np.arcsin(asin_argument) + np.pi/6.0)
+    else:
+        raise RuntimeError("Invalid root selected. Choose 0, 1 or 2.")
+
+    return sol - a / 3.0
+
+
+def invWLC_equation(d, Lp, Lc, St, kT=4.11):
+    return solve_formatter(WLC_equation('f', Lp, Lc, St, kT), 'f', d)
+
+
+def invWLC_equation_tex(d, Lp, Lc, St, kT=4.11):
+    return solve_formatter_tex(WLC_equation_tex('f', Lp, Lc, St, kT), 'f', d)
+
+
+def invWLC(d, Lp, Lc, St, kT=4.11):
+    """Inverted Odijk's Worm-like Chain model
+
+    References:
+      1. T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules
+         28, 7016-7018 (1995).
+      2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
+         DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+
+    Parameters
+    ----------
+    d : array_like
+        extension [um]
+    Lp : float
+        persistence length [nm]
+    Lc : float
+        contour length [um]
+    St : float
+        stretching modulus [pN]
+    kT : float
+        Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
+    """
+    #
+    # In short, this model was analytically solved, since it is basically a cubic equation. There are some issues
+    # with this inverted model. Its derivatives are not defined everywhere, as they contain divisions by zero in
+    # specific places due to the cube roots involved. This was worked around by preventing the denominators in these
+    # equations to go to zero by clamping them to a lower bound. This results in far better numerical behaviour than
+    # even the finite difference approximations.
+    #
+    # Define:
+    #   alpha = (distance/Lc) - 1.0
+    #   beta = 1.0 / St
+    #   gamma = kT / Lp
+    #
+    # This allows us to obtain simple polynomial coefficients for the Odijk model. We divide the polynomial by the
+    # leading coefficient to make things simpler for us. This leads to the following equations:
+    #
+    #   denom = beta ** 2.0
+    #   a = - (2.0 * alpha * beta) / denom = - 2.0 * alpha / beta
+    #   b = alpha * alpha / denom = (alpha * alpha) / (beta * beta)
+    #   c = - 0.25 * gamma / denom = - gamma / (4 * beta * beta)
+    #
+    # We can see now that parameterizing w.r.t. St is easier than b and define:
+    alpha = (d / Lc) - 1.0
+    gamma = kT / Lp
+
+    a = - 2.0 * alpha * St
+    b = (alpha * alpha) * (St * St)
+    c = - 0.25 * gamma * (St * St)
+
+    return solve_cubic_wlc(a, b, c, 2)
+
+
+def calc_root1_invwlc(det, p, q, dp_da, dq_da, dq_db):
+    # Calculate the first root for det < 0
+    # Note that dp/dc = 0, dp_db = 1, dq_dc = 1
+
+    sqrt_det = np.sqrt(det)
+    term1 = np.abs(sqrt_det - 0.5 * q)      # Technically, the absolute is not part of this solution.
+    term2 = np.abs(-sqrt_det - 0.5 * q)     # But it can cause numerical issues if we raise negative values to a root.
+    t1 = term1 ** (2 / 3)
+    t2 = term2 ** (2 / 3)
+
+    # Derivatives of cube roots are not defined everywhere.
+    #
+    # The derivatives go over the bit where the cube roots are non-differentiable in the region of the model where it
+    # switches from entropic to enthalpic behaviour. Even the finite difference derivatives look terrible here.
+    #
+    # When we approach Lc, t2 tends to zero, which causes problems with the division later.
+    t1[abs(t1) < 1e-5] = 1e-5
+    t2[abs(t2) < 1e-5] = 1e-5
+
+    # When the discriminant goes to zero however, it means there are now repeated roots.
+    sqrt_det[abs(sqrt_det) < 1e-5] = 1e-5
+
+    # Compute all the elements required to evaluate the chain rule
+    dy_ddet = 1.0 / (6.0 * sqrt_det * t1) - 1.0 / (6.0 * sqrt_det * t2)
+    dy_dq = -1.0 / (6.0 * t1) - 1.0 / (6.0 * t2)
+    dy_da = -(1.0 / 3.0)
+
+    ddet_dp = p * p / 9.0
+    ddet_dq = 0.5 * q
+
+    # Total derivatives, terms multiplied by zero are omitted. Terms that are one are also omitted.
+    # dp_db = dq_dc = 1
+    total_dy_da = dy_ddet * ddet_dp * dp_da + dy_ddet * ddet_dq * dq_da + dy_dq * dq_da + dy_da
+    total_dy_db = dy_ddet * ddet_dp + dy_ddet * ddet_dq * dq_db + dy_dq * dq_db
+    total_dy_dc = dy_ddet * ddet_dq + dy_dq
+
+    return total_dy_da, total_dy_db, total_dy_dc
+
+
+def calc_triple_root_invwlc(p, q, dp_da, dq_da, dq_db, root):
+    # If we define:
+    #   sqmp = sqrt(-p)
+    #   F = 3 * sqrt(3) * q / (2 * sqmp**3 )
+    #
+    # Then the solution is:
+    #   2 /sqrt(3) * sqmp * cos((1/3) * asin(F) + pi/6) - a / 3
+    #
+    # Note that dp/dc = 0, dp_db = 1, dq_dc = 1
+    # The rest of this file is simply applying the chain rule.
+    sqmp = np.sqrt(-p)
+    F = 3.0 * np.sqrt(3.0) * q / (2.0 * sqmp ** 3)
+
+    dF_dsqmp = -9 * np.sqrt(3) * q / (2 * sqmp ** 4)
+    dF_dq = 3.0 * np.sqrt(3) / (2.0 * sqmp ** 3)
+    dsqmp_dp = -1.0 / (2.0 * sqmp)
+    dy_da = -1.0 / 3.0
+
+    if root == 0:
+        arg = np.arcsin(F) / 3.0
+        dy_dsqmp = 2.0 * np.sqrt(3.0) * np.sin(arg) / 3.0
+        dy_dF = 2.0 * np.sqrt(3.0) * sqmp * np.cos(arg) / (9.0 * np.sqrt(1.0 - F ** 2))
+    elif root == 1:
+        arg = np.arcsin(F) / 3.0 + np.pi / 3.0
+        dy_dsqmp = -2.0 * np.sqrt(3.0) * np.sin(arg) / 3.0
+        dy_dF = -2.0 * np.sqrt(3.0) * sqmp * np.cos(arg) / (9.0 * np.sqrt(1.0 - F ** 2))
+    elif root == 2:
+        arg = np.arcsin(F) / 3.0 + np.pi / 6.0
+        dy_dsqmp = 2.0 * np.sqrt(3.0) * np.cos(arg) / 3.0
+        dy_dF = -2.0 * np.sqrt(3.0) * sqmp * np.sin(arg) / (9.0 * np.sqrt(1.0 - F * F))
+
+    # Total derivatives
+    total_dy_da = dy_dsqmp * dsqmp_dp * dp_da + \
+        dy_dF * (dF_dsqmp * dsqmp_dp * dp_da + dF_dq * dq_da) + \
+        dy_da
+    total_dy_db = dy_dsqmp * dsqmp_dp + \
+        dy_dF * (dF_dsqmp * dsqmp_dp + dF_dq * dq_db)
+    total_dy_dc = dy_dF * dF_dq
+
+    return total_dy_da, total_dy_db, total_dy_dc
+
+
+def invwlc_root_derivatives(a, b, c, selected_root):
+    """Calculate the root derivatives of a cubic polynomial with respect to the polynomial coefficients.
+
+    For a polynomial of the form:
+        x**3 + a * x**2 + b * x + c = 0
+
+    Note that this is not a general root-finding function, but tailored for use with the inverted WLC model. For det < 0
+    it returns the derivatives of the first root. For det > 0 it returns the derivatives of the third root.
+
+    Parameters
+    ----------
+    a, b, c: array_like
+        Coefficients of the reduced cubic polynomial.
+        x**3 + a x**2 + b x + c = 0
+    selected_root: integer
+        which root to compute the derivative of
+    """
+    p = b - a * a / 3.0
+    q = 2.0 * a * a * a / 27.0 - a * b / 3.0 + c
+    det = q * q / 4.0 + p * p * p / 27.0
+
+    # Determine derivatives of our transformation from polynomial coefficients to helper coordinates p and q
+    dp_da = -2.0 * a / 3.0
+    dq_da = 2.0 * a ** 2.0 / 9.0 - b / 3.0
+    dq_db = -a / 3.0
+
+    total_dy_da = np.zeros(det.shape)
+    total_dy_db = np.zeros(det.shape)
+    total_dy_dc = np.zeros(det.shape)
+
+    mask = det > 0
+    total_dy_da[mask], total_dy_db[mask], total_dy_dc[mask] = \
+        calc_root1_invwlc(det[mask], p[mask], q[mask], dp_da[mask], dq_da[mask], dq_db[mask])
+
+    nmask = np.logical_not(mask)
+    total_dy_da[nmask], total_dy_db[nmask], total_dy_dc[nmask] = \
+        calc_triple_root_invwlc(p[nmask], q[nmask], dp_da[nmask], dq_da[nmask], dq_db[nmask], selected_root)
+
+    return total_dy_da, total_dy_db, total_dy_dc
+
+
+def invWLC_jac(d, Lp, Lc, St, kT=4.11):
+    alpha = (d / Lc) - 1.0
+    gamma = kT / Lp
+
+    St_squared = St * St
+    a = - 2.0 * alpha * St
+    b = (alpha * alpha) * St_squared
+    c = - 0.25 * gamma * St_squared
+
+    total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 2)
+
+    # Map back to our output parameters
+    da_dLc = 2.0 * St * d / Lc ** 2
+    da_dSt = - 2.0 * alpha
+    db_dLc = -2.0 * St ** 2 * d * alpha / Lc ** 2
+    db_dSt = 2.0 * St * alpha ** 2
+    dc_dLp = 0.25 * St_squared * kT / Lp ** 2
+    dc_dSt = -0.5 * St * gamma
+    dc_dkT = -0.25 * St_squared / Lp
+
+    # Terms multiplied by zero are omitted. Terms that are one are also omitted.
+    total_dy_dLp = total_dy_dc * dc_dLp
+    total_dy_dLc = total_dy_da * da_dLc + total_dy_db * db_dLc
+    total_dy_dSt = total_dy_da * da_dSt + total_dy_db * db_dSt + total_dy_dc * dc_dSt
+    total_dy_dkT = total_dy_dc * dc_dkT
+
+    return [total_dy_dLp, total_dy_dLc, total_dy_dSt, total_dy_dkT]
+
+
+def invWLC_derivative(d, Lp, Lc, St, kT = 4.11):
+    alpha = (d / Lc) - 1.0
+    gamma = kT / Lp
+
+    St_squared = St * St
+    a = - 2.0 * alpha * St
+    b = (alpha * alpha) * St_squared
+    c = - 0.25 * gamma * St_squared
+
+    total_dy_da, total_dy_db, _ = invwlc_root_derivatives(a, b, c, 2)
+
+    # Map back to our output parameters
+    da_dd = -2.0 * St / Lc
+    db_dd = 2 * St ** 2 * (-1.0 + d / Lc) / Lc
+
+    return total_dy_da * da_dd + total_dy_db * db_dd
+
+
+def WLC_derivative(f, Lp, Lc, St, kT = 4.11):
+    x0 = 1.0 / f
+    return Lc * (0.25 * x0 * np.sqrt(kT * x0 / Lp) + 1.0 / St)
+
+
+def FJC_derivative(f, Lp, Lc, St, kT=4.11):
+    """Derivative of the FJC model w.r.t. the independent variable"""
+    x0 = 1.0/St
+    x1 = 2.0*Lp/kT
+    x2 = f*x1
+    x3 = 0.5*kT/Lp
+
+    # Overflow protection
+    sinh_term = np.zeros(x2.shape)
+    sinh_term[x2 < 300] = 1.0/np.sinh(x2[x2 < 300])**2
+
+    return Lc*x0*(coth(x2) - x3/f) + Lc*(f*x0 + 1.0)*(-x1*sinh_term + x3/f**2)
+
+
+def invFJC(d, Lp, Lc, St, kT=4.11):
+    """Inverted Freely-Jointed Chain
+
+    References:
+       1. S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The
+          Elastic Response of Individual Double-Stranded and Single-Stranded
+          DNA Molecules, Science 271, 795-799 (1996).
+       2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
+          DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+
+    Parameters
+    ----------
+    d : array_like
+        distance [um]
+    Lp : float
+        persistence length [nm]
+    Lc : float
+        contour length [um]
+    St : float
+        elastic modulus [pN]
+    kT : float
+        Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
+    """
+    f_min = 0
+    f_max = np.inf
+
+    return invert_function(d, 1.0, f_min, f_max,
+                           lambda f_trial: FJC(f_trial, Lp, Lc, St, kT),
+                           lambda f_trial: FJC_derivative(f_trial, Lp, Lc, St, kT))
+
+
+def marko_sigga_ewlc_solve_force_equation(d, Lp, Lc, St, kT=4.11):
+    return solve_formatter(f'(1/4) * (1 - ({d}/{Lc}) + (f/{St}))**(-2) - (1/4) + ({d}/{Lc}) - (f/{St})', "f",
+                           f'f*{Lp}/{kT}')
+
+
+def marko_sigga_ewlc_solve_force_equation_tex(d, Lp, Lc, St, kT=4.11):
+    dLc = latex_frac(d, Lc)
+    FSt = latex_frac("f", St)
+    lhs = latex_frac(f"f {Lp}", kT)
+
+    return solve_formatter_tex(f"{latex_frac(1, 4)}\\left(1 - {dLc} + {FSt}\\right)^{{-2}} - {latex_frac(1, 4)} + "
+                               f"{dLc} - {FSt}", "f", lhs)
+
+
+def marko_sigga_ewlc_solve_force(d, Lp, Lc, St, kT=4.11):
+    """Margo-Siggia's Worm-like Chain model with distance as dependent parameter (useful for F < 10 pN).
+    These equations were symbolically derived. The expressions are not pretty, but they work."""
+    c = -St ** 3 * d * kT * (1.5 * Lc ** 2 - 2.25 * Lc * d + d ** 2) / (Lc ** 3 * (Lp * St + kT))
+    b = St ** 2 * (Lc ** 2 * Lp * St + 1.5 * Lc ** 2 * kT - 2 * Lc * Lp * St * d - 4.5 * Lc * d * kT +
+                   Lp * St * d ** 2 + 3 * d ** 2 * kT) / (Lc ** 2 * (Lp * St + kT))
+    a = St * (2 * Lc * Lp * St + 2.25 * Lc * kT - 2 * Lp * St * d - 3 * d * kT) / (Lc * (Lp * St + kT))
+
+    return solve_cubic_wlc(a, b, c, 2)
+
+
+def marko_sigga_ewlc_solve_force_jac(d, Lp, Lc, St, kT=4.11):
+    c = -St ** 3 * d * kT * (1.5 * Lc ** 2 - 2.25 * Lc * d + d ** 2) / (Lc ** 3 * (Lp * St + kT))
+    b = St ** 2 * (Lc ** 2 * Lp * St + 1.5 * Lc ** 2 * kT - 2 * Lc * Lp * St * d - 4.5 * Lc * d * kT +
+                   Lp * St * d ** 2 + 3 * d ** 2 * kT) / (Lc ** 2 * (Lp * St + kT))
+    a = St * (2 * Lc * Lp * St + 2.25 * Lc * kT - 2 * Lp * St * d - 3 * d * kT) / (Lc * (Lp * St + kT))
+
+    total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 2)
+
+    # Map back to our output parameters
+    denom1 = (Lc ** 3 * (Lp * St + kT) ** 2)
+    denom2 = (Lc * (Lp ** 2 * St ** 2 + 2.0 * Lp * St * kT + kT ** 2))
+    dkT = d * kT
+    dc_dLc = St ** 3 * dkT * (1.5 * Lc ** 2 - 4.5 * Lc * d + 3.0 * d ** 2) / (Lc ** 4 * (Lp * St + kT))
+    dc_dSt = -St ** 2 * dkT * (2 * Lp * St + 3 * kT) * (1.5 * Lc ** 2 - 2.25 * Lc * d + d ** 2) / denom1
+    dc_dLp = St ** 4 * dkT * (1.5 * Lc ** 2 - 2.25 * Lc * d + d ** 2) / denom1
+    dc_dkT = -Lp * St ** 4 * d * (1.5 * Lc ** 2 - 2.25 * Lc * d + d ** 2) / denom1
+    db_dLc = St ** 2 * d * (2.0 * Lc * Lp * St + 4.5 * Lc * kT - 2.0 * Lp * St * d -
+                                   6.0 * d * kT) / (Lc ** 3 * (Lp * St + kT))
+    db_dSt = St * (2.0 * Lc ** 2 * Lp ** 2 * St ** 2 + 4.5 * Lc ** 2 * Lp * St * kT + 3.0 * Lc ** 2 * kT ** 2 -
+                   4.0 * Lc * Lp ** 2 * St ** 2 * d - 10.5 * Lc * Lp * St * d * kT -
+                   9.0 * Lc * d * kT ** 2 + 2.0 * Lp ** 2 * St ** 2 * d ** 2 +
+                   6.0 * Lp * St * d ** 2 * kT + 6.0 * d ** 2 * kT ** 2) / (Lc * denom2)
+    db_dLp = -St ** 3 * kT * (0.5 * Lc ** 2 - 2.5 * Lc * d + 2.0 * d ** 2) / (Lc * denom2)
+    db_dkT = Lp * St ** 3 * (0.5 * Lc ** 2 - 2.5 * Lc * d + 2.0 * d ** 2) / (Lc * denom2)
+    da_dLc = St * d * (2 * Lp * St + 3 * kT) / (Lc ** 2 * (Lp * St + kT))
+    da_dSt = (-Lp * St * (2 * Lc * Lp * St + 2.25 * Lc * kT - 2 * Lp * St * d - 3 * d * kT) +
+              (Lp * St + kT) * (2 * Lc * Lp * St + 2.25 * Lc * kT - 2 * Lp * St * d +
+                                2 * Lp * St * (Lc - d) - 3 * d * kT)) / (Lc * (Lp * St + kT) ** 2)
+    da_dLp = -St ** 2 * kT * (0.25 * Lc - d) / denom2
+    da_dkT = Lp * St ** 2 * (0.25 * Lc - d) / denom2
+
+    # Terms multiplied by zero are omitted. Terms that are one are also omitted.
+    total_dy_dLp = total_dy_da * da_dLp + total_dy_db * db_dLp + total_dy_dc * dc_dLp
+    total_dy_dLc = total_dy_da * da_dLc + total_dy_db * db_dLc + total_dy_dc * dc_dLc
+    total_dy_dSt = total_dy_da * da_dSt + total_dy_db * db_dSt + total_dy_dc * dc_dSt
+    total_dy_dkT = total_dy_da * da_dkT + total_dy_db * db_dkT + total_dy_dc * dc_dkT
+
+    return [total_dy_dLp, total_dy_dLc, total_dy_dSt, total_dy_dkT]
+
+
+def marko_sigga_ewlc_solve_force_derivative(d, Lp, Lc, St, kT = 4.11):
+    c = -St ** 3 * d * kT * (1.5 * Lc ** 2 - 2.25 * Lc * d + d ** 2) / (Lc ** 3 * (Lp * St + kT))
+    b = St ** 2 * (Lc ** 2 * Lp * St + 1.5 * Lc ** 2 * kT - 2 * Lc * Lp * St * d - 4.5 * Lc * d * kT +
+                   Lp * St * d ** 2 + 3 * d ** 2 * kT) / (Lc ** 2 * (Lp * St + kT))
+    a = St * (2 * Lc * Lp * St + 2.25 * Lc * kT - 2 * Lp * St * d - 3 * d * kT) / (Lc * (Lp * St + kT))
+
+    total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 2)
+
+    # Map back to our output parameters
+    denom = (Lc * (Lp * St + kT))
+    dc_dd = -St ** 3 * kT * (1.5 * Lc ** 2 - 4.5 * Lc * d + 3.0 * d ** 2) / (Lc * Lc * denom)
+    db_dd = St ** 2 * (-2 * Lc * Lp * St - 4.5 * Lc * kT + 2 * Lp * St * d + 6 * d * kT) / (Lc * denom)
+    da_dd = -St * (2 * Lp * St + 3 * kT) / denom
+
+    return total_dy_da * da_dd + total_dy_db * db_dd + total_dy_dc * dc_dd
+
+
+def marko_sigga_ewlc_solve_distance_equation(f, Lp, Lc, St, kT=4.11):
+    return solve_formatter(f'(1/4) * (1 - (d/{Lc}) + ({f}/{St}))**(-2) - (1/4) + (d/{Lc}) - ({f}/{St})',
+                           "d", f'{f}*{Lp}/{kT}')
+
+
+def marko_sigga_ewlc_solve_distance_equation_tex(f, Lp, Lc, St, kT=4.11):
+    dLc = latex_frac("d", Lc)
+    FSt = latex_frac(f, St)
+    lhs = latex_frac(f"{f} {Lp}", kT)
+
+    return solve_formatter_tex(f"{latex_frac(1, 4)}\\left(1 - {dLc} + {FSt}\\right)^{{-2}} - {latex_frac(1, 4)} + "
+                               f"{dLc} - {FSt}", "d", lhs)
+
+
+def marko_sigga_ewlc_solve_distance(f, Lp, Lc, St, kT=4.11):
+    c = -f * Lc ** 3 * (f ** 2 * Lp * St + f ** 2 * kT + 2 * f * Lp * St ** 2 + 2.25 * f * St * kT + Lp * St ** 3 + 1.5 * St ** 2 * kT) / (St ** 3 * kT)
+    b = Lc ** 2 * (2 * f ** 2 * Lp * St + 3 * f ** 2 * kT + 2 * f * Lp * St ** 2 + 4.5 * f * St * kT + 1.5 * St ** 2 * kT) / (St ** 2 * kT)
+    a = -f * Lc * Lp / kT - 3 * f * Lc / St - 2.25 * Lc
+
+    return solve_cubic_wlc(a, b, c, 1)
+
+
+def marko_sigga_ewlc_solve_distance_jac(f, Lp, Lc, St, kT=4.11):
+    c = -f * Lc ** 3 * (f ** 2 * Lp * St + f ** 2 * kT + 2 * f * Lp * St ** 2 + 2.25 * f * St * kT + Lp * St ** 3 + 1.5 * St ** 2 * kT) / (St ** 3 * kT)
+    b = Lc ** 2 * (2 * f ** 2 * Lp * St + 3 * f ** 2 * kT + 2 * f * Lp * St ** 2 + 4.5 * f * St * kT + 1.5 * St ** 2 * kT) / (St ** 2 * kT)
+    a = -f * Lc * Lp / kT - 3 * f * Lc / St - 2.25 * Lc
+
+    total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 1)
+
+    # Map back to our output parameters
+    dc_dLc = -3 * f * Lc ** 2 * (f ** 2 * Lp * St + f ** 2 * kT + 2 * f * Lp * St ** 2 + 2.25 * f * St * kT +
+                                 Lp * St ** 3 + 1.5 * St ** 2 * kT) / (St ** 3 * kT)
+    dc_dSt = f * Lc ** 3 * (2.0 * f ** 2 * Lp * St + 3.0 * f ** 2 * kT + 2.0 * f * Lp * St ** 2 + 4.5 * f * St * kT +
+                            1.5 * St ** 2 * kT) / (St ** 4 * kT)
+    dc_dLp = -f * Lc ** 3 * (f ** 2 + 2 * f * St + St ** 2) / (St ** 2 * kT)
+    dc_dkT = f * Lc ** 3 * Lp * (f ** 2 + 2 * f * St + St ** 2) / (St ** 2 * kT ** 2)
+    db_dLc = 4 * f ** 2 * Lc * Lp / (St * kT) + 6 * f ** 2 * Lc / St ** 2 + 4 * f * Lc * Lp / kT + 9.0 * f * Lc / St + 3.0 * Lc
+    db_dSt = -f * Lc ** 2 * (2.0 * f * Lp * St + 6.0 * f * kT + 4.5 * St * kT) / (St ** 3 * kT)
+    db_dLp = 2 * f * Lc ** 2 * (f + St) / (St * kT)
+    db_dkT = -2 * f * Lc ** 2 * Lp * (f + St) / (St * kT ** 2)
+    da_dLc = -f * Lp / kT - 3 * f / St - 2.25
+    da_dSt = 3 * f * Lc / St ** 2
+    da_dLp = -f * Lc / kT
+    da_dkT = f * Lc * Lp / kT ** 2
+
+    # Terms multiplied by zero are omitted. Terms that are one are also omitted.
+    total_dy_dLp = total_dy_da * da_dLp + total_dy_db * db_dLp + total_dy_dc * dc_dLp
+    total_dy_dLc = total_dy_da * da_dLc + total_dy_db * db_dLc + total_dy_dc * dc_dLc
+    total_dy_dSt = total_dy_da * da_dSt + total_dy_db * db_dSt + total_dy_dc * dc_dSt
+    total_dy_dkT = total_dy_da * da_dkT + total_dy_db * db_dkT + total_dy_dc * dc_dkT
+
+    return [total_dy_dLp, total_dy_dLc, total_dy_dSt, total_dy_dkT]
+
+
+def marko_sigga_ewlc_solve_distance_derivative(f, Lp, Lc, St, kT = 4.11):
+    fsq = f * f
+    c = -f * Lc ** 3 * (f ** 2 * Lp * St + fsq * kT + 2 * f * Lp * St ** 2 +
+                        2.25 * f * St * kT + Lp * St ** 3 + 1.5 * St ** 2 * kT) / (St ** 3 * kT)
+    b = Lc ** 2 * (2 * f ** 2 * Lp * St + 3 * fsq * kT + 2 * f * Lp * St ** 2 +
+                   4.5 * f * St * kT + 1.5 * St ** 2 * kT) / (St ** 2 * kT)
+    a = -f * Lc * Lp / kT - 3 * f * Lc / St - 2.25 * Lc
+
+    total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 1)
+
+    # Map back to our output parameters
+    dc_df = -Lc ** 3 * (3.0 * fsq * Lp * St + 3.0 * fsq * kT + 4.0 * f * Lp * St ** 2 +
+                        4.5 * f * St * kT + Lp * St ** 3 + 1.5 * St ** 2 * kT) / (St ** 3 * kT)
+    db_df = Lc ** 2 * (4 * f * Lp * St + 6 * f * kT + 2 * Lp * St ** 2 + 4.5 * St * kT) / (St ** 2 * kT)
+    da_df = -Lc * Lp / kT - 3 * Lc / St
+
+    return total_dy_da * da_df + total_dy_db * db_df + total_dy_dc * dc_df

--- a/lumicks/pylake/fitting/detail/utilities.py
+++ b/lumicks/pylake/fitting/detail/utilities.py
@@ -44,3 +44,31 @@ def print_styled(style, print_string, **kwargs):
     }
     if style in print_dict:
         print(print_dict[style] + print_string + '\033[0m')
+
+
+def latex_sqrt(arg):
+    return f"\\sqrt{{{arg}}}"
+
+
+def latex_frac(a, b):
+    return f"\\frac{{{a}}}{{{b}}}"
+
+
+def solve_formatter(a, solved_for, rhs):
+    return f"argmin[{solved_for}](norm({a}-{rhs}))"
+
+
+def solve_formatter_tex(a, solved_for, rhs):
+    norm = f"\\left\\|{a} - {rhs}\\right\\|"
+    return f"\\underset{{{solved_for}}}{{arg\\,min}}\\left({norm}_{2}\\right)"
+
+
+def escape_tex(name):
+    def escape_underscores(txt):
+        return '\\_'.join(txt.split('_'))
+
+    splits = name.split('/')
+    if len(splits) > 1:
+        return escape_underscores(splits[1]) + '_{' + escape_underscores(splits[0]) + "}"
+    else:
+        return escape_underscores(name)

--- a/lumicks/pylake/fitting/detail/utilities.py
+++ b/lumicks/pylake/fitting/detail/utilities.py
@@ -1,0 +1,25 @@
+from collections import OrderedDict
+import numpy as np
+
+
+def unique_idx(input_list):
+    """
+    Determine unique elements of a list and return indices which reconstruct the original list from the unique elements.
+    """
+    unique_list = []
+    [unique_list.append(x) for x in input_list if x not in unique_list]
+    inverse_list = [unique_list.index(l) for l in input_list]
+    return unique_list, inverse_list
+
+
+def parse_transformation(params, param_transform={}):
+    transformed = OrderedDict(zip(params, params))
+
+    for key, value in param_transform.items():
+        if key in transformed:
+            transformed[key] = value
+        else:
+            raise KeyError(f"Parameter {key} to be substituted not found in model. Valid keys for this model are: "
+                           f"{[x for x in transformed.keys()]}.")
+
+    return transformed

--- a/lumicks/pylake/fitting/detail/utilities.py
+++ b/lumicks/pylake/fitting/detail/utilities.py
@@ -23,3 +23,24 @@ def parse_transformation(params, param_transform={}):
                            f"{[x for x in transformed.keys()]}.")
 
     return transformed
+
+
+def optimal_plot_layout(n_plots):
+    n_x = np.ceil(np.sqrt(n_plots))
+    n_y = np.ceil(n_plots/n_x)
+
+    return n_x, n_y
+
+
+def print_styled(style, print_string, **kwargs):
+    print_dict = {
+        'header': '\033[95m',
+        'ok_blue': '\033[94m',
+        'ok_green': '\033[92m',
+        'warning': '\033[93m',
+        'fail': '\033[91m',
+        'bold': '\033[1m',
+        'underline': '\033[4m'
+    }
+    if style in print_dict:
+        print(print_dict[style] + print_string + '\033[0m')

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -1,0 +1,514 @@
+from .parameters import Params
+from .datasets import Datasets
+from .model import Model
+from collections import OrderedDict
+from ..detail.utilities import unique, lighten_color
+from .detail.derivative_manipulation import numerical_jacobian
+from .detail.utilities import print_styled, optimal_plot_layout
+import numpy as np
+import scipy.optimize as optim
+import matplotlib.pyplot as plt
+
+
+def front(x):
+    return next(iter(x))
+
+
+class Fit:
+    """Object which is used for fitting. It is a collection of models and their data. Once data is loaded, a fit object
+    contains parameters, which can be fitted by invoking fit.
+
+    Parameters
+    ----------
+    *models
+        Variable number of `pylake.fitting.Model`.
+
+    Examples
+    --------
+    ::
+
+        from lumicks import pylake
+
+        dna_model = pylake.inverted_odijk("DNA")
+        fit = pylake.FdFit(dna_model)
+        data = fit.add_data("Dataset 1", force, distance)
+
+        fit["DNA/Lp"].lower_bound = 35  # Set lower bound for DNA Lp
+        fit["DNA/Lp"].upper_bound = 80  # Set upper bound for DNA Lp
+        fit.fit()
+
+        fit.plot("Dataset 1", "k--")  # Plot the fitted model
+    """
+    def __init__(self, *models):
+        self.models = {id(m): m for m in models}
+        self.datasets = {id(m): self._dataset(m) for m in models}
+        self._params = Params()
+        self._invalidate_build()
+
+    def _dataset(self, model):
+        return Datasets(model, self)
+
+    def update_params(self, other):
+        """Sets parameters if they are found in the target fit.
+
+        Parameters
+        ----------
+        other : Fit or Params
+        """
+        if isinstance(other, Params):
+            self.params.update_params(other)
+        elif isinstance(other, self.__class__):
+            self.params.update_params(other.params)
+        else:
+            raise RuntimeError("Did not pass compatible argument to update_params")
+
+    def __getitem__(self, item):
+        if isinstance(item, Model):
+            return self.datasets[id(item)]
+        elif len(self.datasets) == 1 and item in front(self.datasets.values()).names:
+            return self.params[front(self.datasets.values()).data[item]]
+        else:
+            return self.params[item]
+
+    @property
+    def data(self):
+        if len(self.datasets) > 1:
+            raise RuntimeError("This Fit is comprised of multiple models. Please access data for a particular model by "
+                               "invoking fit[model].data[dataset_name].")
+
+        return front(self.datasets.values()).data
+
+    def _add_data(self, name, x, y, params={}):
+        if len(self.datasets) > 1:
+            raise RuntimeError("This Fit is comprised of multiple models. Please add data to a particular model by "
+                               "invoking fit[model].add_data(...)")
+
+        return front(self.datasets.values())._add_data(name, x, y, params)
+
+    @property
+    def has_jacobian(self):
+        """Returns true if it is possible to evaluate the Jacobian of the fit."""
+        has_jacobian = True
+        for model in self.models.values():
+            has_jacobian = has_jacobian and model.has_jacobian
+
+        return has_jacobian
+
+    @property
+    def n_residuals(self):
+        """Number of data points."""
+        self._rebuild()
+        count = 0
+        for data in self.datasets.values():
+            count += data.n_residuals
+
+        return count
+
+    @property
+    def n_params(self):
+        """Number of parameters in the Fit"""
+        self._rebuild()
+        return len(self._params)
+
+    @property
+    def params(self):
+        """Fit parameters. See also `pylake.fitting.Params`"""
+        self._rebuild()
+        return self._params
+
+    @property
+    def dirty(self):
+        """Validate that all the Datasets that we are about the fit were actually linked."""
+        dirty = not self._built
+        for data in self.datasets.values():
+            dirty = dirty or not data.built
+
+        return dirty
+
+    def _rebuild(self):
+        """Checks whether the model state is up to date. Any user facing methods should ideally check whether the model
+        needs to be rebuilt."""
+        if self.dirty:
+            self._build_fit()
+
+    def _invalidate_build(self):
+        self._built = False
+
+    def _build_fit(self):
+        """This function generates the global parameter list from the parameters of the individual sub models.
+        It also generates unique conditions from the data specification."""
+        all_parameter_names = [p for data_set in self.datasets.values() for p in data_set._transformed_params]
+        all_defaults = [d for data_set in self.datasets.values() for d in data_set._defaults]
+        unique_parameter_names = unique(all_parameter_names)
+        parameter_lookup = OrderedDict(zip(unique_parameter_names, np.arange(len(unique_parameter_names))))
+
+        for data in self.datasets.values():
+            data._link_data(parameter_lookup)
+
+        defaults = [all_defaults[all_parameter_names.index(l)] for l in unique_parameter_names]
+        self._params._set_params(unique_parameter_names, defaults)
+        self._built = True
+
+    def _prepare_fit(self):
+        """Checks whether the model is ready for fitting and returns the current parameter values, which parameters are
+        fitted and the parameter bounds."""
+        self._rebuild()
+        assert self.n_residuals > 0, "This model has no data associated with it."
+        assert self.n_params > 0, "This model has no parameters. There is nothing to fit."
+        return self.params.values, self.params.fitted, self.params.lower_bounds, self.params.upper_bounds
+
+    def _fit(self, parameter_vector, lb, ub, fitted, show_fit=False, **kwargs):
+        """Fit the model
+
+        Parameters
+        ----------
+        parameter_vector : array_like
+            List of parameters
+        lb : array_like
+            list of lower parameter bounds
+        ub : array_like
+            list of lower parameter bounds
+        show_fit : bool
+            show fitting (slow!)
+        fitted : array_like
+            list of which parameters are fitted
+        """
+        if show_fit:
+            fig = plt.gcf()
+
+        def residual(params):
+            parameter_vector[fitted] = params
+
+            if show_fit:
+                parameter_names = self.params.keys
+                for name, value in zip(parameter_names, parameter_vector):
+                    self.params[name] = value
+                plt.figure(fig.number)
+                for model in self.models.values():
+                    self[model].plot()
+                fig.canvas.draw()
+                fig.canvas.flush_events()
+                fig.clf()
+
+            return self._calculate_residual(parameter_vector)
+
+        def jacobian(params):
+            parameter_vector[fitted] = params
+            return self._calculate_jacobian(parameter_vector)[:, fitted]
+
+        result = optim.least_squares(residual, parameter_vector[fitted],
+                                     jac=jacobian if self.has_jacobian else "2-point",
+                                     bounds=(lb[fitted], ub[fitted]),
+                                     method='trf', ftol=1e-8, xtol=1e-8, gtol=1e-8, **kwargs)
+
+        parameter_vector[fitted] = result.x
+
+        return parameter_vector
+
+    def fit(self, show_fit=False, **kwargs):
+        """Fit the model
+
+        Parameters
+        ----------
+        show_fit : bool
+            Show the fitting procedure as it is progressing.
+        """
+        parameter_vector, fitted, lb, ub = self._prepare_fit()
+
+        out_of_bounds = np.logical_or(parameter_vector[fitted] < lb[fitted], parameter_vector[fitted] > ub[fitted])
+        if np.any(out_of_bounds):
+            raise ValueError(f"Initial parameters {self.params.keys[fitted][out_of_bounds]} are outside the "
+                             f"parameter bounds. Please set value, lower_bound and upper_bound for these parameters"
+                             f"to consistent values.")
+
+        parameter_vector = self._fit(parameter_vector, lb, ub, fitted, show_fit=show_fit, **kwargs)
+
+        parameter_names = self.params.keys
+        for name, value in zip(parameter_names, parameter_vector):
+            self.params[name] = value
+
+        return self
+
+    def _calculate_residual(self, parameter_values=[]):
+        self._rebuild()
+        if len(parameter_values) == 0:
+            parameter_values = self.params.values
+
+        residual_idx = 0
+        residual = np.zeros(self.n_residuals)
+        for model in self.models.values():
+            current_residual = model._calculate_residual(self.datasets[id(model)], parameter_values)
+            current_n = len(current_residual)
+            residual[residual_idx:residual_idx + current_n] = current_residual
+            residual_idx += current_n
+
+        return residual
+
+    def _calculate_jacobian(self, parameter_values=[]):
+        self._rebuild()
+        if len(parameter_values) == 0:
+            parameter_values = self.params.values
+
+        residual_idx = 0
+        jacobian = np.zeros((self.n_residuals, len(parameter_values)))
+        for model in self.models.values():
+            current_jacobian = model._calculate_jacobian(self.datasets[id(model)], parameter_values)
+            current_n = current_jacobian.shape[0]
+            jacobian[residual_idx:residual_idx + current_n, :] = current_jacobian
+            residual_idx += current_n
+
+        return jacobian
+
+    def verify_jacobian(self, params, plot=0, verbose=True, dx=1e-6, **kwargs):
+        self._rebuild()
+        if len(params) != len(self._params):
+            raise ValueError("Parameter vector has invalid length. "
+                             f"Expected: {len(self._params)}, got: {len(params)}.")
+
+        jacobian = self._calculate_jacobian(params).transpose()
+        jacobian_fd = numerical_jacobian(self._calculate_residual, params, dx)
+
+        if plot:
+            n_x, n_y = optimal_plot_layout(len(self.params))
+            for i_parameter, parameter in enumerate(self.params):
+                plt.subplot(n_x, n_y, i_parameter + 1)
+                plt.plot(np.transpose(jacobian[i_parameter, :]), linewidth=2)
+                plt.plot(np.transpose(jacobian_fd[i_parameter, :]), '--', linewidth=1)
+                plt.title(parameter)
+                plt.legend(['Analytic', 'FD'])
+
+        is_close = np.allclose(jacobian, jacobian_fd, **kwargs)
+        if not is_close:
+            parameter_names = list(self.params.keys)
+            if verbose:
+                maxima = np.max(jacobian - jacobian_fd, axis=1)
+                for i, v in enumerate(maxima):
+                    if np.allclose(jacobian[i, :], jacobian_fd[i, :]):
+                        print(f"Parameter {parameter_names[i]}({i}): {v}")
+                    else:
+                        print_styled('warning', f'Parameter {parameter_names[i]}({i}): {v}')
+
+        return is_close
+
+    def plot(self, data=None, fmt='', independent=None, legend=True, plot_data=True, overrides=None, **kwargs):
+        """Plot model and data
+
+        Parameters
+        ----------
+            data : str
+                Name of the data set to plot (optional, omission plots all for that model).
+            fmt : str
+                Format string, forwarded to :func:`matplotlib.pyplot.plot`.
+            independent : array_like
+                Array with values for the independent variable (used when plotting the model).
+            legend : bool
+                Show legend (default: True).
+            plot_data : bool
+                Show data (default: True).
+            overrides : dict
+                Parameter / value pairs which override parameter values in the current fit. Should be a dict of
+                {str: float} that provides values for parameters which should be set to particular values in the plot
+                (default: None);
+            ``**kwargs``
+                Forwarded to :func:`matplotlib.pyplot.plot`.
+
+        Examples
+        --------
+        ::
+
+            from lumicks import pylake
+
+            model = pylake.inverted_odijk("DNA")
+            fit = pylake.FdFit(model)
+            fit.add_data("Control", force, distance)
+            fit.fit()
+
+            # Basic plotting of one data set over a custom range can be done by just invoking plot.
+            fit.plot("Control", 'k--', np.arange(2.0, 5.0, 0.01))
+
+            # Have a quick look at what a stiffness of 5 would do to the fit.
+            fit.plot("Control", overrides={"DNA/St": 5})
+
+            # When dealing with multiple models in one fit, one has to select the model first when we want to plot.
+            model1 = pylake.odijk("DNA")
+            model2 = pylake.odijk("DNA") + pylake.odijk("protein")
+            fit[model1].add_data("Control", force1, distance2)
+            fit[model2].add_data("Control", force1, distance2)
+            fit.fit()
+
+            fit = pylake.FdFit(model1, model2)
+            fit[model1].plot("Control")  # Plots data set Control for model 1
+            fit[model2].plot("Control")  # Plots data set Control for model 2
+        """
+        assert len(self.models) == 1, "Please select a model to plot using fit[model].plot(...)."
+        self._plot(front(self.models.values()), data, fmt, overrides, independent, legend, plot_data, **kwargs)
+
+    def _plot(self, model, data, fmt, overrides, independent, legend, plot_data, **kwargs):
+        self._rebuild()
+
+        params, _ = self._override_params(overrides)
+        dataset = self.datasets[id(model)]
+
+        def plot(fit_data):
+            x_values = fit_data.x if independent is None else independent
+            model_lines = model.plot(params[fit_data], x_values, fmt, **kwargs, zorder=1,
+                                     label=fit_data.name + " (model)")
+
+            if plot_data:
+                color = model_lines[0].get_color()
+                fit_data.plot('.', **kwargs, color=lighten_color(color, -.3), zorder=0, label=fit_data.name + " (data)")
+
+        if data:
+            assert data in dataset.data, f"Error: Did not find dataset with name {data}"
+            plot(dataset.data[data])
+        else:
+            for data in dataset.data.values():
+                plot(data)
+
+        if legend:
+            plt.legend()
+
+    def _override_params(self, overrides=None):
+        from copy import deepcopy
+        params = self.params
+
+        params = deepcopy(params)
+        if overrides:
+            for key, value in overrides.items():
+                if key in params:
+                    params[key] = value
+                else:
+                    raise KeyError(f"Parameter {key} is not a parameter used in the fit")
+
+        return params, overrides
+
+    @property
+    def sigma(self):
+        """Error variance of the data points."""
+        # TO DO: Ideally, this will eventually depend on the exact error model used. For now, we use the a-posteriori
+        # variance estimate based on the residual.
+        res = self._calculate_residual()
+        return np.sqrt(np.var(res)) * np.ones(len(res))
+
+    def log_likelihood(self, params=[], sigma=None):
+        """The model residual is given by chi squared = -2 log(L)"""
+        self._rebuild()
+        res = self._calculate_residual(params)
+        sigma = sigma if np.any(sigma) else self.sigma
+        return - (self.n_residuals/2.0) * np.log(2.0 * np.pi) - np.sum(np.log(sigma)) - sum((res/sigma)**2) / 2.0
+
+    @property
+    def aic(self):
+        """Calculates the Akaike Information Criterion:
+
+            AIC = 2 k - 2 ln(L)
+
+        Where k refers to the number of parameters, n to the number of observations (or data points) and L to the
+        maximized value of the likelihood function
+
+        The emphasis of this criterion is future prediction. It does not lead to consistent model selection and is more
+        prone to over-fitting than the Bayesian Information Criterion.
+
+        References:
+            Cavanaugh, J.E., 1997. Unifying the derivations for the Akaike and corrected Akaike information criteria.
+            Statistics & Probability Letters, 33(2), pp.201-208.
+        """
+        self._rebuild()
+        k = sum(self.params.fitted)
+        LL = self.log_likelihood()
+        return 2.0 * k - 2.0 * LL
+
+    @property
+    def aicc(self):
+        """Calculates the Corrected Akaike Information Criterion:
+
+        .. math::
+            AICc = AIC + \\frac{2 k^2 + 2 k}{n - k - 1}
+
+        Where k refers to the number of parameters, n to the number of observations (or data points) and L to the
+        maximized value of the likelihood function
+
+        The emphasis of this criterion is future prediction. Compared to the AIC it should be less prone to overfitting
+        for smaller sample sizes. Analogously to the AIC, it does not lead to a consistent model selection procedure.
+
+        References:
+            Cavanaugh, J.E., 1997. Unifying the derivations for the Akaike and corrected Akaike information criteria.
+            Statistics & Probability Letters, 33(2), pp.201-208.
+        """
+
+        aic = self.aic
+        k = sum(self.params.fitted)
+        return aic + (2.0 * k * k + 2.0 * k)/(self.n_residuals - k - 1.0)
+
+    @property
+    def bic(self):
+        """Calculates the Bayesian Information Criterion:
+
+            BIC = k ln(n) - 2 ln(L)
+
+        Where k refers to the number of parameters, n to the number of observations (or data points) and L to the
+        maximized value of the likelihood function
+
+        The emphasis of the BIC is put on parsimonious models. As such it is less prone to over-fitting. Selection via
+        BIC leads to a consistent model selection procedure, meaning that as the number of data points tends to
+        infinity, BIC will select the true model assuming the true model is in the set of selected models.
+        """
+
+        k = sum(self.params.fitted)
+        return k * np.log(self.n_residuals) - 2.0 * self.log_likelihood()
+
+    @property
+    def cov(self):
+        """Returns the inverse of the approximate Hessian. This approximation is valid when the model fits well (small
+        residuals) and there is sufficient data to assume we're in the asymptotic regime.
+
+        It makes use of the Gauss-Newton approximation of the Hessian, which uses only the first order sensitivity
+        information. This is valid for linear problems and problems near the optimum (assuming the model fits).
+
+        References:
+            Press, W.H., Teukolsky, S.A., Vetterling, W.T. and Flannery, B.P., 1988. Numerical recipes in C.
+
+            Maiwald, T., Hass, H., Steiert, B., Vanlier, J., Engesser, R., Raue, A., Kipkeew, F., Bock, H.H.,
+            Kaschek, D., Kreutz, C. and Timmer, J., 2016. Driving the model to its limit: profile likelihood
+            based model reduction. PloS one, 11(9).
+        """
+        J = self._calculate_jacobian()
+        J = J / np.transpose(np.tile(self.sigma, (J.shape[1], 1)))
+        return np.linalg.pinv(np.transpose(J).dot(J))
+
+    def _repr_html_(self):
+        out_string = "<h4>Fit</h4>\n"
+
+        for model in self.models.values():
+            datasets = ''.join(f"{self.datasets[id(model)]._repr_html_()}<br>\n")
+            out_string += f"<h5>Model: {model.name}</h5>\n"
+            eqn = model.get_formatted_equation_string(tex=True)
+            if eqn:
+                out_string += f"<h5>&ensp;Equation:</h5>${eqn}$<br>\n"
+            out_string += f"<h5>&ensp;Data:</h5>\n{datasets}<br>"
+
+        return out_string + f"<h5>&ensp;Fitted parameters:</h5>\n{self.params._repr_html_()}"
+
+    def __repr__(self):
+        return (f"lumicks.pylake.{self.__class__.__name__}"
+                f"(models={{{', '.join([x.name for x in self.models.values()])}}}, "
+                f"N={self.n_residuals})")
+
+    def __str__(self):
+        indent = 2
+        out_string = "Fit\n"
+
+        for model in self.models.values():
+            datasets = (' ' * indent + '- ' + self.datasets[id(model)].__str__()).splitlines(True)
+            datasets = (' ' * (2 * indent)).join(datasets)
+
+            out_string += f"{' ' * indent}- Model: {model.name}\n"
+
+            eqn = model.get_formatted_equation_string(tex=False)
+            if eqn:
+                out_string += f"{' ' * indent}- Equation:\n      {eqn}\n\n{datasets}"
+
+        return out_string + (
+            f"\n{' ' * indent}- Fitted parameters:\n"
+            f"{(' ' * (2 * indent))}"
+            f"{(' ' * (2 * indent)).join(self.params.__str__().splitlines(True))}")

--- a/lumicks/pylake/fitting/fitdata.py
+++ b/lumicks/pylake/fitting/fitdata.py
@@ -1,0 +1,120 @@
+import numpy as np
+from .parameters import Params
+from collections import OrderedDict
+import matplotlib.pyplot as plt
+
+
+class FitData:
+    """
+    This class contains data to be fitted, and a set of transformations that correspond to this specific data set. The
+    transformations are parameter mappings from the model this data is part of to the outer parameters (the ones that
+    are going to be fitted in the global fit).
+
+    Parameters
+    ----------
+    name : str
+        name of this dataset
+    x, y : array_like
+        Actual data
+    transformations : OrderedDict
+        set of transformations from internal model parameters to outer parameters
+    """
+    def __init__(self, name, x, y, transformations):
+        self.x = np.asarray(x, dtype=np.float64)
+        self.y = np.asarray(y, dtype=np.float64)
+        self.name = name
+        self.transformations = transformations
+
+    @property
+    def independent(self):
+        """Values for the independent variable"""
+        return self.x
+
+    @property
+    def dependent(self):
+        """Values for the dependent variable"""
+        return self.y
+
+    @property
+    def condition_string(self):
+        return '|'.join(str(x) for x in self.transformations.values())
+
+    def get_params(self, params):
+        """
+        This function maps parameters from a global fit parameter vector into internal parameters for this model,
+        which can be used to simulate this model.
+
+        Parameters
+        ----------
+        params : Params
+            Fit parameters, typically obtained from a Fit.
+        """
+        mapping = OrderedDict((key, params[x]) if isinstance(x, str) else (key, float(x)) for
+                              key, x in self.transformations.items())
+        return Params(**mapping)
+
+    @property
+    def parameter_names(self):
+        """
+        Parameter names for free parameters after transformation
+        """
+        return [x for x in self.transformations.values() if isinstance(x, str)]
+
+    @property
+    def source_parameter_names(self):
+        """
+        Parameter names for free parameters before transformation
+        """
+        return [x for x, y in self.transformations.items() if isinstance(y, str)]
+
+    def plot(self, fmt, **kwargs):
+        return plt.plot(self.x, self.y, fmt, **kwargs)
+
+    def __repr__(self):
+        out_string = f'{self.__class__.__name__}({self.name}, N={len(self.independent)}'
+
+        changes = []
+        for i, v in self.transformations.items():
+            if i != v:
+                changes.append([i, str(v)])
+
+        if len(changes) > 0:
+            out_string += ', Transformations: ' + ', '.join([' → '.join(s) for s in changes])
+
+        return out_string + ')'
+
+
+class Condition:
+    """
+    This class maintains the linkage between the index-based parameter vectors and matrices for a data-set. It is not
+    intended to be a user facing class as working with raw indices is error prone.
+    """
+    def __init__(self, transformations, global_dictionary):
+        from copy import deepcopy
+        self.transformations = deepcopy(transformations)
+
+        # Which sensitivities actually need to be exported?
+        self.p_external = np.flatnonzero([True if isinstance(x, str) else False for x in self.transformed])
+
+        # p_global_indices contains a list with indices for each parameter that is mapped to the globals
+        self._p_global_indices = [global_dictionary.get(key, None) for key in self.transformed]
+
+        # p_indices map internal sensitivities to the global parameters. Note that they are part of the "public"
+        # interface. Basically, it is the indices of the exported model variables in the global parameter vector.
+        self.p_indices = [x for x in self._p_global_indices if x is not None]
+
+        # Which sensitivities are local (set to a fixed local value)?
+        self.p_local = [None if isinstance(x, str) else x for x in self.transformed]
+
+    @property
+    def transformed(self):
+        return self.transformations.values()
+
+    def localize_sensitivities(self, sensitivities):
+        """Convert raw model sensitivities to external sensitivities as used by the Fit."""
+        return sensitivities[:, self.p_external]
+
+    def get_local_params(self, par_global):
+        """Grab parameters required to simulate the model from the global parameter vector. Merge in the local
+        parameters as well."""
+        return [par_global[a] if a is not None else b for a, b in zip(self._p_global_indices, self.p_local)]

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -1,0 +1,353 @@
+from .parameters import Parameter, Params
+from .detail.utilities import optimal_plot_layout, print_styled
+from .detail.derivative_manipulation import numerical_jacobian, numerical_diff
+from collections import OrderedDict
+from copy import deepcopy
+
+import inspect
+import types
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+class Model:
+    def __init__(self, name, model_function, dependent=None, independent=None, jacobian=None, derivative=None, eqn=None,
+                 eqn_tex=None, **kwargs):
+        """
+        Model constructor. A Model must be named, and this name will appear in the model parameters.
+
+        Ideally a jacobian and derivative w.r.t. the independent variable are provided with every model. This will
+        allow much higher performance when fitting. Jacobians and derivatives are automatically propagated to composite
+        models, inversions of models etc. provided that all participating models have jacobians and derivatives
+        specified.
+
+        Parameters
+        ----------
+        name : str
+            Name for the model. This name will be prefixed to the model parameter names.
+        model_function : callable
+            Function containing the model function. Must return the model prediction given values for the independent
+            variable and parameters.
+        dependent : str (optional)
+            Name of the dependent variable
+        independent : str (optional)
+            Name of the independent variable
+        jacobian : callable (optional)
+            Function which computes the first order derivatives with respect to the parameters for this model.
+            When supplied, this function is used to speed up the optimization considerably.
+        derivative : callable (optional)
+            Function which computes the first order derivative with respect to the independent parameter. When supplied
+            this speeds up model inversions considerably.
+        eqn : str (optional)
+            Equation that this model is specified by.
+        eqn_tex : str (optional)
+            Equation that this model is specified by using TeX formatting.
+        **kwargs
+            Key pairs containing parameter defaults. For instance, Lc=Parameter(...)
+
+        Examples
+        --------
+        ::
+
+            from lumicks import pylake
+
+            dna_model = pylake.inverted_odijk("DNA")
+            fit = pylake.FdFit(dna_model)
+            fit.add_data("my data", force, distance)
+
+            fit["DNA/Lp"].lower_bound = 35  # Set lower bound for DNA Lp
+            fit["DNA/Lp"].upper_bound = 80  # Set upper bound for DNA Lp
+            fit.fit()
+
+            fit.plot("my data", "k--")  # Plot the fitted model
+        """
+        assert isinstance(name, str), "First argument must be a model name."
+        assert isinstance(model_function, types.FunctionType), "Model must be a callable."
+
+        if jacobian:
+            assert isinstance(jacobian, types.FunctionType), "Jacobian must be a callable."
+
+        if derivative:
+            assert isinstance(derivative, types.FunctionType), "Derivative must be a callable."
+
+        def formatter(x):
+            return f"{name}/{x}"
+
+        self.name = name
+        (self.eqn, self.eqn_tex) = (eqn, eqn_tex)
+        self.model_function = model_function
+
+        args = inspect.getfullargspec(model_function).args
+        parameter_names = args[1:]
+        self.independent = independent if independent else args[0]
+        self.dependent = dependent
+
+        for key in kwargs:
+            assert key in parameter_names, "Attempted to set default for parameter which is not present in model."
+
+        self._params = OrderedDict()
+        for key in parameter_names:
+            if key in kwargs:
+                assert isinstance(kwargs[key], Parameter), "Passed a non-parameter as model default."
+                if kwargs[key].shared:
+                    self._params[key] = deepcopy(kwargs[key])
+                else:
+                    self._params[formatter(key)] = deepcopy(kwargs[key])
+            else:
+                self._params[formatter(key)] = None
+
+        self._jacobian = jacobian
+        self._derivative = derivative
+
+    def __call__(self, independent, params):
+        """Evaluate the model for specific parameters
+
+        Parameters
+        ----------
+        independent : array_like
+        params : ``pylake.fitting.Params``
+        """
+        independent = np.asarray(independent, dtype=np.float64)
+        return self._raw_call(independent, np.asarray([params[name].value for name in self.parameter_names],
+                                                      dtype=np.float64))
+
+    def _raw_call(self, independent, param_vector):
+        return self.model_function(independent, *param_vector)
+
+    def get_formatted_equation_string(self, tex):
+        if self.eqn:
+            if tex:
+                return (f"${self.dependent}\\left({self.independent}\\right) = "
+                        f"{self.eqn_tex(self.independent, *[escape_tex(x) for x in self._params.keys()])}$")
+            else:
+                return (f"{self.dependent}({self.independent}) = "
+                        f"{self.eqn(self.independent, *[x.replace('/', '.') for x in self._params.keys()])}")
+
+    def _repr_html_(self):
+        doc_string = ''
+        try:
+            doc = self.model_function.__doc__.replace('\n', '  <br>\n')
+            doc_string = f"{doc}  <br><br>\n"
+        except AttributeError:
+            # If it is not a top level model, there will be no docstring. This is fine.
+            pass
+
+        equation = self.get_formatted_equation_string(tex=True)
+        equation = f"<h5>Model equation:</h5>\n{equation}<br><br>\n" if equation else ""
+
+        model_info = (f"<h5>Model: {self.name}</h5>\n"
+                      f"{doc_string}{equation}"
+                      f"<h5>Parameter defaults:</h5>\n"
+                      f"{Params(**self._params)._repr_html_()}\n")
+
+        return model_info
+
+    def __repr__(self):
+        equation = self.get_formatted_equation_string(tex=False)
+        equation = f"Model equation:\n\n{equation}\n\n" if equation else ""
+
+        model_info = (f"Model: {self.name}\n\n"
+                      f"{equation}Parameter defaults:\n\n"
+                      f"{Params(**self._params)._repr_()}\n")
+
+        return model_info
+
+    @property
+    def defaults(self):
+        return self._params
+
+    @property
+    def parameter_names(self):
+        return [x for x in self._params.keys()]
+
+    def jacobian(self, independent, param_vector):
+        """
+        Return model sensitivities at specific values for the independent variable. Returns None when the model does not
+        have an appropriately defined Jacobian.
+
+        Parameters
+        ----------
+        independent : array_like
+            Values for the independent variable at which the Jacobian needs to be returned.
+        param_vector : array_like
+            Parameter vector at which to simulate.
+        """
+        if self.has_jacobian:
+            independent = np.asarray(independent, dtype=np.float64)
+            return self._jacobian(independent, *param_vector)
+        else:
+            raise RuntimeError(f"Jacobian was requested but not supplied in model {self.name}.")
+
+    def derivative(self, independent, param_vector):
+        """
+        Return derivative w.r.t. the independent variable at specific values for the independent variable. Returns None
+        when the model does not have an appropriately defined derivative.
+
+        Parameters
+        ----------
+        independent : array_like
+            Values for the independent variable at which the derivative needs to be returned.
+        param_vector : array_like
+            Parameter vector at which to simulate.
+        """
+        if self.has_derivative:
+            independent = np.asarray(independent, dtype=np.float64)
+            return self._derivative(independent, *param_vector)
+        else:
+            raise RuntimeError(f"Derivative was requested but not supplied in model {self.name}.")
+
+    @property
+    def has_jacobian(self):
+        """Returns true if the model can return an analytically computed Jacobian."""
+        if self._jacobian:
+            return True
+
+    @property
+    def has_derivative(self):
+        """Returns true if the model can return an analytically computed derivative w.r.t. the independent variable."""
+        if self._derivative:
+            return True
+
+    def _calculate_residual(self, data_sets, global_param_values):
+        """Calculate the model residual
+        """
+        residual_idx = 0
+        residual = np.zeros(data_sets.n_residuals)
+        for condition, data_list in data_sets.conditions():
+            p_local = condition.get_local_params(global_param_values)
+            for data in data_list:
+                y_model = self._raw_call(data.x, p_local)
+
+                residual[residual_idx:residual_idx + len(y_model)] = data.y - y_model
+                residual_idx += len(y_model)
+
+        return residual
+
+    def _calculate_jacobian(self, data_sets, global_param_values):
+        residual_idx = 0
+        jacobian = np.zeros((data_sets.n_residuals, len(global_param_values)))
+        for condition, data_list in data_sets.conditions():
+            p_local = condition.get_local_params(global_param_values)
+            p_indices = condition.p_indices
+            for data in data_list:
+                sensitivities = condition.localize_sensitivities(np.transpose(self.jacobian(data.x, p_local)))
+                n_res = sensitivities.shape[0]
+
+                jacobian[residual_idx:residual_idx + n_res, p_indices] -= sensitivities
+
+                residual_idx += n_res
+
+        return jacobian
+
+    def verify_jacobian(self, independent, params, plot=False, verbose=True, dx=1e-6, **kwargs):
+        """
+        Verify this model's Jacobian with respect to the independent variable by comparing it to the Jacobian
+        obtained with finite differencing.
+
+        Parameters
+        ----------
+        independent : array_like
+            Values for the independent variable at which to compare the Jacobian.
+        params : array_like
+            Parameter vector at which to compare the Jacobian.
+        plot : bool
+            Plot the results (default = False)
+        verbose : bool
+            Print the result (default = True)
+        dx : float
+            Finite difference excursion.
+        **kwargs :
+            Forwarded to `~matplotlib.pyplot.plot`.
+        """
+        if len(params) != len(self._params):
+            raise ValueError("Parameter vector has invalid length. "
+                             f"Expected: {len(self._params)}, got: {len(params)}.")
+
+        independent = np.asarray(independent, dtype=np.float64)
+        jacobian = self.jacobian(independent, params)
+        jacobian_fd = numerical_jacobian(lambda param_values: self._raw_call(independent, param_values),
+                                         params, dx=dx)
+
+        jacobian = np.asarray(jacobian)
+        if plot:
+            n_x, n_y = optimal_plot_layout(len(self._params))
+            for i_param, param in enumerate(self._params):
+                plt.subplot(n_x, n_y, i_param+1)
+                l1 = plt.plot(independent, np.transpose(jacobian[i_param, :]))
+                l2 = plt.plot(independent, np.transpose(jacobian_fd[i_param, :]), '--')
+                plt.title(param)
+                plt.legend({'Analytic', 'FD'})
+
+        is_close = np.allclose(jacobian, jacobian_fd, **kwargs)
+        if not is_close:
+            if verbose:
+                maxima = np.max(jacobian - jacobian_fd, axis=1)
+                for i, v in enumerate(maxima):
+                    if np.allclose(jacobian[i, :], jacobian_fd[i, :]):
+                        print(f"Parameter {self.parameter_names[i]}({i}): {v}")
+                    else:
+                        print_styled('warning', f'Parameter {self.parameter_names[i]}({i}): {v}')
+
+        return is_close
+
+    def verify_derivative(self, independent, params, dx=1e-6, **kwargs):
+        """
+        Verify this model's derivative with respect to the independent variable by comparing it to the derivative
+        obtained with finite differencing.
+
+        Parameters
+        ----------
+        independent : array_like
+            Values for the independent variable at which to compare the derivative.
+        params : array_like
+            Parameter vector at which to compare the derivative.
+        dx : float
+            Finite difference excursion.
+        """
+
+        if len(params) != len(self._params):
+            raise ValueError("Parameter vector has invalid length. "
+                             f"Expected: {len(self._params)}, got: {len(params)}.")
+
+        derivative = self.derivative(independent, params)
+        derivative_fd = numerical_diff(lambda x: self._raw_call(x, params), independent, dx=dx)
+
+        return np.allclose(derivative, derivative_fd, **kwargs)
+
+    def plot(self, params, independent, fmt='', **kwargs):
+        """Plot this model for a specific data set.
+
+        Parameters
+        ----------
+        params : Params
+            Parameter set, typically obtained from a Fit.
+        independent : array_like
+            Array of values for the independent variable.
+        fmt : str (optional)
+            Plot formatting string (see `matplotlib.pyplot.plot` documentation).
+        **kwargs :
+            Forwarded to `~matplotlib.pyplot.plot`.
+
+        Examples
+        --------
+        ::
+
+            dna_model = pylake.inverted_odijk("DNA")  # Use an inverted Odijk eWLC model.
+            fit = pylake.FdFit(dna_model)
+            fit.add_data("data1", force1, distance1)
+            fit.add_data("data2", force2, distance2, {"DNA/Lc": "DNA/Lc_RecA"})
+            fit.fit()
+
+            # Option 1
+            fit.plot("data 1", 'k--', distance1)  # Plot model simulations for data set 1
+            fit.plot("data 2", 'k--', distance2)  # Plot model simulations for data set 2
+
+            # Option 2
+            dna_model.plot(fit["data1"], distance1, 'k--')  # Plot model simulations for data set 1
+            dna_model.plot(fit["data2"], distance2, 'k--')  # Plot model simulations for data set 2
+        """
+        # Admittedly not very pythonic, but the errors you get otherwise are confusing.
+        if not isinstance(params, Params):
+            raise RuntimeError('Did not pass Params')
+
+        return plt.plot(independent, self(independent, params), fmt, **kwargs)

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -1,5 +1,5 @@
 from .parameters import Parameter, Params
-from .detail.utilities import optimal_plot_layout, print_styled
+from .detail.utilities import optimal_plot_layout, print_styled, solve_formatter_tex, escape_tex
 from .detail.derivative_manipulation import numerical_jacobian, numerical_diff, invert_function, invert_jacobian, \
     invert_derivative
 from collections import OrderedDict

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -1,7 +1,7 @@
 from .parameters import Parameter, Params
 from .detail.utilities import optimal_plot_layout, print_styled, solve_formatter_tex, escape_tex, solve_formatter
 from .detail.derivative_manipulation import numerical_jacobian, numerical_diff, invert_function, invert_jacobian, \
-    invert_derivative
+    invert_derivative, invert_function_interpolation
 from collections import OrderedDict
 from copy import deepcopy
 

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -1,5 +1,5 @@
 from .parameters import Parameter, Params
-from .detail.utilities import optimal_plot_layout, print_styled, solve_formatter_tex, escape_tex
+from .detail.utilities import optimal_plot_layout, print_styled, solve_formatter_tex, escape_tex, solve_formatter
 from .detail.derivative_manipulation import numerical_jacobian, numerical_diff, invert_function, invert_jacobian, \
     invert_derivative
 from collections import OrderedDict

--- a/lumicks/pylake/fitting/models.py
+++ b/lumicks/pylake/fitting/models.py
@@ -1,0 +1,292 @@
+from .parameters import Parameter
+
+
+def force_offset(name):
+    """Offset on the the model output.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    """
+    from .model import Model
+    from .detail.model_implementation import (
+        force_offset_model,
+        offset_model_jac,
+        offset_model_derivative,
+        offset_equation,
+        offset_equation_tex
+    )
+
+    return Model(
+        name,
+        force_offset_model,
+        dependent="f",
+        jacobian=offset_model_jac,
+        eqn=offset_equation,
+        eqn_tex=offset_equation_tex,
+        derivative=offset_model_derivative,
+        f_offset=Parameter(value=0.01, lower_bound=-0.1, upper_bound=0.1, unit="pN"),
+    )
+
+
+def distance_offset(name):
+    """Offset on the the model output.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    """
+    from .model import Model
+    from .detail.model_implementation import (
+        distance_offset_model,
+        offset_model_jac,
+        offset_model_derivative,
+        offset_equation,
+        offset_equation_tex
+    )
+
+    return Model(
+        name,
+        distance_offset_model,
+        dependent="d",
+        jacobian=offset_model_jac,
+        eqn=offset_equation,
+        eqn_tex=offset_equation_tex,
+        derivative=offset_model_derivative,
+        d_offset=Parameter(value=0.01, lower_bound=-0.1, upper_bound=0.1, unit="micron"),
+    )
+
+
+def marko_siggia_ewlc_force(name):
+    """Marko Siggia's Worm-like Chain model with force as dependent parameter.
+
+    References:
+        1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
+        8759-8770 (1995).
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    """
+    from .model import Model
+    from .detail.model_implementation import (
+        marko_sigga_ewlc_solve_force,
+        marko_sigga_ewlc_solve_force_jac,
+        marko_sigga_ewlc_solve_force_derivative,
+        marko_sigga_ewlc_solve_force_equation,
+        marko_sigga_ewlc_solve_force_equation_tex,
+        Defaults,
+    )
+
+    return Model(
+        name,
+        marko_sigga_ewlc_solve_force,
+        dependent="f",
+        jacobian=marko_sigga_ewlc_solve_force_jac,
+        derivative=marko_sigga_ewlc_solve_force_derivative,
+        eqn=marko_sigga_ewlc_solve_force_equation,
+        eqn_tex=marko_sigga_ewlc_solve_force_equation_tex,
+        kT=Defaults.kT,
+        Lp=Defaults.Lp,
+        Lc=Defaults.Lc,
+        St=Defaults.St,
+    )
+
+
+def marko_siggia_ewlc_distance(name):
+    """Marko Siggia's Worm-like Chain model with distance as dependent parameter.
+
+    References:
+        1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
+        8759-8770 (1995).
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    """
+    from .model import Model
+    from .detail.model_implementation import (
+        marko_sigga_ewlc_solve_distance,
+        marko_sigga_ewlc_solve_distance_jac,
+        marko_sigga_ewlc_solve_distance_derivative,
+        marko_sigga_ewlc_solve_distance_equation,
+        marko_sigga_ewlc_solve_distance_equation_tex,
+        Defaults,
+    )
+
+    return Model(
+        name,
+        marko_sigga_ewlc_solve_distance,
+        dependent="d",
+        jacobian=marko_sigga_ewlc_solve_distance_jac,
+        derivative=marko_sigga_ewlc_solve_distance_derivative,
+        eqn=marko_sigga_ewlc_solve_distance_equation,
+        eqn_tex=marko_sigga_ewlc_solve_distance_equation_tex,
+        kT=Defaults.kT,
+        Lp=Defaults.Lp,
+        Lc=Defaults.Lc,
+        St=Defaults.St,
+    )
+
+
+def marko_siggia_simplified(name):
+    """Markov Siggia's Worm-like Chain model based on only entropic contributions (valid for F << 10 pN).
+
+    References:
+        1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
+        8759-8770 (1995).
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    """
+    from .model import Model
+    from .detail.model_implementation import (
+        Marko_Siggia,
+        Marko_Siggia_jac,
+        Marko_Siggia_derivative,
+        Marko_Siggia_equation,
+        Marko_Siggia_equation_tex,
+        Defaults,
+    )
+
+    return Model(
+        name,
+        Marko_Siggia,
+        dependent="f",
+        jacobian=Marko_Siggia_jac,
+        derivative=Marko_Siggia_derivative,
+        eqn=Marko_Siggia_equation,
+        eqn_tex=Marko_Siggia_equation_tex,
+        kT=Defaults.kT,
+        Lp=Defaults.Lp,
+        Lc=Defaults.Lc,
+    )
+
+
+def odijk(name):
+    """Odijk's Extensible Worm-Like Chain model with distance as dependent variable (useful for 10 pN < F < 30 pN).
+
+    References:
+      1. T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules
+         28, 7016-7018 (1995).
+      2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
+         DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    """
+    from .model import Model
+    from .detail.model_implementation import WLC, WLC_jac, WLC_derivative, WLC_equation, WLC_equation_tex, Defaults
+
+    return Model(
+        name,
+        WLC,
+        dependent="d",
+        jacobian=WLC_jac,
+        derivative=WLC_derivative,
+        eqn=WLC_equation,
+        eqn_tex=WLC_equation_tex,
+        kT=Defaults.kT,
+        Lp=Defaults.Lp,
+        Lc=Defaults.Lc,
+        St=Defaults.St,
+    )
+
+
+def inverted_odijk(name):
+    """Odijk's Extensible Worm-Like Chain model with force as dependent variable (useful for 10 pN < F < 30 pN).
+
+    References:
+      1. T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules
+         28, 7016-7018 (1995).
+      2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
+         DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    """
+    from .model import Model
+    from .detail.model_implementation import (
+        invWLC,
+        invWLC_jac,
+        invWLC_derivative,
+        invWLC_equation,
+        invWLC_equation_tex,
+        Defaults
+    )
+
+    return Model(
+        name,
+        invWLC,
+        dependent="f",
+        jacobian=invWLC_jac,
+        derivative=invWLC_derivative,
+        eqn=invWLC_equation,
+        eqn_tex=invWLC_equation_tex,
+        kT=Defaults.kT,
+        Lp=Defaults.Lp,
+        Lc=Defaults.Lc,
+        St=Defaults.St,
+    )
+
+
+def freely_jointed_chain(name):
+    """Freely-Jointed Chain with distance as dependent parameter.
+
+    References:
+        1. S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The
+           Elastic Response of Individual Double-Stranded and Single-Stranded
+           DNA Molecules, Science 271, 795-799 (1996).
+        2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
+           DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    """
+    from .model import Model
+    from .detail.model_implementation import FJC, FJC_jac, FJC_derivative, FJC_equation, FJC_equation_tex, Defaults
+
+    return Model(
+        name,
+        FJC,
+        dependent="d",
+        jacobian=FJC_jac,
+        eqn=FJC_equation,
+        eqn_tex=FJC_equation_tex,
+        derivative=FJC_derivative,
+        kT=Defaults.kT,
+        Lp=Defaults.Lp,
+        Lc=Defaults.Lc,
+        St=Defaults.St,
+    )
+
+
+def inverted_freely_jointed_chain(name):
+    """Inverted Freely-Jointed Chain with force as dependent parameter.
+
+    References:
+        1. S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The
+           Elastic Response of Individual Double-Stranded and Single-Stranded
+           DNA Molecules, Science 271, 795-799 (1996).
+        2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
+           DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    """
+    from .model import InverseModel
+    return InverseModel(freely_jointed_chain(name))

--- a/lumicks/pylake/fitting/models.py
+++ b/lumicks/pylake/fitting/models.py
@@ -290,3 +290,91 @@ def inverted_freely_jointed_chain(name):
     """
     from .model import InverseModel
     return InverseModel(freely_jointed_chain(name))
+
+
+def twistable_wlc(name):
+    """Twistable Worm-like Chain model. With distance as dependent variable.
+
+    References:
+       1. P. Gross et al., Quantifying how DNA stretches, melts and changes
+          twist under tension, Nature Physics 7, 731-736 (2011).
+       2. Broekmans, Onno D., et al. DNA twist stability changes with
+          magnesium (2+) concentration, Physical review letters 116.25,
+          258102 (2016).
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    """
+    from .model import Model
+    from .detail.model_implementation import (
+        tWLC,
+        tWLC_jac,
+        tWLC_derivative,
+        tWLC_equation,
+        tWLC_equation_tex,
+        Defaults
+    )
+
+    return Model(
+        name,
+        tWLC,
+        dependent="d",
+        jacobian=tWLC_jac,
+        derivative=tWLC_derivative,
+        eqn=tWLC_equation,
+        eqn_tex=tWLC_equation_tex,
+        kT=Defaults.kT,
+        Lp=Defaults.Lp,
+        Lc=Defaults.Lc,
+        St=Defaults.St,
+        Fc=Parameter(value=30.6, lower_bound=0.0, upper_bound=50.0, unit="pN"),
+        C=Parameter(value=440.0, lower_bound=0.0, upper_bound=5000.0, unit="pN*nm**2"),
+        g0=Parameter(value=-637, lower_bound=-5000.0, upper_bound=0.0, unit="pN*nm"),
+        g1=Parameter(value=17.0, lower_bound=-100.0, upper_bound=1000.0, unit="nm"),
+    )
+
+
+def inverted_twistable_wlc(name):
+    """Twistable Worm-like Chain model. With force as dependent variable. This model uses a more performant implementation
+    for inverting the model. It inverts the model by interpolating the forward curve and using this interpolant to
+    invert the function.
+
+    References:
+       1. P. Gross et al., Quantifying how DNA stretches, melts and changes
+          twist under tension, Nature Physics 7, 731-736 (2011).
+       2. Broekmans, Onno D., et al. DNA twist stability changes with
+          magnesium (2+) concentration, Physical review letters 116.25,
+          258102 (2016).
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    """
+    from .model import Model
+    from .detail.model_implementation import (
+        invtWLC,
+        invtWLC_jac,
+        invtWLC_equation,
+        invtWLC_equation_tex,
+        Defaults
+    )
+
+    return Model(
+        name,
+        invtWLC,
+        dependent="f",
+        jacobian=invtWLC_jac,
+        eqn=invtWLC_equation,
+        eqn_tex=invtWLC_equation_tex,
+        kT=Defaults.kT,
+        Lp=Defaults.Lp,
+        Lc=Defaults.Lc,
+        St=Defaults.St,
+        Fc=Parameter(value=30.6, lower_bound=0.0, upper_bound=50.0, unit="pN"),
+        C=Parameter(value=440.0, lower_bound=0.0, upper_bound=5000.0, unit="pN*nm**2"),
+        g0=Parameter(value=-637, lower_bound=-5000.0, upper_bound=0.0, unit="pN*nm"),
+        g1=Parameter(value=17.0, lower_bound=0.0, upper_bound=1000.0, unit="nm"),
+    )

--- a/lumicks/pylake/fitting/parameter_trace.py
+++ b/lumicks/pylake/fitting/parameter_trace.py
@@ -1,0 +1,69 @@
+import numpy as np
+import scipy.optimize as optim
+
+
+def parameter_trace(model, params, inverted_parameter, independent, dependent, **kwargs):
+    """Invert a model with respect to one parameter. This function fits a unique parameter for every data point in
+    this data-set while keeping all other parameters fixed. This can be used to for example invert the model with
+    respect to the contour length or some other parameter.
+
+    Parameters
+    ----------
+    model : Model
+        Fitting model.
+    params : Params
+        Model parameters.
+    inverted_parameter : str
+        Parameter to invert.
+    independent : array_like
+        Vector of values for the independent variable
+    dependent : array_like
+        Vector of values for the dependent variable
+    **kwargs :
+        Forwarded to scipy.optimize.least_squares
+
+    Examples
+    --------
+    ::
+
+        # Define the model to be fitted
+        model = pylake.inverted_odijk("model") + pylake.force_offset("model")
+
+        # Fit the overall model first
+        model.add_data("dataset1", f=force_data, d=distance_data)
+        current_fit = pylake.FdFit(model)
+        data_handle = current_fit.add_data("my data", force, distance)
+        current_fit.fit()
+
+        # Calculate a per data point contour length
+        lcs = parameter_trace(model, current_fit[data_handle], "model/Lc", distance, force)
+    """
+    param_names = model.parameter_names
+    assert inverted_parameter in params, f"Inverted parameter not in model parameter vector {params}."
+    for key in param_names:
+        assert key in params, f"Missing parameter {key} in supplied parameter vector."
+
+    # Grab reference parameter vector and index for the parameter list
+    param_vector = [params[key].value for key in param_names]
+    lb = params[inverted_parameter].lower_bound
+    ub = params[inverted_parameter].upper_bound
+    inverted_parameter_index = param_names.index(inverted_parameter)
+
+    def fit_single_point(x, y):
+        x = np.asarray([x])
+
+        def residual(inverted_parameter_value):
+            param_vector[inverted_parameter_index] = inverted_parameter_value
+            return y - model._raw_call(x, param_vector)
+
+        def jacobian(inverted_parameter_value):
+            param_vector[inverted_parameter_index] = inverted_parameter_value
+            return -model.jacobian(x, param_vector)[inverted_parameter_index]
+
+        jac = jacobian if model.has_jacobian else "2-point"
+        result = optim.least_squares(residual, param_vector[inverted_parameter_index], jac=jac,
+                                     bounds=(lb, ub), method='trf', **kwargs)
+
+        return result.x[0]
+
+    return np.asarray([fit_single_point(x, y) for (x, y) in zip(independent, dependent)])

--- a/lumicks/pylake/fitting/parameters.py
+++ b/lumicks/pylake/fitting/parameters.py
@@ -1,0 +1,182 @@
+import numpy as np
+from collections import OrderedDict
+from tabulate import tabulate
+
+
+class Parameter:
+    __slots__ = ['value', 'lower_bound', 'upper_bound', 'fixed', 'shared', 'unit']  # Fixed attributes
+
+    def __init__(self, value=0.0, lower_bound=-np.inf, upper_bound=np.inf, fixed=False, shared=False,
+                 unit=None):
+        """Model parameter
+
+        Parameters
+        ----------
+        value : float
+            Parameter value
+        lower_bound, upper_bound : float
+            Lower and upper bound used in the fitting process. Parameters are not allowed to go beyond these bounds.
+        fixed : bool
+            Is this parameter fixed (not estimated from data)?
+        shared : bool
+            Is this parameter typically model specific or shared between models? An example of a model specific
+            parameter is the contour length of a protein, whereas the Boltzmann constant times temperate (kT) is an
+            example of a parameter that is typically shared between models.
+        unit : str
+            Unit of the parameter
+        """
+        self.value = value
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+        self.fixed = fixed
+        self.shared = shared
+        self.unit = unit
+
+    def __eq__(self, other):
+        return all((getattr(self, x) == getattr(other, x) for x in self.__slots__)) \
+            if isinstance(other, self.__class__) else False
+
+    def __repr__(self):
+        return f"lumicks.pylake.fdfit.Parameter(value: {self.value}, lower bound: {self.lower_bound}, upper bound: " \
+               f"{self.upper_bound}, fixed: {self.fixed})"
+
+    def __str__(self):
+        return self.__repr__()
+
+
+class Params:
+    """
+    Model parameters. Internally stored as a list of Parameter.
+
+    Examples
+    --------
+    ::
+        fit = pylake.FdFit(pylake.odijk("my_model"))
+
+        print(fit.params)  # Prints the model parameters
+        fit["test_parameter"].value = 5  # Set parameter test_parameter to 5
+        fit["fix_me"].fixed = True  # Fix parameter fix_me (do not fit)
+
+        # Copy parameters from another Parameters into this one.
+        parameters.update_params(other_parameters)
+
+        # Copy the parameters from an earlier fit into the combined model.
+        fit_combined_model.update_params(fit)
+    """
+    def __init__(self, **kwargs):
+        self._src = OrderedDict()
+        for key, value in kwargs.items():
+            if isinstance(value, Parameter):
+                self._src[key] = value
+            else:
+                self._src[key] = Parameter(float(value)) if value else Parameter(0)
+
+    def __iter__(self):
+        return self._src.__iter__()
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__ if isinstance(other, self.__class__) else False
+
+    def update_params(self, other):
+        """
+        Sets parameters if they are found in the target parameter list.
+
+        Parameters
+        ----------
+        other : Params
+        """
+        if isinstance(other, Params):
+            found = False
+            for key, param in other._src.items():
+                if key in self._src:
+                    self._src[key] = param
+                    found = True
+
+            if not found:
+                raise RuntimeError("Tried to set parameters which do not exist in the target model.")
+        else:
+            raise RuntimeError("Attempt to stream non-parameter list to parameter list.")
+
+    def items(self):
+        return self._src.items()
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            raise IndexError("Slicing not supported. Only indexing.")
+
+        if item in self._src:
+            return self._src[item]
+        else:
+            raise IndexError(f"Parameter {item} does not exist.")
+
+    def __setitem__(self, item, value):
+        if item in self._src:
+            self._src[item].value = value
+        else:
+            raise IndexError(f"Parameter {item} not found in parameter vector {self.keys}!")
+
+    def __len__(self):
+        return len(self._src)
+
+    def _print_data(self):
+        table = [[key, par.value, f'[{par.unit}]' if par.unit else 'NA', not par.fixed, par.lower_bound,
+                  par.upper_bound] for key, par in self._src.items()]
+        header = ['Name', 'Value', 'Unit', 'Fitted', 'Lower bound', 'Upper bound']
+        return table, header
+
+    def _repr_html_(self):
+        table, header = self._print_data()
+        return tabulate(table, header, tablefmt="html")
+
+    def _repr_(self):
+        table, header = self._print_data()
+        return tabulate(table, header, tablefmt="text")
+
+    def __str__(self):
+        if len(self._src) > 0:
+            table, header = self._print_data()
+            return tabulate(table, header)
+        else:
+            return "No parameters"
+
+    def _set_params(self, params, defaults):
+        """Rebuild the parameter vector. Note that this can potentially alter the parameter order if the strings are
+        given in a different order.
+
+        It mutates the parameter vector to contain the elements as specified in "parameters" with the defaults as
+        specified in defaults. If the parameter already exists in the vector nothing happens to it. If it doesn't,
+        it gets initialized to its default.
+
+        Parameters
+        ----------
+        params : list of str
+            parameter names
+        defaults : Parameter or None
+            default parameter objects
+        """
+        new_params = OrderedDict(zip(params, [x if isinstance(x, Parameter) else Parameter() for x in defaults]))
+        for key, value in self._src.items():
+            if key in new_params:
+                new_params[key] = value
+
+        self._src = new_params
+
+    @property
+    def keys(self):
+        return np.asarray([key for key in self._src.keys()])
+
+    @property
+    def values(self):
+        return np.asarray([param.value for param in self._src.values()], dtype=np.float64)
+
+    @property
+    def fitted(self):
+        return np.asarray([not param.fixed for param in self._src.values()], dtype=np.bool)
+
+    @property
+    def lower_bounds(self):
+        return np.asarray([param.lower_bound for param in self._src.values()], dtype=np.float64)
+
+    @property
+    def upper_bounds(self):
+        return np.asarray([param.upper_bound for param in self._src.values()], dtype=np.float64)

--- a/lumicks/pylake/fitting/parameters.py
+++ b/lumicks/pylake/fitting/parameters.py
@@ -101,8 +101,13 @@ class Params:
         return self._src.items()
 
     def __getitem__(self, item):
+        from .fitdata import FitData
+
         if isinstance(item, slice):
             raise IndexError("Slicing not supported. Only indexing.")
+
+        if isinstance(item, FitData):
+            return item.get_params(self)
 
         if item in self._src:
             return self._src[item]

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -3,10 +3,10 @@ import numpy as np
 
 from collections import OrderedDict
 from ..fitting.parameters import Params, Parameter
-from ..fitting.detail.utilities import parse_transformation, unique_idx
+from ..fitting.detail.utilities import parse_transformation, unique_idx, escape_tex, latex_sqrt
 from ..fitting.detail.link_functions import generate_conditions
 from ..fitting.fitdata import Condition, FitData
-from ..fitting.model import Model, CompositeModel, InverseModel
+from ..fitting.model import Model, InverseModel
 
 
 def test_transformation_parser():
@@ -218,6 +218,7 @@ def test_integration_test_fitting():
     model = Model("M", linear, jacobian=linear_jac_wrong)
     assert not model.verify_jacobian([1, 2, 3], [1, 1])
 
+
 def test_model_composition():
     def f(x, a, b):
         return a + b * x
@@ -279,3 +280,11 @@ def test_model_composition():
 
     assert m1.subtract_independent_offset().verify_jacobian(t, [-1.0, 2.0, 3.0], verbose=False)
     assert m1.subtract_independent_offset().verify_derivative(t, [-1.0, 2.0, 3.0])
+
+
+def test_tex_replacement():
+    assert escape_tex("DNA/Hi") == "Hi_{DNA}"
+    assert escape_tex("DNA/Hi_There") == "Hi\\_There_{DNA}"
+    assert escape_tex("DNA_model/Hi_There") == "Hi\\_There_{DNA\\_model}"
+    assert escape_tex("Hi_There") == "Hi\\_There"
+    assert latex_sqrt("test") == r"\sqrt{test}"

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -4,15 +4,16 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup
 
 from collections import OrderedDict
-from ..fitting.parameters import Params, Parameter
+from ..fitting.parameters import Params
 from ..fitting.detail.utilities import parse_transformation, unique_idx, escape_tex, latex_sqrt
 from ..fitting.detail.link_functions import generate_conditions
 from ..fitting.fitdata import Condition, FitData
 from ..fitting.model import Model, InverseModel
-from ..fitting.datasets import Datasets, FdDatasets
+from ..fitting.datasets import Datasets
 from ..fitting.fit import Fit, FdFit
 from ..fitting.detail.model_implementation import solve_cubic_wlc, invwlc_root_derivatives
 from ..fitting.models import *
+from ..fitting.parameter_trace import parameter_trace
 
 
 def test_transformation_parser():
@@ -622,6 +623,49 @@ def test_model_composition():
     inverted = composite.invert()
     assert inverted.dependent == "f"
     assert inverted.independent == "d"
+
+
+def test_parameter_inversion():
+    def f(x, a, b):
+        return a + b * x
+
+    def f_jac(x, a, b):
+        return np.vstack((np.ones((1, len(x))), x))
+
+    def g(x, a, d, b):
+        return a - b * x + d * x * x
+
+    def g_jac(x, a, d, b):
+        return np.vstack((np.ones((1, len(x))), x * x, -x))
+
+    def f_der(x, a, b):
+        return b * np.ones((len(x)))
+
+    def g_der(x, a, d, b):
+        return - b * np.ones((len(x))) + 2.0 * d * x
+
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    a_true = 5.0
+    b_true = np.array([1.0, 2.0, 3.0, 4.0, 10.0])
+    f_data = f(x, a_true, b_true)
+    model = Model("f", f, jacobian=f_jac, derivative=f_der)
+    fit = Fit(model)
+    fit._add_data("test", x, f_data)
+    fit.params["f/a"].value = a_true
+    fit.params["f/b"].value = 1.0
+    assert np.allclose(parameter_trace(model, fit.params, 'f/b', x, f_data), b_true)
+
+    a_true = 5.0
+    b_true = 3.0
+    d_true = np.array([1.0, 2.0, 3.0, 4.0, 10.0])
+    f_plus_g_data = f(x, a_true, b_true) + g(x, a_true, d_true, b_true)
+    model = Model("f", f, jacobian=f_jac, derivative=f_der) + Model("f", g, jacobian=g_jac, derivative=g_der)
+    fit = Fit(model)
+    fit._add_data("test", x, f_data)
+    fit.params["f/a"].value = a_true
+    fit.params["f/b"].value = b_true
+    fit.params["f/d"].value = 1.0
+    assert np.allclose(parameter_trace(model, fit.params, 'f/d', x, f_plus_g_data), d_true)
 
 
 def test_uncertainty_analysis():

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -1,0 +1,81 @@
+import pytest
+import numpy as np
+
+from ..fitting.parameters import Params, Parameter
+
+
+def test_params():
+    assert Parameter(5.0) == Parameter(5.0)
+    assert not Parameter(5.0) == Parameter(4.0)
+    assert Parameter(5.0, 0.0) == Parameter(5.0, 0.0)
+    assert not Parameter(5.0, 0.0) == Parameter(5.0, 1.0)
+    assert Parameter(5.0, 0.0, 1.0) == Parameter(5.0, 0.0, 1.0)
+    assert not Parameter(5.0, 0.0, 1.0) == Parameter(5.0, 0.0, 2.0)
+    assert Parameter(5.0, 0.0, 1.0, fixed=True) == Parameter(5.0, 0.0, 1.0, fixed=True)
+    assert not Parameter(5.0, 0.0, 1.0, fixed=True) == Parameter(5.0, 0.0, 1.0, fixed=False)
+    assert Parameter(5.0, 0.0, 1.0, unit="pN") == Parameter(5.0, 0.0, 1.0, unit="pN")
+    assert not Parameter(5.0, 0.0, 1.0, unit="pN") == Parameter(5.0, 0.0, 1.0, unit="potatoes")
+
+    assert Params(**{"M/a": Parameter(5.0), "M/b": Parameter(5.0)}) == \
+        Params(**{"M/a": Parameter(5.0), "M/b": Parameter(5.0)})
+
+    assert not Params(**{"M/a": Parameter(5.0), "M/b": Parameter(5.0)}) == \
+        Params(**{"M/a": Parameter(5.0), "M/b": Parameter(6.0)})
+
+    with pytest.raises(RuntimeError):
+        Params(**{"M/a": Parameter(5.0), "M/b": Parameter(5.0)}).update_params(5)
+
+    with pytest.raises(IndexError):
+        Params(**{"M/a": Parameter(5.0), "M/b": Parameter(5.0)})["M/a":"M/b"]
+
+    with pytest.raises(IndexError):
+        Params(**{"M/a": Parameter(5.0), "M/b": Parameter(5.0)})["M/c"].value = 5
+
+    with pytest.raises(IndexError):
+        Params(**{"M/a": Parameter(5.0), "M/b": Parameter(5.0)})["M/c"] = 5
+
+    assert str(Params()) == "No parameters"
+    assert str(Parameter(5.0, 0.0, 1.0, fixed=True)) == \
+        f"lumicks.pylake.fdfit.Parameter(value: {5.0}, lower bound: {0.0}, upper bound: {1.0}, fixed: {True})"
+
+    params = Params()
+    params._set_params(['alpha', 'beta', 'gamma'], [None]*3)
+    assert (params['beta'].value == 0.0)
+
+    params['beta'].value = 5.0
+    assert (np.allclose(params.values, [0.0, 5.0, 0.0]))
+
+    params._set_params(['alpha', 'beta', 'gamma', 'delta'], [None]*4)
+    assert (params['beta'].value == 5.0)
+    assert (np.allclose(params.values, [0.0, 5.0, 0.0, 0.0]))
+
+    params['gamma'].value = 6.0
+    params['delta'] = 7.0
+    params['gamma'].lower_bound = -4.0
+    params['gamma'].upper_bound = 5.0
+    assert (np.allclose(params.values, [0.0, 5.0, 6.0, 7.0]))
+    assert (np.allclose(params.lower_bounds, [-np.inf, -np.inf, -4.0, -np.inf]))
+    assert (np.allclose(params.upper_bounds, [np.inf, np.inf, 5.0, np.inf]))
+
+    assert(len(params) == 4.0)
+    params._set_params(['alpha', 'beta', 'delta'], [None]*3)
+    assert (np.allclose(params.values, [0.0, 5.0, 7.0]))
+    assert ([p for p in params] == ['alpha', 'beta', 'delta'])
+    assert(len(params) == 3.0)
+
+    for i, p in params.items():
+        p.value = 1.0
+
+    assert (np.allclose(params.values, [1.0, 1.0, 1.0]))
+
+    params = Params()
+    params._set_params(['alpha', 'beta', 'gamma'], [Parameter(2), Parameter(3), Parameter(4)])
+    params2 = Params()
+    params2._set_params(['gamma', 'potato', 'beta'], [Parameter(10), Parameter(11), Parameter(12)])
+    params.update_params(params2)
+    assert np.allclose(params.values, [2, 12, 10])
+
+    params2 = Params()
+    params2._set_params(['spaghetti'], [Parameter(10), Parameter(12)])
+    with pytest.raises(RuntimeError):
+        params.update_params(params2)

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -276,3 +276,6 @@ def test_model_composition():
     assert not (InverseModel(m1_wrong_derivative) + m2).verify_jacobian(t, [-1.0, 2.0, 3.0], verbose=False)
     assert not (InverseModel(m1_wrong_jacobian) + m2).verify_jacobian(t, [-1.0, 2.0, 3.0], verbose=False)
     assert not (InverseModel(m1_wrong_derivative) + m2).verify_derivative(t, [-1.0, 2.0, 3.0])
+
+    assert m1.subtract_independent_offset().verify_jacobian(t, [-1.0, 2.0, 3.0], verbose=False)
+    assert m1.subtract_independent_offset().verify_derivative(t, [-1.0, 2.0, 3.0])

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -8,6 +8,7 @@ from ..fitting.detail.link_functions import generate_conditions
 from ..fitting.fitdata import Condition, FitData
 from ..fitting.model import Model, InverseModel
 from ..fitting.datasets import Datasets
+from ..fitting.fit import Fit
 
 
 def test_transformation_parser():
@@ -185,6 +186,22 @@ def test_model_defaults():
     def g(data, mu, sig, a, b, c, d, e, f, q):
         return (data - mu) * 2
 
+    m = Model("M", g, f=Parameter(5))
+    f = Fit(m)
+    f._add_data("test", [1, 2, 3], [2, 3, 4])
+    f._add_data("test2", [1, 2, 3], [2, 3, 4], params={'M/f': 'f/new'})
+    f._build_fit()
+
+    assert (f["M/a"].value == Parameter().value)
+    assert (f.params["M/a"].value == Parameter().value)
+    assert (f.params["f/new"].value == 5)
+    assert (f.params["M/f"].value == 5)
+
+    # Check whether each parameter is actually unique
+    f.params["f/new"] = 6
+    assert (f.params["f/new"].value == 6)
+    assert (f.params["M/f"].value == 5)
+
     # Test whether providing a default for a parameter that doesn't exist throws
     with pytest.raises(AssertionError):
         Model("M", g, z=Parameter(5))
@@ -216,6 +233,128 @@ def test_datasets_build_status():
     assert not d.built
 
 
+def test_model_fit_object_linking():
+    def fetch_params(keys, indices):
+        p_list = list(f.params.keys)
+        return [p_list[x] if x is not None else None for x in indices]
+
+    def g(data, mu, sig, a, b, c, d, e, f, q):
+        return (data - mu) * 2
+
+    def h(data, mu, e, q, c, r):
+        return (data - mu) * 2
+
+    all_params = ["M/mu", "M/sig", "M/a", "M/b", "M/d", "M/e", "M/f", "M/q"]
+    m = Model("M", g, d=Parameter(4))
+    m2 = Model("M", h)
+
+    # Model should not be built
+    f = Fit(m, m2)
+    f[m]._add_data("test", [1, 2, 3], [2, 3, 4], {'M/c': 4})
+    assert f.dirty
+
+    # Asking for the parameters should have triggered a build
+    f.params
+    assert not f.dirty
+    assert set(f.params.keys) == set(all_params)
+
+    # Check the parameters included in the model
+    assert np.allclose(f.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
+    assert np.all(f.datasets[id(m)]._conditions[0].p_local == [None, None, None, None, 4, None, None, None, None])
+    assert fetch_params(f.params, f.datasets[id(m)]._conditions[0]._p_global_indices) == \
+           ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e", "M/f", "M/q"]
+
+    # Loading data should make it dirty again
+    f[m]._add_data("test2", [1, 2, 3], [2, 3, 4], {'M/c': 4, 'M/e': 'M/e_new'})
+    assert f.dirty
+
+    # Check the parameters included in the model
+    f._rebuild()
+    assert np.allclose(f.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
+    assert np.all(f.datasets[id(m)]._conditions[0].p_local == [None, None, None, None, 4, None, None, None, None])
+    assert fetch_params(f.params, f.datasets[id(m)]._conditions[0]._p_global_indices) == \
+           ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e", "M/f", "M/q"]
+
+    assert np.allclose(f.datasets[id(m)]._conditions[1].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
+    assert np.all(f.datasets[id(m)]._conditions[1].p_local == [None, None, None, None, 4, None, None, None, None])
+    assert fetch_params(f.params, f.datasets[id(m)]._conditions[1]._p_global_indices) == \
+           ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e_new", "M/f", "M/q"]
+
+    # Load data into model 2
+    f[m2]._add_data("test", [1, 2, 3], [2, 3, 4], {'M/c': 4, 'M/r': 6})
+    assert f.dirty
+
+    # Since M/r is set fixed in that model, it should not appear as a parameter
+    all_params = ["M/mu", "M/sig", "M/a", "M/b", "M/d", "M/e", "M/e_new", "M/f", "M/q"]
+    assert set(f.params.keys) == set(all_params)
+
+    all_params = ["M/mu", "M/sig", "M/a", "M/b", "M/d", "M/e", "M/e_new", "M/f", "M/q", "M/r"]
+    f[m2]._add_data("test2", [1, 2, 3], [2, 3, 4], {'M/c': 4, 'M/e': 5})
+    assert set(f.params.keys) == set(all_params)
+    assert np.allclose(f.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
+    assert np.all(f.datasets[id(m)]._conditions[0].p_local == [None, None, None, None, 4, None, None, None, None])
+    assert fetch_params(f.params, f.datasets[id(m)]._conditions[0]._p_global_indices) == \
+           ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e", "M/f", "M/q"]
+
+    assert np.allclose(f.datasets[id(m)]._conditions[1].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
+    assert np.all(f.datasets[id(m)]._conditions[1].p_local == [None, None, None, None, 4, None, None, None, None])
+    assert fetch_params(f.params, f.datasets[id(m)]._conditions[1]._p_global_indices) == \
+           ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e_new", "M/f", "M/q"]
+
+    assert np.allclose(f.datasets[id(m2)]._conditions[0].p_external, [0, 1, 2])
+    assert np.all(f.datasets[id(m2)]._conditions[0].p_local == [None, None, None, 4, 6])
+    assert fetch_params(f.params, f.datasets[id(m2)]._conditions[0]._p_global_indices) == \
+           ["M/mu", "M/e", "M/q", None, None]
+
+    assert fetch_params(f.params, f.datasets[id(m2)]._conditions[1]._p_global_indices) == \
+           ["M/mu", None, "M/q", None, "M/r"]
+
+    f.update_params(Params(**{"M/mu": 4, "M/sig": 6}))
+    assert f["M/mu"].value == 4
+    assert f["M/sig"].value == 6
+
+    f2 = Fit(m)
+    f2._add_data("test", [1, 2, 3], [2, 3, 4])
+    f2["M/mu"].value = 12
+
+    f.update_params(f2)
+    assert f["M/mu"].value == 12
+
+    with pytest.raises(RuntimeError):
+        f.update_params(5)
+
+
+def test_jacobian_test_fit():
+    def f(x, a, b):
+        return a + b * x
+
+    def f_jac(x, a, b):
+        return np.vstack((np.ones((1, len(x))), x))
+
+    def f_der(x, a, b):
+        return b * np.ones((len(x)))
+
+    def f_jac_wrong(x, a, b):
+        return np.vstack((2.0*np.ones((1, len(x))), x))
+
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    a_true, b_true = (5.0, 5.0)
+    f_data = f(x, a_true, b_true)
+    model = Model("f", f, jacobian=f_jac, derivative=f_der)
+    fit = Fit(model)
+    fit._add_data("test", x, f_data)
+    fit.params["f/a"].value = a_true
+    fit.params["f/b"].value = b_true
+    assert fit.verify_jacobian(fit.params.values)
+
+    model_bad = Model("f", f, jacobian=f_jac_wrong, derivative=f_der)
+    fit = Fit(model_bad)
+    fit._add_data("test", x, f_data)
+    fit.params["f/a"].value = a_true
+    fit.params["f/b"].value = b_true
+    assert not fit.verify_jacobian(fit.params.values)
+
+
 def test_integration_test_fitting():
     def linear(x, a, b):
         f = a * x + b
@@ -238,6 +377,48 @@ def test_integration_test_fitting():
 
     model = Model("M", linear, jacobian=linear_jac_wrong)
     assert not model.verify_jacobian([1, 2, 3], [1, 1])
+
+    model = Model("M", linear, jacobian=linear_jac)
+    fit = Fit(model)
+    x = np.arange(3)
+    for i in np.arange(3):
+        y = 4.0*x*i + 5.0
+        fit._add_data(f"test {i}", x, y, params={'M/a': f'slope_{i}'})
+
+    y = 4.0*x + 10.0
+    fit._add_data("test x", x, y, params={'M/a': 'slope_1', 'M/b': 'M/b_2'})
+
+    # Test whether fixed parameters are not fitted
+    fit["slope_2"].fixed = True
+    fit.fit()
+    assert (np.isclose(fit["slope_2"].value, 0))
+
+    fit["slope_2"].fixed = False
+    fit.fit()
+    assert(len(fit.params.values) == 5)
+    assert(len(fit.params) == 5)
+    assert(fit.n_residuals == 12)
+    assert(fit.n_params == 5)
+
+    assert(np.isclose(fit.params["slope_0"].value, 0))
+    assert(np.isclose(fit.params["slope_1"].value, 4))
+    assert(np.isclose(fit.params["slope_2"].value, 8))
+    assert(np.isclose(fit.params["M/b"].value, 5))
+    assert(np.isclose(fit.params["M/b_2"].value, 10))
+
+    # Verify that fixed parameters are correctly removed from sub-models
+    model = Model("M", linear, jacobian=linear_jac)
+    fit = Fit(model)
+    fit._add_data("test1", x, 4.0*x + 5.0, {'M/a': 4})
+    fit._add_data("test2", x, 8.0*x + 10.0, {'M/b': 10})
+    fit.fit()
+    assert (np.isclose(fit.params["M/b"].value, 5))
+    assert (np.isclose(fit.params["M/a"].value, 8))
+
+    fit["M/a"].upper_bound = 4
+    fit["M/a"].value = 5
+    with pytest.raises(ValueError):
+        fit.fit()
 
 
 def test_model_composition():
@@ -301,6 +482,124 @@ def test_model_composition():
 
     assert m1.subtract_independent_offset().verify_jacobian(t, [-1.0, 2.0, 3.0], verbose=False)
     assert m1.subtract_independent_offset().verify_derivative(t, [-1.0, 2.0, 3.0])
+
+
+def test_uncertainty_analysis():
+    x = np.arange(10)
+    y = np.array([8.24869073, 7.77648717, 11.9436565, 14.85406276, 22.73081526, 20.39692261, 32.48962353, 31.4775862,
+                  37.63807819, 40.50125925])
+
+    def quad(x, a=1, b=1, c=1):
+        return a * x * x + b * x + c
+
+    def quad_jac(x, a=1, b=1, c=1):
+        return np.vstack((x*x, x, np.ones(len(x))))
+
+    def linear(x, a=1, b=1):
+        f = a * x + b
+        return f
+
+    def linear_jac(x, a, b):
+        J = np.vstack((x, np.ones(len(x))))
+        return J
+
+    linear_model = Model("linear", linear, jacobian=linear_jac)
+    linear_fit = Fit(linear_model)
+    linear_fit._add_data("test", x, y)
+    linear_fit.fit()
+    model_quad = Model("quad", quad, jacobian=quad_jac)
+    quad_fit = Fit(model_quad)
+    quad_fit._add_data("test", x, y)
+    quad_fit.fit()
+
+    assert np.allclose(linear_fit.cov, np.array([[0.06819348, -0.30687066], [-0.30687066,  1.94351415]]))
+    assert np.allclose(quad_fit.cov, np.array([[0.00973206, -0.08758855,  0.11678473],
+                                               [-0.08758855,  0.85058215, -1.33134597],
+                                               [0.11678473, -1.33134597,  3.17654476]]))
+
+    assert np.allclose(linear_fit.aic, 49.652690269143434)
+    assert np.allclose(linear_fit.aicc, 51.36697598342915)
+    assert np.allclose(linear_fit.bic, 50.25786045513153)
+
+    assert np.allclose(quad_fit.aic, 50.74643780988533)
+    assert np.allclose(quad_fit.aicc, 54.74643780988533)
+    assert np.allclose(quad_fit.bic, 51.654193088867466)
+
+
+def test_parameter_availability():
+    x = np.arange(10)
+    y = np.array([8.24869073, 7.77648717, 11.9436565, 14.85406276, 22.73081526, 20.39692261, 32.48962353, 31.4775862,
+                  37.63807819, 40.50125925])
+
+    def linear(x, a=1, b=1):
+        f = a * x + b
+        return f
+
+    def linear_jac(x, a, b):
+        J = np.vstack((x, np.ones(len(x))))
+        return J
+
+    linear_model = Model("linear", linear, jacobian=linear_jac)
+    linear_fit = Fit(linear_model)
+
+    with pytest.raises(IndexError):
+        linear_fit.params["linear/a"]
+
+    linear_fit._add_data("test", x, y, {'linear/a': 5})
+    linear_fit = Fit(linear_model)
+
+    # Parameter linear_a is not actually a parameter in the fit object at this point (it was set to 5)
+    with pytest.raises(IndexError):
+        linear_fit.params["linear/a"]
+
+    linear_fit._add_data("test", x, y)
+    assert linear_fit.params["linear/a"]
+
+
+def test_data_loading():
+    m = Model("M", lambda x, a: a*x)
+    fit = Fit(m)
+    fit._add_data("test", [1, np.nan, 3], [2, np.nan, 4])
+    assert np.allclose(fit[m].data["test"].x, [1, 3])
+    assert np.allclose(fit[m].data["test"].y, [2, 4])
+    assert np.allclose(fit[m].data["test"].independent, [1, 3])
+    assert np.allclose(fit[m].data["test"].dependent, [2, 4])
+
+    # Name must be unique
+    with pytest.raises(KeyError):
+        fit._add_data("test", [1, 3, 5], [2, 4, 5])
+
+    with pytest.raises(AssertionError):
+        fit._add_data("test2", [1, 3], [2, 4, 5])
+
+    with pytest.raises(AssertionError):
+        fit._add_data("test3", [1, 3, 5], [2, 4])
+
+    with pytest.raises(AssertionError):
+        fit._add_data("test4", [[1, 3, 5]], [[2, 4, 5]])
+
+
+def test_parameter_slicing():
+    # Tests whether parameters coming from a Fit can be sliced by a data handle,
+    # i.e. fit.params[data_handle]
+
+    def dummy(t, p1, p2, p3):
+        return t * p1 + t * p2 * p2 + t * p3 * p3 * p3
+
+    model = Model("dummy", dummy, p2=Parameter(2), p3=Parameter(3), p1=Parameter(1))
+    fit = Fit(model)
+    data_set = fit._add_data("data1", [1, 1, 1], [1, 2, 3], {'dummy/p2': 'dummy/p2_b'})
+    parameter_slice = fit.params[data_set]
+    assert (parameter_slice["dummy/p1"].value == 1)
+    assert (parameter_slice["dummy/p2"].value == 2)
+    assert (parameter_slice["dummy/p3"].value == 3)
+
+    data_set2 = fit._add_data("data2", [1, 1, 1], [1, 2, 3], {'dummy/p2': 'dummy/p2_c'})
+    fit.params["dummy/p2_c"] = 5
+    parameter_slice = fit.params[data_set]
+    assert (parameter_slice["dummy/p2"].value == 2)
+    parameter_slice = fit.params[data_set2]
+    assert (parameter_slice["dummy/p2"].value == 5)
 
 
 def test_tex_replacement():

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -1,7 +1,31 @@
 import pytest
 import numpy as np
 
+from collections import OrderedDict
 from ..fitting.parameters import Params, Parameter
+from ..fitting.detail.utilities import parse_transformation
+from ..fitting.detail.link_functions import generate_conditions
+from ..fitting.fitdata import Condition, FitData
+
+
+def test_transformation_parser():
+    pars = ['blip', 'foo']
+    assert parse_transformation(pars, {'foo': 'new_foo'}) == OrderedDict((('blip', 'blip'), ('foo', 'new_foo')))
+    assert parse_transformation(pars, {'foo': 5}) == OrderedDict((('blip', 'blip'), ('foo', 5)))
+
+    with pytest.raises(KeyError):
+        parse_transformation(pars, {'blap': 'new_foo'}) == OrderedDict((('blip', 'blip'), ('foo', 'new_foo')))
+
+    param_names = ['gamma', 'alpha', 'beta', 'delta']
+    params = OrderedDict(zip(param_names, param_names))
+    post_params = parse_transformation(params, {'gamma': 'gamma_specific', 'beta': 'beta_specific'})
+    assert (post_params['gamma'] == 'gamma_specific')
+    assert (post_params['alpha'] == 'alpha')
+    assert (post_params['beta'] == 'beta_specific')
+    assert (post_params['delta'] == 'delta')
+
+    with pytest.raises(KeyError):
+        parse_transformation(params, {'doesnotexist': 'yep'})
 
 
 def test_params():
@@ -79,3 +103,53 @@ def test_params():
     params2._set_params(['spaghetti'], [Parameter(10), Parameter(12)])
     with pytest.raises(RuntimeError):
         params.update_params(params2)
+
+
+def test_build_conditions():
+    param_names = ['a', 'b', 'c']
+    parameter_lookup = OrderedDict(zip(param_names, np.arange(len(param_names))))
+    d1 = FitData("name1", [1, 2, 3], [1, 2, 3], parse_transformation(param_names))
+    d2 = FitData("name2", [1, 2, 3], [1, 2, 3], parse_transformation(param_names))
+    d3 = FitData("name3", [1, 2, 3], [1, 2, 3], parse_transformation(param_names))
+
+    assert generate_conditions({"name1": d1, "name2": d2, "name3": d3}, parameter_lookup, param_names)
+
+    # Tests whether we pick up when a parameter that's generated in a transformation doesn't actually exist in the
+    # combined model
+    d4 = FitData("name4", [1, 2, 3], [1, 2, 3], parse_transformation(param_names, {'c': 'i_should_not_exist'}))
+    with pytest.raises(AssertionError):
+        assert generate_conditions({"name1": d1, "name2": d2, "name4": d4}, parameter_lookup, param_names)
+
+    # Tests whether we pick up on when a parameter exists in the model, but there's no transformation for it.
+    d5 = FitData("name5", [1, 2, 3], [1, 2, 3], parse_transformation(param_names))
+    param_names = ['a', 'b', 'c', 'i_am_new']
+    parameter_lookup = OrderedDict(zip(param_names, np.arange(len(param_names))))
+    with pytest.raises(AssertionError):
+        assert generate_conditions({"name1": d1, "name2": d2, "name5": d5}, parameter_lookup, param_names)
+
+    # Verify that the data gets linked up to the correct conditions
+    d1 = FitData("name1", [1, 2, 3], [1, 2, 3], parse_transformation(param_names))
+    d2 = FitData("name2", [1, 2, 3], [1, 2, 3], parse_transformation(param_names))
+    d6 = FitData("name6", [1, 2, 3], [1, 2, 3], parse_transformation(param_names, {'c': 'i_am_new'}))
+    conditions, data_link = generate_conditions({"name1": d1, "name2": d2, "name3": d6}, parameter_lookup, param_names)
+    assert np.all(data_link[0] == [d1, d2])
+    assert np.all(data_link[1] == [d6])
+
+    # Test whether a parameter transformation to a value doesn't lead to an error
+    d4 = FitData("name4", [1, 2, 3], [1, 2, 3], parse_transformation(param_names, {'c': 5}))
+    assert generate_conditions({"name1": d1, "name2": d2, "name3": d4}, parameter_lookup, param_names)
+
+
+def test_condition_struct():
+    param_names = ['gamma', 'alpha', 'beta', 'delta', 'gamma_specific', 'beta_specific', 'zeta']
+    parameter_lookup = OrderedDict(zip(param_names, np.arange(len(param_names))))
+    param_trafos = parse_transformation(['gamma', 'alpha', 'beta', 'delta', 'zeta'],
+                                            {'gamma': 'gamma_specific', 'delta': 5, 'beta': 'beta_specific'})
+    param_vector = np.array([2, 4, 6, 8, 10, 12, 14])
+
+    c = Condition(param_trafos, parameter_lookup)
+    assert (np.all(c.p_local == [None, None, None, 5, None]))
+    assert (np.allclose(param_vector[c.p_indices], [10, 4, 12, 14]))
+    assert (np.all(c.p_external == np.array([0, 1, 2, 4])))
+    assert (list(c.transformed) == ['gamma_specific', 'alpha', 'beta_specific', 5, 'zeta'])
+    assert (np.allclose(c.get_local_params(param_vector), [10, 4, 12, 5, 14]))

--- a/lumicks/pylake/tests/test_utilities.py
+++ b/lumicks/pylake/tests/test_utilities.py
@@ -1,5 +1,7 @@
-from lumicks.pylake.detail.utilities import first
+from lumicks.pylake.detail.utilities import first, unique, get_color, lighten_color
 import pytest
+import matplotlib as mpl
+import numpy as np
 
 
 def test_first():
@@ -10,3 +12,13 @@ def test_first():
         first((1, 2, 3), condition=lambda x: x % 5 == 0)
     with pytest.raises(StopIteration):
         first(())
+
+
+def test_unique():
+    uiq = unique(['str', 'str', 'hmm', 'potato', 'hmm', 'str'])
+    assert(uiq == ['str', 'hmm', 'potato'])
+
+
+def test_colors():
+    [mpl.colors.to_rgb(get_color(k)) for k in range(30)]
+    assert np.allclose(lighten_color([0.5, 0, 0], .2), [.7, 0, 0])

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     packages=PEP420PackageFinder.find(include=["lumicks.*"]),
     python_requires='>=3.6',
     install_requires=['pytest>=3.5', 'h5py>=2.9, <3.0', 'numpy>=1.14, <2',
-                      'scipy>=1.1, <2', 'matplotlib>=2.2', 'tifffile>=2018.11.6'],
+                      'scipy>=1.1, <2', 'matplotlib>=2.2', 'tifffile>=2018.11.6',
+                      'tabulate==0.8.6'],
     zip_safe=False,
 )


### PR DESCRIPTION
This pull requests adds F, d fitting capabilities to pylake. This framework allows global fitting of multiple datasets simultaneously, keeping some parameters the same between datasets and varying others. It also includes several polymer models that are typically used in literature. Where possible, models were provided in analytical form.

To improve performance, model Jacobians are provided and propagated via the chain rule for composite and inverted models. For the inverse models where the inverse is not available as an analytical function, the inversion was performed using least_squares (again using the analytical jacobian if supplied), or, in the case of the tWLC interpolation. 

Tests were added for each of the models as well as the complete fitting infrastructure.

It also adds API documentation, a tutorial and two examples.