### PR TITLE
Hotfix damaged kymographs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
 - "3.7-dev"
 install:
 - pip install .
+- pip install virtualenv==16.3.0
+before_script:
+  - python -c 'import os, virtualenv; virtualenv.install_distutils(os.environ["VIRTUAL_ENV"])'
 script:
 - pytest
 deploy:

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * Add literature page to the documentation.
 * Fix docstring for `Fit.plot()`.
 * Verify starting timestamp when reconstructing Kymo or Scan.
+* Optimized reconstruction algorithm for sum.
 
 ## v0.5.0 | 2020-06-08
 * Added F, d Fitting functionality (beta, see docs tutorial section `Fd Fitting` and examples `Twistable Worm-Like-Chain Fitting` and `RecA Fd Fitting`).

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## v0.5.1 | t.b.d.
 * Add literature page to the documentation.
 * Fix docstring for `Fit.plot()`.
+* Verify starting timestamp when reconstructing Kymo or Scan.
 
 ## v0.5.0 | 2020-06-08
 * Added F, d Fitting functionality (beta, see docs tutorial section `Fd Fitting` and examples `Twistable Worm-Like-Chain Fitting` and `RecA Fd Fitting`).

--- a/lumicks/pylake/fitting/detail/utilities.py
+++ b/lumicks/pylake/fitting/detail/utilities.py
@@ -26,8 +26,8 @@ def parse_transformation(params, param_transform={}):
 
 
 def optimal_plot_layout(n_plots):
-    n_x = np.ceil(np.sqrt(n_plots))
-    n_y = np.ceil(n_plots/n_x)
+    n_x = int(np.ceil(np.sqrt(n_plots)))
+    n_y = int(np.ceil(n_plots/n_x))
 
     return n_x, n_y
 

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -4,7 +4,7 @@ import warnings
 
 from .detail.mixin import PhotonCounts
 from .detail.mixin import ExcitationLaserPower
-from .detail.image import reconstruct_image, save_tiff, ImageMetadata, line_timestamps_image, \
+from .detail.image import reconstruct_image_sum, reconstruct_image, save_tiff, ImageMetadata, line_timestamps_image, \
     seek_timestamp_next_line
 from .detail.timeindex import to_timestamp
 from .detail.utilities import first
@@ -99,8 +99,7 @@ class Kymo(PhotonCounts, ExcitationLaserPower):
     def _image(self, color):
         if color not in self._cache:
             photon_counts = getattr(self, f"{color}_photon_count").data
-            self._cache[color] = reconstruct_image(photon_counts, self.infowave.data,
-                                                   self.pixels_per_line).T
+            self._cache[color] = reconstruct_image_sum(photon_counts, self.infowave.data, self.pixels_per_line).T
         return self._cache[color]
 
     def _has_incorrect_start(self, timeline_start):

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -2,7 +2,7 @@ import json
 import numpy as np
 
 from .kymo import Kymo
-from .detail.image import reconstruct_image, reconstruct_num_frames
+from .detail.image import reconstruct_image_sum, reconstruct_image, reconstruct_num_frames
 
 
 class Scan(Kymo):
@@ -48,8 +48,8 @@ class Scan(Kymo):
     def _image(self, color):
         if color not in self._cache:
             photon_counts = getattr(self, f"{color}_photon_count").data
-            self._cache[color] = reconstruct_image(photon_counts, self.infowave.data,
-                                                   self.pixels_per_line, self.lines_per_frame)
+            self._cache[color] = reconstruct_image_sum(photon_counts, self.infowave.data, self.pixels_per_line,
+                                                       self.lines_per_frame)
         return self._cache[color]
 
     def _timestamps(self, sample_timestamps):

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -860,8 +860,19 @@ def test_analytic_roots():
     a = np.array([0])
     b = np.array([-3])
     c = np.array([1])
-    print(np.allclose(np.sort(np.roots([1, a, b, c])), np.sort(
-        [solve_cubic_wlc(a, b, c, 0)[0], solve_cubic_wlc(a, b, c, 1)[0], solve_cubic_wlc(a, b, c, 2)[0]])))
+
+    assert np.allclose(
+        np.sort(np.roots(np.array([np.array(1.0), a, b, c], dtype=np.float64))),
+        np.sort(
+            np.array(
+                [
+                    solve_cubic_wlc(a, b, c, 0)[0],
+                    solve_cubic_wlc(a, b, c, 1)[0],
+                    solve_cubic_wlc(a, b, c, 2)[0],
+                ],
+            )
+        ),
+    )
 
     with pytest.raises(RuntimeError):
         solve_cubic_wlc(a, b, c, 3)
@@ -873,9 +884,8 @@ def test_analytic_roots():
         db = (solve_cubic_wlc(a, b + dx, c, root) - ref_root) / dx
         dc = (solve_cubic_wlc(a, b, c + dx, root) - ref_root) / dx
 
