### PR TITLE
Include downsampled_force## when printing File

### DIFF
--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -142,15 +142,23 @@ class File(Group, Force, DownsampledFD, PhotonCounts, PhotonTimeTags):
         return print_attributes(self.h5) + "\n" + print_group(self.h5) + \
             ''.join((print_dicts(field) for field in self.redirect_list.values())) + "\n" + \
             ''.join((print_force(field) for field in ['force1x', 'force1y', 'force2x', 'force2y',
-                                                      'force3x', 'force3y', 'force4x', 'force4y']))
+                                                      'force3x', 'force3y', 'force4x', 'force4y'])) + "\n" + \
+            ''.join((print_force(field) for field in ['downsampled_force1x', 'downsampled_force1y', 
+                                                      'downsampled_force2x', 'downsampled_force2y',
+                                                      'downsampled_force3x', 'downsampled_force3y', 
+                                                      'downsampled_force4x', 'downsampled_force4y']))
 
     def _get_force(self, n, xy):
+        """Return a Slice of force measurements, including calibration
+           Note: direct access to HDF dataset does not include calibration data """
         force_group = self.h5["Force HF"][f"Force {n}{xy}"]
         calibration_data = ForceCalibration.from_dataset(self.h5, n, xy)
 
         return Continuous.from_dataset(force_group, "Force (pN)", calibration_data)
 
     def _get_downsampled_force(self, n, xy):
+        """Return a Slice of low frequency force measurements, including calibration if applicable
+           Note: direct access to HDF dataset does not include calibration data """
         group = self.h5["Force LF"]
 
         def make(channel):

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -183,6 +183,9 @@ def test_repr_and_str(h5_file):
             
             .force1x
             .force1y
+
+            .downsampled_force1x
+            .downsampled_force1y
         """)
     if f.format_version == 2:
         assert str(f) == dedent("""\
@@ -252,6 +255,11 @@ def test_repr_and_str(h5_file):
             .force1y
               .calibration
             .force2x
+              .calibration
+
+            .downsampled_force1x
+              .calibration
+            .downsampled_force1y
               .calibration
         """)
 


### PR DESCRIPTION
**Why this PR?**
to make clear that the `downsampled_force##` attributes exist in the file