### PR TITLE
Kymo plot with histogram

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Allow `nbAgg` backend to be used for interactive plots in Jupyter notebooks (i.e. `%matplotlib notebook`). Note that this backend doesn't work for JupyterLab (please see the [FAQ](https://lumicks-pylake.readthedocs.io/en/simplify_widgets/install.html#frequently-asked-questions) for more information).
 * Added `refine_lines_centroid` for refining lines detected by the kymotracking algorithm. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
 * Added `Kymo.plot_with_force` for plotting a kymograph and corresponding force channel downsampled to the same time ranges of the scan lines.
+* Added `Kymo.plot_with_position_histogram` and `Kymo.plot_with_time_histogram` for plotting a kymograph and corresponding histogram along selected axis.
 * Fixed exception message in `downsampled_to` which erroneously suggested to use `force=True` when downsampling a variable frequency channel, while the correct argument is `method="force"`.
 * Fixed minor bug in `Kymo` plot functions which incorrectly set the time limits. Now, pixel centers are aligned with the mean time for each line.
 * Added `save` to KymoLineGroup for saving tracked Kymograph traces to a file. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -196,7 +196,7 @@ def h5_file(tmpdir_factory, request):
                             "num of pixels": 5,
                             "pixel size (nm)": 10,
                             "scan time (ms)": 0,
-                            "scan width (um)": 36.07468112612217
+                            "scan width (um)": 5 * 0.010
                         }
                     ]
                 }


### PR DESCRIPTION
**Why this PR?**
User request for histograms plotted alongside a kymo (for example, to visualize binding events)
- can histogram along either time or position axes
- user inputs the number of pixels to bin together
Example:
![image](https://user-images.githubusercontent.com/61475504/101916352-1d3d0100-3bc7-11eb-9cf0-9ce51f76017f.png)