-        print([da[0], db[0], dc[0]])
-        print(np.array(invwlc_root_derivatives(a, b, c, root)))
-        assert np.allclose(np.array(invwlc_root_derivatives(a, b, c, root)), np.array([da, db, dc]), atol=1e-5, rtol=1e-5)
+        assert np.allclose(np.array(invwlc_root_derivatives(a, b, c, root)), np.array([da, db, dc]), atol=1e-5,
+                           rtol=1e-5)
 
     test_root_derivatives(0)
     test_root_derivatives(1)

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
-from lumicks.pylake.detail.image import reconstruct_image, reconstruct_num_frames, save_tiff, ImageMetadata, line_timestamps_image
+from lumicks.pylake.detail.image import reconstruct_image, reconstruct_image_sum, reconstruct_num_frames, save_tiff,\
+    ImageMetadata, line_timestamps_image
 
 
 def test_metadata_from_json():
@@ -56,6 +57,14 @@ def test_reconstruct():
     assert image.shape == (2, 2)
     assert np.all(image == [[4, 8], [12, 0]])
 
+    image = reconstruct_image_sum(the_data, infowave, 5)
+    assert image.shape == (1, 5)
+    assert np.all(image == [4, 8, 12, 0, 0])
+
+    image = reconstruct_image_sum(the_data, infowave, 2)
+    assert image.shape == (2, 2)
+    assert np.all(image == [[4, 8], [12, 0]])
+
 
 def test_reconstruct_multiframe():
     size = 100
@@ -69,6 +78,13 @@ def test_reconstruct_multiframe():
     assert reconstruct_image(the_data, infowave, 2, 2).shape == (3, 2, 2)
     assert reconstruct_image(the_data, infowave, 2, 3).shape == (2, 3, 2)
     assert reconstruct_image(the_data, infowave, 2, 5).shape == (5, 2)
+
+    assert reconstruct_image_sum(the_data, infowave, 5).shape == (2, 5)
+    assert reconstruct_image_sum(the_data, infowave, 2).shape == (5, 2)
+    assert reconstruct_image_sum(the_data, infowave, 1).shape == (10, 1)
+    assert reconstruct_image_sum(the_data, infowave, 2, 2).shape == (3, 2, 2)
+    assert reconstruct_image_sum(the_data, infowave, 2, 3).shape == (2, 3, 2)
+    assert reconstruct_image_sum(the_data, infowave, 2, 5).shape == (5, 2)
 
     assert reconstruct_num_frames(infowave, 2, 2) == 3
     assert reconstruct_num_frames(infowave, 2, 3) == 2

--- a/lumicks/pylake/tests/test_scan.py
+++ b/lumicks/pylake/tests/test_scan.py
@@ -10,11 +10,11 @@ def test_scans(h5_file):
 
         assert repr(scan) == "Scan(pixels=(5, 4))"
 
-        reference_timestamps = [[2.006250e+10, 2.109375e+10, 2.206250e+10, 2.309375e+10],
-                                [2.025000e+10, 2.128125e+10, 2.225000e+10, 2.328125e+10],
-                                [2.043750e+10, 2.146875e+10, 2.243750e+10, 2.346875e+10],
-                                [2.062500e+10, 2.165625e+10, 2.262500e+10, 2.365625e+10],
-                                [2.084375e+10, 2.187500e+10, 2.284375e+10, 2.387500e+10]]
+        reference_timestamps = np.array([[2.006250e+10, 2.109375e+10, 2.206250e+10, 2.309375e+10],
+                                        [2.025000e+10, 2.128125e+10, 2.225000e+10, 2.328125e+10],
+                                        [2.043750e+10, 2.146875e+10, 2.243750e+10, 2.346875e+10],
+                                        [2.062500e+10, 2.165625e+10, 2.262500e+10, 2.365625e+10],
+                                        [2.084375e+10, 2.187500e+10, 2.284375e+10, 2.387500e+10]], dtype=np.int64)
 
         assert np.allclose(scan.timestamps, np.transpose(reference_timestamps))
         assert scan.num_frames == 1
@@ -30,3 +30,14 @@ def test_scans(h5_file):
 
         with pytest.raises(NotImplementedError):
             scan["1s":"2s"]
+
+
+def test_damaged_scan(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+
+    if f.format_version == 2:
+        scan = f.scans["Scan1"]
+
+        scan.start = scan.red_photon_count.timestamps[0] - 1  # Assume the user incorrectly exported only a partial scan
+        with pytest.raises(RuntimeError):
+            scan.red_image.shape


### PR DESCRIPTION
Related to issues [LAKE-94](https://lumicks.atlassian.net/browse/LAKE-94) and [NG-2706](https://lumicks.atlassian.net/browse/NG-2706). We got a file through support that had a kymograph for which the corresponding photon channel data was not available all the way up to the start (i.e.. `photon_count._src.start > kymo.start`). In this case reconstruction would quietly fail and produce wrong images and timestamps.

This PR fixes that. 

For kymographs it reconstructs by omitting the first line (and giving a warning about the issue). For scans it raises an exception, as there's not enough information to reliably reconstruct a multi-image scan.

It also implements a more efficient way of doing the reconstruction for photon counts that doesn't rely on fixed pixel size. Originally, I was also going to treat the timestamps in this manner, but this could lead to overflows in cumsum, even when subtracting the timestamp at `t=0` (to get rid of the since epoch offset). Overflow occurs at `t = (np.sqrt(i_max*2*(facq/time_format) + (1/8)) + .5)/(facq)` which for the normal samplerate is around 485.9 seconds of acquisition.