### PR TITLE
Kymotracker Algorithm 2

### DIFF
--- a/lumicks/pylake/kymotracker/detail/peakfinding.py
+++ b/lumicks/pylake/kymotracker/detail/peakfinding.py
@@ -1,0 +1,129 @@
+import numpy as np
+from scipy.ndimage import gaussian_filter, grey_dilation
+from scipy.signal import convolve2d
+import math
+
+
+def peak_estimate(data, half_width, thresh):
+    """Estimate initial peak locations from data. Peaks are detected by dilating the image, and then determining which
+    pixels did not change. These pixels correspond to local maxima. A threshold is then applied to select which ones
+    are relevant.
+
+    Parameters
+    ----------
+    data : array_like
+        A 2D image of pixel data.
+    half_width : int
+        How much to dilate the image in pixels. This is value should be half of the width we are looking for
+        (rounded upwards). Prior to peak finding, the image is dilated symmetrically. With a half_width of 1 this
+        means turning [0 0 1 0 0] into [0 1 1 1 0] prior to peak-finding.
+    thresh : float
+        Threshold for accepting something as a peak.
+    """
+    dilation_factor = int(math.ceil(half_width)) * 2 + 1
+    data = gaussian_filter(data, [.5, .5])
+    dilated = grey_dilation(data, (dilation_factor, 0))
+    dilated[dilated < thresh] = -1
+    coordinates, time_points = np.where(data == dilated)
+    return coordinates, time_points
+
+
+class KymoPeaks:
+    """Stores local maxima found in a kymograph on a per-frame basis."""
+
+    class Frame:
+        """Stores local maxima found in a kymograph for a single frame."""
+        def __init__(self, coordinates, time_points, peak_amplitudes):
+            self.coordinates = coordinates
+            self.time_points = time_points
+            self.peak_amplitudes = peak_amplitudes
+            self.unassigned = []
+
+        def reset_assignment(self):
+            self.unassigned = np.ones(self.time_points.shape, dtype=np.bool)
+
+    def __init__(self, coordinates, time_points, peak_amplitudes):
+        assert len(coordinates) == len(time_points)
+        assert len(peak_amplitudes) == len(time_points)
+
+        self.frames = []
+        max_frame = math.ceil(np.max(time_points))
+        for current_frame in np.arange(max_frame + 1):
+            (in_frame_idx,) = np.where(
+                np.logical_and(
+                    time_points >= current_frame, time_points < current_frame + 1
+                )
+            )
+            self.frames.append(
+                self.Frame(
+                    coordinates[in_frame_idx],
+                    time_points[in_frame_idx],
+                    peak_amplitudes[in_frame_idx],
+                )
+            )
+
+    def reset_assignment(self):
+        for frame in self.frames:
+            frame.reset_assignment()
+
+    def flatten(self):
+        coordinates = np.hstack([frame.coordinates for frame in self.frames])
+        time_points = np.hstack([frame.time_points for frame in self.frames])
+        peak_amplitudes = np.hstack([frame.peak_amplitudes for frame in self.frames])
+
+        return coordinates, time_points, peak_amplitudes
+
+
+def refine_peak_based_on_moment(data, coordinates, time_points, half_kernel_size, max_iter=100, eps=1e-7):
+    """This function adjusts the coordinates estimate by a brightness weighted centroid around the initial estimate.
+    This estimate is obtained by filtering the image with a kernel. If a pixel offset has a larger magnitude than 0.5
+    then the pixel is moved and the centroid recomputed. The process is repeated until there are no more changes.
+    Convergence usually occurs within a few iterations.
+
+    Parameters
+    ----------
+    data : array_like
+        A 2D image of pixel data (first axis corresponds to coordinates, second to time points).
+    coordinates : array_like
+        Initial coordinate estimates.
+    time_points : array_like
+        Time points at which the coordinate estimates were made.
+    half_kernel_size : int
+        Half of the kernel size in pixels. The kernel is used to refine the line estimate. The kernel size used for this
+        refinement will be 2 * half_kernel_size + 1.
+    max_iter : int
+        Maximum number of iterations
+    eps : float
+        We add a little offset to the normalization to prevent divisions by zeros on pixels that did not have any photon
+        counts. Eps sets this offset.
+    """
+    half_kernel_size = int(math.ceil(half_kernel_size))
+    dir_kernel = np.expand_dims(np.arange(half_kernel_size, -(half_kernel_size + 1), -1), 1)
+    mean_kernel = np.ones((2 * half_kernel_size + 1, 1))
+    coordinates = np.copy(coordinates)
+
+    m0 = convolve2d(data, mean_kernel, 'same')
+    subpixel_offset = convolve2d(data, dir_kernel, 'same') / (m0 + eps)
+
+    iteration = 0
+    done = False
+    max_coordinates = subpixel_offset.shape[0]
+    while not done:
+        offsets = subpixel_offset[coordinates, time_points]
+        out_of_bounds, = np.nonzero(abs(offsets) > 0.5)
+        coordinates[out_of_bounds] += np.sign(offsets[out_of_bounds]).astype(np.int)
+
+        # Edge cases (literally)
+        low = coordinates < 0
+        coordinates[low] = 0
+        high = coordinates >= max_coordinates
+        coordinates[high] = max_coordinates - 1
+
+        done = out_of_bounds.size - np.sum(low) - np.sum(high) == 0
+
+        if iteration > max_iter:
+            raise RuntimeError("Iteration limit exceeded")
+
+        iteration += 1
+
+    return KymoPeaks(coordinates + subpixel_offset[coordinates, time_points], time_points, m0[coordinates, time_points])

