### PR TITLE
Better caching

### DIFF
--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -158,5 +158,17 @@ class EmptyKymo(Kymo):
     def _plot(self, image, **kwargs):
         raise RuntimeError("Cannot plot empty kymograph")
 
-    def _image(self, color):
+    def _image(self):
         return np.empty((self.pixels_per_line, 0))
+
+    @property
+    def red_image(self):
+        return self._image()
+
+    @property
+    def green_image(self):
+        return self._image()
+
+    @property
+    def blue_image(self):
+        return self._image()

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "tabulate==0.8.6",
         "opencv-python>=3.0",
         "ipywidgets>=7.0.0",
+        "cachetools>=3.1",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
**Why this PR?**
Currently, caching for expensive calculations is handled manually (and not implemented for timestamps). Would be better to let a dedicated caching package handle this.

**How does this PR make things better?**

- caching is handled through `cachetools` method decorator 
- caching is implemented for `timestamps` along with `{color}_image`
- all calculations are handled through a single method `_from_infowave` (and `_timestamps` and `_image` have been removed)