### PR TITLE
fdfit: Added simplified Marko Siggia model for protein studies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.1 | t.b.d.
+
+* Added inverted simplified Marko Siggia model with only entropic contributions to `FdFitter`.
+
 ## v0.6.0 | 2020-08-18
 
 * Plot and return images and timestamps for scans using physical coordinate system rather than fast and slow scanning axis. In v5.0, this resulted in a failed reconstruction and `Scan.pixels_per_line` being defined as pixels along the x axis. `Scan.pixels_per_line` and `Kymo.pixels_per_line` now return the number of pixels along the fast axis. This fix was also applied to the timestamps. In the previous version, for a multi-frame scan where the y-axis is the fast axis, you could incorrectly get the time between pixels on the fast axis by calculating `scan.timestamps[0, 0, 1] - scan.timestamps[0, 0, 0]`. In the new version, this is `scan.timestamps[0, 1, 0] - scan.timestamps[0, 0, 0]` (note that the image array convention is `[frame, height, width]`). **Note that this is a breaking change affecting scans with the fast axis in y direction!**

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,6 +38,7 @@ FD Fitting
     marko_siggia_ewlc_force
     marko_siggia_ewlc_distance
     marko_siggia_simplified
+    inverted_marko_siggia_simplified
     odijk
     inverted_odijk
     freely_jointed_chain

--- a/lumicks/pylake/fitting/detail/model_implementation.py
+++ b/lumicks/pylake/fitting/detail/model_implementation.py
@@ -41,17 +41,17 @@ def offset_model_derivative(x, offset):
     return np.zeros(len(x))
 
 
-def Marko_Siggia_equation(d, Lp, Lc, kT):
+def marko_siggia_simplified_equation(d, Lp, Lc, kT):
     return f"({kT}/{Lp}) * ((1/4) * (1-({d}/{Lc}))**(-2) + ({d}/{Lc}) - (1/4))"
 
 
-def Marko_Siggia_equation_tex(d, Lp, Lc, kT):
+def marko_siggia_simplified_equation_tex(d, Lp, Lc, kT):
     return (f"\\frac{{{kT}}}{{{Lp}}} \\left(\\frac{{1}}{{4}} \\left(1-\\frac{{{d}}}{{{Lc}}}\\right)^{{-2}} + "
                 f"\\frac{{{d}}}{{{Lc}}} - \\frac{{1}}{{4}}\\right)")
 
 
-def Marko_Siggia(d, Lp, Lc, kT):
-    """Markov Siggia's Worm-like Chain model based on only entropic contributions. Valid for F < 10 pN).
+def marko_siggia_simplified(d, Lp, Lc, kT):
+    """Marko Siggia's Worm-like Chain model based on only entropic contributions. Valid for F < 10 pN).
 
     References:
         1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
@@ -64,13 +64,13 @@ def Marko_Siggia(d, Lp, Lc, kT):
     return (kT/Lp) * (.25 * (1.0-d_div_Lc)**(-2) + d_div_Lc - .25)
 
 
-def Marko_Siggia_jac(d, Lp, Lc, kT):
+def marko_siggia_simplified_jac(d, Lp, Lc, kT):
     return np.vstack((-0.25*Lc**2*kT/(Lp**2*(Lc - d)**2) + 0.25*kT/Lp**2 - d*kT/(Lc*Lp**2),
                      -0.5*Lc*d*kT/(Lp*(Lc - d)**3) - d*kT/(Lc**2*Lp),
                      0.25*Lc**2/(Lp*(Lc - d)**2) - 0.25/Lp + d/(Lc*Lp)))
 
 
-def Marko_Siggia_derivative(d, Lp, Lc, kT):
+def marko_siggia_simplified_derivative(d, Lp, Lc, kT):
     return 0.5*Lc**2*kT/(Lp*(Lc - d)**3) + kT/(Lc*Lp)
 
 
@@ -640,12 +640,12 @@ def invFJC(d, Lp, Lc, St, kT=4.11):
                            lambda f_trial: FJC_derivative(f_trial, Lp, Lc, St, kT))
 
 
