### PR TITLE
ci: switch to headless backend for mpl tests

### DIFF
--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -2,6 +2,12 @@ import h5py
 import numpy as np
 import pytest
 import json
+import matplotlib.pyplot as plt
+
+
+def pytest_configure():
+    # Use a headless backend for testing
+    plt.switch_backend('agg')
 
 
 # We generate mock data files for different versions of the Bluelake HDF5 file


### PR DESCRIPTION
**Why this PR?**
Builds are occassionally failing on GitHub actions because of Tk dependencies (see error below).
`_tkinter.TclError: Can't find a usable tk.tcl in the following directories`

This is not something we want to explicitly test. In this PR we switch to a headless `Agg` backend.