### PR TITLE
nbwidgets: mouse drag

### DIFF
--- a/lumicks/pylake/nb_widgets/detail/mouse.py
+++ b/lumicks/pylake/nb_widgets/detail/mouse.py
@@ -1,0 +1,59 @@
+class MouseDragCallback:
+    def __init__(self, axes, button, callback):
+        """Callback handler to handle mouse dragging for a particular button. Callback is called with x, y, dx, dy as
+        arguments.
+
+        Parameters
+        ----------
+        axes : :class:`~matplotlib.axes.Axes`
+            Axes to attach the callback to.
+        button : int
+            Which button to respond to (0: Left, 1: Middle, 2: Right).
+        callback : callable
+            Which function to call when dragging takes place. Note that this function should have the following input
+            signature: fun(x, y, dx, dy) where x, y are the location in data space and dx and dy are the dragging
+            distances in data space.
+        """
+        self._axes = axes
+        self._button = button
+        self._callback = callback
+        self.dragging = 0
+        self.x_last = 0
+        self.y_last = 0
+        self._axes.get_figure().canvas.mpl_connect("button_press_event", lambda event: self.button_down(event))
+        self._axes.get_figure().canvas.mpl_connect("button_release_event", lambda event: self.button_release(event))
+        self._axes.get_figure().canvas.mpl_connect("motion_notify_event", lambda event: self.handle_motion(event))
+
+    def button_down(self, event):
+        if event.inaxes == self._axes and not event.canvas.widgetlock.locked():
+            if event.button == self._button:
+                self.dragging = True
+                self.x_last = event.xdata
+                self.y_last = event.ydata
+
+    def button_release(self, event):
+        if event.button == self._button:
+            self.dragging = False
+
+    def handle_motion(self, event):
+        # There's an issue that if you drag outside the figure, the release is not detected. Hence the
+        # event.inaxes != self._axes also leads to dragging being disabled
+        if event.button != self._button or event.inaxes != self._axes:
+            self.dragging = False
+
+        if self.dragging:
+            dx = event.xdata - self.x_last
+            dy = event.ydata - self.y_last
+
+            # Convert to mouse position
+            to_display_position = self._axes.transData
+            old_position = to_display_position.transform((event.xdata, event.ydata))
+
+            self._callback(event.xdata, event.ydata, dx, dy)
+
+            # User may have changed the limits, so convert back to data position for the dx and dy in data space
+            to_data_position = self._axes.transData.inverted()
+            x_new, y_new = to_data_position.transform(old_position)
+
+            self.x_last = x_new
+            self.y_last = y_new

--- a/lumicks/pylake/nb_widgets/tests/conftest.py
+++ b/lumicks/pylake/nb_widgets/tests/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+class MockEvent:
+    class Canvas:
+        class WidgetLock:
+            def __init__(self, locked):
+                self.am_locked = locked
+
+            def locked(self):
+                return self.am_locked
+
+        def __init__(self, locked):
+            self.widgetlock = self.WidgetLock(locked)
+
+    def __init__(self, axis, x, y, button, widget_lock):
+        self.inaxes = axis
+        self.xdata = x
+        self.ydata = y
+        self.button = button
+        self.canvas = self.Canvas(widget_lock)
+
+
+@pytest.fixture
+def mockevent():
+    return lambda axis, x, y, button, widget_lock: MockEvent(axis, x, y, button, widget_lock)

--- a/lumicks/pylake/nb_widgets/tests/test_mouse.py
+++ b/lumicks/pylake/nb_widgets/tests/test_mouse.py
@@ -1,0 +1,84 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from lumicks.pylake.nb_widgets.detail.mouse import MouseDragCallback
+
+
+def test_mouse_drag(mockevent):
+    plt.plot([1, 2, 3, 4, 5], [5, 6, 7, 8, 9])
+    plt.xlim([0, 5])
+    plt.ylim([5, 10])
+    ax = plt.gca()
+
+    current_x, current_y, current_dx, current_dy = 0, 0, 0, 0
+
+    def callback(x, y, dx, dy):
+        nonlocal current_x, current_y, current_dx, current_dy
+        current_x, current_y, current_dx, current_dy = x, y, dx, dy
+
+    button = 1
+    mouse_drag = MouseDragCallback(ax, button, callback)
+    assert not mouse_drag.dragging
+
+    mouse_drag.button_down(mockevent(ax, 1, 1, button + 1, 1))  # Wrong button for this callback
+    assert not mouse_drag.dragging
+
+    mouse_drag.button_down(mockevent(ax, 1, 1, button, 1))  # Blocked widget
+    assert not mouse_drag.dragging
+
+    mouse_drag.button_down(mockevent(ax, 1, 1, button, 0))
+    assert mouse_drag.dragging
+
+    mouse_drag.button_down(mockevent(ax, 1, 1, button, 0))
+    assert np.allclose(current_x, 0)
+
+    mouse_drag.handle_motion(mockevent(ax, 2, 2, button, 0))
+    assert np.allclose(current_x, 2)
+    assert np.allclose(current_y, 2)
+    assert np.allclose(current_dx, 1)
+    assert np.allclose(current_dy, 1)
+
+    mouse_drag.handle_motion(mockevent(ax, 5, 5, button, 0))
+    assert np.allclose(current_x, 5)
+    assert np.allclose(current_y, 5)
+    assert np.allclose(current_dx, 3)
+    assert np.allclose(current_dy, 3)
+
+    mouse_drag.button_release(mockevent(ax, 1, 1, button, 0))
+    mouse_drag.handle_motion(mockevent(ax, 15, 15, button, 0))
+    assert np.allclose(current_x, 5)
+    assert np.allclose(current_y, 5)
+    assert np.allclose(current_dx, 3)
+    assert np.allclose(current_dy, 3)
+
+
+def test_mouse_drag_lim_change(mockevent):
+    """When limits change, the coordinate system changes. This test tests whether that is taken into account
+    correctly."""
+    plt.plot([1, 2, 3, 4, 5], [5, 6, 7, 8, 9])
+    plt.xlim([0, 5])
+    plt.ylim([5, 10])
+    ax = plt.gca()
+
+    current_x, current_y, current_dx, current_dy = 0, 0, 0, 0
+
+    def callback(x, y, dx, dy):
+        nonlocal current_x, current_y, current_dx, current_dy
+        xl = plt.gca().get_xlim()
+        plt.xlim([xl[0]+dx, xl[1] + dx])
+        current_x, current_y, current_dx, current_dy = x, y, dx, dy
+
+    mouse_drag = MouseDragCallback(ax, 1, callback)
+    mouse_drag.button_down(mockevent(ax, 1, 1, 1, 0))
+    mouse_drag.handle_motion(mockevent(ax, 1, 1, 1, 0))
+
+    mouse_drag.handle_motion(mockevent(ax, 2, 2, 1, 0))
+    assert np.allclose(current_x, 2)
+    assert np.allclose(current_y, 2)
+    assert np.allclose(current_dx, 1)
+    assert np.allclose(current_dy, 1)
+
+    mouse_drag.handle_motion(mockevent(ax, 2, 2, 1, 0))
+    assert np.allclose(current_x, 2)
+    assert np.allclose(current_y, 2)
+    assert np.allclose(current_dx, -1)
+    assert np.allclose(current_dy, 0)


### PR DESCRIPTION
**Why this PR?**
It is required for the kymotracker widget to work.

**What is it?**
It's a small handler to deal with mouse drag events on a plot where the axis limits respond to dragging.
I have also factored out the mocked mouse event to be able to reuse it in different tests.