### PR TITLE
release: readying for release v0.7.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,16 +1,25 @@
 # Changelog
 
-## v0.7.2 | t.b.d.
+## v0.7.2 | 2020-01-14
 
-* Support Python 3.9 on Windows (this required bumping the `h5py` requirement to >= 3.0).
-* Include `ipywidgets` as a dependency so users don't have to install it themselves.
+#### New features
+
+* Support Python 3.9 (this required bumping the `h5py` requirement to >= 3.0).
+* Added `refine_lines_centroid()` for refining lines detected by the kymotracking algorithm. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
+* Added `Kymo.plot_with_force()` for plotting a kymograph and corresponding force channel downsampled to the same time ranges of the scan lines.
+* Added `Kymo.plot_with_position_histogram()` and `Kymo.plot_with_time_histogram()` for plotting a kymograph and corresponding histogram along selected axis.
+* Added `KymoLineGroup.save()` for saving tracked Kymograph traces to a file. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
 * Allow `nbAgg` backend to be used for interactive plots in Jupyter notebooks (i.e. `%matplotlib notebook`). Note that this backend doesn't work for JupyterLab (please see the [FAQ](https://lumicks-pylake.readthedocs.io/en/simplify_widgets/install.html#frequently-asked-questions) for more information).
-* Added `refine_lines_centroid` for refining lines detected by the kymotracking algorithm. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
-* Added `Kymo.plot_with_force` for plotting a kymograph and corresponding force channel downsampled to the same time ranges of the scan lines.
-* Added `Kymo.plot_with_position_histogram` and `Kymo.plot_with_time_histogram` for plotting a kymograph and corresponding histogram along selected axis.
-* Fixed exception message in `downsampled_to` which erroneously suggested to use `force=True` when downsampling a variable frequency channel, while the correct argument is `method="force"`.
-* Fixed minor bug in `Kymo` plot functions which incorrectly set the time limits. Now, pixel centers are aligned with the mean time for each line.
-* Added `save` to KymoLineGroup for saving tracked Kymograph traces to a file. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
+* Show `downsampled_force` channels when printing a `File`.
+
+#### Bug fixes
+
+* Fixed exception message in `Slice.downsampled_to()` which erroneously suggested to use `force=True` when downsampling a variable frequency channel, while the correct argument is `method="force"`.
+* Fixed bug in `Kymo` plot functions which incorrectly set the time limits. Now, pixel centers are aligned with the mean time for each line.
+
+#### Other
+
+* Include `ipywidgets` as a dependency so users don't have to install it themselves.
 * Switch `opencv` dependency to headless version.
 
 ## v0.7.1 | 2020-11-19
@@ -24,6 +33,7 @@
 ## v0.7.0 | 2020-11-04
 
 #### New features
+
 * Added `seconds` attribute to `Slice`. See [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#channels) for more information.
 * Added `downsampled_to` to `Slice` for downsampling channel data to a new sampling frequency. See section on downsampling in [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#downsampling).
 * Added `save_as` to `File` for exporting compressed HDF5 files or omitting specific channels from an HDF5 file. See tutorial on [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#exporting-h5-files) for more information.
@@ -37,12 +47,14 @@
 * Added `Kymo.pixelsize_um` and `Scan.pixelsize_um` for obtaining the pixel size for various axes.
 
 #### Bug fixes
+
 * Improved accuracy of covariance matrix computation. To compute the covariance matrix of the parameter estimates, it is required to estimate the standard deviation of the residuals. This calculation was previously biased by not correctly taking into account the number of degrees of freedom. This is fixed now.
 * Fixed bug in `CorrelatedStack.plot_correlated` which lead to the start index of the frame being added twice when the movie had been sliced.
 * Fixed bug in `File.scans` so that a warning is generated when a scan is missing metadata. Other scans that can be loaded properly are still accessible.
 * Fixed bug in `plot_correlated` which did not allow plotting camera images correlated to channel data when the channel data did not completely cover the camera image stack.
 
 #### Breaking changes
+
 * Fixed bug in `downsampled_over` which affects people who used it with `where="center"`. With these settings the function returns timestamps at the center of the ranges being downsampled over. In the previous version, this timestamp included the end timestamp (i.e. t1 <= t <= t2), now it has been changed to exclude the end timestamp (i.e. t1 <= t < t2) making it consistent with `downsampled_by` for integer downsampling rates.
 * Fixed bug in `File.point_scans` to return `PointScan` instances. Previously, attempts to access this property would cause an error due to missing `PointScan.from_dataset` method. Note that the `__init__` method arguments of `PointScan` have been changed to be in line with `Kymo` and `Scan`.
 

--- a/lumicks/pylake/__about__.py
+++ b/lumicks/pylake/__about__.py
@@ -1,5 +1,5 @@
 __title__ = "lumicks.pylake"
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 __summary__ = "Bluelake data analysis tools"
 __url__ = "https://github.com/lumicks/pylake"
 

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -8,7 +8,6 @@ from .fitting.fit import FdFit
 from lumicks.pylake.fitting.parameter_trace import parameter_trace
 from lumicks.pylake.nb_widgets.fd_selector import FdRangeSelector, FdRangeSelectorWidget
 from lumicks.pylake.kymotracker.kymotracker import track_greedy, track_lines, filter_lines, refine_lines_centroid
-from lumicks.pylake.nb_widgets.kymotracker_widgets import KymoWidgetGreedy
 
 
 def pytest(args=None, plugins=None):


### PR DESCRIPTION
**Why this PR?**
- Want to release v0.7.2.
- Put a date in the changelog.
- Hide the kymotracker widget from the public API as there is no documentation for it yet and there is still an outstanding issue with Jupyter notebook (see other PR).