### PR TITLE
Kymo plot time limits

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## v0.7.1 | t. b. d.
 * Add workaround for `Scan` and `Kymo` which could prevent valid scans and kymos from being opened when the `start` timestamp of a scan or kymo had a value before the actual start of the timeline channels. The cause of this subsample time difference was the lack of quantization of a delay when acquiring STED images.
+* Fixed bug in `Kymo` plotting functions. Previously, the time limits were calculated using the fly-in/out times which could lead to subtle discrepancies when comparing against force channels. These dead times are now omitted.
 
 ## v0.7.0 | 2020-11-04
 

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -32,6 +32,13 @@ Access the raw image data::
     # Plot manually
     plt.imshow(rgb)
 
+There are also convenience functions to plot individual color channels and the full RGB image::
+
+    plt.subplot(2, 1, 1)
+    kymo.plot_rgb()
+    plt.subplot(2, 1, 2)
+    kymo.plot_blue()
+
 The images can also be exported in the TIFF format::
 
     kymo.save_tiff("image.tiff")

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -187,7 +187,8 @@ class Kymo(PhotonCounts, ExcitationLaserPower):
         import matplotlib.pyplot as plt
 
         width_um = self._ordered_axes()[0]["scan width (um)"]
-        duration = (self.stop - self.start) / 1e9
+        ts = self.timestamps
+        duration = (ts[0, -1] - ts[0, 0]) / 1e9
 
         default_kwargs = dict(
             # With origin set to upper (default) bounds should be given as (0, n, n, 0)

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -2,6 +2,8 @@ import numpy as np
 from lumicks import pylake
 import pytest
 from lumicks.pylake.kymo import EmptyKymo
+import matplotlib.pyplot as plt
+from matplotlib.testing.decorators import cleanup
 
 
 def test_kymo_properties(h5_file):
@@ -117,3 +119,14 @@ def test_damaged_kymo(h5_file):
         with pytest.warns(RuntimeWarning):
             assert kymo.red_image.shape == (5, 3)
         assert np.allclose(kymo.red_image.data, kymo_reference[:, 1:])
+
+
+@cleanup
+def test_plotting(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+    if f.format_version == 2:
+        kymo = f.kymos["Kymo1"]
+        
+        kymo.plot_red()
+        assert np.allclose(np.sort(plt.xlim()), [0, 3.03125])
+        assert np.allclose(np.sort(plt.ylim()), [0, 36.075])


### PR DESCRIPTION
This PR fixes a bug in `kymo._plot()` to ensure plotted time limits exclude fly-in/out times. Previously time limits were calculated from `kymo.start` and `kymo.stop` which can lead to subtle time discrepancies when comparing with force channels. Here the time limits are adjusted to the center timestamp of the first and last scan lines.