-def marko_sigga_ewlc_solve_force_equation(d, Lp, Lc, St, kT=4.11):
+def marko_siggia_ewlc_solve_force_equation(d, Lp, Lc, St, kT=4.11):
     return solve_formatter(f'(1/4) * (1 - ({d}/{Lc}) + (f/{St}))**(-2) - (1/4) + ({d}/{Lc}) - (f/{St})', "f",
                            f'f*{Lp}/{kT}')
 
 
-def marko_sigga_ewlc_solve_force_equation_tex(d, Lp, Lc, St, kT=4.11):
+def marko_siggia_ewlc_solve_force_equation_tex(d, Lp, Lc, St, kT=4.11):
     dLc = latex_frac(d, Lc)
     FSt = latex_frac("f", St)
     lhs = latex_frac(f"f {Lp}", kT)
@@ -654,7 +654,7 @@ def marko_sigga_ewlc_solve_force_equation_tex(d, Lp, Lc, St, kT=4.11):
                                f"{dLc} - {FSt}", "f", lhs)
 
 
-def marko_sigga_ewlc_solve_force(d, Lp, Lc, St, kT=4.11):
+def marko_siggia_ewlc_solve_force(d, Lp, Lc, St, kT=4.11):
     """Margo-Siggia's Worm-like Chain model with distance as dependent parameter (useful for F < 10 pN).
     These equations were symbolically derived. The expressions are not pretty, but they work."""
     c = -St ** 3 * d * kT * (1.5 * Lc ** 2 - 2.25 * Lc * d + d ** 2) / (Lc ** 3 * (Lp * St + kT))
@@ -665,7 +665,7 @@ def marko_sigga_ewlc_solve_force(d, Lp, Lc, St, kT=4.11):
     return solve_cubic_wlc(a, b, c, 2)
 
 
-def marko_sigga_ewlc_solve_force_jac(d, Lp, Lc, St, kT=4.11):
+def marko_siggia_ewlc_solve_force_jac(d, Lp, Lc, St, kT=4.11):
     c = -St ** 3 * d * kT * (1.5 * Lc ** 2 - 2.25 * Lc * d + d ** 2) / (Lc ** 3 * (Lp * St + kT))
     b = St ** 2 * (Lc ** 2 * Lp * St + 1.5 * Lc ** 2 * kT - 2 * Lc * Lp * St * d - 4.5 * Lc * d * kT +
                    Lp * St * d ** 2 + 3 * d ** 2 * kT) / (Lc ** 2 * (Lp * St + kT))
@@ -705,7 +705,7 @@ def marko_sigga_ewlc_solve_force_jac(d, Lp, Lc, St, kT=4.11):
     return [total_dy_dLp, total_dy_dLc, total_dy_dSt, total_dy_dkT]
 
 
-def marko_sigga_ewlc_solve_force_derivative(d, Lp, Lc, St, kT = 4.11):
+def marko_siggia_ewlc_solve_force_derivative(d, Lp, Lc, St, kT = 4.11):
     c = -St ** 3 * d * kT * (1.5 * Lc ** 2 - 2.25 * Lc * d + d ** 2) / (Lc ** 3 * (Lp * St + kT))
     b = St ** 2 * (Lc ** 2 * Lp * St + 1.5 * Lc ** 2 * kT - 2 * Lc * Lp * St * d - 4.5 * Lc * d * kT +
                    Lp * St * d ** 2 + 3 * d ** 2 * kT) / (Lc ** 2 * (Lp * St + kT))
@@ -722,12 +722,12 @@ def marko_sigga_ewlc_solve_force_derivative(d, Lp, Lc, St, kT = 4.11):
     return total_dy_da * da_dd + total_dy_db * db_dd + total_dy_dc * dc_dd
 
 
-def marko_sigga_ewlc_solve_distance_equation(f, Lp, Lc, St, kT=4.11):
+def marko_siggia_ewlc_solve_distance_equation(f, Lp, Lc, St, kT=4.11):
     return solve_formatter(f'(1/4) * (1 - (d/{Lc}) + ({f}/{St}))**(-2) - (1/4) + (d/{Lc}) - ({f}/{St})',
                            "d", f'{f}*{Lp}/{kT}')
 
 
