### PR TITLE
Missing meta

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * Add widget to graphically slice a `Slice` in Jupyter Notebooks. It can be opened by calling `channel.range_selector`. For more information, see [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
 * Fixed bug in `CorrelatedStack.plot_correlated` which lead to the start index of the frame being added twice when the movie had been sliced.
 * Fixed bug in `File.point_scans` to return `PointScan` instances. Previously, attempts to access this property would cause an error due to missing `PointScan.from_dataset` method. **Note that the `__init__` method arguments of `PointScan` have been changed to be in line with `Kymo` and `Scan`!**
+* Fixed bug in `File.scans` so that a warning is generated when a scan is missing metadata. Other scans that can be loaded properly are still accessible.
 * *Bugfix: fixed bug in `downsampled_over` which affects people who used it with `where="center"`. With these settings the function returns timestamps at the center of the ranges being downsampled over. In the previous version, this timestamp included the end timestamp (i.e. x <= t <= x), now it has been changed to exclude the end timestamp (i.e. x <= t < x) making it consistent with `downsampled_by` for integer downsampling rates.*
 * Bugfix: fixed bug in `plot_correlated` which did not allow plotting camera images correlated to channel data when the channel data did not completely cover the camera image stack. 
 

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -281,7 +281,11 @@ class Kymo(PhotonCounts, ExcitationLaserPower):
         start = h5py_dset.attrs["Start time (ns)"]
         stop = h5py_dset.attrs["Stop time (ns)"]
         name = h5py_dset.name.split("/")[-1]
-        json_data = json.loads(h5py_dset[()])["value0"]
+        try:
+            json_data = json.loads(h5py_dset[()])["value0"]
+        except KeyError:
+            raise KeyError(f"Scan '{name}' is missing metadata and cannot be loaded")
+
         return cls(name, file, start, stop, json_data)
 
 

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -267,6 +267,16 @@ def test_invalid_access(h5_file):
             m["Kymo1"]
 
 
+def test_missing_metadata(h5_file_missing_meta):
+    f = pylake.File.from_h5py(h5_file_missing_meta)
+    if f.format_version == 2:
+        with pytest.warns(UserWarning) as record:
+            scans = f.scans
+            assert len(scans) == 1
+            assert len(record) == 1
+            assert record[0].message.args[0] == "Scan 'fast Y slow X no meta' is missing metadata and cannot be loaded"
+
+
 def _internal_h5_export_api(file, *args, **kwargs):
     return write_h5(file.h5, *args, **kwargs)
 


### PR DESCRIPTION
This PR fixes a bug where if a file contains a scan that is missing metadata, none of the scans could be loaded. Now a warning is generated and the scan that is missing metadata is ignored while all other scans are accessible.

_**Update Nov 2**_
This PR is now based on #68 