### PR TITLE
ci: support python 3.9

### DIFF
--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.2 | t.b.d.
+
+* Support Python 3.9 on Windows (this required bumping the `h5py` requirement to >= 3.0).
+
 ## v0.7.1 | 2020-11-19
 
 * Add `start` and `stop` property to `Slice`. These return the timestamp in nanoseconds.

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,15 @@ setup(
 
     packages=PEP420PackageFinder.find(include=["lumicks.*"]),
     python_requires='>=3.6',
-    install_requires=['pytest>=3.5', 'h5py>=2.9, <3.0', 'numpy>=1.14, <2',
-                      'scipy>=1.1, <2', 'matplotlib>=2.2', 'tifffile>=2018.11.6',
-                      'tabulate==0.8.6', 'opencv-python>=3.0'],
+    install_requires=[
+        "pytest>=3.5",
+        "h5py>=3.0, <4",
+        "numpy>=1.14, <2",
+        "scipy>=1.1, <2",
+        "matplotlib>=2.2",
+        "tifffile>=2018.11.6",
+        "tabulate==0.8.6",
+        "opencv-python>=3.0",
+    ],
     zip_safe=False,
 )


### PR DESCRIPTION
**Why this PR?**
To support Python 3.9 we need wheels for `h5py`. We need to start using the new `h5py` to still get wheels.