-def marko_sigga_ewlc_solve_distance_equation_tex(f, Lp, Lc, St, kT=4.11):
+def marko_siggia_ewlc_solve_distance_equation_tex(f, Lp, Lc, St, kT=4.11):
     dLc = latex_frac("d", Lc)
     FSt = latex_frac(f, St)
     lhs = latex_frac(f"{f} {Lp}", kT)
@@ -736,21 +736,21 @@ def marko_sigga_ewlc_solve_distance_equation_tex(f, Lp, Lc, St, kT=4.11):
                                f"{dLc} - {FSt}", "d", lhs)
 
 
-def inverted_simplified_marko_sigga_coefficients(f, Lp, Lc, kT):
+def inverted_marko_siggia_simplified_coefficients(f, Lp, Lc, kT):
     a = - Lc * (f * Lp / kT + 2.25)
     b = Lc ** 2.0 * (2.0 * f * Lp / kT + 1.5)
     c = - f * Lc ** 3.0 * Lp / kT
     return a, b, c
 
 
-def inverted_simplified_marko_sigga(f, Lp, Lc, kT=4.11):
-    a, b, c = inverted_simplified_marko_sigga_coefficients(f, Lp, Lc, kT)
+def inverted_marko_siggia_simplified(f, Lp, Lc, kT=4.11):
+    a, b, c = inverted_marko_siggia_simplified_coefficients(f, Lp, Lc, kT)
 
     return solve_cubic_wlc(a, b, c, 1)
 
 
-def inverted_simplified_marko_sigga_jac(f, Lp, Lc, kT=4.11):
-    a, b, c = inverted_simplified_marko_sigga_coefficients(f, Lp, Lc, kT)
+def inverted_marko_siggia_simplified_jac(f, Lp, Lc, kT=4.11):
+    a, b, c = inverted_marko_siggia_simplified_coefficients(f, Lp, Lc, kT)
 
     total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 1)
 
@@ -772,8 +772,8 @@ def inverted_simplified_marko_sigga_jac(f, Lp, Lc, kT=4.11):
     return [total_dy_dLp, total_dy_dLc, total_dy_dkT]
 
 
-def inverted_simplified_marko_sigga_derivative(f, Lp, Lc, kT = 4.11):
-    a, b, c = inverted_simplified_marko_sigga_coefficients(f, Lp, Lc, kT)
+def inverted_marko_siggia_simplified_derivative(f, Lp, Lc, kT = 4.11):
+    a, b, c = inverted_marko_siggia_simplified_coefficients(f, Lp, Lc, kT)
     total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 1)
 
     da_df = -Lc * Lp / kT
@@ -783,12 +783,12 @@ def inverted_simplified_marko_sigga_derivative(f, Lp, Lc, kT = 4.11):
     return total_dy_da * da_df + total_dy_db * db_df + total_dy_dc * dc_df
 
 
-def inverted_simplified_marko_sigga_equation(f, Lp, Lc, kT=4.11):
+def inverted_marko_siggia_simplified_equation(f, Lp, Lc, kT=4.11):
     return solve_formatter(f'(1/4) * (1 - (d/{Lc}))**(-2) - (1/4) + (d/{Lc})',
                            "d", f'{f}*{Lp}/{kT}')
 
 
-def inverted_simplified_marko_sigga_equation_tex(f, Lp, Lc, kT=4.11):
+def inverted_marko_siggia_simplified_equation_tex(f, Lp, Lc, kT=4.11):
     dLc = latex_frac("d", Lc)
     lhs = latex_frac(f"{f} {Lp}", kT)
 
@@ -796,7 +796,7 @@ def inverted_simplified_marko_sigga_equation_tex(f, Lp, Lc, kT=4.11):
                                lhs)
 
 
