### PR TITLE
ci import time tests

### DIFF
--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -21,5 +21,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install .
     - name: Pytest
-      run: |
-        pytest --color=yes
+      run: pytest lumicks/pylake --color=yes --runslow

--- a/lumicks/pylake/tests/test_import_time.py
+++ b/lumicks/pylake/tests/test_import_time.py
@@ -1,0 +1,21 @@
+from textwrap import dedent
+import numpy as np
+import subprocess
+import sys
+import pytest
+
+
+@pytest.mark.slow
+def test_disabling_capturing(report_line):
+    repeats = 3
+
+    code = dedent("""\
+        import time
+        tic = time.time()
+        import lumicks.pylake
+        print(time.time() - tic)
+        """)
+
+    times = [float(subprocess.check_output([f'{sys.executable}', '-c', code])) for i in range(repeats)]
+
+    report_line(f"Module import time: {np.mean(times):.2f} +- {np.std(times):.2f} seconds (N={repeats})")


### PR DESCRIPTION
This PR adds a test which measures how much time it takes to import Pylake.

**Why this PR?**
As we are pulling in more and more dependencies, we might want to keep an eye on import times.

![image](https://user-images.githubusercontent.com/19836026/97987049-efe88080-1dda-11eb-8751-8f03e0ade31f.png)

**Why this implementation?**
- Option A. Downside: Measures time taken to spin up python itself.
```python
def import_pylake():
  subprocess.run(['python', '-c', 'import lumicks.pylake'])

  times = timeit.repeat(import_pylake, number=1, repeat=3)
  print(f"Pylake import time: {np.mean(times)} +- {np.std(times)}")
```

- Option B. Downside: Little control over output string. Reparsing the output of timeit would have been messy since it specifies time with prefixes to the units.
```
subprocess.run(['python', '-m', 'timeit', '--number=1', '--repeat=1', 'import lumicks.pylake'])
```

- Option C. This is more or less the implementation used now.
```
code = dedent("""\
  import time
  tic = time.time()
  import lumicks.pylake
  print(time.time() - tic)
""")

times = [float(subprocess.check_output(['python', '-c', code])) for i in range(repeats)]
print(f"  pylake import time: {np.mean(times)} +- {np.std(times)}")
```