### PR TITLE
Kymo plot with downsampled force

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * Include `ipywidgets` as a dependency so users don't have to install it themselves.
 * Allow `nbAgg` backend to be used for interactive plots in Jupyter notebooks (i.e. `%matplotlib notebook`). Note that this backend doesn't work for JupyterLab (please see the [FAQ](https://lumicks-pylake.readthedocs.io/en/simplify_widgets/install.html#frequently-asked-questions) for more information).
 * Added `refine_lines_centroid` for refining lines detected by the kymotracking algorithm. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
+* Added `Kymo.plot_with_force` for plotting a kymograph and corresponding force channel downsampled to the same time ranges of the scan lines.
 * Fixed exception message in `downsampled_to` which erroneously suggested to use `force=True` when downsampling a variable frequency channel, while the correct argument is `method="force"`.
 
 ## v0.7.1 | 2020-11-19

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -209,9 +209,19 @@ def h5_file(tmpdir_factory, request):
         mock_file.make_continuous_channel("Photon count", "Green", np.int64(20e9), freq, counts)
         mock_file.make_continuous_channel("Photon count", "Blue", np.int64(20e9), freq, counts)
         mock_file.make_continuous_channel("Info wave", "Info wave", np.int64(20e9), freq, infowave)
+        
         ds = mock_file.make_json_data("Kymograph", "Kymo1", json_string)
         ds.attrs["Start time (ns)"] = np.int64(20e9)
         ds.attrs["Stop time (ns)"] = np.int64(20e9 + len(infowave) * freq)
+        # Force channel that overlaps kymo; step from high to low force
+        force_data = np.hstack((np.ones(35) * 30,
+                                np.ones(35) * 10))
+        force_start = np.int64(ds.attrs["Start time (ns)"] - (freq*5)) # before infowave
+        mock_file.make_continuous_channel("Force HF", "Force 2x", force_start, freq, force_data)
+        mock_file.make_calibration_data("1", "Force 2x", {calibration_time_field: 0})
+        mock_file.make_calibration_data("2", "Force 2x", {calibration_time_field: 1})
+        mock_file.make_calibration_data("3", "Force 2x", {calibration_time_field: 10})
+        mock_file.make_calibration_data("4", "Force 2x", {calibration_time_field: 100})
 
         def generate_scan_json(axis_1, n_pixels_1, axis_2, n_pixels_2):
             return enc.encode({

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -201,6 +201,9 @@ def test_repr_and_str(h5_file):
               Force 1y:
               - Data type: float64
               - Size: 5
+              Force 2x:
+              - Data type: float64
+              - Size: 70
             Force LF:
               Force 1x:
               - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
@@ -247,6 +250,8 @@ def test_repr_and_str(h5_file):
             .force1x
               .calibration
             .force1y
+              .calibration
+            .force2x
               .calibration
         """)
 

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -130,3 +130,18 @@ def test_plotting(h5_file):
         kymo.plot_red()
         assert np.allclose(np.sort(plt.xlim()), [0, 3.03125])
         assert np.allclose(np.sort(plt.ylim()), [0, 36.075])
+
+
+@cleanup        
+def test_plotting_with_force(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+    if f.format_version == 2:
+        kymo = f.kymos["Kymo1"]
+
+        ds = kymo._downsample_channel(2, "x", reduce=np.mean)
+        assert np.allclose(ds.data, [30, 30, 10, 10])
+        assert np.all(np.equal(ds.timestamps, kymo.timestamps[2]))
+
+        kymo.plot_with_force(force_channel="2x", color_channel="red")
+        assert np.allclose(np.sort(plt.xlim()), [0, 3], atol=0.05)
+        assert np.allclose(np.sort(plt.ylim()), [10, 30])


### PR DESCRIPTION
This PR adds functionality for automatically downsampling a force channel over the time ranges of the kymograph scan lines and plotting the image and downsampled force.

* added `Kymo.plot_with_force()`
* added `Kymo._downsample_channel()` to automatically calculate scanline time ranges and return appropriately downsampled channel