### PR TITLE
change deprecated field access result from exception to warning

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v0.6.1 | t.b.d.
+## v0.6.1 | 2020-08-31
 
 * Added inverted simplified Marko Siggia model with only entropic contributions to `FdFitter`.
+* Change exception that was being raised on non-API field access such as `Calibration`, `Marker`, `FD Curve`, `Kymograph` and `Scan` to a `FutureWarning` rather than an exception.
 
 ## v0.6.0 | 2020-08-18
 

--- a/lumicks/pylake/group.py
+++ b/lumicks/pylake/group.py
@@ -1,4 +1,5 @@
 import h5py
+import warnings
 from .channel import channel_class
 
 
@@ -17,8 +18,8 @@ class Group:
     def __getitem__(self, item):
         """Return a subgroup or a bluelake timeline channel"""
         if item in self.redirect_list:
-            raise IndexError(f"Direct access to this field is not supported. Use file.{self.redirect_list[item]} "
-                             f"instead. In case raw access is needed, go through the fn.h5 directly.")
+            warnings.warn(f"Direct access to this field is deprecated. Use file.{self.redirect_list[item]} instead. "
+                          f"In case raw access is needed, go through the fn.h5 directly.", FutureWarning)
 
         thing = self.h5[item]
         if type(thing) is h5py.Group:

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -69,6 +69,10 @@ class MockDataFile_v2(MockDataFile_v1):
         for i, v in attributes.items():
             field.attrs[i] = v
 
+    def make_fd(self):
+        if "FD Curve" not in self.file:
+            self.file.create_group("FD Curve")
+
     def make_marker(self, marker_name, attributes):
         if "Marker" not in self.file:
             self.file.create_group("Marker")
@@ -135,6 +139,7 @@ def h5_file(tmpdir_factory, request):
 
         mock_file.make_marker("test_marker", {'Start time (ns)': 100, 'Stop time (ns)': 200})
         mock_file.make_marker("test_marker2", {'Start time (ns)': 200, 'Stop time (ns)': 300})
+        mock_file.make_fd()
 
         counts = np.uint32([2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1, 8, 0,
                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0,

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -89,8 +89,11 @@ def test_marker(h5_file):
     f = pylake.File.from_h5py(h5_file)
 
     if f.format_version == 2:
+        with pytest.warns(FutureWarning):
+            m = f["Marker"]
+
         with pytest.raises(IndexError):
-            f["Marker"]["test_marker"]
+            m["test_marker"]
 
         assert np.isclose(f.markers["test_marker"].start, 100)
         assert np.isclose(f.markers["test_marker"].stop, 200)
@@ -128,20 +131,21 @@ def test_groups(h5_file):
 
 def test_redirect_list(h5_file):
     f = pylake.File.from_h5py(h5_file)
-    with pytest.raises(IndexError):
-        f["Calibration"]
+    if f.format_version == 2:
+        with pytest.warns(FutureWarning):
+            f["Calibration"]
 
-    with pytest.raises(IndexError):
-        f["Marker"]
+        with pytest.warns(FutureWarning):
+            f["Marker"]
 
-    with pytest.raises(IndexError):
-        f["FD Curve"]
+        with pytest.warns(FutureWarning):
+            f["FD Curve"]
 
-    with pytest.raises(IndexError):
-        f["Kymograph"]
+        with pytest.warns(FutureWarning):
+            f["Kymograph"]
 
-    with pytest.raises(IndexError):
-        f["Scan"]
+        with pytest.warns(FutureWarning):
+            f["Scan"]
 
 
 def test_repr_and_str(h5_file):
@@ -246,5 +250,8 @@ def test_invalid_access(h5_file):
     f = pylake.File.from_h5py(h5_file)
 
     if f.format_version == 2:
+        with pytest.warns(FutureWarning):
+            m = f["Kymograph"]
+
         with pytest.raises(IndexError):
-            f["Kymograph"]["Kymo1"]
+            m["Kymo1"]


### PR DESCRIPTION
To avoid breaking people's code, this PR changes an `IndexError` exception that we raised upon accessing a field covered by the API by a `FutureWarning`.