### PR TITLE
kymotracker: add refinement pt. 1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Support Python 3.9 on Windows (this required bumping the `h5py` requirement to >= 3.0).
 * Include `ipywidgets` as a dependency so users don't have to install it themselves.
 * Allow `nbAgg` backend to be used for interactive plots in Jupyter notebooks (i.e. `%matplotlib notebook`). Note that this backend doesn't work for JupyterLab (please see the [FAQ](https://lumicks-pylake.readthedocs.io/en/simplify_widgets/install.html#frequently-asked-questions) for more information).
+* Added `refine_lines_centroid` for refining lines detected by the kymotracking algorithm. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
 
 ## v0.7.1 | 2020-11-19
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -58,6 +58,7 @@ Kymotracking
     track_greedy
     track_lines
     filter_lines
+    refine_lines_centroid
 
 Notebook widgets
 ----------------

--- a/docs/tutorial/kymo_refine.png
+++ b/docs/tutorial/kymo_refine.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1b13ff7cf5e4086412c966d8c0822fad7cd2e651062f19b0497d35897b32aca
+size 23875

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -83,6 +83,28 @@ Plotting all the detected traces is also quite easy by iterating over the list o
 
 .. image:: kymotracked.png
 
+Once we are happy with the traces found by the algorithm, we may still want to refine them. Since the algorithm finds
+traces by determining local peaks and stringing these together, it is possible that some scan lines in the kymograph
+don't have an explicit point on the trace associated with them. Using :func:`~lumicks.pylake.refine_lines_centroid` we
+can refine the traces found by the algorithm. This function interpolates the lines such that each time point gets its
+own point on the trace. Subsequently, these points are then refined using a brightness weighted centroid. Let's perform
+line refinement and plot the longest trace::
+
+    longest_trace_idx = np.argmax([len(trace) for trace in traces])  # Get the longest trace
+
+    refined = lk.refine_lines_centroid(traces, line_width=3)
+
+    plt.plot(refined[longest_index].time_idx, refined[longest_index].coordinate_idx, '.')
+    plt.plot(traces[longest_index].time_idx, traces[longest_index].coordinate_idx, '.')
+    plt.legend(["Post refinement", "Pre-refinement"])
+    plt.ylabel('Position [pixels]')
+    plt.xlabel('Time [pixels]')
+
+.. image:: kymo_refine.png
+
+We can see now that a few points were added post refinement (shown in blue). The others remain unchanged, since we used
+the same `line_width`.
+
 Fortunately, the signal to noise level in this kymograph is quite good. In practice, when the signal to noise is lower,
 one will have to resort to some fine tuning of the algorithm parameters over different regions of the kymograph to get
 an acceptable result.

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -7,7 +7,7 @@ from .correlated_stack import CorrelatedStack
 from .fitting.fit import FdFit
 from lumicks.pylake.fitting.parameter_trace import parameter_trace
 from lumicks.pylake.nb_widgets.fd_selector import FdRangeSelector, FdRangeSelectorWidget
-from lumicks.pylake.kymotracker.kymotracker import track_greedy, track_lines, filter_lines
+from lumicks.pylake.kymotracker.kymotracker import track_greedy, track_lines, filter_lines, refine_lines_centroid
 
 
 def pytest(args=None, plugins=None):

