### PR TITLE
kymo: fix plot time extent

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * Added `refine_lines_centroid` for refining lines detected by the kymotracking algorithm. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
 * Added `Kymo.plot_with_force` for plotting a kymograph and corresponding force channel downsampled to the same time ranges of the scan lines.
 * Fixed exception message in `downsampled_to` which erroneously suggested to use `force=True` when downsampling a variable frequency channel, while the correct argument is `method="force"`.
+* Fixed minor bug in `Kymo` plot functions which incorrectly set the time limits. Now, pixel centers are aligned with the mean time for each line.
 
 ## v0.7.1 | 2020-11-19
 

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -189,10 +189,12 @@ class Kymo(PhotonCounts, ExcitationLaserPower):
         width_um = self._ordered_axes()[0]["scan width (um)"]
         ts = self.timestamps
         duration = (ts[0, -1] - ts[0, 0]) / 1e9
+        linetime = (ts[0, 1] - ts[0, 0]) / 1e9
 
         default_kwargs = dict(
             # With origin set to upper (default) bounds should be given as (0, n, n, 0)
-            extent=[0, duration, width_um, 0],
+            # pixel center aligned with mean time per line
+            extent=[-0.5 * linetime, duration + 0.5 * linetime, width_um, 0],
             aspect=(image.shape[0] / image.shape[1]) * (duration / width_um)
         )
 

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -128,7 +128,7 @@ def test_plotting(h5_file):
         kymo = f.kymos["Kymo1"]
         
         kymo.plot_red()
-        assert np.allclose(np.sort(plt.xlim()), [0, 3.03125])
+        assert np.allclose(np.sort(plt.xlim()), [-0.5, 3.5], atol=0.05)
         assert np.allclose(np.sort(plt.ylim()), [0, 36.075])
 
 
@@ -143,5 +143,5 @@ def test_plotting_with_force(h5_file):
         assert np.all(np.equal(ds.timestamps, kymo.timestamps[2]))
 
         kymo.plot_with_force(force_channel="2x", color_channel="red")
-        assert np.allclose(np.sort(plt.xlim()), [0, 3], atol=0.05)
+        assert np.allclose(np.sort(plt.xlim()), [-0.5, 3.5], atol=0.05)
         assert np.allclose(np.sort(plt.ylim()), [10, 30])


### PR DESCRIPTION
**Why this PR?**
Currently, the plotting functions for `Kymo` incorrectly set the time extent of the image, leading to a subtle bug (see image below)

**How does this PR make things better?**
By adjusting the time extent (essentially adding an extra line time) the line time points now correspond with the center of the pixel. 

Shown below is a simple dataset of 12 pixels with a timestep of 1

![image](https://user-images.githubusercontent.com/61475504/101041328-ab3c3a80-357c-11eb-9243-9102f6ba41e1.png)
