### PR TITLE
deps: switch to headless opencv

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * Fixed exception message in `downsampled_to` which erroneously suggested to use `force=True` when downsampling a variable frequency channel, while the correct argument is `method="force"`.
 * Fixed minor bug in `Kymo` plot functions which incorrectly set the time limits. Now, pixel centers are aligned with the mean time for each line.
 * Added `save` to KymoLineGroup for saving tracked Kymograph traces to a file. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
+* Switch `opencv` dependency to headless version.
 
 ## v0.7.1 | 2020-11-19
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "matplotlib>=2.2",
         "tifffile>=2018.11.6",
         "tabulate==0.8.6",
-        "opencv-python>=3.0",
+        "opencv-python-headless>=3.0",
         "ipywidgets>=7.0.0",
         "cachetools>=3.1",
     ],


### PR DESCRIPTION
**Why this PR?**
We don't want to ship Qt with Pylake as this can lead to issues with Bluelake.

Note that there is no headless opencv available for anaconda; but this shouldn't be an issue since we use pip for BL.