--- a/lumicks/pylake/kymotracker/detail/peakfinding.py
+++ b/lumicks/pylake/kymotracker/detail/peakfinding.py
@@ -123,7 +123,7 @@ def refine_peak_based_on_moment(data, coordinates, time_points, half_kernel_size
     else:
         raise RuntimeError("Iteration limit exceeded")
 
-    return KymoPeaks(coordinates + subpixel_offset[coordinates, time_points], time_points, m0[coordinates, time_points])
+    return coordinates + subpixel_offset[coordinates, time_points], time_points, m0[coordinates, time_points]
 
 
 def merge_close_peaks(peaks, minimum_distance):

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -1,5 +1,4 @@
 import numpy as np
-import matplotlib.pyplot as plt
 
 
 class KymoLine:
@@ -42,6 +41,12 @@ class KymoLine:
         time_match = np.logical_and(time_idx < rect[1][0], time_idx >= rect[0][0])
         coord_match = np.logical_and(coordinate_idx < rect[1][1], coordinate_idx >= rect[0][1])
         return np.any(np.logical_and(time_match, coord_match))
+
+    def interpolate(self):
+        """Interpolate Kymoline to whole pixel values"""
+        interpolated_time = np.arange(int(np.min(self.time_idx)), int(np.max(self.time_idx)) + 1, 1)
+        interpolated_coord = np.interp(interpolated_time, self.time_idx, self.coordinate_idx)
+        return KymoLine(interpolated_time, interpolated_coord, self.image_data)
 
     def sample_from_image(self, num_pixels, reduce=np.sum):
         """Sample from image using coordinates from this KymoLine.

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -1,4 +1,5 @@
-from lumicks.pylake.kymotracker.detail.peakfinding import peak_estimate, refine_peak_based_on_moment, merge_close_peaks
+from lumicks.pylake.kymotracker.detail.peakfinding import peak_estimate, refine_peak_based_on_moment, merge_close_peaks, \
+    KymoPeaks
 from lumicks.pylake.kymotracker.detail.trace_line_2d import detect_lines, points_to_line_segments
 from lumicks.pylake.kymotracker.detail.scoring_functions import kymo_score
 import numpy as np
@@ -84,7 +85,7 @@ def track_greedy(data, line_width, pixel_threshold, window=8, sigma=None, vel=0.
     if len(coordinates) == 0:
         return []
 
-    peaks = refine_peak_based_on_moment(data_selection, coordinates, time_points, np.ceil(.5*line_width))
+    peaks = KymoPeaks(*refine_peak_based_on_moment(data_selection, coordinates, time_points, np.ceil(.5*line_width)))
     peaks = merge_close_peaks(peaks, np.ceil(.5*line_width))
     lines = points_to_line_segments(
         peaks,

--- a/lumicks/pylake/kymotracker/tests/test_peakfinding.py
+++ b/lumicks/pylake/kymotracker/tests/test_peakfinding.py
@@ -14,7 +14,7 @@ def test_peak_estimation(location):
 
     # Deliberately mis-shift the initial guess
     position = position + 5
-    peaks = refine_peak_based_on_moment(data, position, time, 4)
+    peaks = KymoPeaks(*refine_peak_based_on_moment(data, position, time, 4))
     assert np.abs(peaks.frames[0].coordinates[0] - location) < 1e-3
 
 

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -1,10 +1,36 @@
+from lumicks.pylake.kymotracker.kymotracker import refine_lines_centroid
 from lumicks.pylake.kymotracker.detail.trace_line_2d import KymoLine
 import numpy as np
+import pytest
 
 
 def test_kymoline_interpolation():
     time_idx = [1.0, 3.0, 5.0]
     coordinate_idx = [1.0, 3.0, 3.0]
     interpolated = KymoLine(time_idx, coordinate_idx).interpolate()
-    np.allclose(interpolated.time_idx, [1.0, 2.0, 3.0, 4.0, 5.0])
-    np.allclose(interpolated.coordinate_idx, [1.0, 2.0, 3.0, 3.0, 3.0])
+    assert np.allclose(interpolated.time_idx, [1.0, 2.0, 3.0, 4.0, 5.0])
+    assert np.allclose(interpolated.coordinate_idx, [1.0, 2.0, 3.0, 3.0, 3.0])
+
+
+def test_refinement_2d():
+    time_idx = np.array([1, 2, 3, 4, 5])
+    coordinate_idx = np.array([1, 2, 3, 3, 3])
+
+    # Draw image with a deliberate offset
+    offset = 2
+    image = np.zeros((7, 7))
+    image[coordinate_idx + offset, time_idx] = 5
+    image[coordinate_idx - 1 + offset, time_idx] = 1
+    image[coordinate_idx + 1 + offset, time_idx] = 1
+
+    line = refine_lines_centroid([KymoLine(time_idx[::2], coordinate_idx[::2], image_data=image)], 5)[0]
+    assert np.allclose(line.time_idx, time_idx)
+    assert np.allclose(line.coordinate_idx, coordinate_idx + offset)
+
+
+@pytest.mark.parametrize("loc", [25.3, 25.5, 26.25, 23.6])
+def test_refinement_line(loc, inv_sigma=0.3):
+    xx = np.arange(0, 50) - loc
+    image = np.exp(-inv_sigma * xx * xx)
+    line = refine_lines_centroid([KymoLine([0], [25], image_data=np.expand_dims(image, 1))], 5)[0]
+    assert np.allclose(line.coordinate_idx, loc, rtol=1e-2)

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -1,0 +1,10 @@
+from lumicks.pylake.kymotracker.detail.trace_line_2d import KymoLine
+import numpy as np
+
+
+def test_kymoline_interpolation():
+    time_idx = [1.0, 3.0, 5.0]
+    coordinate_idx = [1.0, 3.0, 3.0]
+    interpolated = KymoLine(time_idx, coordinate_idx).interpolate()
+    np.allclose(interpolated.time_idx, [1.0, 2.0, 3.0, 4.0, 5.0])
+    np.allclose(interpolated.coordinate_idx, [1.0, 2.0, 3.0, 3.0, 3.0])


### PR DESCRIPTION
**Why this PR?**
When performing Kymotracking using the greedy algorithm, one strings together a sequence of points that fall above a certain threshold into a trace. This means gaps can occur in the trace. This PR adds a method which interpolates the traces, and then tweaks those points based on the local brightness (using the brightness weighted centroid).

Before:
![image](https://user-images.githubusercontent.com/19836026/99300876-6fe7ff00-284d-11eb-99f5-2f0769c9a8d7.png)

After:
![image](https://user-images.githubusercontent.com/19836026/99300914-82623880-284d-11eb-8a1e-2f8a49a2461c.png)

**Why part 1?**
Ideally this method is followed up by a more extensive fitting procedure that will take into account the Poissonian nature of the measurement.

Docs: https://lumicks-pylake.readthedocs.io/en/kymo_refinement_pt1/tutorial/kymotracking.html

I added a paragraph on the refinement (look for refine_lines_centroid).