### PR TITLE
channel: fix exception message downsampled_to

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * Include `ipywidgets` as a dependency so users don't have to install it themselves.
 * Allow `nbAgg` backend to be used for interactive plots in Jupyter notebooks (i.e. `%matplotlib notebook`). Note that this backend doesn't work for JupyterLab (please see the [FAQ](https://lumicks-pylake.readthedocs.io/en/simplify_widgets/install.html#frequently-asked-questions) for more information).
 * Added `refine_lines_centroid` for refining lines detected by the kymotracking algorithm. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
+* Fixed exception message in `downsampled_to` which erroneously suggested to use `force=True` when downsampling a variable frequency channel, while the correct argument is `method="force"`.
 
 ## v0.7.1 | 2020-11-19
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -192,24 +192,28 @@ class Slice:
         # prevent upsampling
         if np.any(target_timestep < source_timestep):
             slow = 1e9 / np.max(source_timestep)
-            raise ValueError(f"requested frequency ({frequency:0.1g} Hz) is faster than slowest current sampling rate ({slow:0.1g} Hz)")
+            raise ValueError(f"Requested frequency ({frequency:0.1g} Hz) is faster than slowest current sampling rate "
+                             f"({slow:0.1g} Hz)")
 
         if method == "force":
             pass
         else:
             # must specifically force downsampling for variable frequency
             if len(source_timestep) > 1:
-                raise ValueError(("This slice contains variable sampling frequencies leading to a variable timestep and an unequal number of samples "
-                                  "contributing to each sample. Use 'force=True' to ignore this error and evaluate the result."))    
+                raise ValueError(("This slice contains variable sampling frequencies leading to a variable timestep "
+                                  "and an unequal number of samples contributing to each sample. Use 'method='force' "
+                                  "to ignore this error and evaluate the result."))
             # ratio of current/new frequencies must be integer to ensure equal timesteps
             remainder = target_timestep % source_timestep
             if remainder != 0:
                 if method == "ceil":
                     target_timestep -= remainder
                 else: # method == 'safe'
-                    raise ValueError(("The desired sample rate will not result in time steps that are an exact multiple of the current sampling time. "
-                                      "To round the sample rate up to the nearest frequency which fulfills this condition please specify method='ceil'. "
-                                      "To force the target sample rate (leading to unequal timesteps in the returned Slice, specify method='force'."))
+                    raise ValueError(("The desired sample rate will not result in time steps that are an exact "
+                                      "multiple of the current sampling time. To round the sample rate up to the "
+                                      "nearest frequency which fulfills this condition please specify method='ceil'. "
+                                      "To force the target sample rate (leading to unequal timesteps in the returned "
+                                      "Slice, specify method='force'."))
 
         t = np.arange(self._src.start, self._src.stop, target_timestep)
         new_ranges = [(t1, t2) for t1, t2 in zip(t[:-1], t[1:])]


### PR DESCRIPTION
**Why this PR?**
When downsampling variable TimeSeries the command suggests to use `Force=True` rather than `method=”force”` which was a previous API in the PR that was never released. This exception should correctly reflect what a user actually has to do.

![image](https://user-images.githubusercontent.com/19836026/100751670-e78a6200-33e7-11eb-803d-2b8ca0e51454.png)
