### PR TITLE
scan: allow exporting plots to video formats

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ## v0.6.3 | t.b.d.
 
-* Add `save_as` to `File` for exporting compressed HDF5 files, or omitting specific channels from an HDF5 file.
+* Add `save_as` to `File` for exporting compressed HDF5 files, or omitting specific channels from an HDF5 file See tutorial on [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#exporting-h5-files) for more information.
+* Add `Scan.export_video_red`, `Scan.export_video_green`, `Scan.export_video_blue` and `Scan.export_video_rgb` to export multi-frame videos to video files or GIFs. See tutorial on [confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html) for more information.
 
 ## v0.6.2 | 2020-09-21
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -98,6 +98,19 @@ If you already have Pylake installed and you want to update to the latest versio
     conda update lumicks.pylake
 
 
+.. _ffmpeg_installation:
+
+Optional dependencies
+---------------------
+
+.. rubric:: ffmpeg
+
+Exporting to compressed video formats requires an additional dependency named ffmpeg which must be installed separately.
+When using conda, ffmpeg can be installed as follows::
+
+    conda install -c conda-forge ffmpeg
+
+
 Troubleshooting
 ---------------
 

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -26,6 +26,11 @@ Or just pick a single one::
     scan = file.scans["name"]
     scan.plot_red()
 
+If a few pixels dominate the image, one might want to set the scale by hand. We can pass an extra argument to `plot_red`
+named `vmax` to accomplish this. This parameter gets forwarded to :func:`matplotlib.pyplot.imshow`::
+
+    scan.plot_red(vmax=5)
+
 Access the raw image data::
 
     rgb = scan.rgb_image  # matrix with `shape == (h, w, 3)`
@@ -51,3 +56,16 @@ Multi-frame scans are also supported::
     print(scan.rgb_image.shape)  # (self.num_frames, h, w, 3) -> three color channels
 
     scan.plot(frame=3)  # plot the third frame -- defaults to the first frame if no argument is given
+
+Scans can also be exported to video formats.
+Exporting the red channel of a multi-scan GIF can be done as follows for example::
+
+    scan.export_video_red("test_red.gif")
+
+Or if we want to export a subset of frames (the first frame being 10, and the last frame being 40) of all three channels
+at a frame rate of 40 frames per second, we can do this::
+
+    scan.export_video_rgb("test_rgb.gif", start_frame=10, end_frame=40, fps=40)
+
+For other video formats such as `.mp4` or `.avi`, ffmpeg must be installed. See
+:ref:`installation instructions <ffmpeg_installation>` for more information on this.

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -191,7 +191,7 @@ class Kymo(PhotonCounts, ExcitationLaserPower):
         }
 
         image = getattr(self, f"{color}_image")
-        self._plot(image, **{"cmap": linear_colormaps[color], **kwargs})
+        return self._plot(image, **{"cmap": linear_colormaps[color], **kwargs})
 
     def plot_red(self, **kwargs):
         """Plot an image of the red photon channel
@@ -201,7 +201,7 @@ class Kymo(PhotonCounts, ExcitationLaserPower):
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`.
         """
-        self._plot_color("red", **kwargs)
+        return self._plot_color("red", **kwargs)
 
     def plot_green(self, **kwargs):
         """Plot an image of the green photon channel
@@ -211,7 +211,7 @@ class Kymo(PhotonCounts, ExcitationLaserPower):
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`.
         """
-        self._plot_color("green", **kwargs)
+        return self._plot_color("green", **kwargs)
 
     def plot_blue(self, **kwargs):
         """Plot an image of the blue photon channel
@@ -221,7 +221,7 @@ class Kymo(PhotonCounts, ExcitationLaserPower):
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`.
         """
-        self._plot_color("blue", **kwargs)
+        return self._plot_color("blue", **kwargs)
 
     def plot_rgb(self, **kwargs):
         """Plot a full rbg kymograph image
@@ -233,7 +233,7 @@ class Kymo(PhotonCounts, ExcitationLaserPower):
         """
         image = self.rgb_image
         image = image / np.max(image)
-        self._plot(image, **kwargs)
+        return self._plot(image, **kwargs)
 
     def save_tiff(self, filename, dtype=np.float32, clip=False):
         """Save the RGB photon counts to a TIFF image

--- a/lumicks/pylake/tests/test_scan.py
+++ b/lumicks/pylake/tests/test_scan.py
@@ -120,3 +120,17 @@ def test_plotting(h5_file):
         scan.plot_rgb()
         assert np.allclose(np.sort(plt.xlim()), [0, .191 * 4])
         assert np.allclose(np.sort(plt.ylim()), [0, .197 * 3])
+
+
+def test_movie_export(tmpdir_factory, h5_file):
+    from os import stat
+
+    f = pylake.File.from_h5py(h5_file)
+    tmpdir = tmpdir_factory.mktemp("pylake")
+
+    if f.format_version == 2:
+        scan = f.scans["fast Y slow X multiframe"]
+        scan.export_video_red(f"{tmpdir}/red.gif", 0, 4)
+        assert stat(f"{tmpdir}/red.gif").st_size > 0
+        scan.export_video_rgb(f"{tmpdir}/rgb.gif", 0, 4)
+        assert stat(f"{tmpdir}/rgb.gif").st_size > 0


### PR DESCRIPTION
This PR adds a feature to `scan` that's been requested a few times, namely the ability to export multi-frame scans to movie formats such as `.avi`, .`mp4` and `.gif`.

I decided to use the `matplotlib` animation module for this, since it allows us to easily export the axes with and doesn't require any fiddling with ffmpeg or other converters ourselves.

One thing to note is that I update the `imshow` data rather than replot it entirely every time. This is a lot faster than the alternative.

By default it uses `Pillow` (which already ships with `mpl`), and will allow you to generate GIFs. If `ffmpeg` is installed it will use that instead since it supports far more formats. I added some conda instructions to the installation instructions for installing `ffmpeg`. While that binary is GPL-3.0, it's really just a separate binary that we would not be shipping or linking.

Relevant readthedocs here: https://lumicks-pylake.readthedocs.io/en/movies/tutorial/images.html