### PR TITLE
[blocked for now] kymo: add downsampled_by to kymo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.2 | t.b.d.
+
+* Add `downsampled_by` to kymo. When downsampling photon counts of the pixels downsampled over are summed, while their timestamps are averaged.
+
 ## v0.6.1 | 2020-08-31
 
 * Added inverted simplified Marko Siggia model with only entropic contributions to `FdFitter`.

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -40,3 +40,16 @@ Kymographs can also be sliced in order to obtain a specific time range.
 For example, one can plot the region of the kymograph between 175 and 180 seconds using::
 
     kymo["175s":"180s"].plot_red()
+
+We can obtain the pixel timestamps by invoking `.timestamps`::
+
+    kymo.timestamps
+
+These timestamps are defined as the mean of the timestamps contributing to that pixel.
+
+Kymographs can also be downsampled in case the signal to noise isn't high enough::
+
+    kymo.downsampled_by(2)
+
+Note that for downsampled kymographs, the timestamps are defined as the average of the timestamps corresponding to the
+pixels which were summed.

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -33,6 +33,9 @@ class Scan(Kymo):
     def __getitem__(self, item):
         raise NotImplementedError("Indexing and slicing are not implemented for scans")
 
+    def downsampled_by(self, downsampling_factor):
+        raise NotImplementedError("Downsampling is not supported for scans")
+
     @property
     def num_frames(self):
         if self._num_frames == 0:

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -15,6 +15,8 @@ def test_kymo_properties(h5_file):
                                         [2.062500e+10, 2.165625e+10, 2.262500e+10, 2.365625e+10],
                                         [2.084375e+10, 2.187500e+10, 2.284375e+10, 2.387500e+10]], np.int64)
 
+        kymo_reference = np.transpose([[2, 0, 0, 0, 2], [0, 0, 0, 0, 0], [1, 0, 0, 0, 1], [0, 1, 1, 1, 0]])
+
         assert repr(kymo) == "Kymo(pixels=5)"
         assert kymo.has_fluorescence
         assert not kymo.has_force
@@ -25,7 +27,23 @@ def test_kymo_properties(h5_file):
         assert kymo.blue_image.shape == (5, 4)
         assert kymo.green_image.shape == (5, 4)
         assert np.allclose(kymo.timestamps, reference_timestamps)
+        assert np.allclose(kymo.red_image.data, kymo_reference)
         assert kymo.fast_axis == "X"
+
+        downsampled_kymo = kymo.downsampled_by(2)
+        reference_timestamps_downsampled = np.vstack((np.mean(reference_timestamps[:, 0:2], axis=1),
+                                                      np.mean(reference_timestamps[:, 2:4], axis=1))).transpose()
+        reference_downsampled = np.vstack((np.sum(kymo_reference[:, 0:2], axis=1),
+                                           np.sum(kymo_reference[:, 2:4], axis=1))).transpose()
+        assert repr(downsampled_kymo) == "Kymo(pixels=5, downsampled_by=2)"
+        assert downsampled_kymo.pixels_per_line == 5
+        assert downsampled_kymo.rgb_image.shape == (5, 2, 3)
+        assert downsampled_kymo.red_image.shape == (5, 2)
+        assert downsampled_kymo.blue_image.shape == (5, 2)
+        assert downsampled_kymo.green_image.shape == (5, 2)
+        assert np.allclose(downsampled_kymo.timestamps, reference_timestamps_downsampled)
+        assert np.allclose(downsampled_kymo.red_image.data, reference_downsampled)
+        assert downsampled_kymo.fast_axis == "X"
 
 
 def test_kymo_slicing(h5_file):

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,6 @@ setup(
     python_requires='>=3.6',
     install_requires=['pytest>=3.5', 'h5py>=2.9, <3.0', 'numpy>=1.14, <2',
                       'scipy>=1.1, <2', 'matplotlib>=2.2', 'tifffile>=2018.11.6',
-                      'tabulate==0.8.6'],
+                      'tabulate==0.8.6', 'scikit-image>=0.17.2'],
     zip_safe=False,
 )


### PR DESCRIPTION
Kymographs frequently have to be downsampled prior to analysis. This PR adds `downsampled_by` to kymo.

By default, photon counts are summed, and timestamps averaged (analogously to how its done over the pixels and for channel data now). Something can be said for taking the minimum of the timestamps as well however. Especially considering how the time point corresponding to the mean of two adjacent pixels isn't even part of the same line.