--- a/lumicks/pylake/kymotracker/detail/scoring_functions.py
+++ b/lumicks/pylake/kymotracker/detail/scoring_functions.py
@@ -1,44 +1,50 @@
 import numpy as np
 
 
-def cone_score(x, t, vel, sigma, sigma_diffusion):
-    """This function returns an estimates mean and sigma for future time points based on a velocity, fixed uncertainty
-    and diffusion rate. This is used to compute a scoring function to determine whether two local maxima should be
-    linked.
+def kymo_diff_score(t, coordinate, t_prediction, vel, sigma, sigma_diffusion):
+    """Estimate mean and sigma for future time points.
+
+    This function returns a mean and sigma based on a velocity, fixed uncertainty and diffusion rate. This is used to
+    compute a scoring function to determine whether two local maxima should be linked.
 
     We expect the future to be a combination of a base uncertainty, a diffusion and a constant velocity. The stdev for
     the particle at time point t for the diffusion process is given by:
         sigma(t) = N(mu(t), sigma*sqrt(t)).
-    mu is simply given by the prediction based on velocity.
+    mu is simply given by the prediction based on constant velocity in this model.
 
     Parameters
     ----------
-        x : array_like
-            Coordinates
-        t : array_like
-            Time points
+        t : float
+            Current time
+        coordinate : float
+            Current position
+        t_prediction : array_like
+            Coordinates for which to compute a probability
         vel : float
             Estimated velocity of the particle
-        sigma : float
-            Base positional variability
+        sigma: float
+            Starting uncertainty of the cone.
         sigma_diffusion : float
             Sigma representing diffusion. For diffusion, the spread is characterized by:
