### PR TITLE
kymotracker: save tracked kymos to file

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * Added `Kymo.plot_with_force` for plotting a kymograph and corresponding force channel downsampled to the same time ranges of the scan lines.
 * Fixed exception message in `downsampled_to` which erroneously suggested to use `force=True` when downsampling a variable frequency channel, while the correct argument is `method="force"`.
 * Fixed minor bug in `Kymo` plot functions which incorrectly set the time limits. Now, pixel centers are aligned with the mean time for each line.
+* Added `save` to KymoLineGroup for saving tracked Kymograph traces to a file. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
 
 ## v0.7.1 | 2020-11-19
 

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -148,6 +148,19 @@ that the trace was based on.
 .. image:: kymo_sumcounts.png
 
 
+Exporting kymograph traces
+--------------------------
+
+Exporting kymograph traces to `csv` files is easy. Just invoke `save` on the returned value::
+
+    traces.save("traces.csv")
+
+By default, this saves the kymograph in pixel coordinates. We can also save calibrated coordinates and photon counts by
+passing a calibration factor for the x-axis and y-axis and a width in pixels to sum counts over::
+
+    traces.save("traces_calibrated.csv", dt=kymo.line_time_seconds, dx=kymo.pixelsize_um, sampling_width=3)
+
+
 How the algorithms work
 -----------------------
 :func:`~lumicks.pylake.track_greedy`

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -99,3 +99,33 @@ class KymoLine:
 
     def __len__(self):
         return len(self.coordinate_idx)
+
+
+class KymoLineGroup:
+    """Kymograph lines"""
+    def __init__(self, kymo_lines):
+        self._src = kymo_lines
+
+    def __iter__(self):
+        return self._src.__iter__()
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            return KymoLineGroup(self._src[item])
+        else:
+            return self._src[item]
+
+    def __setitem__(self, item, value):
+        raise NotImplementedError("Cannot overwrite KymoLines.")
+
+    def __len__(self):
+        return len(self._src)
+
+    def extend(self, other):
+        if isinstance(other, self.__class__):
+            self._src.extend(other._src)
+        elif isinstance(other, self._src[0].__class__):
+            self._src.extend([other])
+        else:
+            raise TypeError(f"You can only extend a {self.__class__} with a {self.__class__} or "
+                            f"{self._src[0].__class__}")

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -2,6 +2,7 @@ from lumicks.pylake.kymotracker.detail.peakfinding import peak_estimate, refine_
     KymoPeaks
 from lumicks.pylake.kymotracker.detail.trace_line_2d import detect_lines, points_to_line_segments
 from lumicks.pylake.kymotracker.detail.scoring_functions import kymo_score
+from lumicks.pylake.kymotracker.kymoline import KymoLineGroup
 import numpy as np
 
 