-def marko_sigga_ewlc_solve_distance(f, Lp, Lc, St, kT=4.11):
+def marko_siggia_ewlc_solve_distance(f, Lp, Lc, St, kT=4.11):
     c = -f * Lc ** 3 * (f ** 2 * Lp * St + f ** 2 * kT + 2 * f * Lp * St ** 2 + 2.25 * f * St * kT + Lp * St ** 3 + 1.5 * St ** 2 * kT) / (St ** 3 * kT)
     b = Lc ** 2 * (2 * f ** 2 * Lp * St + 3 * f ** 2 * kT + 2 * f * Lp * St ** 2 + 4.5 * f * St * kT + 1.5 * St ** 2 * kT) / (St ** 2 * kT)
     a = -f * Lc * Lp / kT - 3 * f * Lc / St - 2.25 * Lc
@@ -804,7 +804,7 @@ def marko_sigga_ewlc_solve_distance(f, Lp, Lc, St, kT=4.11):
     return solve_cubic_wlc(a, b, c, 1)
 
 
-def marko_sigga_ewlc_solve_distance_jac(f, Lp, Lc, St, kT=4.11):
+def marko_siggia_ewlc_solve_distance_jac(f, Lp, Lc, St, kT=4.11):
     c = -f * Lc ** 3 * (f ** 2 * Lp * St + f ** 2 * kT + 2 * f * Lp * St ** 2 + 2.25 * f * St * kT + Lp * St ** 3 + 1.5 * St ** 2 * kT) / (St ** 3 * kT)
     b = Lc ** 2 * (2 * f ** 2 * Lp * St + 3 * f ** 2 * kT + 2 * f * Lp * St ** 2 + 4.5 * f * St * kT + 1.5 * St ** 2 * kT) / (St ** 2 * kT)
     a = -f * Lc * Lp / kT - 3 * f * Lc / St - 2.25 * Lc
@@ -836,7 +836,7 @@ def marko_sigga_ewlc_solve_distance_jac(f, Lp, Lc, St, kT=4.11):
     return [total_dy_dLp, total_dy_dLc, total_dy_dSt, total_dy_dkT]
 
 
-def marko_sigga_ewlc_solve_distance_derivative(f, Lp, Lc, St, kT = 4.11):
+def marko_siggia_ewlc_solve_distance_derivative(f, Lp, Lc, St, kT = 4.11):
     fsq = f * f
     c = -f * Lc ** 3 * (f ** 2 * Lp * St + fsq * kT + 2 * f * Lp * St ** 2 +
                         2.25 * f * St * kT + Lp * St ** 3 + 1.5 * St ** 2 * kT) / (St ** 3 * kT)

--- a/lumicks/pylake/fitting/models.py
+++ b/lumicks/pylake/fitting/models.py
@@ -134,7 +134,8 @@ def marko_siggia_ewlc_distance(name):
 
 
 def marko_siggia_simplified(name):
-    """Markov Siggia's Worm-like Chain model based on only entropic contributions (valid for F << 10 pN).
+    """Markov Siggia's Worm-like Chain model based on only entropic contributions (valid for F << 10 pN). This model
+    has force as a dependent variable.
 
     References:
         1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
@@ -163,6 +164,43 @@ def marko_siggia_simplified(name):
         derivative=Marko_Siggia_derivative,
         eqn=Marko_Siggia_equation,
         eqn_tex=Marko_Siggia_equation_tex,