-                Sigma(t) = sigma_diffusion * sqrt(t)
+              Sigma(t) = sigma_diffusion * sqrt(t)
             Note that sigma_diffusion equates to sqrt(2*D) where D is the diffusion constant.
     """
 
-    assert np.all(t > 0)
-    mu_t = x + vel * t
-    sigma_t = sigma + sigma_diffusion * np.sqrt(t)
+    temporal_diff = t_prediction - t
+    assert np.all(temporal_diff > 0)
+    mu_t = coordinate + vel * temporal_diff
+    sigma_t = sigma + sigma_diffusion * np.sqrt(temporal_diff)
 
     return mu_t, sigma_t
 
 
-def build_score_matrix(lines, times, coordinates, sigma, sigma_diffusion, sigma_cutoff, vel):
-    """Builds a score matrix for a combination of lines and positions. The score matrix contains a score for each
-    line, point pair. For each line, we calculate a penalty function which reflects a score associated with connecting
-    those two lines. In the current implementation these are based on a Gaussian cone around the most likely trajectory.
-    Sigma provides a starting width, whereas diffusion widens the cone over time.
+def build_score_matrix(lines, times, coordinates, model, sigma_cutoff):
+    """Build score matrix for a combination of lines and positions.
+
+    The score matrix contains a score for each line, point pair. For each line, we calculate a penalty function which
+    reflects a score associated with connecting those two lines. In the current implementation these are based on a
+    Gaussian cone around the most likely trajectory. Sigma provides a starting width, whereas diffusion widens the cone
+    over time.
 
     Since the score is simply used as a relative scoring metric, and we are not interested in the absolute values,
     we do not have to exponentiate the Gaussian.
@@ -48,31 +54,24 @@ def build_score_matrix(lines, times, coordinates, sigma, sigma_diffusion, sigma_
 
     Parameters
     ----------
-    lines: list of pylake.Line
+    lines: List[pylake.Line]
     times: array_like
         Time points corresponding to the identified kymograph peaks.
     coordinates : array_like
         Positions of the identified kymograph peaks.
-    sigma: float
-        Starting uncertainty of the cone.
-    sigma_diffusion:
-        Sigma representing diffusion. For diffusion, the spread is characterized by:
-          Sigma(t) = sigma_diffusion * sqrt(t)
-        Note that sigma_diffusion equates to sqrt(2*D) where D is the diffusion constant.
+    model : callable
+        Model which takes a particle's time and position and a list of prediction time points and then produces a mu
+        and sigma for each of these future time points.
     sigma_cutoff: float
         At what fraction of sigma are points not going to be connected to this line at all?
-    vel: float
-        mean velocity of moving particles.
     """
     score_matrix = -np.inf * np.ones((len(lines), len(coordinates)))
 
     for i, line in enumerate(lines):
         tip_time = line.time[-1]
         tip_position = line.coordinate[-1]
-        temporal_diff = times - tip_time
 
-        # Calculate probability cone
-        mu_t, sigma_t = cone_score(tip_position, temporal_diff, vel, sigma, sigma_diffusion)
+        mu_t, sigma_t = model(tip_time, tip_position, times)
         cutoff_lb = mu_t - sigma_cutoff * sigma_t
         cutoff_ub = mu_t + sigma_cutoff * sigma_t
 
