### PR TITLE
ci: add test badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Lumicks pylake 
 
-[![Build Status](https://travis-ci.org/lumicks/pylake.svg?branch=master)](https://travis-ci.org/lumicks/pylake)
+![Build Status](https://github.com/lumicks/pylake/workflows/pytest/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/lumicks-pylake/badge/?version=latest)](https://lumicks-pylake.readthedocs.io/en/latest/?badge=latest)
 
 This Python package includes data analysis tools for Bluelake HDF5 data.


### PR DESCRIPTION
**Why this PR?**
Because we'd like the badge to not point to Travis when we're actually using GitHub actions.