+        kT=Defaults.kT,
+        Lp=Defaults.Lp,
+        Lc=Defaults.Lc,
+    )
+
+
+def inverted_marko_siggia_simplified(name):
+    """Markov Siggia's Worm-like Chain model based on only entropic contributions (valid for F << 10 pN). This model
+    has distance as a dependent variable.
+
+    References:
+        1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
+        8759-8770 (1995).
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    """
+    from .model import Model
+    from .detail.model_implementation import (
+        inverted_simplified_marko_sigga,
+        inverted_simplified_marko_sigga_jac,
+        inverted_simplified_marko_sigga_derivative,
+        inverted_simplified_marko_sigga_equation,
+        inverted_simplified_marko_sigga_equation_tex,
+        Defaults,
+    )
+
+    return Model(
+        name,
+        inverted_simplified_marko_sigga,
+        dependent="d",
+        jacobian=inverted_simplified_marko_sigga_jac,
+        derivative=inverted_simplified_marko_sigga_derivative,
+        eqn=inverted_simplified_marko_sigga_equation,
+        eqn_tex=inverted_simplified_marko_sigga_equation_tex,
         kT=Defaults.kT,
         Lp=Defaults.Lp,
         Lc=Defaults.Lc,

--- a/lumicks/pylake/fitting/models.py
+++ b/lumicks/pylake/fitting/models.py
@@ -73,22 +73,22 @@ def marko_siggia_ewlc_force(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        marko_sigga_ewlc_solve_force,
-        marko_sigga_ewlc_solve_force_jac,
-        marko_sigga_ewlc_solve_force_derivative,
-        marko_sigga_ewlc_solve_force_equation,
-        marko_sigga_ewlc_solve_force_equation_tex,
+        marko_siggia_ewlc_solve_force,
+        marko_siggia_ewlc_solve_force_jac,
+        marko_siggia_ewlc_solve_force_derivative,
+        marko_siggia_ewlc_solve_force_equation,
+        marko_siggia_ewlc_solve_force_equation_tex,
         Defaults,
     )
 
     return Model(
         name,
-        marko_sigga_ewlc_solve_force,
+        marko_siggia_ewlc_solve_force,
         dependent="f",
-        jacobian=marko_sigga_ewlc_solve_force_jac,
-        derivative=marko_sigga_ewlc_solve_force_derivative,
-        eqn=marko_sigga_ewlc_solve_force_equation,
-        eqn_tex=marko_sigga_ewlc_solve_force_equation_tex,
+        jacobian=marko_siggia_ewlc_solve_force_jac,
+        derivative=marko_siggia_ewlc_solve_force_derivative,
+        eqn=marko_siggia_ewlc_solve_force_equation,
+        eqn_tex=marko_siggia_ewlc_solve_force_equation_tex,
         kT=Defaults.kT,
         Lp=Defaults.Lp,
         Lc=Defaults.Lc,
@@ -110,22 +110,22 @@ def marko_siggia_ewlc_distance(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        marko_sigga_ewlc_solve_distance,
-        marko_sigga_ewlc_solve_distance_jac,
-        marko_sigga_ewlc_solve_distance_derivative,
-        marko_sigga_ewlc_solve_distance_equation,
-        marko_sigga_ewlc_solve_distance_equation_tex,
+        marko_siggia_ewlc_solve_distance,
+        marko_siggia_ewlc_solve_distance_jac,
+        marko_siggia_ewlc_solve_distance_derivative,
+        marko_siggia_ewlc_solve_distance_equation,
+        marko_siggia_ewlc_solve_distance_equation_tex,
         Defaults,
     )
 
     return Model(
         name,
-        marko_sigga_ewlc_solve_distance,
+        marko_siggia_ewlc_solve_distance,
         dependent="d",
-        jacobian=marko_sigga_ewlc_solve_distance_jac,
-        derivative=marko_sigga_ewlc_solve_distance_derivative,
-        eqn=marko_sigga_ewlc_solve_distance_equation,
-        eqn_tex=marko_sigga_ewlc_solve_distance_equation_tex,
+        jacobian=marko_siggia_ewlc_solve_distance_jac,
+        derivative=marko_siggia_ewlc_solve_distance_derivative,
+        eqn=marko_siggia_ewlc_solve_distance_equation,
+        eqn_tex=marko_siggia_ewlc_solve_distance_equation_tex,
         kT=Defaults.kT,
         Lp=Defaults.Lp,
         Lc=Defaults.Lc,
@@ -134,7 +134,7 @@ def marko_siggia_ewlc_distance(name):
 
 
 def marko_siggia_simplified(name):
-    """Markov Siggia's Worm-like Chain model based on only entropic contributions (valid for F << 10 pN). This model
+    """Marko Siggia's Worm-like Chain model based on only entropic contributions (valid for F << 10 pN). This model
     has force as a dependent variable.
 
     References:
@@ -148,22 +148,22 @@ def marko_siggia_simplified(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        Marko_Siggia,
-        Marko_Siggia_jac,
-        Marko_Siggia_derivative,
-        Marko_Siggia_equation,
-        Marko_Siggia_equation_tex,
+        marko_siggia_simplified,
+        marko_siggia_simplified_jac,
+        marko_siggia_simplified_derivative,
+        marko_siggia_simplified_equation,
+        marko_siggia_simplified_equation_tex,
         Defaults,
     )
 
     return Model(
         name,
-        Marko_Siggia,
+        marko_siggia_simplified,
         dependent="f",
-        jacobian=Marko_Siggia_jac,
-        derivative=Marko_Siggia_derivative,
-        eqn=Marko_Siggia_equation,
-        eqn_tex=Marko_Siggia_equation_tex,
+        jacobian=marko_siggia_simplified_jac,
+        derivative=marko_siggia_simplified_derivative,
+        eqn=marko_siggia_simplified_equation,
+        eqn_tex=marko_siggia_simplified_equation_tex,
         kT=Defaults.kT,
         Lp=Defaults.Lp,
         Lc=Defaults.Lc,
@@ -171,7 +171,7 @@ def marko_siggia_simplified(name):
 
 
 def inverted_marko_siggia_simplified(name):
-    """Markov Siggia's Worm-like Chain model based on only entropic contributions (valid for F << 10 pN). This model
+    """Marko Siggia's Worm-like Chain model based on only entropic contributions (valid for F << 10 pN). This model
     has distance as a dependent variable.
 
     References:
@@ -185,22 +185,22 @@ def inverted_marko_siggia_simplified(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        inverted_simplified_marko_sigga,
-        inverted_simplified_marko_sigga_jac,
-        inverted_simplified_marko_sigga_derivative,
-        inverted_simplified_marko_sigga_equation,
-        inverted_simplified_marko_sigga_equation_tex,
+        inverted_marko_siggia_simplified,
+        inverted_marko_siggia_simplified_jac,
+        inverted_marko_siggia_simplified_derivative,
+        inverted_marko_siggia_simplified_equation,
+        inverted_marko_siggia_simplified_equation_tex,
         Defaults,
     )
 
     return Model(
         name,
-        inverted_simplified_marko_sigga,
+        inverted_marko_siggia_simplified,
         dependent="d",
-        jacobian=inverted_simplified_marko_sigga_jac,
-        derivative=inverted_simplified_marko_sigga_derivative,
-        eqn=inverted_simplified_marko_sigga_equation,
-        eqn_tex=inverted_simplified_marko_sigga_equation_tex,
+        jacobian=inverted_marko_siggia_simplified_jac,
+        derivative=inverted_marko_siggia_simplified_derivative,
+        eqn=inverted_marko_siggia_simplified_equation,
+        eqn_tex=inverted_marko_siggia_simplified_equation_tex,
         kT=Defaults.kT,
         Lp=Defaults.Lp,
         Lc=Defaults.Lc,


### PR DESCRIPTION
For protein studies (and the notebook we want to release), the simple (non-extensible) version of the Marko Siggia model is often used to model the protein state. It's basically the Marko Siggia model without the stretch modulus (which is equivalent to a stretch modulus of infinity).

We already have both forms of the full Marko Siggia model in the FdFitter. By both forms, I mean one version of the model with force as independent parameter, and one version of the model with distance as independent parameter. While it's technically possible to just set the stretch modulus to a very large value, this can lead to numerical problems during optimization and is just a generally icky thing to do.

We also already have the simplified Marko Siggia model in the FdFitter.

However, when working with composite models, we would like to do something like `(lk.odijk() + lk.inverted_marko()).invert()` and it would be really bad form (and result in terrible performance) to invert the simplified Marko Siggia model twice when there's an analytic form for its inverse.

Hence this PR introduces the inverted Marko Siggia model.