### PR TITLE
kymo: fix coordinates displayed on axis

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * Add slicing (by time) for `FDCurve`.
 * Add widget to slice Fd's with from Jupyter Notebooks.
 * Fixed bug in `FdRangeSelectorWidget` that prevented drawing to the correct axes when other axes has focus.
+* Fixed displayed coordinates to correctly reflect position in `Kymo.plot_red()`, `Kymo.plot_green()`, `Kymo.plot_blue()` and `Kymo.plot_rgb()`. The data origin (e.g. `kymo.red_image[0, 0]`) is displayed on the top left of the image in these plots, whereas previously this was not reflected correctly in the coordinates displayed on the plot axes (placing the coordinate origin at the bottom left).
 
 ## v0.6.1 | 2020-08-31
 

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -171,7 +171,8 @@ class Kymo(PhotonCounts, ExcitationLaserPower):
         duration = (self.stop - self.start) / 1e9
 
         default_kwargs = dict(
-            extent=[0, duration, 0, width_um],
+            # With origin set to upper (default) bounds should be given as (0, n, n, 0)
+            extent=[0, duration, width_um, 0],
             aspect=(image.shape[0] / image.shape[1]) * (duration / width_um)
         )
 


### PR DESCRIPTION
This PR flips the displayed coordinates to correctly reflect position in `Kymo.plot_red()`, `Kymo.plot_green()`, `Kymo.plot_blue()` and `Kymo.plot_rgb()`.

While the origin of the image data has always been at the top left, previously the coordinate y=0 was displayed at the bottom left, incorrectly indicating that the origin was on the bottom left.