### PR TITLE
widgets: make unfocused fdwidget plot to correct axes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Support plotting Z-axis scans. Z-axis scans would previously throw an exception due to how the physical dimensions were fetched. This issue is now resolved.
 * Add slicing (by time) for `FDCurve`.
 * Add widget to slice Fd's with from Jupyter Notebooks.
+* Fixed bug in `FdRangeSelectorWidget` that prevented drawing to the correct axes when other axes has focus.
 
 ## v0.6.1 | 2020-08-31
 

--- a/lumicks/pylake/nb_widgets/fd_selector.py
+++ b/lumicks/pylake/nb_widgets/fd_selector.py
@@ -39,7 +39,7 @@ class FdRangeSelectorWidget:
             self.update_plot()
 
         # Draw a vertical line for some immediate visual feedback
-        plt.axvline(self.to_seconds(fd_timestamp))
+        self._axes.axvline(self.to_seconds(fd_timestamp))
         self._axes.get_figure().canvas.draw()
 
     def _remove_range(self, fd_timestamp):
@@ -87,13 +87,16 @@ class FdRangeSelectorWidget:
             self._axes.axvline(t_start)
             self._axes.axvline(t_end)
             self._axes.axvspan(t_start, t_end, alpha=0.15, color='blue')
-            plt.text((t_start + t_end) / 2, 0, i)
+            self._axes.text((t_start + t_end) / 2, 0, i)
 
+        old_axis = plt.gca()
+        plt.sca(self._axes)
         self.fd_curve.f.plot(linestyle='', marker='.', markersize=1)
         self.connect_click_callback()
 
         plt.ylabel('Force [pN]')
         plt.xlabel('Time [s]')
+        plt.sca(old_axis)
 
     @property
     def fdcurves(self):


### PR DESCRIPTION
This solves an annoying bug that can occur when a different figure got focus in a Jupyter notebook in the meantime.

Before:
![bugged](https://user-images.githubusercontent.com/19836026/93593767-f6e73b00-f9b4-11ea-96a9-9d86eb532a24.gif)

After:
![fixed](https://user-images.githubusercontent.com/19836026/93593776-fb135880-f9b4-11ea-9431-81d4222bc2c2.gif)
