### PR TITLE
channel: fix exception downsampled_over over gap

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.3 | t.b.d.
+
+* Fix `downsampled_over` to ignore gaps rather than result in an unhandled exception. Previously when you downsampled a `TimeSeries` channel which had a gap in its data, `downsampled_over` would try to compute the mean of an empty subsection, which raises an exception. Now this case is gracefully handled.
+
 ## v0.7.2 | 2020-01-14
 
 #### New features

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -148,14 +148,17 @@ class Slice:
 
         t = np.zeros(len(range_list), dtype=self._src.timestamps.dtype)
         d = np.zeros(len(range_list))
-        for i, time_range in enumerate(range_list):
+        idx = 0
+        for time_range in range_list:
             start, stop = time_range
             subset = self[start:stop]
-            ts = subset.timestamps
-            t[i] = (ts[0] + ts[-1]) // 2 if where == 'center' else start
-            d[i] = reduce(subset.data)
+            if len(subset.timestamps) > 0:
+                ts = subset.timestamps
+                t[idx] = (ts[0] + ts[-1]) // 2 if where == 'center' else start
+                d[idx] = reduce(subset.data)
+                idx += 1
 
-        return Slice(TimeSeries(d, t), self.labels)
+        return Slice(TimeSeries(d[:idx], t[:idx]), self.labels)
 
     def downsampled_to(self, frequency, reduce=np.mean, where='center', method="safe"):
         """Return a copy of this slice downsampled to a specified frequency

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -518,6 +518,16 @@ def test_consistency_downsampled_to():
     assert np.allclose(one_step.timestamps, two_step.timestamps)
 
 
+def test_downsampled_over_no_data_gap():
+    t = np.array([0, 1, 2, 3, 10, 11, 12, 13, 14, 15])
+    d = np.arange(10)
+    s = channel.Slice(channel.TimeSeries(d, t))
+    ranges = [(t1, t2) for t1, t2 in zip(np.arange(0, 16, 2), np.arange(2, 18, 2))]
+    ts = s.downsampled_over(ranges)
+    assert np.allclose(ts.timestamps, [0, 2, 10, 12, 14])
+    assert np.allclose(ts.data, [0.5, 2.5, 4.5, 6.5, 8.5])
+
+
 def test_downsampling_over_subset():
     d = np.arange(1, 24)
     s = channel.Slice(channel.Continuous(d, 0, 10))


### PR DESCRIPTION
*Why this PR?*
Sometimes, `TimeSeries` data can contain a large gap. When you `downsample_over` a gap you get an exception (since some of the slices are empty). This can happen for example when you have data where the distance lock is turned off and then on.

This PR fixes that by ignoring samples where there is no data. Note that since we don't guarantee that a `Slice` of `TimeSeries` is contiguous, it should be evident that the returned `Slice` doesn't have to be either.