### PR TITLE
Don't force users to install ipympl + faq

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## v0.7.2 | t.b.d.
 
 * Support Python 3.9 on Windows (this required bumping the `h5py` requirement to >= 3.0).
+* Include `ipywidgets` as a dependency so users don't have to install it themselves.
 
 ## v0.7.1 | 2020-11-19
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 * Support Python 3.9 on Windows (this required bumping the `h5py` requirement to >= 3.0).
 * Include `ipywidgets` as a dependency so users don't have to install it themselves.
+* Allow `nbAgg` backend to be used for interactive plots in Jupyter notebooks (i.e. `%matplotlib notebook`). Note that this backend doesn't work for JupyterLab (please see the [FAQ](https://lumicks-pylake.readthedocs.io/en/simplify_widgets/install.html#frequently-asked-questions) for more information).
 
 ## v0.7.1 | 2020-11-19
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -117,3 +117,73 @@ Troubleshooting
 If you run into any errors after installation, try updating all conda packages to the latest versions using the following command::
 
     conda update --all
+
+
+Frequently asked questions
+--------------------------
+
+**Why are the plots in my notebook not interactive?**
+
+To enable interactive plots, you have to invoke the correct `magic commands <https://ipython.readthedocs.io/en/stable/interactive/magics.html>`_
+in the notebook. When using Jupyter notebook, the following command will switch the `matplotlib` backend from the inline
+one (which renders images) to the interactive backend::
+
+    %matplotlib notebook
+
+You can also choose to install `ipympl`, which can perform better in some cases. You can install it with `pip`::
+
+    pip install ipympl
+
+or `conda`::
+
+    conda install -c conda-forge ipympl
+
+The `ipympl` backend can be activated by invoking the following magic command in a notebook::
+
+    %matplotlib widget
+
+*Note that switching backends typically requires you to restart the Jupyter kernel*. When using JupyterLab, `ipympl` is
+the only backend that provides interactive plots with Pylake.
+
+
+**Conda takes a long time to resolve the environment and then fails. What can I do?**
+
+Several packages depend on each other. Sometimes, finding a suitable collection of packages that is compatible can be
+problematic. One way to work around this is to make a separate environment for working with `pylake`. You can create a
+new environment named `pylake` by invoking the following in the anaconda prompt::
+
+    conda create -n pylake
+
+The environment can then be activated by calling `activate`::
+
+    conda activate pylake
+
+You can see that it is activated, because `pylake` should now be prefixed to the path in your anaconda prompt. We can
+install `pylake` and `jupyter notebook` in this environment by invoking the following commands::
+
+    conda install -c conda-forge lumicks.pylake
+    conda install -c conda-forge jupyter notebook
+
+It should be possible to open a jupyter notebook in this environment by calling `jupyter notebook`. Note that if you
+are used to starting Jupyter from the anaconda navigator, you will have to set the environment to `pylake` for it to
+have access to the pylake package.
+
+
+**How do I check which version of pylake I have?**
+
+From within `python` or a `notebook` you can invoke::
+
+    import lumicks.pylake as lk
+    lk.__version__
+
+Which should return the version number.
+
+
+**How do I know whether Pylake installed correctly?**
+
+You can run the test suite as follows::
+
+    import lumicks.pylake as lk
+    lk.pytest()
+
+If all tests pass (except for the slow ones which are skipped) then your installation of `pylake` is good to go.

--- a/lumicks/pylake/nb_widgets/fd_selector.py
+++ b/lumicks/pylake/nb_widgets/fd_selector.py
@@ -129,14 +129,10 @@ class FdRangeSelector:
         fd_curves : dict
             Dictionary of `lumicks.pylake.FdCurve`
         """
+        import ipywidgets
 
         if len(fd_curves) == 0:
             raise ValueError("F,d selector widget cannot open without a non-empty dictionary containing F,d curves.")
-
-        try:
-            import ipywidgets
-        except ImportError:
-            raise RuntimeError("This widget requires ipywidgets to be installed to work. Please install it.")
 
         if "ipympl" not in plt.get_backend():
             raise RuntimeError(("Please enable the widgets backend for this plot to work. You can do this by invoking "

--- a/lumicks/pylake/nb_widgets/fd_selector.py
+++ b/lumicks/pylake/nb_widgets/fd_selector.py
@@ -134,10 +134,12 @@ class FdRangeSelector:
         if len(fd_curves) == 0:
             raise ValueError("F,d selector widget cannot open without a non-empty dictionary containing F,d curves.")
 
-        if "ipympl" not in plt.get_backend():
-            raise RuntimeError(("Please enable the widgets backend for this plot to work. You can do this by invoking "
-                                "%matplotlib widget. Please note that you may have to restart the notebook kernel for "
-                                "this to work."))
+        if not any(backend in plt.get_backend() for backend in ("nbAgg", "ipympl")):
+            raise RuntimeError(("Please enable an interactive matplotlib backend for this plot to work. In jupyter"
+                                "notebook you can do this by invoking either %matplotlib notebook or %matplotlib "
+                                "widget (the latter requires ipympl to be installed). In Jupyter Lab only the latter "
+                                "works. Please note that you may have to restart the notebook kernel for this to "
+                                "work."))
 
         plt.figure()
         self.axes = plt.axes()

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "tifffile>=2018.11.6",
         "tabulate==0.8.6",
         "opencv-python>=3.0",
+        "ipywidgets>=7.0.0",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
**Why this PR?**
This PR hopes to make it simpler for our users to get the interactive widgets to work.

**How?**
`Pylake` checked explicitly whether the backend is `ipympl` and threw an exception if it wasn't. In Jupyter notebook, the backend `nbagg` is installed by default and would also be suitable for displaying our interactive plots.

The second change introduced in this PR is that `ipywidgets` is added as an explicit dependency. Some of our users may not know how to install it, and it'd be nice to just have it dealt with.

I also added a few FAQ issues to the docs that come up frequently.

**Docs:**
https://lumicks-pylake.readthedocs.io/en/simplify_widgets/install.html#faq