### PR TITLE
CorrelatedStack: bugfix in plot_correlated to prevent misalignment

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * fdfit: Add profile likelihood method to FdFitter. See [confidence intervals and standard errors](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/fdfitting.html#confidence-intervals-and-standard-errors).
 * Add `downsampled_to` to `Slice` for downsampling channel data to a new sampling frequency.
 * Add widget to graphically slice a `Slice` in Jupyter Notebooks. It can be opened by calling `channel.range_selector`. For more information, see [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
+* Fixed bug in `CorrelatedStack.plot_correlated` which lead to the start index of the frame being added twice when the movie had been sliced.
 
 
 ## v0.6.2 | 2020-09-21

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -188,7 +188,7 @@ class CorrelatedStack:
         import matplotlib.pyplot as plt
 
         downsampled = channel_slice.downsampled_over(self.timestamps, where='left')
-        fetched_frame = self._get_frame(self.start_idx + frame)
+        fetched_frame = self._get_frame(frame)
         aspect_ratio = fetched_frame.data.shape[0] / np.max([fetched_frame.data.shape])
 
         fig, (ax1, ax2) = plt.subplots(1, 2, figsize=plt.figaspect(aspect_ratio/2))
@@ -217,8 +217,8 @@ class CorrelatedStack:
 
             if not event.canvas.widgetlock.locked() and event.inaxes == ax1:
                 time = event.xdata * 1e9 + t0
-                for img_idx in np.arange(self.start_idx, self.stop_idx):
-                    current_frame = self._get_frame(self.start_idx + img_idx)
+                for img_idx in np.arange(0, self.num_frames):
+                    current_frame = self._get_frame(img_idx)
 
                     if current_frame.start < time < current_frame.stop:
                         poly.remove()


### PR DESCRIPTION
**Why this PR?**
- There is a critical bug in `CorrelatedStack.plot_correlated` that happens when a `TiffStack` is sliced and then plotted correlated to `Channel` data. In this case, the start index is added twice since `get_frame` already takes into account the start index.

**What this PR adds**
- A fix for the bug and a regression test so that this does not happen again.