### PR TITLE
Refactor image reconstruction

### DIFF
--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -67,15 +67,13 @@ class Kymo(ConfocalImage):
         warnings.warn("Start of the kymograph was truncated. Omitting the truncated first line.",
                         RuntimeWarning)
 
-    def _image(self, color):
-        if color not in self._cache:
-            photon_counts = getattr(self, f"{color}_photon_count").data
-            self._cache[color] = reconstruct_image_sum(photon_counts, self.infowave.data, self.pixels_per_line).T
-        return self._cache[color]
+    def _to_spatial(self, data):
+        """Spatial data as rows, time as columns"""
+        return data.T
 
-    def _timestamps(self, sample_timestamps):
-        return reconstruct_image(sample_timestamps, self.infowave.data,
-                                 self.pixels_per_line, reduce=np.mean).T
+    @property
+    def _shape(self):
+        return (self.pixels_per_line, )
 
     @property
     def line_time_seconds(self):

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -49,19 +49,19 @@ def test_reconstruct():
     infowave = np.array([0, 1, 0, 1, 1, 0, 2, 1, 0, 1, 0, 0, 1, 2, 1, 1, 1, 2])
     the_data = np.array([1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3])
 
-    image = reconstruct_image(the_data, infowave, 5)
+    image = reconstruct_image(the_data, infowave, (5, ))
     assert image.shape == (1, 5)
     assert np.all(image == [4, 8, 12, 0, 0])
 
-    image = reconstruct_image(the_data, infowave, 2)
+    image = reconstruct_image(the_data, infowave, (2, ))
     assert image.shape == (2, 2)
     assert np.all(image == [[4, 8], [12, 0]])
 
-    image = reconstruct_image_sum(the_data, infowave, 5)
+    image = reconstruct_image_sum(the_data, infowave, (5, ))
     assert image.shape == (1, 5)
     assert np.all(image == [4, 8, 12, 0, 0])
 
-    image = reconstruct_image_sum(the_data, infowave, 2)
+    image = reconstruct_image_sum(the_data, infowave, (2, ))
     assert image.shape == (2, 2)
     assert np.all(image == [[4, 8], [12, 0]])
 
@@ -72,19 +72,19 @@ def test_reconstruct_multiframe():
     infowave[9::10] = 2
     the_data = np.arange(size)
 
-    assert reconstruct_image(the_data, infowave, 5).shape == (2, 5)
-    assert reconstruct_image(the_data, infowave, 2).shape == (5, 2)
-    assert reconstruct_image(the_data, infowave, 1).shape == (10, 1)
-    assert reconstruct_image(the_data, infowave, 2, 2).shape == (3, 2, 2)
-    assert reconstruct_image(the_data, infowave, 2, 3).shape == (2, 3, 2)
-    assert reconstruct_image(the_data, infowave, 2, 5).shape == (5, 2)
+    assert reconstruct_image(the_data, infowave, (5, )).shape == (2, 5)
+    assert reconstruct_image(the_data, infowave, (2, )).shape == (5, 2)
+    assert reconstruct_image(the_data, infowave, (1, )).shape == (10, 1)
+    assert reconstruct_image(the_data, infowave, (2, 2)).shape == (3, 2, 2)
+    assert reconstruct_image(the_data, infowave, (3, 2)).shape == (2, 3, 2)
+    assert reconstruct_image(the_data, infowave, (5, 2)).shape == (1, 5, 2)
 
-    assert reconstruct_image_sum(the_data, infowave, 5).shape == (2, 5)
-    assert reconstruct_image_sum(the_data, infowave, 2).shape == (5, 2)
-    assert reconstruct_image_sum(the_data, infowave, 1).shape == (10, 1)
-    assert reconstruct_image_sum(the_data, infowave, 2, 2).shape == (3, 2, 2)
-    assert reconstruct_image_sum(the_data, infowave, 2, 3).shape == (2, 3, 2)
-    assert reconstruct_image_sum(the_data, infowave, 2, 5).shape == (5, 2)
+    assert reconstruct_image_sum(the_data, infowave, (5, )).shape == (2, 5)
+    assert reconstruct_image_sum(the_data, infowave, (2, )).shape == (5, 2)
+    assert reconstruct_image_sum(the_data, infowave, (1, )).shape == (10, 1)
+    assert reconstruct_image_sum(the_data, infowave, (2, 2)).shape == (3, 2, 2)
+    assert reconstruct_image_sum(the_data, infowave, (3, 2)).shape == (2, 3, 2)
+    assert reconstruct_image_sum(the_data, infowave, (5, 2)).shape == (1, 5, 2)
 
     assert reconstruct_num_frames(infowave, 2, 2) == 3
     assert reconstruct_num_frames(infowave, 2, 3) == 2


### PR DESCRIPTION
**Why this PR?**
Currently, there is a lot of duplicated code in `reconstruct_image()` and `reconstruct_image_sum()`. Additionally these functions have an optional `lines_per_frame` kwarg to handle reconstructing 2D images, which leads to different call signatures from `Scan` and `Kymo`

**How does this PR make things better?**

- duplicated code in `reconstruct_image()` and `reconstruct_image_sum()` is pulled out into separate helper functions
- a private `_shape` property is added to `Scan` and `Kymo` which can be used directly in the image reconstruction functions rather than the current `pixels_per_line` and optional `lines_per_frame` arguments
- this allows for a homogenous call to the reconstruction functions; therefore `_image()` and `_timestamps()` are moved to `ConfocalImage` mixin class rather than being implemented separately in `Kymo` and `Scan`

**NOTE**
Because the call signature for the image reconstruction functions changed, the arguments in `test_image.py` for these functions needed to be flipped.
