### PR TITLE
fdfit: skip std errors in absence of jacobian

### DIFF
--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -228,8 +228,9 @@ class Fit:
         for name, value in zip(parameter_names, parameter_vector):
             self.params[name] = value
 
-        for name, value in zip(parameter_names, np.diag(self.cov)):
-            self.params[name].stderr = np.sqrt(value)
+        if self.has_jacobian:
+            for name, value in zip(parameter_names, np.diag(self.cov)):
+                self.params[name].stderr = np.sqrt(value)
 
         return self
 
@@ -540,9 +541,13 @@ class Fit:
             based model reduction. PloS one, 11(9).
         """
         # Note that this approximation is only valid if the noise on each data set is the same.
-        J = self._calculate_jacobian()
-        J = J / np.transpose(np.tile(self.sigma, (J.shape[1], 1)))
-        return np.linalg.pinv(np.transpose(J).dot(J))
+        if self.has_jacobian:
+            J = self._calculate_jacobian()
+            J = J / np.transpose(np.tile(self.sigma, (J.shape[1], 1)))
+            return np.linalg.pinv(np.transpose(J).dot(J))
+        else:
+            raise NotImplementedError("In order to calculate a covariance matrix, a model Jacobian has to be specified"
+                                      "for the model.")
 
     def _repr_html_(self):
         out_string = "<h4>Fit</h4>\n"

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -1110,3 +1110,17 @@ def test_interpolation_inversion():
     parvec = [5.77336105517341, 7.014180463612673, 1500.0000064812095, 4.11]
     result = np.array([0.17843862, 0.18101283, 0.18364313, 0.18633117, 0.18907864])
     assert np.allclose(m._raw_call(np.arange(10, 250, 50) / 1000, parvec), result)
+
+
+def test_no_jac():
+    x = np.arange(10)
+    y = np.array([8.24869073, 7.77648717, 11.9436565, 14.85406276, 22.73081526, 20.39692261, 32.48962353, 31.4775862,
+                  37.63807819, 40.50125925])
+
+    linear_model = Model("linear", lambda x, a, b: a * x + b)
+    linear_fit = Fit(linear_model)
+    linear_fit._add_data("test", x, y, {'linear/a': 5})
+    linear_fit.fit()
+
+    with pytest.raises(NotImplementedError):
+        linear_fit.cov


### PR DESCRIPTION
**Why this PR?**
Currently, when you specify a model without a Jacobian in the `FdFit` package, you get an error after fitting when it attempts to compute standard errors. This PR checks whether they are specified and if not, we don't compute them.

It also adds an explicit `NotImplementedError` when the user _does_ try to get the covariance matrix when there's no Jacobian for the model. Eventually we may want to add finite differencing, but that needs a bit more investigation.