### PR TITLE
channel: add range slicer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@
 * Add `Kymo.pixelsize_um` and `Scan.pixelsize_um` for obtaining the pixel size for various axes.
 * fdfit: To compute the covariance matrix of the estimates, it is required to estimate the standard deviation of the residuals. This calculation was previously biased by not correctly taking into account the number of degrees of freedom. This is fixed now.
 * fdfit: Add profile likelihood method to FdFitter. See [confidence intervals and standard errors](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/fdfitting.html#confidence-intervals-and-standard-errors).
+* Add widget to graphically slice a `Slice` in Jupyter Notebooks. It can be opened by calling `channel.range_selector`. For more information, see [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
+
 
 ## v0.6.2 | 2020-09-21
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -58,3 +58,13 @@ Kymotracking
     track_greedy
     track_lines
     filter_lines
+
+Notebook widgets
+----------------
+
+.. autosummary::
+    :toctree: _api
+
+    FdRangeSelector
+    nb_widgets.fd_selector.SliceRangeSelectorWidget
+    nb_widgets.fd_selector.FdRangeSelectorWidget

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -66,5 +66,5 @@ Notebook widgets
     :toctree: _api
 
     FdRangeSelector
-    nb_widgets.fd_selector.SliceRangeSelectorWidget
+    nb_widgets.fd_selector.SliceRangeSelector
     nb_widgets.fd_selector.FdRangeSelectorWidget

--- a/docs/tutorial/nbwidgets.rst
+++ b/docs/tutorial/nbwidgets.rst
@@ -10,13 +10,43 @@ to help you analyze your data. To enable such widgets, start the notebook with::
 
     %matplotlib widget
 
+Channel slicing
+---------------
+
+Let's say we want to do some analyses on slices of channel data. It would be nice to just quickly visually select some
+regions using a widget. Let's load the file and run the widget::
+
+    file = lk.File("file.h5")
+    channel = file["Force LF"]["Force 1x"]
+    selector = channel.range_selector
+
+.. image:: slice_widget.png
+
+You can use the left mouse button to select time ranges (by clicking the left and then the right boundary of the region
+you wish to select). The right mouse button can be used to remove previous selections. We can access the selected
+timestamps of the ranges we selected by invoking
+:attr:`~lumicks.pylake.nb_widgets.fd_selector.SliceRangeSelectorWidget.ranges`::
+
+    >>> selector.ranges
+    [array([1572279165841737600, 1572279191523516800], dtype=int64),
+    array([1572279201850211200, 1572279224153072000], dtype=int64)]
+
+And the actual slices from :attr:`~lumicks.pylake.nb_widgets.fd_selector.SliceRangeSelectorWidget.slices`. If we want to
+plot all of our selections in separate plots for instance, we can do the following::
+
+    for data_slice in selector.slices:
+        plt.figure()
+        data_slice.plot()
+
+.. image:: slice_widget2.png
+
+
 F,d selection
 -------------
 
 Assume we have an F,d curve we want to analyze. We know that this file contains one F,d curve which should be split up
-into two segments that we should be analyzing separately. Let's load the file and run the widget::
+into two segments that we should be analyzing separately::
 
-    file = lk.File("file.h5")
     fdcurves = file.fdcurves
     selector = lk.FdRangeSelector(fdcurves)
 

--- a/docs/tutorial/nbwidgets.rst
+++ b/docs/tutorial/nbwidgets.rst
@@ -25,13 +25,13 @@ regions using a widget. Let's load the file and run the widget::
 You can use the left mouse button to select time ranges (by clicking the left and then the right boundary of the region
 you wish to select). The right mouse button can be used to remove previous selections. We can access the selected
 timestamps of the ranges we selected by invoking
-:attr:`~lumicks.pylake.nb_widgets.fd_selector.SliceRangeSelectorWidget.ranges`::
+:attr:`~lumicks.pylake.nb_widgets.fd_selector.SliceRangeSelector.ranges`::
 
     >>> selector.ranges
     [array([1572279165841737600, 1572279191523516800], dtype=int64),
     array([1572279201850211200, 1572279224153072000], dtype=int64)]
 
-And the actual slices from :attr:`~lumicks.pylake.nb_widgets.fd_selector.SliceRangeSelectorWidget.slices`. If we want to
+And the actual slices from :attr:`~lumicks.pylake.nb_widgets.fd_selector.SliceRangeSelector.slices`. If we want to
 plot all of our selections in separate plots for instance, we can do the following::
 
     for data_slice in selector.slices:

--- a/docs/tutorial/slice_widget.png
+++ b/docs/tutorial/slice_widget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dbd6cea979ad184616e166734d9039a9b4e3163394e6496e4d1492545c302ab
+size 27168

--- a/docs/tutorial/slice_widget2.png
+++ b/docs/tutorial/slice_widget2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8715213c477d30ea27e0df1ad9489f5e7d103e841be7ed2e218a6eb3c7a909b4
+size 26227

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from .detail.timeindex import to_timestamp
 from .calibration import ForceCalibration
-from lumicks.pylake.nb_widgets.fd_selector import SliceRangeSelectorWidget
+from lumicks.pylake.nb_widgets.fd_selector import SliceRangeSelector
 
 
 class Slice:
@@ -168,7 +168,7 @@ class Slice:
 
     @property
     def range_selector(self):
-        return SliceRangeSelectorWidget(self)
+        return SliceRangeSelector(self)
 
 
 def _downsample(data, factor, reduce):

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from .detail.timeindex import to_timestamp
 from .calibration import ForceCalibration
+from lumicks.pylake.nb_widgets.fd_selector import SliceRangeSelectorWidget
 
 
 class Slice:
@@ -164,6 +165,10 @@ class Slice:
         plt.xlabel(self.labels.get("x", "Time") + " (s)")
         plt.ylabel(self.labels.get("y", "y"))
         plt.title(self.labels.get("title", "title"))
+
+    @property
+    def range_selector(self):
+        return SliceRangeSelectorWidget(self)
 
 
 def _downsample(data, factor, reduce):

--- a/lumicks/pylake/nb_widgets/fd_selector.py
+++ b/lumicks/pylake/nb_widgets/fd_selector.py
@@ -3,7 +3,7 @@ import numpy as np
 import time
 
 
-class SliceRangeSelectorWidget:
+class SliceRangeSelector:
     def __init__(self, channel_slice, axes=None, show=True):
         self._axes = axes if axes else plt.axes(label=f"lk_slice_widget_{time.time()}")
         self.slice = channel_slice
@@ -109,7 +109,7 @@ class SliceRangeSelectorWidget:
         return [self.slice[start:stop] for start, stop in self._ranges]
 
 
-class FdRangeSelectorWidget(SliceRangeSelectorWidget):
+class FdRangeSelectorWidget(SliceRangeSelector):
     def __init__(self, fd_curve, axes=None, show=True):
         super().__init__(fd_curve.f, axes, show)
         self.fd_curve = fd_curve

--- a/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
+++ b/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
@@ -124,3 +124,10 @@ def test_multi_selector_widget():
 
     with pytest.raises(RuntimeError):
         FdRangeSelector({"fd1": fd_curve1, "fd2": fd_curve2})
+
+
+@cleanup
+def test_slice_widget_opens():
+    channel = Slice(TimeSeries([1, 2, 3, 4], [100, 200, 300, 400]))
+
+    channel.range_selector


### PR DESCRIPTION
This PR generalizes the interactive range slicer to be used on channel data in addition to on F,d curves.

Why this PR:
- Makes it easier to extract chunks of channel data that one is interested in for further analysis.
- Extending this feature from just F,d to channels in general was requested.
- Makes sure that the widget gets a copy of the timestamp ranges involved rather than a reference (so that if the user messes with the ranges, the widget doesn't actually break)

![image](https://user-images.githubusercontent.com/19836026/97046086-24f10980-1577-11eb-887d-5a29fd77cce9.png)

Docs here: https://lumicks-pylake.readthedocs.io/en/slice_selector/tutorial/nbwidgets.html
