### PR TITLE
channel: add function to downsample like bluelake

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## v0.7.1 | t. b. d.
 * Add workaround for `Scan` and `Kymo` which could prevent valid scans and kymos from being opened when the `start` timestamp of a scan or kymo had a value before the actual start of the timeline channels. The cause of this subsample time difference was the lack of quantization of a delay when acquiring STED images.
 * Fixed bug in `Kymo` plotting functions. Previously, the time limits were calculated using the fly-in/out times which could lead to subtle discrepancies when comparing against force channels. These dead times are now omitted.
+* Added `Slice.downsampled_like` to downsample a high frequency channel according to the timestamps of a low frequency channel, using the same downsampling method as Bluelake.
 
 ## v0.7.0 | 2020-11-04
 

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -183,7 +183,7 @@ Note that this same flag can also be used to force a specific downsampling rate 
 A slice can also be downsampled over arbitrary time segments by using `downsampled_over` and supplying a 
 list of `(start, stop)` tuples indicating over which ranges to apply the function.
 
-Finally, a slice that contains equally spaced timestamps can be downsampled by a specific factor using `downsampled_by`
+A slice that contains equally spaced timestamps can be downsampled by a specific factor using `downsampled_by`
 *(note that the ratio of the original/final sampling frequencies must be an integer.)*::
 
     channel = file.force1x # original frequency 78125 Hz
@@ -191,6 +191,15 @@ Finally, a slice that contains equally spaced timestamps can be downsampled by a
 
     ds_channel = channel.downsampled_by(5)
     ds_timestep = np.diff(ds_channel.timestamps[:2]) * 1e-9  # timestep 64 us
+
+Sometimes, one may want to downsample a high frequency channel in exactly the same way that a Bluelake low frequency
+channel is sampled. For this purpose you can use `downsampled_like`::
+
+    lf_data = file["Force LF"]["Force 1x"]
+    downsampled = file["Force HF"]["Force 1x"].downsampled_like(lf_data)
+
+    plt.plot((lf_data.timestamps - lf_data.timestamps[0])/1e9, lf_data.data)
+    plt.plot((downsampled.timestamps - lf_data.timestamps[0])/1e9, downsampled.data)
 
 Calibrations
 ------------

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -505,3 +505,22 @@ def test_downsampling_over_subset():
     sd = s.downsampled_over([(20, 40), (40, 60), (60, 80)])
     np.allclose(sd.data, [(3+4)/2, (4+5)/2, (5+6)/2])
     np.allclose(sd.timestamps, [(20+30)/2, (40+50)/2, (60+70)/2])
+
+
+def test_downsampling_like():
+    d = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9]
+    s = channel.Slice(channel.Continuous(d, 100, 2))
+
+    t_downsampled = np.array([0, 4, 8, 12, 16, 34, 40, 46, 50, 54]) + 100
+    y_downsampled = np.array([0, 1, 2, 3, 4, 6, 7, 8, 9, 10])
+    reference = channel.Slice(channel.TimeSeries(y_downsampled, t_downsampled))
+
+    ds = s.downsampled_like(reference)
+    assert np.allclose(t_downsampled[1:-1], ds.timestamps)
+    assert np.allclose(y_downsampled[1:-1], ds.data)
+
+    with pytest.raises(NotImplementedError):
+        reference.downsampled_like(reference)
+
+    with pytest.raises(AssertionError):
+        s.downsampled_like(s)


### PR DESCRIPTION
**Why this PR?**
It was requested to have a function which downsamples exactly like Bluelake does.

**How does it work?**
Bluelake averages backward in time from the end (i.e. `[t-dt : t]`) using the frame time. We can reconstruct this frame time from the consecutive time stamps.

When the framerate changes, it takes some time for new images to arrive. The code shouldn't average that entire time and instead just use the new framerate based on the timesteps that follow.

**Why not via downsampled_over?**
The difference in how the change in framerate is handled warranted a separate function.

Test with actual bluelake data with varying framerate (first samples cannot be reconstructed since there is no HF data there):
![image](https://user-images.githubusercontent.com/19836026/98860045-63396480-2463-11eb-9b44-0b7b3971ed5d.png)

The residual when they overlap:
![image](https://user-images.githubusercontent.com/19836026/98860089-6fbdbd00-2463-11eb-8f55-c07fd56aa6cb.png)