@@ -98,7 +99,7 @@ def track_greedy(data, line_width, pixel_threshold, window=8, sigma=None, vel=0.
     for line in lines:
         line.image_data = data
 
-    return [line.with_offset(rect[0][0], rect[0][1]) for line in lines] if rect else lines
+    return KymoLineGroup([line.with_offset(rect[0][0], rect[0][1]) for line in lines] if rect else lines)
 
 
 def track_lines(data, line_width, max_lines, start_threshold=0.005, continuation_threshold=0.005, angle_weight=10.0,
@@ -161,7 +162,7 @@ def track_lines(data, line_width, max_lines, start_threshold=0.005, continuation
     for line in lines:
         line.image_data = data
 
-    return [line.with_offset(rect[0][0], rect[0][1]) for line in lines] if rect else lines
+    return KymoLineGroup([line.with_offset(rect[0][0], rect[0][1]) for line in lines] if rect else lines)
 
 
 def filter_lines(lines, minimum_length):
@@ -174,7 +175,7 @@ def filter_lines(lines, minimum_length):
     minimum_length : int
         Minimum length for the line to be accepted.
     """
-    return [line for line in lines if len(line) >= minimum_length]
+    return KymoLineGroup([line for line in lines if len(line) >= minimum_length])
 
 
 def refine_lines_centroid(lines, line_width):
@@ -207,4 +208,4 @@ def refine_lines_centroid(lines, line_width):
         line.coordinate_idx = coordinate_idx[current: current + line_length]
         current += line_length
 
-    return interpolated_lines
+    return KymoLineGroup(interpolated_lines)

--- a/lumicks/pylake/kymotracker/tests/test_io.py
+++ b/lumicks/pylake/kymotracker/tests/test_io.py
@@ -1,0 +1,78 @@
+from lumicks.pylake.kymotracker.kymoline import KymoLine, KymoLineGroup, import_kymolinegroup_from_csv
+import numpy as np
+import pytest
+
+
+@pytest.fixture(scope="session")
+def kymolinegroup_io_data():
+    test_img = np.zeros((8, 8))
+
+    k1 = KymoLine([1, 2, 3], [2, 3, 4], test_img)
+    k2 = KymoLine([2, 3, 4], [3, 4, 5], test_img)
+    k3 = KymoLine([3, 4, 5], [4, 5, 6], test_img)
+    k4 = KymoLine([4, 5, 6], [5, 6, 7], test_img)
+    lines = KymoLineGroup([k1, k2, k3, k4])
+
+    for k in lines:
+        test_img[k.coordinate_idx, k.time_idx] = 2
+        test_img[np.array(k.coordinate_idx) - 1, k.time_idx] = 1
+
+    return test_img, lines
+
+
+def read_txt(testfile, delimiter):
+    raw_data = np.loadtxt(testfile, delimiter=delimiter, unpack=True)
+    with open(testfile, "r") as f:
+        data = {}
+        header = f.readline().rstrip().split(delimiter)
+        line_idx = raw_data[0, :]
+        for key, col in zip(header, raw_data):
+            data[key] = [col[np.argwhere(line_idx == idx).flatten()] for idx in np.unique(line_idx)]
+
+        return data
+
+
+@pytest.mark.parametrize("dt, dx, delimiter, sampling_width, sampling_outcome",
+                         [[1.0, 1.0, ';', 0, 2],
+                          [2.0, 1.0, ';', 0, 2],
+                          [1.0, 2.0, ';', 0, 2],
+                          [1.0, 1.0, ',', 0, 2],
+                          [1.0, 1.0, ';', 1, 3],
+                          [None, None, ';', 1, 3],
+                          [None, None, ';', None, 3],
+                          [1.0, 2.0, ';', None, None],
+                          [None, 1.0, ';', None, None],
+                          [1.0, None, ';', None, None]])
+def test_kymolinegroup_io(tmpdir_factory, kymolinegroup_io_data, dt, dx, delimiter, sampling_width, sampling_outcome):
+    test_img, lines = kymolinegroup_io_data
+
+    # Test round trip through the API
+    testfile = f"{tmpdir_factory.mktemp('pylake')}/test.csv"
+    lines.save(testfile, dt, dx, delimiter, sampling_width)
+    read_file = import_kymolinegroup_from_csv(testfile, test_img, delimiter=delimiter)
+
+    # Test raw fields
+    data = read_txt(testfile, delimiter)
+
+    for line1, line2 in zip(lines, read_file):
+        assert np.allclose(np.array(line1.coordinate_idx), np.array(line2.coordinate_idx))
+        assert np.allclose(np.array(line1.time_idx), np.array(line2.time_idx))
+
+    if not dt:
+        assert "time" not in data
+    else:
+        for line1, time in zip(lines, data["time"]):
+            assert np.allclose(np.array(line1.time_idx) * dt, time)
+
+    if not dx:
+        assert "coordinate" not in data
+    else:
+        for line1, coord in zip(lines, data["coordinate"]):
+            assert np.allclose(np.array(line1.coordinate_idx) * dx, coord)
+
+    if sampling_width is None:
+        assert len([key for key in data.keys() if "counts" in key]) == 0
+    else:
+        count_field = [key for key in data.keys() if "counts" in key][0]
+        for line1, cnt in zip(lines, data[count_field]):
+            assert np.allclose([sampling_outcome] * len(line1.coordinate_idx), cnt)


### PR DESCRIPTION
**Why this PR?**
Being able to write kymograph traces to csv was requested by multiple customers. We already have this functionality on Harbor, but it would be nice to add a nicer API for it. This PR is also preparation for the kymotracker notebook widget PR which relies on this functionality being present.

Note that only the `save` functionality is exposed. The `load` functionality is also implemented (and tested), and needed for the widget.

Originally, this was going to be a PR with the widget as well, but I decided to split it up seeing how this refactor of how KymoLines are handled made it a bit bigger than intended already.

**Why KymoLines?**
I debated between just having save to csv a free function, but ended up choosing to write a small API to collect multiple `KymoLine` instances. The reason for this is is that I suspect that this will be less error prone to deal with, and will eventually help us when we start having more complicated calibration procedures. It also constrains the number of potential mistakes a user can make when it comes to passing things to save.

**Why did you piggyback a test on this?**
Because I needed to ensure that `filter_lines` stays functional and it had somehow escaped testing the first time.

Documentation can be found here: https://lumicks-pylake.readthedocs.io/en/kymotracker_saveload/tutorial/kymotracking.html#exporting-kymograph-traces