### PR TITLE
Downsampled over fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * Add widget to graphically slice a `Slice` in Jupyter Notebooks. It can be opened by calling `channel.range_selector`. For more information, see [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
 * Fixed bug in `CorrelatedStack.plot_correlated` which lead to the start index of the frame being added twice when the movie had been sliced.
 * *Bugfix: fixed bug in `downsampled_over` which affects people who used it with `where="center"`. With these settings the function returns timestamps at the center of the ranges being downsampled over. In the previous version, this timestamp included the end timestamp (i.e. x <= t <= x), now it has been changed to exclude the end timestamp (i.e. x <= t < x) making it consistent with `downsampled_by` for integer downsampling rates.*
+* Bugfix: fixed bug in `plot_correlated` which did not allow plotting camera images correlated to channel data when the channel data did not completely cover the camera image stack. 
 
 ## v0.6.2 | 2020-09-21
 

--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,7 @@
 * Add `downsampled_to` to `Slice` for downsampling channel data to a new sampling frequency.
 * Add widget to graphically slice a `Slice` in Jupyter Notebooks. It can be opened by calling `channel.range_selector`. For more information, see [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
 * Fixed bug in `CorrelatedStack.plot_correlated` which lead to the start index of the frame being added twice when the movie had been sliced.
-
+* *Bugfix: fixed bug in `downsampled_over` which affects people who used it with `where="center"`. With these settings the function returns timestamps at the center of the ranges being downsampled over. In the previous version, this timestamp included the end timestamp (i.e. x <= t <= x), now it has been changed to exclude the end timestamp (i.e. x <= t < x) making it consistent with `downsampled_by` for integer downsampling rates.*
 
 ## v0.6.2 | 2020-09-21
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -108,7 +108,8 @@ class Slice:
             cases, e.g. photon counts.
         where : str
             Where to put the final time point.
-            'center' time point is put at (start + stop) / 2
+            'center' time point is put at (timestamps_subset[0] + timestamps_subset[-1]) / 2, where timestamps_subset
+            are the timestamps corresponding to the samples being downsampled over.
             'left' time point is put at start
 
         Examples
@@ -125,8 +126,8 @@ class Slice:
             raise TypeError("Did not pass timestamps to range_list.")
 
         assert len(range_list[0]) == 2, "Did not pass timestamps to range_list."
-        assert self._src.start < range_list[-1][1], "No overlap between CorrelatedStack and selected channel."
-        assert self._src.stop > range_list[0][0], "No overlap between CorrelatedStack and selected channel"
+        assert self._src.start < range_list[-1][1], "No overlap between range and selected channel."
+        assert self._src.stop > range_list[0][0], "No overlap between range and selected channel"
 
         if where != 'center' and where != 'left':
             raise ValueError("Invalid argument for where. Valid options are center and left")
@@ -136,7 +137,8 @@ class Slice:
         for i, time_range in enumerate(range_list):
             start, stop = time_range
             subset = self[start:stop]
-            t[i] = (start + stop) // 2 if where == 'center' else start
+            ts = subset.timestamps
+            t[i] = (ts[0] + ts[-1]) // 2 if where == 'center' else start
             d[i] = reduce(subset.data)
 
         return Slice(TimeSeries(d, t), self.labels)
@@ -154,7 +156,8 @@ class Slice:
             cases, e.g. photon counts.
         where : str
             Where to put the final time point.
-            'center' time point is put at (start + stop) / 2
+            'center' time point is put at (timestamps_subset[0] + timestamps_subset[-1]) / 2, where timestamps_subset
+            are the timestamps corresponding to the samples being downsampled over.
             'left' time point is put at start
         method : str
             How to handle target sample times that are not exact multiples of the current sample time.

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -132,6 +132,10 @@ class Slice:
         if where != 'center' and where != 'left':
             raise ValueError("Invalid argument for where. Valid options are center and left")
 
+        # Only use the frames that are actually fully covered by channel data
+        range_list = [frame_range for frame_range in range_list
+                      if frame_range[0] >= self._src.start and frame_range[1] <= self._src.stop]
+
         t = np.zeros(len(range_list), dtype=self._src.timestamps.dtype)
         d = np.zeros(len(range_list))
         for i, time_range in enumerate(range_list):

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -2,8 +2,6 @@ import numpy as np
 import os
 import re
 
-from .channel import Slice, TimeSeries
-
 
 class TiffFrame:
     """Thin wrapper around a TIFF frame stack. For camera videos timestamps are stored in the DateTime tag in

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os
 import re
+import warnings
 
 
 class TiffFrame:
@@ -186,6 +187,10 @@ class CorrelatedStack:
         import matplotlib.pyplot as plt
 
         downsampled = channel_slice.downsampled_over(self.timestamps, where='left')
+
+        if len(downsampled.timestamps) < len(self.timestamps):
+            warnings.warn("Only subset of time range available for selected channel")
+
         fetched_frame = self._get_frame(frame)
         aspect_ratio = fetched_frame.data.shape[0] / np.max([fetched_frame.data.shape])
 
@@ -195,6 +200,7 @@ class CorrelatedStack:
         ax1.step(t, y, where='pre')
         ax2.tick_params(axis='both', which='both', bottom=False, left=False, labelbottom=False, labelleft=False)
         image_object = ax2.imshow(fetched_frame.data, cmap='gray')
+        plt.title(f"Frame {frame}")
 
         # Make sure the y-axis limits stay fixed when we add our little indicator rectangle
         y1, y2 = ax1.get_ylim()
@@ -218,7 +224,8 @@ class CorrelatedStack:
                 for img_idx in np.arange(0, self.num_frames):
                     current_frame = self._get_frame(img_idx)
 
-                    if current_frame.start < time < current_frame.stop:
+                    if current_frame.start <= time < current_frame.stop:
+                        plt.title(f"Frame {img_idx}")
                         poly.remove()
                         image_object.set_data(current_frame.data)
                         poly = update_position(current_frame)

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -8,14 +8,14 @@ def test_calibration_timeseries_channels():
     time_field = 'Stop time (ns)'
     mock_calibration = ForceCalibration(time_field=time_field,
                                         items=[
-                                           {'Calibration Data': 50, time_field: 50},
-                                           {'Calibration Data': 20, time_field: 20},
-                                           {'Calibration Data': 30, time_field: 30},
-                                           {'Calibration Data': 40, time_field: 40},
-                                           {'Calibration Data': 80, time_field: 80},
-                                           {'Calibration Data': 90, time_field: 90},
-                                           {'Calibration Data': 120, time_field: 120},
-                                       ])
+                                            {'Calibration Data': 50, time_field: 50},
+                                            {'Calibration Data': 20, time_field: 20},
+                                            {'Calibration Data': 30, time_field: 30},
+                                            {'Calibration Data': 40, time_field: 40},
+                                            {'Calibration Data': 80, time_field: 80},
+                                            {'Calibration Data': 90, time_field: 90},
+                                            {'Calibration Data': 120, time_field: 120},
+                                        ])
 
     # Channel should have calibration points 40, 50 since this is the only area that has force data.
     cc = channel.Slice(channel.TimeSeries([14, 15, 16, 17], [40, 50, 60, 70]),
@@ -247,6 +247,7 @@ def test_timetags_indexing():
 def test_time_indexing():
     """String time-based indexing"""
     s = channel.Slice(channel.TimeSeries([1, 2, 3, 4, 5], [1400, 2500, 16e6, 34e9, 122 * 1e9]))
+
     # --> in time indices: ['0ns', '1100ns', '15.9986ms', '33.99s', '2m 2s']
 
     def assert_equal(actual, expected):
@@ -346,7 +347,7 @@ def test_seconds_property():
 def test_continuous_downsampling_to():
     # Continuous
     d = np.arange(1, 24)
-    s = channel.Slice(channel.Continuous(d, 0, 500)) # 2 MHz
+    s = channel.Slice(channel.Continuous(d, 0, 500))  # 2 MHz
 
     # to 1000 ns step
     s2a = s.downsampled_to(1e6, where='left')
@@ -354,7 +355,7 @@ def test_continuous_downsampling_to():
     assert np.allclose(s2a.data, [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5, 21.5])
 
     s2b = s.downsampled_to(1e6, where='center')
-    assert np.all(np.equal(s2b.timestamps, [500, 1500, 2500, 3500, 4500, 5500, 6500, 7500, 8500, 9500, 10500]))
+    assert np.all(np.equal(s2b.timestamps, (np.arange(0, 10500, 1000) + np.arange(500, 10501, 1000)) / 2))
     assert np.allclose(s2a.data, [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5, 21.5])
 
     # upsampling
@@ -365,12 +366,13 @@ def test_continuous_downsampling_to():
     with pytest.raises(ValueError):
         s.downsampled_to(3e5, where="left")
 
-    # force non-integer ratio
+    # non-integer ratio
     s3a = s.downsampled_to(3e5, where='left', method="ceil")
     assert np.all(np.equal(s3a.timestamps, [0, 3000, 6000]))
     assert np.allclose(s3a.data, [3.5, 9.5, 15.5])
+
     s3b = s.downsampled_to(3e5, where='center', method="ceil")
-    assert np.all(np.equal(s3b.timestamps, [1500, 4500, 7500]))
+    assert np.all(np.equal(s3b.timestamps, [(0+2500)/2, (3000+5500)/2, (6000+8500)/2]))
     assert np.allclose(s3a.data, [3.5, 9.5, 15.5])
 
 
@@ -378,7 +380,7 @@ def test_continuous_like_downsampling_to():
     # timesteps = 500 ns
     # frequencies = 2 MHz
     t = np.arange(0, 11001, 500)
-    d = np.arange(1, t.size+1)
+    d = np.arange(1, t.size + 1)
     s = channel.Slice(channel.TimeSeries(d, t))
 
     # to 1000 ns step
@@ -387,7 +389,7 @@ def test_continuous_like_downsampling_to():
     assert np.allclose(s2a.data, [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5, 21.5])
 
     s2b = s.downsampled_to(1e6, where='center')
-    assert np.all(np.equal(s2b.timestamps, [500, 1500, 2500, 3500, 4500, 5500, 6500, 7500, 8500, 9500, 10500]))
+    assert np.all(np.equal(s2b.timestamps, (np.arange(0, 10500, 1000) + np.arange(500, 10501, 1000)) / 2))
     assert np.allclose(s2a.data, [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5, 21.5])
 
     # upsampling
@@ -403,7 +405,7 @@ def test_continuous_like_downsampling_to():
     assert np.all(np.equal(s3a.timestamps, [0, 3000, 6000]))
     assert np.allclose(s3a.data, [3.5, 9.5, 15.5])
     s3b = s.downsampled_to(3e5, where='center', method="ceil")
-    assert np.all(np.equal(s3b.timestamps, [1500, 4500, 7500]))
+    assert np.all(np.equal(s3b.timestamps, [(0+2500)/2, (3000+5500)/2, (6000+8500)/2]))
     assert np.allclose(s3a.data, [3.5, 9.5, 15.5])
 
 
@@ -412,9 +414,9 @@ def test_variable_downsampling_to():
     # frequencies = 2 MHz, 1 MHz
     t = np.hstack((np.arange(0, 5001, 500),
                    np.arange(6000, 14001, 1000)))
-    d = np.arange(1, t.size+1)
+    d = np.arange(1, t.size + 1)
     s = channel.Slice(channel.TimeSeries(data=d, timestamps=t))
-    
+
     with pytest.raises(ValueError):
         s.downsampled_to(3e6)
 
@@ -423,10 +425,22 @@ def test_variable_downsampling_to():
 
     # to 2000 ns step
     s2a = s.downsampled_to(5e5, where="left", method="force")
-    assert np.all(np.equal(s2a.timestamps, [0, 2000, 4000, 6000, 8000,10000, 12000]))
+    assert np.all(np.equal(s2a.timestamps, [0, 2000, 4000, 6000, 8000, 10000, 12000]))
     assert np.allclose(s2a.data, [2.5, 6.5, 10.0, 12.5, 14.5, 16.5, 18.5])
     s2b = s.downsampled_to(5e5, where="center", method="force")
-    assert np.all(np.equal(s2b.timestamps, [1000, 3000, 5000, 7000, 9000, 11000, 13000]))
+
+    # Original samples are 0 500 1000 1500 2000 2500 3000 3500 4000 4500 5000   6000 7000 8000 ...
+    assert np.all(np.equal(s2b.timestamps, np.array(
+                    [
+                        (2000 - 500) / 2,
+                        (2000 + 4000 - 500) / 2,
+                        (4000 + 5000) / 2,
+                        (6000 + 8000 - 1000) / 2,
+                        (8000 + 10000 - 1000) / 2,
+                        (10000 + 12000 - 1000) / 2,
+                        (12000 + 14000 - 1000) / 2,
+                    ]
+                ).astype(np.int64)))
     assert np.allclose(s2b.data, [2.5, 6.5, 10.0, 12.5, 14.5, 16.5, 18.5])
 
     # to 3333 ns step
@@ -434,5 +448,60 @@ def test_variable_downsampling_to():
     assert np.all(np.equal(s3a.timestamps, [0, 3333, 6666, 9999]))
     assert np.allclose(s3a.data, [4.0, 10.0, 14.0, 17.5])
     s3b = s.downsampled_to(3e5, where="center", method="force")
-    assert np.all(np.equal(s3b.timestamps, [1666, 4999, 8332, 11665]))
+
+    assert np.all(np.equal(s3b.timestamps, [3000/2, (3000 + 6500)/2, (7000 + 9000)/2, (10000 + 13000)/2]))
     assert np.allclose(s3b.data, [4.0, 10.0, 14.0, 17.5])
+
+    with pytest.raises(ValueError):
+        s.downsampled_to(3e8)
+
+
+def test_downsampling_consistency():
+    d = np.arange(1, 24)
+    s = channel.Slice(channel.Continuous(d, 0, 10))
+
+    # Multiple of 5 should downsample to the same irrespective of the method
+    # Source frequency was 1e9 / 10 Hz. So we go to .2e8 Hz.
+    s1 = s.downsampled_to(.2e8)
+    s2 = s.downsampled_by(5)
+    assert np.allclose(s1.data, s2.data)
+    assert np.allclose(s1.timestamps, s2.timestamps)
+
+    d = np.arange(1, 24)
+    s = channel.Slice(channel.Continuous(d, 5, 10))
+
+    # Multiple of 5 should downsample to the same irrespective of the method
+    # Source frequency was 1e9 / 10 Hz. So we go to .2e8 Hz.
+    s1 = s.downsampled_to(.2e8)
+    s2 = s.downsampled_by(5)
+    assert np.allclose(s1.data, s2.data)
+    assert np.allclose(s1.timestamps, s2.timestamps)
+
+    # Multiple of 5 should downsample to the same irrespective of the method
+    # Source frequency was 1e9 / 7 Hz.
+    d = np.arange(1, 24)
+    s = channel.Slice(channel.Continuous(d, 0, 7))
+    s1 = s.downsampled_to(int(1e9 / 7 / 5))
+    s2 = s.downsampled_by(5)
+    assert np.allclose(s1.data, s2.data)
+    assert np.allclose(s1.timestamps, s2.timestamps)
+
+
+def test_consistency_downsampled_to():
+    d = np.arange(1, 41)
+    s = channel.Slice(channel.Continuous(d, 50, 10))
+
+    one_step = s.downsampled_to(.1e8)
+    two_step = s.downsampled_to(.2e8).downsampled_to(.1e8)
+
+    assert np.allclose(one_step.data, two_step.data)
+    assert np.allclose(one_step.timestamps, two_step.timestamps)
+
+
+def test_downsampling_over_subset():
+    d = np.arange(1, 24)
+    s = channel.Slice(channel.Continuous(d, 0, 10))
+
+    sd = s.downsampled_over([(20, 40), (40, 60), (60, 80)])
+    np.allclose(sd.data, [(3+4)/2, (4+5)/2, (5+6)/2])
+    np.allclose(sd.timestamps, [(20+30)/2, (40+50)/2, (60+70)/2])

--- a/lumicks/pylake/tests/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_correlated_stack.py
@@ -102,11 +102,11 @@ def test_correlation():
     # slice based on a stack.
     ch = cc.downsampled_over(stack[0:3].timestamps)
     assert(np.allclose(ch.data, [np.mean(np.arange(10, 18, 2)), np.mean(np.arange(20, 28, 2)), np.mean(np.arange(30, 38, 2))]))
-    assert (np.allclose(ch.timestamps, [(10 + 18) / 2, (20 + 28) / 2, (30 + 38) / 2]))
+    assert (np.allclose(ch.timestamps, [(10 + 16) / 2, (20 + 26) / 2, (30 + 36) / 2]))
 
     ch = cc.downsampled_over(stack[1:4].timestamps)
     assert (np.allclose(ch.data, [np.mean(np.arange(20, 28, 2)), np.mean(np.arange(30, 38, 2)), np.mean(np.arange(40, 48, 2))]))
-    assert (np.allclose(ch.timestamps, [(20 + 28) / 2, (30 + 38) / 2, (40 + 48) / 2]))
+    assert (np.allclose(ch.timestamps, [(20 + 26) / 2, (30 + 36) / 2, (40 + 46) / 2]))
 
     with pytest.raises(TypeError):
         cc.downsampled_over(stack[1:4])


### PR DESCRIPTION
**Why this PR?**

This PR fixes two issues:

- `downsampled_over` used to be inconsistent with `downsampled_by`. The two did not produce the same timestamps when downsampling over integer frequency ratios. When downsampling the new timestamp should not have been `(subset.start + subset.stop)/2` but `(subset.timestamps[0] + subset.timestamps[-1])/2`

- The second one came  up during WIT testing, which is that when the h5 is smaller than the tiff exported, you can't use `correlatedstack` at all anymore. This PR fixes that by omitting those points in the downsampled series and raises a warning when this is the case.

- Tests were added to prevent the same inconsistency from popping up again.