### PR TITLE
Allow plotting with respect to a different timestamp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * Add workaround for `Scan` and `Kymo` which could prevent valid scans and kymos from being opened when the `start` timestamp of a scan or kymo had a value before the actual start of the timeline channels. The cause of this subsample time difference was the lack of quantization of a delay when acquiring STED images.
 * Fixed bug in `Kymo` plotting functions. Previously, the time limits were calculated using the fly-in/out times which could lead to subtle discrepancies when comparing against force channels. These dead times are now omitted.
 * Added `Slice.downsampled_like` to downsample a high frequency channel according to the timestamps of a low frequency channel, using the same downsampling method as Bluelake.
+* Add `start` and `stop` property to `Slice`.
 
 ## v0.7.0 | 2020-11-04
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Fixed bug in `Kymo` plotting functions. Previously, the time limits were calculated using the fly-in/out times which could lead to subtle discrepancies when comparing against force channels. These dead times are now omitted.
 * Added `Slice.downsampled_like` to downsample a high frequency channel according to the timestamps of a low frequency channel, using the same downsampling method as Bluelake.
 * Add `start` and `stop` property to `Slice`.
+* Add `start` argument to `Slice.plot()` which allows you to use a specific timestamp as time point zero. See [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#channels) for more information.
 
 ## v0.7.0 | 2020-11-04
 

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -151,6 +151,13 @@ Once you access the raw data, those are regular arrays which use regular array i
     channel_slice = file.force1x['1.5s':'20s']  # timestamps
     data_slice = file.force1x.data[20:40]  # indices into the array
 
+Plotting is typically performed with the origin of the plot set to the timestamp of the start of the slice. Sometimes, you may want to plot two slices together that have different starting times. You can pass a custom reference timestamp to the plotting function to make sure they use the same time shift::
+
+    first_slice = file.force1x['5s':'10s']
+    second_slice = file.force1x['15s':'20s']
+    first_slice.plot()
+    second_slice.plot(start=first_slice.start)  # we want to use the start of first_slice as time point "zero"
+
 Downsampling
 ^^^^^^^^^^^^
 

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -205,8 +205,8 @@ channel is sampled. For this purpose you can use `downsampled_like`::
     lf_data = file["Force LF"]["Force 1x"]
     downsampled = file["Force HF"]["Force 1x"].downsampled_like(lf_data)
 
-    plt.plot((lf_data.timestamps - lf_data.timestamps[0])/1e9, lf_data.data)
-    plt.plot((downsampled.timestamps - lf_data.timestamps[0])/1e9, downsampled.data)
+    lf_data.plot()
+    downsampled.plot(start=lf_data.start)
 
 Calibrations
 ------------

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -276,17 +276,20 @@ class Slice:
 
         return Slice(TimeSeries(downsampled, timestamps))
 
-    def plot(self, **kwargs):
+    def plot(self, start=None, **kwargs):
         """A simple line plot to visualize the data over time
 
         Parameters
         ----------
+        start : int64
+            Origin timestamp. This can be used to plot two slices starting at different times on the same axis.
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.plot`.
         """
         import matplotlib.pyplot as plt
 
-        plt.plot(self.seconds, self.data, **kwargs)
+        start = start if start is not None else self._src.start
+        plt.plot((self._src.timestamps - start) * 1e-9, self.data, **kwargs)
         plt.xlabel(self.labels.get("x", "Time") + " (s)")
         plt.ylabel(self.labels.get("y", "y"))
         plt.title(self.labels.get("title", "title"))

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -54,6 +54,16 @@ class Slice:
         return self.__class__(data_source, self.labels, self._calibration)
 
     @property
+    def start(self):
+        """Starting timestamp of this time series in nanoseconds"""
+        return self._src.start
+
+    @property
+    def stop(self):
+        """End timestamp of this time series in nanoseconds"""
+        return self._src.stop
+
+    @property
     def data(self):
         """The primary values of this channel slice"""
         return self._src.data

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -2,6 +2,8 @@ import pytest
 import numpy as np
 from lumicks.pylake import channel
 from lumicks.pylake.calibration import ForceCalibration
+import matplotlib as mpl
+from matplotlib.testing.decorators import cleanup
 
 
 def test_calibration_timeseries_channels():
@@ -542,3 +544,25 @@ def test_downsampling_like():
 
     with pytest.raises(AssertionError):
         s.downsampled_like(s)
+
+@cleanup
+def test_channel_plot():
+    def testLine(x, y):
+        data = [obj for obj in mpl.pyplot.gca().get_children() if isinstance(obj, mpl.lines.Line2D)]
+        assert len(data) == 1
+        line = data[0].get_data()
+        assert np.allclose(line[0], x)
+        assert np.allclose(line[1], y)
+
+    d = np.arange(1, 24)
+    s = channel.Slice(channel.Continuous(d, int(5e9), int(10e9)))
+    s.plot()
+    testLine(np.arange(0, 230, 10), d)
+
+    mpl.pyplot.gca().clear()
+    s.plot(start=0)
+    testLine(np.arange(5, 230, 10), d)
+
+    mpl.pyplot.gca().clear()
+    s.plot(start=100e9)
+    testLine(np.arange(0, 230, 10) - 100 + 5, d)

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -148,6 +148,24 @@ def test_empty_slice():
     assert len(s[1:2].timestamps) == 0
 
 
+def test_start_stop():
+    s = channel.Slice(channel.TimeSeries([14, 15, 16, 17], [4, 6, 8, 10]))
+    assert np.allclose(s.start, 4)
+    assert np.allclose(s.stop, 10 + 1)
+
+    s = channel.Slice(channel.Continuous([14, 15, 16, 17], 4, 2))
+    assert np.allclose(s.start, 4)
+    assert np.allclose(s.stop, 12)
+
+    s = channel.Slice(channel.TimeTags([14, 15, 16, 17]))
+    assert np.allclose(s.start, 14)
+    assert np.allclose(s.stop, 17 + 1)
+
+    s = channel.Slice(channel.TimeTags([14, 15, 16, 17], 4, 30))
+    assert np.allclose(s.start, 4)
+    assert np.allclose(s.stop, 30)
+
+
 def test_timeseries_indexing():
     """The default integer indices are in timestamps (ns)"""
     s = channel.Slice(channel.TimeSeries([14, 15, 16, 17], [4, 5, 6, 7]))


### PR DESCRIPTION
**Why this PR?**
Quite often, you want to plot two slices of something together. It can be inconvenient to use a different starting point for the time axes. For example, when comparing downsampled data to the normal data, it can be pretty annoying that there is an apparent time shift when the initial sample is different. Or when you want to plot two slices together, you might want to be able to align them quickly and conveniently.

**How does this PR make things better?**
This PR exposes `start` and `stop` on `Slice` and allows you to `.plot()` with a custom starting timestamp.

```python
first_slice = file.force1x['5s':'10s']
second_slice = file.force1x['15s':'20s']
first_slice.plot()
second_slice.plot(start=first_slice.start)  # we want to use the start of first_slice as time point "zero"
```