### PR TITLE
github: Add codeowners file to auto-assign reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*.py @lumicks/python_review


### PR DESCRIPTION
When any `.py` file is modified in a PR, 2 people from the @lumicks/python_review team will be assigned to review it. Only one person actually needs to review. Two are selected so as not to put too much pressure on one person if they are busy. @lumicks/python_review Please coordinate with the other person that you're assigned with so that we don't end up with no reviews.