### PR TITLE
scan: fix reconstruction bug when fast axis in y direction

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## v0.5.1 | t.b.d.
+## v0.6.0 | t.b.d.
 * Add literature page to the documentation.
 * Fix docstring for `Fit.plot()`.
 * Verify starting timestamp when reconstructing Kymo or Scan.
 * Optimized reconstruction algorithm for sum.
+* Fixed bug related to reconstruction failing for images with flipped fast and slow axis.
+* Plot and return images and timestamps for kymos using physical coordinate system rather than fast and slow scanning axis. Note that this is a potentially breaking change!
 
 ## v0.5.0 | 2020-06-08
 * Added F, d Fitting functionality (beta, see docs tutorial section `Fd Fitting` and examples `Twistable Worm-Like-Chain Fitting` and `RecA Fd Fitting`).

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -81,6 +81,14 @@ class Kymo(PhotonCounts, ExcitationLaserPower):
         return first(self.json["scan volume"]["scan axes"], lambda x: x["axis"] == axis)
 
     @property
+    def _fast_axis_metadata(self):
+        return self.json["scan volume"]["scan axes"][0]
+
+    @property
+    def fast_axis(self):
+        return "X" if self._fast_axis_metadata["axis"] == 0 else "Y"
+
+    @property
     def has_fluorescence(self) -> bool:
         return self.json["fluorescence"]
 
@@ -94,7 +102,7 @@ class Kymo(PhotonCounts, ExcitationLaserPower):
 
     @property
     def pixels_per_line(self):
-        return self._get_axis_metadata(0)["num of pixels"]
+        return self._fast_axis_metadata["num of pixels"]
 
     def _image(self, color):
         if color not in self._cache:

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -226,6 +226,46 @@ def h5_file(tmpdir_factory, request):
         ds.attrs["Start time (ns)"] = np.int64(20e9)
         ds.attrs["Stop time (ns)"] = np.int64(20e9 + len(infowave) * freq)
 
+        json_string = enc.encode({
+            "value0": {
+                "cereal_class_version": 1,
+                "fluorescence": True,
+                "force": False,
+                "scan count": 0,
+                "scan volume": {
+                    "center point (um)": {
+                        "x": 58.075877109272604,
+                        "y": 31.978375270573267,
+                        "z": 0
+                    },
+                    "cereal_class_version": 1,
+                    "pixel time (ms)": 0.2,
+                    "scan axes": [
+                        {
+                            "axis": 1,
+                            "cereal_class_version": 1,
+                            "num of pixels": 4,
+                            "pixel size (nm)": 10,
+                            "scan time (ms)": 0,
+                            "scan width (um)": 36.07468112612217
+                        },
+                        {
+                            "axis": 0,
+                            "cereal_class_version": 1,
+                            "num of pixels": 3,
+                            "pixel size (nm)": 10,
+                            "scan time (ms)": 0,
+                            "scan width (um)": 36.07468112612217
+                        },
+                    ]
+                }
+            }
+        })
+
+        ds = mock_file.make_json_data("Scan", "Scan2", json_string)
+        ds.attrs["Start time (ns)"] = np.int64(20e9)
+        ds.attrs["Stop time (ns)"] = np.int64(20e9 + len(infowave) * freq)
+
     return mock_file.file
 
 

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -9,8 +9,20 @@ def test_scans(h5_file):
     f = pylake.File.from_h5py(h5_file)
     if f.format_version == 2:
         scan = f.scans["Scan1"]
-        assert scan.pixels_per_line == 5
-        assert np.allclose(scan.red_image, [[2, 0, 0, 0, 2], [0, 0, 0, 0, 0], [1, 0, 0, 0, 1], [0, 1, 1, 1, 0]])
+        assert scan.pixels_per_line == 4  # Fast axis
+        assert np.allclose(scan.red_image, np.transpose([[2, 0, 0, 0], [2, 0, 0, 0], [0, 0, 1, 0], [0, 0, 1, 0], [1, 1, 1, 0]]))
+
+        scan2 = f.scans["Scan2"]
+        reference = np.array([[[2, 0, 0, 0], [2, 0, 0, 0], [0, 0, 1, 0]], [[0, 0, 1, 0], [1, 1, 1, 0], [0, 0, 0, 0]]])
+        reference = np.transpose(reference, [0, 2, 1])
+        assert np.allclose(scan2.red_image, reference)
+
+        scan2 = f.scans["Scan2"]
+        rgb = np.zeros((2, 4, 3, 3))
+        rgb[:, :, :, 0] = reference
+        rgb[:, :, :, 1] = reference
+        rgb[:, :, :, 2] = reference
+        assert np.allclose(scan2.rgb_image, rgb)
 
 
 def test_kymos(h5_file):
