### PR TITLE
Allow exporting h5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.3 | t.b.d.
+
+* Add `save_as` to `File` for exporting compressed HDF5 files, or omitting specific channels from an HDF5 file.
+
 ## v0.6.2 | 2020-09-21
 
 * Support plotting Z-axis scans. Z-axis scans would previously throw an exception due to how the physical dimensions were fetched. This issue is now resolved.

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -177,3 +177,14 @@ We can find the start and stop time with ``.start`` and ``.stop``.
 
     >>> print(file.markers["FRAP 3"].stop)
     1573136602571107585
+
+Exporting h5 files
+------------------
+
+We can save the Bluelake HDF5 file to a different filename by using :meth:`~lumicks.pylake.File.save_as`. When
+transferring data, it can be beneficial to omit some channels from the h5 file, or use a higher compression ratio. In
+particular, high frequency channels tend to take up a lot of space, and aren't always necessary for every analysis::
+
+    file.save_as("no_hf.h5", omit_data={"Force HF/*"})  # Omit high frequency force data from export
+
+We use `fnmatch` patterns for specifying which fields to omit from the saved `h5` file.

--- a/docs/tutorial/nbwidgets.rst
+++ b/docs/tutorial/nbwidgets.rst
@@ -13,8 +13,8 @@ to help you analyze your data. To enable such widgets, start the notebook with::
 F,d selection
 -------------
 
-Assume we have an F,d curve we want to analyze we want to analyze. We know that this file contains one F,d curve which
-should be split up into two segments that we should be analyzing separately. Let's load the file and run the widget::
+Assume we have an F,d curve we want to analyze. We know that this file contains one F,d curve which should be split up
+into two segments that we should be analyzing separately. Let's load the file and run the widget::
 
     file = lk.File("file.h5")
     fdcurves = file.fdcurves

--- a/lumicks/pylake/detail/h5_helper.py
+++ b/lumicks/pylake/detail/h5_helper.py
@@ -1,0 +1,40 @@
+import h5py
+from fnmatch import fnmatch
+
+
+def write_h5(h5_file, output_filename, compression_level=5, omit_data={}):
+    """Write a modified h5 file to disk.
+
+    Parameters
+    ----------
+    h5_file : h5py.File
+        loaded h5 file
+    output_filename : str
+        Output file name.
+    compression_level : int
+        Compression level for gzip compression.
+    omit_data : Set[str]
+        Which data sets to omit. Should be a set of h5 paths.
+    """
+
+    with h5py.File(output_filename, "w") as out_file:
+
+        def traversal_function(name, node):
+            if any([fnmatch(name, o) for o in omit_data]):
+                print(f"Omitted {name} from export")
+                return
+
+            if isinstance(node, h5py.Dataset):
+                if node.dtype.kind == "O":
+                    # Non-numerical data doesn't support compression
+                    out_file.create_dataset(name, data=node)
+                else:
+                    # Numerical data can benefit a lot from compression
+                    out_file.create_dataset(name, data=node, compression="gzip", compression_opts=compression_level)
+            else:
+                out_file.create_group(f'{name}')
+
+            out_file[name].attrs.update(node.attrs)
+
+        h5_file.visititems(traversal_function)
+        out_file.attrs.update(h5_file.attrs)


### PR DESCRIPTION
One issue with uploading data to Harbor is that data files are often quite big. Very often, one doesn't need the high frequency channels for a particular dataset, or one might want to compress using a higher compression ratio. For this, `export_h5` was added to the `File` interface.

See also: https://lumicks-pylake.readthedocs.io/en/export_h5/tutorial/file.html