### PR TITLE
scan/kymo: workaround for non-quantized start timestamp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.7.1 | t. b. d.
+* Add workaround for `Scan` and `Kymo` which could prevent valid scans and kymos from being opened when the `start` timestamp of a scan or kymo had a value before the actual start of the timeline channels. The cause of this subsample time difference was the lack of quantization of a delay when acquiring STED images.
+
 ## v0.7.0 | 2020-11-04
 
 #### New features

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -112,7 +112,8 @@ def test_damaged_kymo(h5_file):
         kymo = f.kymos["Kymo1"]
         kymo_reference = np.transpose([[2, 0, 0, 0, 2], [0, 0, 0, 0, 0], [1, 0, 0, 0, 1], [0, 1, 1, 1, 0]])
 
-        kymo.start = kymo.red_photon_count.timestamps[0] - 1  # Assume the user incorrectly exported only a partial Kymo
+        # Assume the user incorrectly exported only a partial Kymo
+        kymo.start = kymo.red_photon_count.timestamps[0] - 62500000
         with pytest.warns(RuntimeWarning):
             assert kymo.red_image.shape == (5, 3)
         assert np.allclose(kymo.red_image.data, kymo_reference[:, 1:])

--- a/lumicks/pylake/tests/test_scan.py
+++ b/lumicks/pylake/tests/test_scan.py
@@ -104,9 +104,16 @@ def test_damaged_scan(h5_file):
     if f.format_version == 2:
         scan = f.scans["fast Y slow X"]
 
-        scan.start = scan.red_photon_count.timestamps[0] - 1  # Assume the user incorrectly exported only a partial scan
+        # Assume the user incorrectly exported only a partial scan (62500000 is the time step)
+        scan.start = scan.red_photon_count.timestamps[0] - 62500000
         with pytest.raises(RuntimeError):
             scan.red_image.shape
+
+        # Test for workaround for a bug in the STED delay mechanism which could result in scan start times ending up
+        # within the sample time.
+        scan = f.scans["fast Y slow X"]
+        scan.start = scan.red_photon_count.timestamps[0] - 62400000
+        scan.red_image.shape
 
 
 @cleanup


### PR DESCRIPTION
**What is this PR?**
Due to an issue with the implementation of the sted delay, the starting timestamp of a scan is not necessarily quantized to a multiple of the samplerate. This leads to an exception in the function which checks whether the start of the scan was truncated. In this PR, we allow for a small discrepancy here (within a time step) to accomodate for the quantization mishap (since the channel data can start a fraction of a sample after the scan start time).

**Why this PR?**
Since systems shipped that have this delay mechanism, we need to handle it gracefully in Pylake for both scans and kymos.