@@ -81,3 +80,29 @@ def build_score_matrix(lines, times, coordinates, sigma, sigma_diffusion, sigma_
         score_matrix[i, candidates] = -((coordinates[candidates] - mu_t[candidates]) / sigma_t[candidates]) ** 2
 
     return score_matrix
+
+
+def kymo_score(vel=0, sigma=2, diffusion=0):
+    """Return callable model used for computing linking scores.
+
+    Model is comprised of a constant velocity (vel), an uncertainty (sigma) and a diffusion component (diffusion).
+    Based on these three pieces of information, one can compute a mean and sigma for future time points given by:
+
+        mu(t) = x + vel * t
+        sigma(t) = sigma + sigma_diffusion * sqrt(t)
+
+    These two values describe a probability density which is returned by the function.
+
+    Parameters
+    ----------
+    vel: float
+        mean velocity of the tracks.
+    sigma: float
+        noise around the track position.
+    diffusion: float
+        diffusion constant.
+    """
+    def prediction_model(t, coordinate, t_prediction):
+        return kymo_diff_score(t, coordinate, t_prediction, vel, sigma, np.sqrt(2 * diffusion))
+
+    return prediction_model

--- a/lumicks/pylake/kymotracker/detail/scoring_functions.py
+++ b/lumicks/pylake/kymotracker/detail/scoring_functions.py
@@ -1,0 +1,83 @@
+import numpy as np
+
+
+def cone_score(x, t, vel, sigma, sigma_diffusion):
+    """This function returns an estimates mean and sigma for future time points based on a velocity, fixed uncertainty
+    and diffusion rate. This is used to compute a scoring function to determine whether two local maxima should be
+    linked.
+
+    We expect the future to be a combination of a base uncertainty, a diffusion and a constant velocity. The stdev for
+    the particle at time point t for the diffusion process is given by:
+        sigma(t) = N(mu(t), sigma*sqrt(t)).
+    mu is simply given by the prediction based on velocity.
+
+    Parameters
+    ----------
+        x : array_like
+            Coordinates
+        t : array_like
+            Time points
+        vel : float
+            Estimated velocity of the particle
+        sigma : float
+            Base positional variability
+        sigma_diffusion : float
+            Sigma representing diffusion. For diffusion, the spread is characterized by:
+                Sigma(t) = sigma_diffusion * sqrt(t)
+            Note that sigma_diffusion equates to sqrt(2*D) where D is the diffusion constant.
+    """
+
+    assert np.all(t > 0)
+    mu_t = x + vel * t
+    sigma_t = sigma + sigma_diffusion * np.sqrt(t)
+
+    return mu_t, sigma_t
+
+
+def build_score_matrix(lines, times, coordinates, sigma, sigma_diffusion, sigma_cutoff, vel):
+    """Builds a score matrix for a combination of lines and positions. The score matrix contains a score for each
+    line, point pair. For each line, we calculate a penalty function which reflects a score associated with connecting
+    those two lines. In the current implementation these are based on a Gaussian cone around the most likely trajectory.
+    Sigma provides a starting width, whereas diffusion widens the cone over time.
+
+    Since the score is simply used as a relative scoring metric, and we are not interested in the absolute values,
+    we do not have to exponentiate the Gaussian.
+
+    Above a certain cutoff value (sigma_cutoff), connections are considered very unlikely and candidates in those
+    regions are considered to not be able to be part of the same line.
+
+    Parameters
+    ----------
+    lines: list of pylake.Line
+    times: array_like
+        Time points corresponding to the identified kymograph peaks.
+    coordinates : array_like
+        Positions of the identified kymograph peaks.
+    sigma: float
+        Starting uncertainty of the cone.
+    sigma_diffusion:
+        Sigma representing diffusion. For diffusion, the spread is characterized by:
+          Sigma(t) = sigma_diffusion * sqrt(t)
+        Note that sigma_diffusion equates to sqrt(2*D) where D is the diffusion constant.
+    sigma_cutoff: float
+        At what fraction of sigma are points not going to be connected to this line at all?
+    vel: float
+        mean velocity of moving particles.
+    """
+    score_matrix = -np.inf * np.ones((len(lines), len(coordinates)))
+
+    for i, line in enumerate(lines):
+        tip_time = line.time[-1]
+        tip_position = line.coordinate[-1]
+        temporal_diff = times - tip_time
+
+        # Calculate probability cone
+        mu_t, sigma_t = cone_score(tip_position, temporal_diff, vel, sigma, sigma_diffusion)
+        cutoff_lb = mu_t - sigma_cutoff * sigma_t
+        cutoff_ub = mu_t + sigma_cutoff * sigma_t
+
+        candidates = np.logical_and(coordinates > cutoff_lb, coordinates < cutoff_ub)
+
+        score_matrix[i, candidates] = -((coordinates[candidates] - mu_t[candidates]) / sigma_t[candidates]) ** 2
+
+    return score_matrix

--- a/lumicks/pylake/kymotracker/detail/trace_line_2d.py
+++ b/lumicks/pylake/kymotracker/detail/trace_line_2d.py
@@ -311,8 +311,8 @@ def detect_lines(data, line_width, start_threshold=.5, continuation_threshold=.1
 
     return detect_lines_from_geometry(masked_derivative, positions, normals, start_threshold, continuation_threshold,
                                       max_lines, angle_weight, force_dir)
-                                      
-                                      
+
+
 def append_next_point(line, frame, score_fun):
     """Scores potential peak points and selects the most optimal one. If an acceptable point is found, the function
     returns True, adds the point to the line and marks it as assigned in the frame.
@@ -338,6 +338,8 @@ def append_next_point(line, frame, score_fun):
             line.append(candidate_times[selected], candidate_coordinates[selected])
             frame.unassigned[candidate_idx[selected]] = False
             return True
+
+    return False
 
 
 def extend_line(line, peaks, window, score_fun):
@@ -365,7 +367,7 @@ def extend_line(line, peaks, window, score_fun):
             break
 
 
-def points_to_line_segments(peaks, window=10, vel=0, sigma=2, diffusion=0, sigma_cutoff=2):
+def points_to_line_segments(peaks, prediction_model, window=10, sigma_cutoff=2):
     """Starts from a list of coordinates and attempts to string them together.
 
         For each frame:
@@ -377,37 +379,29 @@ def points_to_line_segments(peaks, window=10, vel=0, sigma=2, diffusion=0, sigma
           - If we've exhausted the maximum number of window frames to look ahead, we terminate the line.
         - When there are no more line starts, go to the next frame.
 
-    Which point to connect to is determined by considering a model comprised of a constant velocity (vel), an
-    uncertainty (sigma) and a diffusion component (diffusion). Based on these three pieces of information, one can
-    compute a mean and sigma for future time points given by:
+    Which point to connect to is determined by considering a prediction model. This prediction model returns a mu and
+    sigma that describes a Gaussian curve which reflects the probability of finding a particle in a certain area
+    on a future frame. In addition to a maximum window (maximum number of frames that a particle is expected to be able
+    to disappear), there is also a sigma_cutoff parameter. This parameter controls the width of the cone in which
+    particles may be accepted. Setting this value to two (meaning two sigma), means you'd accept the most optimal point
+    falling within two sigma or 95.45% of the mean of the prediction. The lower this value, the fewer points you'll
+    accept and the narrower you expect lines to be.
 
-        mu(t) = x + vel * t
-        sigma(t) = sigma + sigma_diffusion * sqrt(t)
-
-    These two values describe a probability density how likely it is for future points to belong to this line. The most
-    likely candidate from the next frame is chosen. In addition to a maximum window (maximum time that a particle is
-    expected to be able to disappear), there is also a sigma_cutoff parameter. This parameter controls the width of the
-    cone. Setting this value to two (meaning two sigma), means you'd accept the most optimal point falling within two
-    sigma or 95.45% of the mean of the prediction.
-
+    Parameters
+    ----------
     peaks: KymoPeaks.kymotracker.peakfinding.KymoPeaks
         peaks identified as potential lines.
     window: int
         How many frames can a particle disappear before we assume it isn't the same line.
-    vel: float
-        mean velocity of the tracks.
-    sigma: float
-        noise around the track position.
-    diffusion: float
-        diffusion constant.
     sigma_cutoff: float
         sigma cutoff points for the classification on whether it could belong to the same line.
+    prediction_model : callable
+        Function which takes a line and produces a mu and sigma for a list of coordinates.
     """
     peaks.reset_assignment()
 
     def score_matrix(line_list, time, coord):
-        return build_score_matrix(line_list, time, coord, vel=vel, sigma=sigma, sigma_diffusion=np.sqrt(2*diffusion),
-                                  sigma_cutoff=sigma_cutoff).flatten()
+        return build_score_matrix(line_list, time, coord, prediction_model, sigma_cutoff=sigma_cutoff).flatten()
 
     lines = []
     for frame in peaks.frames:

--- a/lumicks/pylake/kymotracker/tests/test_peakfinding.py
+++ b/lumicks/pylake/kymotracker/tests/test_peakfinding.py
@@ -1,4 +1,5 @@
-from lumicks.pylake.kymotracker.detail.peakfinding import peak_estimate, refine_peak_based_on_moment, KymoPeaks
+from lumicks.pylake.kymotracker.detail.peakfinding import peak_estimate, refine_peak_based_on_moment, KymoPeaks, \
+    merge_close_peaks
 import pytest
 import numpy as np
 
@@ -29,3 +30,25 @@ def test_kymopeaks():
     assert np.allclose(peaks.frames[1].time_points, [1.0, 1.0])
     assert np.allclose(peaks.frames[0].peak_amplitudes, [2.0, 3.0])
     assert np.allclose(peaks.frames[1].peak_amplitudes, [3.0, 2.0])
+
+
+def test_peak_proximity_removal():
+    # First time frame we choose the right one first, then the second one. Second time frame vice versa.
+    coordinates = np.array([3.2, 4.1, 6.4, 8.2, 12.1, 12.2, 3.2, 4.1, 6.4, 8.2, 12.1, 12.2])
+    time_points = np.array([0.0, 0.0, 0.0, 0.0,  0.0, 0.0,  1.0, 1.0, 1.0, 1.0, 1.0,  1.0])
+    peak_amplitudes = np.array([2.0, 3.0, 3.0, 2.0,  3.0, 2.0,  3.0, 2.0, 0.0, 0.0, 2.0,  3.0])
+    peaks = KymoPeaks(coordinates, time_points, peak_amplitudes)
+
+    new_peaks = merge_close_peaks(peaks, 1.0)
+    assert np.allclose(new_peaks.frames[0].coordinates, [4.1, 6.4, 8.2, 12.1])
+    assert np.allclose(new_peaks.frames[1].coordinates, [3.2, 6.4, 8.2, 12.2])
+
+    permute = [1, 2, 9, 5, 3, 11, 4, 8, 7, 0, 6, 10]
+    coordinates = coordinates[permute]
+    time_points = time_points[permute]
+    peak_amplitudes = peak_amplitudes[permute]
+    peaks = KymoPeaks(coordinates, time_points, peak_amplitudes)
+
+    new_peaks = merge_close_peaks(peaks, 1.0)
+    assert set(new_peaks.frames[0].coordinates) == {4.1, 6.4, 8.2, 12.1}
+    assert set(new_peaks.frames[1].coordinates) == {3.2, 6.4, 8.2, 12.2}

--- a/lumicks/pylake/kymotracker/tests/test_peakfinding.py
+++ b/lumicks/pylake/kymotracker/tests/test_peakfinding.py
@@ -1,0 +1,31 @@
+from lumicks.pylake.kymotracker.detail.peakfinding import peak_estimate, refine_peak_based_on_moment, KymoPeaks
+import pytest
+import numpy as np
+
+
+@pytest.mark.parametrize("location", [12.3, 12.7, 11.7, 11.49, 11.51])
+def test_peak_estimation(location):
+    x = np.arange(25)
+    data = np.tile(np.exp(-(x - location) ** 2), (1, 1)).T
+
+    position, time = peak_estimate(data, 7, thresh=.4)
+    assert position[0] == round(location)
+
+    # Deliberately mis-shift the initial guess
+    position = position + 5
+    peaks = refine_peak_based_on_moment(data, position, time, 4)
+    assert np.abs(peaks.frames[0].coordinates[0] - location) < 1e-3
+
+
+def test_kymopeaks():
+    # First time frame we choose the right one first, then the second one. Second time frame vice versa.
+    coordinates = np.array([3.2, 4.1, 6.4, 8.2])
+    time_points = np.array([0.0, 1.0, 0.5, 1.0])
+    peak_amplitudes = np.array([2.0, 3.0, 3.0, 2.0])
+    peaks = KymoPeaks(coordinates, time_points, peak_amplitudes)
+    assert np.allclose(peaks.frames[0].coordinates, [3.2, 6.4])
+    assert np.allclose(peaks.frames[1].coordinates, [4.1, 8.2])
+    assert np.allclose(peaks.frames[0].time_points, [0.0, 0.5])
+    assert np.allclose(peaks.frames[1].time_points, [1.0, 1.0])
+    assert np.allclose(peaks.frames[0].peak_amplitudes, [2.0, 3.0])
+    assert np.allclose(peaks.frames[1].peak_amplitudes, [3.0, 2.0])

--- a/lumicks/pylake/kymotracker/tests/test_tracing.py
+++ b/lumicks/pylake/kymotracker/tests/test_tracing.py
@@ -1,4 +1,4 @@
-from lumicks.pylake.kymotracker.detail.scoring_functions import build_score_matrix
+from lumicks.pylake.kymotracker.detail.scoring_functions import build_score_matrix, kymo_score
 from lumicks.pylake.kymotracker.detail.trace_line_2d import KymoLine, append_next_point, extend_line, \
     points_to_line_segments
 from lumicks.pylake.kymotracker.detail.peakfinding import KymoPeaks
@@ -17,7 +17,7 @@ def test_score_matrix():
         times = np.hstack((times, t * np.ones(len(unique_coordinates))))
 
     # No velocity
-    matrix = np.reshape(build_score_matrix(lines, times, positions, vel=0, sigma=.5, sigma_diffusion=.5,
+    matrix = np.reshape(build_score_matrix(lines, times, positions, kymo_score(vel=0, sigma=.5, diffusion=.125),
                                            sigma_cutoff=2), ((len(unique_times), -1)))
     reference = [
         [-np.inf, -np.inf, -1.0, -0.0, -1.0, -np.inf, -np.inf],
@@ -46,7 +46,7 @@ def test_score_matrix():
     assert np.allclose(matrix, reference)
 
     # With velocity
-    matrix = np.reshape(build_score_matrix(lines, times, positions, vel=1, sigma=.5, sigma_diffusion=.5,
+    matrix = np.reshape(build_score_matrix(lines, times, positions, kymo_score(vel=1, sigma=.5, diffusion=.125),
                                            sigma_cutoff=2), (len(unique_times), -1))
     reference = [
         [-np.inf, -np.inf, -np.inf, -1.0, -0.0, -1.0, -np.inf],
@@ -131,12 +131,12 @@ def test_kymotracker_two_integration():
         np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
     )
 
-    lines = points_to_line_segments(peaks, window=8, vel=0, sigma=1, diffusion=0, sigma_cutoff=2)
+    lines = points_to_line_segments(peaks, kymo_score(vel=0, sigma=1, diffusion=0), window=8, sigma_cutoff=2)
     assert np.allclose(lines[0].coordinate, [1.0, 2.0, 3.0])
     assert np.allclose(lines[1].time, [1.0, 2.0, 3.0, 5.0])
     assert np.allclose(lines[1].coordinate, [4.0, 5.0, 6.0, 7.0])
 
-    lines = points_to_line_segments(peaks, window=1, vel=0, sigma=1, diffusion=0, sigma_cutoff=2)
+    lines = points_to_line_segments(peaks, kymo_score(vel=0, sigma=1, diffusion=0), window=1, sigma_cutoff=2)
     assert np.allclose(lines[0].coordinate, [1.0, 2.0, 3.0])
     assert np.allclose(lines[1].time, [1.0, 2.0, 3.0])
     assert np.allclose(lines[1].coordinate, [4.0, 5.0, 6.0])

--- a/lumicks/pylake/kymotracker/tests/test_tracing.py
+++ b/lumicks/pylake/kymotracker/tests/test_tracing.py
@@ -1,0 +1,57 @@
+from lumicks.pylake.kymotracker.detail.scoring_functions import build_score_matrix
+from lumicks.pylake.kymotracker.detail.trace_line_2d import KymoLine
+import numpy as np
+
+
+def test_score_matrix():
+    lines = [KymoLine([0], [3])]
+    unique_coordinates = np.arange(0, 7)
+    unique_times = np.arange(1, 7)
+
+    positions = np.array([])
+    times = np.array([])
+    for t in unique_times:
+        positions = np.hstack((positions, unique_coordinates))
+        times = np.hstack((times, t * np.ones(len(unique_coordinates))))
+
+    # No velocity
+    matrix = np.reshape(build_score_matrix(lines, times, positions, vel=0, sigma=.5, sigma_diffusion=.5,
+                                           sigma_cutoff=2), ((len(unique_times), -1)))
+    reference = [
+        [-np.inf, -np.inf, -1.0, -0.0, -1.0, -np.inf, -np.inf],
+        [-np.inf, -2.745166004060959, -0.6862915010152397, -0.0, -0.6862915010152397, -2.745166004060959, -np.inf],
+        [-np.inf, -2.1435935394489816, -0.5358983848622454, -0.0, -0.5358983848622454, -2.1435935394489816, -np.inf],
+        [-np.inf, -1.7777777777777777, -0.4444444444444444, -0.0, -0.4444444444444444, -1.7777777777777777, -np.inf],
+        [
+            -3.4376941012509463,
+            -1.5278640450004204,
+            -0.3819660112501051,
+            -0.0,
+            -0.3819660112501051,
+            -1.5278640450004204,
+            -3.4376941012509463,
+        ],
+        [
+            -3.0254695407844476,
+            -1.3446531292375323,
+            -0.3361632823093831,
+            -0.0,
+            -0.3361632823093831,
+            -1.3446531292375323,
+            -3.0254695407844476,
+        ],
+    ]
+    assert np.allclose(matrix, reference)
+
+    # With velocity
+    matrix = np.reshape(build_score_matrix(lines, times, positions, vel=1, sigma=.5, sigma_diffusion=.5,
+                                           sigma_cutoff=2), (len(unique_times), -1))
+    reference = [
+        [-np.inf, -np.inf, -np.inf, -1.0, -0.0, -1.0, -np.inf],
+        [-np.inf, -np.inf, -np.inf, -2.745166004060959, -0.6862915010152397, -0.0, -0.6862915010152397],
+        [-np.inf, -np.inf, -np.inf, -np.inf, -2.1435935394489816, -0.5358983848622454, -0.0],
+        [-np.inf, -np.inf, -np.inf, -np.inf, -np.inf, -1.7777777777777777, -0.4444444444444444],
+        [-np.inf, -np.inf, -np.inf, -np.inf, -np.inf, -3.4376941012509463, -1.5278640450004204],
+        [-np.inf, -np.inf, -np.inf, -np.inf, -np.inf, -np.inf, -3.0254695407844476],
+    ]
+    assert np.allclose(matrix, reference)


### PR DESCRIPTION
This is algorithm 2 for the kymotracker. This one seems to fare a bit better when the kymos are relatively high SNR, but doesn't rely on the assumption that the kymos are inherently lines. As such it seems to require less prefiltering.

The peakfinding is based on section 2.2 from: https://publications.mpi-cbg.de/Sbalzarini_2005_4820.pdf
While the actual particle tracing is a greedy algorithm, that is a bit more akin to: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4907728/pdf/1948.pdf

Except for the fact that for now, velocity in our model is not time-dependent, but a user specified value. Our model for accepting or rejecting the steps, is also slightly different, in the sense that we also try to incorporate diffusion (when relevant).

Next up will be the refinement PR which will build on this and the previous one. Then the API.