### PR TITLE
Add literature page

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## v0.5.1 | t.b.d.
 * Add literature page to the documentation.
+* Fix docstring for `Fit.plot()`.
 
 ## v0.5.0 | 2020-06-08
 * Added F, d Fitting functionality (beta, see docs tutorial section `Fd Fitting` and examples `Twistable Worm-Like-Chain Fitting` and `RecA Fd Fitting`).

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.5.1 | t.b.d.
+* Add literature page to the documentation.
+
 ## v0.5.0 | 2020-06-08
 * Added F, d Fitting functionality (beta, see docs tutorial section `Fd Fitting` and examples `Twistable Worm-Like-Chain Fitting` and `RecA Fd Fitting`).
 * Fixed an issue which prevented images from being reconstructed when a debugger is attached. Problem resided in `reconstruct_image` which threw an exception when attempting to resize a `numpy` array while the debugger was holding a reference to it.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
+    'sphinxcontrib.bibtex',
     'numpydoc',
     'matplotlib.sphinxext.plot_directive',
     'nbexport'
@@ -242,7 +243,8 @@ latex_elements = {
     # 'pointsize': '10pt',
 
     # Additional stuff for the LaTeX preamble.
-    'preamble': r"\definecolor{VerbatimBorderColor}{rgb}{1,1,1}",
+    'preamble': r"\definecolor{VerbatimBorderColor}{rgb}{1,1,1}"
+                r"\usepackage{etoolbox}\patchcmd{\thebibliography}{\section*{\refname}}{}{}{}"
 
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,4 +29,12 @@ where you can also post any questions, comments or issues that you might have.
 
     api
 
-* :ref:`genindex`
+.. toctree::
+    :caption: Literature
+    :maxdepth: 2
+
+    zrefs.rst
+
+.. only:: html
+
+    * :ref:`genindex`

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,0 +1,97 @@
+@article{broekmans2016dna,
+  title={DNA twist stability changes with magnesium (2+) concentration},
+  author={Broekmans, Onno D and King, Graeme A and Stephens, Greg J and Wuite, Gijs JL},
+  journal={Physical review letters},
+  volume={116},
+  number={25},
+  pages={258102},
+  year={2016},
+  publisher={APS}
+}
+
+@article{cavanaugh1997unifying,
+  title={Unifying the derivations for the Akaike and corrected Akaike information criteria},
+  author={Cavanaugh, Joseph E},
+  journal={Statistics \& Probability Letters},
+  volume={33},
+  number={2},
+  pages={201--208},
+  year={1997},
+  publisher={Elsevier}
+}
+
+@article{maiwald2016driving,
+  title={Driving the model to its limit: profile likelihood based model reduction},
+  author={Maiwald, Tim and Hass, Helge and Steiert, Bernhard and Vanlier, Joep and Engesser, Raphael and Raue, Andreas and Kipkeew, Friederike and Bock, Hans H and Kaschek, Daniel and Kreutz, Clemens and others},
+  journal={PloS one},
+  volume={11},
+  number={9},
+  year={2016},
+  publisher={Public Library of Science}
+}
+
+@article{raue2009structural,
+  title={Structural and practical identifiability analysis of partially observed dynamical models by exploiting the profile likelihood},
+  author={Raue, Andreas and Kreutz, Clemens and Maiwald, Thomas and Bachmann, Julie and Schilling, Marcel and Klingm{\"u}ller, Ursula and Timmer, Jens},
+  journal={Bioinformatics},
+  volume={25},
+  number={15},
+  pages={1923--1929},
+  year={2009},
+  publisher={Oxford University Press}
+}
+
+@article{odijk1995stiff,
+  title={Stiff chains and filaments under tension},
+  author={Odijk, Theo},
+  journal={Macromolecules},
+  volume={28},
+  number={20},
+  pages={7016--7018},
+  year={1995},
+  publisher={ACS Publications}
+}
+
+@article{wang1997stretching,
+  title={Stretching DNA with optical tweezers.},
+  author={Wang, Michelle D and Yin, Hong and Landick, Robert and Gelles, Jeff and Block, Steven M},
+  journal={Biophysical journal},
+  volume={72},
+  number={3},
+  pages={1335},
+  year={1997},
+  publisher={The Biophysical Society}
+}
+
+@article{gross2011quantifying,
+  title={Quantifying how DNA stretches, melts and changes twist under tension},
+  author={Gross, Peter and Laurens, Niels and Oddershede, Lene B and Bockelmann, Ulrich and Peterman, Erwin JG and Wuite, Gijs JL},
+  journal={Nature Physics},
+  volume={7},
+  number={9},
+  pages={731--736},
+  year={2011},
+  publisher={Nature Publishing Group}
+}
+
+@article{smith1996overstretching,
+  title={Overstretching B-DNA: the elastic response of individual double-stranded and single-stranded DNA molecules},
+  author={Smith, Steven B and Cui, Yujia and Bustamante, Carlos},
+  journal={Science},
+  volume={271},
+  number={5250},
+  pages={795--799},
+  year={1996},
+  publisher={American Association for the Advancement of Science}
+}
+
+@article{marko1995stretching,
+  title={Stretching dna},
+  author={Marko, John F and Siggia, Eric D},
+  journal={Macromolecules},
+  volume={28},
+  number={26},
+  pages={8759--8770},
+  year={1995},
+  publisher={ACS Publications}
+}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ recommonmark
 scipy
 sphinx
 sphinx_rtd_theme
+sphinxcontrib-bibtex==0.4.2

--- a/docs/zrefs.rst
+++ b/docs/zrefs.rst
@@ -1,0 +1,23 @@
+This page lists references used for implementing specific functionality into Pylake. Please see below for more
+information on these topics.
+
+F,d Fitting
+-----------
+
+Several polymer models from literature were included. These include Odijk's extensible worm-like chain model
+:cite:`odijk1995stiff,wang1997stretching`, the Freely Jointed Chain model
+:cite:`smith1996overstretching,wang1997stretching`, the Marko-Siggia interpolation model :cite:`marko1995stretching`
+and the twistable worm-like chain model :cite:`broekmans2016dna,gross2011quantifying`.
+
+We used :cite:`broekmans2016dna` as reference material throughout the implementation of the F,d fitting routines, both
+as a starting point for the model implementations as well as for the procedure on how to reliably fit the twistable
+worm-like chain model (via its inverted form). For the twistable worm-like chain, we perform model inversion via
+interpolation rather than point-wise inversion through optimization analogously to :cite:`broekmans2016dna`. Parameter
+estimation is performed via Maximum Likelihood Estimation :cite:`maiwald2016driving,raue2009structural`. We also
+implemented several asymptotic information criteria for ranking model fits :cite:`cavanaugh1997unifying`.
+
+References
+----------
+
+.. bibliography:: refs.bib
+   :style: alpha

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -295,22 +295,22 @@ class Fit:
 
         Parameters
         ----------
-            data : str
-                Name of the data set to plot (optional, omission plots all for that model).
-            fmt : str
-                Format string, forwarded to :func:`matplotlib.pyplot.plot`.
-            independent : array_like
-                Array with values for the independent variable (used when plotting the model).
-            legend : bool
-                Show legend (default: True).
-            plot_data : bool
-                Show data (default: True).
-            overrides : dict
-                Parameter / value pairs which override parameter values in the current fit. Should be a dict of
-                {str: float} that provides values for parameters which should be set to particular values in the plot
-                (default: None);
-            ``**kwargs``
-                Forwarded to :func:`matplotlib.pyplot.plot`.
+        data : str
+            Name of the data set to plot (optional, omission plots all for that model).
+        fmt : str
+            Format string, forwarded to :func:`matplotlib.pyplot.plot`.
+        independent : array_like
+            Array with values for the independent variable (used when plotting the model).
+        legend : bool
+            Show legend (default: True).
+        plot_data : bool
+            Show data (default: True).
+        overrides : dict
+            Parameter / value pairs which override parameter values in the current fit. Should be a dict of
+            {str: float} that provides values for parameters which should be set to particular values in the plot
+            (default: None);
+        ``**kwargs``
+            Forwarded to :func:`matplotlib.pyplot.plot`.
 
         Examples
         --------


### PR DESCRIPTION
This PR adds a literature/references page to rtd.

It adds bibtex as a dependency for building the docs (tested on rtd).

Note that the page is called `zref` since it has to be the last page parsed (requirement from sphinxcontrib-bibtex).

I piggybacked a fixup in the docs for `Fit.plot()` since its a small fix and also affects docs.