@@ -96,7 +108,7 @@ def test_properties(h5_file):
     if f.format_version == 1:
         assert f.scans == {}
     else:
-        assert len(f.scans) == 1
+        assert len(f.scans) == 2
     assert f.point_scans == {}
     assert f.fdcurves == {}
 
@@ -217,6 +229,7 @@ def test_repr_and_str(h5_file):
             
             .scans
               - Scan1
+              - Scan2
             
             .force1x
               .calibration

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -25,6 +25,7 @@ def test_kymo_properties(h5_file):
         assert kymo.blue_image.shape == (5, 4)
         assert kymo.green_image.shape == (5, 4)
         assert np.allclose(kymo.timestamps, reference_timestamps)
+        assert kymo.fast_axis == "X"
 
 
 def test_kymo_slicing(h5_file):

--- a/lumicks/pylake/tests/test_scan.py
+++ b/lumicks/pylake/tests/test_scan.py
@@ -8,28 +8,47 @@ def test_scans(h5_file):
     if f.format_version == 2:
         scan = f.scans["Scan1"]
 
-        assert repr(scan) == "Scan(pixels=(5, 4))"
+        assert repr(scan) == "Scan(pixels=(4, 5))"
 
-        reference_timestamps = np.array([[2.006250e+10, 2.109375e+10, 2.206250e+10, 2.309375e+10],
-                                        [2.025000e+10, 2.128125e+10, 2.225000e+10, 2.328125e+10],
-                                        [2.043750e+10, 2.146875e+10, 2.243750e+10, 2.346875e+10],
-                                        [2.062500e+10, 2.165625e+10, 2.262500e+10, 2.365625e+10],
-                                        [2.084375e+10, 2.187500e+10, 2.284375e+10, 2.387500e+10]], dtype=np.int64)
+        reference_timestamps = np.array([[2.006250e+10, 2.025000e+10, 2.043750e+10, 2.062500e+10],
+                                        [2.084375e+10, 2.109375e+10, 2.128125e+10, 2.146875e+10],
+                                        [2.165625e+10, 2.187500e+10, 2.206250e+10, 2.225000e+10],
+                                        [2.243750e+10, 2.262500e+10, 2.284375e+10, 2.309375e+10],
+                                        [2.328125e+10, 2.346875e+10, 2.365625e+10, 2.387500e+10]])
 
         assert np.allclose(scan.timestamps, np.transpose(reference_timestamps))
         assert scan.num_frames == 1
         assert scan.has_fluorescence
         assert not scan.has_force
-        assert scan.pixels_per_line == 5
-        assert scan.lines_per_frame == 4
+        assert scan.pixels_per_line == 4
+        assert scan.lines_per_frame == 5
         assert len(scan.infowave) == 64
         assert scan.rgb_image.shape == (4, 5, 3)
         assert scan.red_image.shape == (4, 5)
         assert scan.blue_image.shape == (4, 5)
         assert scan.green_image.shape == (4, 5)
+        assert scan.fast_axis == "Y"
 
         with pytest.raises(NotImplementedError):
             scan["1s":"2s"]
+
+        scan = f.scans["Scan2"]
+        reference_timestamps2 = np.zeros((2, 4, 3))
+        reference_timestamps2[0, :, :] = reference_timestamps.T[:, :3]
+        reference_timestamps2[1, :, :2] = reference_timestamps.T[:, 3:]
+
+        assert np.allclose(scan.timestamps, reference_timestamps2)
+        assert scan.num_frames == 2
+        assert scan.has_fluorescence
+        assert not scan.has_force
+        assert scan.pixels_per_line == 4
+        assert scan.lines_per_frame == 3
+        assert len(scan.infowave) == 64
+        assert scan.rgb_image.shape == (2, 4, 3, 3)
+        assert scan.red_image.shape == (2, 4, 3)
+        assert scan.blue_image.shape == (2, 4, 3)
+        assert scan.green_image.shape == (2, 4, 3)
+        assert scan.fast_axis == "Y"
 
 
 def test_damaged_scan(h5_file):


### PR DESCRIPTION
Fixes issue in [LAKE-95](https://lumicks.atlassian.net/browse/LAKE-95) pertaining to the reconstruction of scans.

The reconstruction of images with a fast axis in y-direction failed due to changes made in https://github.com/lumicks/pylake/pull/19 . The axis flip should have been implemented post-reconstruction as data is acquired in the order specified in the json (fast axis being the first axis in the list).

This PR fixes the issue as well as hardens some of the scan tests (by including multi-frame scans as this almost caused a regression while doing the fix).