### PR TITLE
FDCurve - distance range selector widget

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,15 +1,21 @@
 # Changelog
 
-## v0.7.3 | t.b.d.
+## v0.8.0 | t.b.d.
 
 #### New features
-* Add widget to graphically slice `FDCurve` by distance in Jupyter Notebooks. It can be opened by calling `pylake.FdDistanceRangeSelector(fdcurves)`. For more information, see the tutorials section on [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
+* Added widget to graphically slice `FDCurve` by distance in Jupyter Notebooks. It can be opened by calling `pylake.FdDistanceRangeSelector(fdcurves)`. For more information, see the tutorials section on [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
+* Added `FDCurve.range_selector()` and `FDCurve.distance_range_selector()`
 
 #### Bug fixes
-* Fix `downsampled_over` to ignore gaps rather than result in an unhandled exception. Previously when you downsampled a `TimeSeries` channel which had a gap in its data, `downsampled_over` would try to compute the mean of an empty subsection, which raises an exception. Now this case is gracefully handled.
+* Fixed `downsampled_over` to ignore gaps rather than result in an unhandled exception. Previously when you downsampled a `TimeSeries` channel which had a gap in its data, `downsampled_over` would try to compute the mean of an empty subsection, which raises an exception. Now this case is gracefully handled.
+
+#### Breaking changes
+* `FdRangeSelectorWidget` is no longer public.
+* Renamed `fd_selector.py` to `range_selector.py`
+* `Slice.range_selector()` is now a method instead of a property
 
 #### Other
-* Add documentation for the Kymotracker widget. See the [Cas9 kymotracking example](https://lumicks-pylake.readthedocs.io/en/latest/examples/cas9_kymotracking/cas9_kymotracking.html) or the [kymotracking tutorial](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
+* Added documentation for the Kymotracker widget. See the [Cas9 kymotracking example](https://lumicks-pylake.readthedocs.io/en/latest/examples/cas9_kymotracking/cas9_kymotracking.html) or the [kymotracking tutorial](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
 
 ## v0.7.2 | 2020-01-14
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,13 @@
 
 ## v0.7.3 | t.b.d.
 
+#### New features
+* Add widget to graphically slice `FDCurve` by distance in Jupyter Notebooks. It can be opened by calling `pylake.FdDistanceRangeSelector(fdcurves)`. For more information, see the tutorials section on [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
+
+#### Bug fixes
 * Fix `downsampled_over` to ignore gaps rather than result in an unhandled exception. Previously when you downsampled a `TimeSeries` channel which had a gap in its data, `downsampled_over` would try to compute the mean of an empty subsection, which raises an exception. Now this case is gracefully handled.
+
+#### Other
 * Add documentation for the Kymotracker widget. See the [Cas9 kymotracking example](https://lumicks-pylake.readthedocs.io/en/latest/examples/cas9_kymotracking/cas9_kymotracking.html) or the [kymotracking tutorial](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
 
 ## v0.7.2 | 2020-01-14

--- a/docs/tutorial/fd_dist_widget.png
+++ b/docs/tutorial/fd_dist_widget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62acfb42113de207e49d5f7d64a22fd007d42ec7b27de7f605f733aaf0342383
+size 28215

--- a/docs/tutorial/fd_dist_widget2.png
+++ b/docs/tutorial/fd_dist_widget2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f7ee5346737a6ea8e5511266ac1b54e0b1bf7aea894abd37ee84533e9c85f3f
+size 32055

--- a/docs/tutorial/fd_dist_widget3.png
+++ b/docs/tutorial/fd_dist_widget3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd7a95245ddd14c4f23bbcdbf7ca906cd8a9bba761c267de83641d48ee4228dc
+size 33305

--- a/docs/tutorial/fd_dist_widget3a.png
+++ b/docs/tutorial/fd_dist_widget3a.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7658c9a3b00257161b31dd9b153b193656ba935e5229a905649782ce610cc74
+size 42544

--- a/docs/tutorial/nbwidgets.rst
+++ b/docs/tutorial/nbwidgets.rst
@@ -44,6 +44,9 @@ plot all of our selections in separate plots for instance, we can do the followi
 F,d selection
 -------------
 
+Range selection by time
+^^^^^^^^^^^^^^^^^^^^^^^
+
 Assume we have an F,d curve we want to analyze. We know that this file contains one F,d curve which should be split up
 into two segments that we should be analyzing separately::
 
@@ -78,6 +81,9 @@ This produces a separate plot for each selection. There's also a more direct way
 
 .. image:: fd_widget3.png
 
+Processing multiple files
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Now let's say our experiment is split up over multiple files, each containing a few F,d curves. We would like to load
 these curves all at once and make our selections. We can do this using automatically using `glob`. With `glob.glob`
 we grab a list of all `.h5` files in the directory `my_directory`. We then iterate over this list and open each file.
@@ -102,3 +108,43 @@ dictionary of curve sets, and not the keys (which in our case are the curve name
         for fdcurve in curve_set:
             plt.figure()
             fdcurve.plot_scatter()
+
+Range selection by distance
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is also possible to select a portion of an F,d curve based on distance::
+
+    selector = lk.FdDistanceRangeSelector(fdcurves)
+
+.. image:: fd_dist_widget.png    
+
+Again, we can retrieve the selected data just as with `FdRangeSelector`::
+
+    original = fdcurves["Fd pull #6"]
+    sliced = selector.fdcurves["Fd pull #6"][0]
+
+    plt.figure()
+
+    plt.subplot(2, 1, 1)
+    original.plot_scatter(label="original")
+    sliced.plot_scatter(label="sliced")
+    plt.legend()
+
+    plt.subplot(2, 1, 2)
+    original.f.plot()
+    sliced.f.plot(start=original.start)
+
+.. image::  fd_dist_widget2.png
+
+The returned F,d curves correspond to the longest contiguous (in time) stretch of data that falls 
+within the distance thresholds. However, noise in the distance measurement can lead to short gaps of the time
+trace falling slightly outside of the thresholds, as illustrated below:
+
+.. image:: fd_dist_widget3a.png
+
+To avoid premature truncation caused by this noise, there is an additional `max_gap` keyword argument 
+to `FdDistanceRangeSelector` that can be used to adjust the acceptable length of noise gaps. The default values
+is zero, such that all data points are guaranteed to fall within the selected distance range. The effect of this 
+argument is shown below for an F,d curve sliced with the same distance thresholds:
+
+.. image:: fd_dist_widget3.png

--- a/docs/tutorial/nbwidgets.rst
+++ b/docs/tutorial/nbwidgets.rst
@@ -18,7 +18,7 @@ regions using a widget. Let's load the file and run the widget::
 
     file = lk.File("file.h5")
     channel = file["Force LF"]["Force 1x"]
-    selector = channel.range_selector
+    selector = channel.range_selector()
 
 .. image:: slice_widget.png
 
@@ -148,3 +148,12 @@ is zero, such that all data points are guaranteed to fall within the selected di
 argument is shown below for an F,d curve sliced with the same distance thresholds:
 
 .. image:: fd_dist_widget3.png
+
+Range selection of single curve
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The selector widgets can also be easily accessed from single F,d curve instances::
+
+    fdcurve = fdcurves["Fd pull #6"]
+    t_selector = fdcurve.range_selector()
+    d_selector = fdcurve.distance_range_selector(max_gap=3)

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -6,7 +6,7 @@ from .fitting.models import *
 from .correlated_stack import CorrelatedStack
 from .fitting.fit import FdFit
 from lumicks.pylake.fitting.parameter_trace import parameter_trace
-from lumicks.pylake.nb_widgets.fd_selector import FdRangeSelector, FdRangeSelectorWidget
+from lumicks.pylake.nb_widgets.range_selector import FdRangeSelector
 from lumicks.pylake.kymotracker.kymotracker import track_greedy, track_lines, filter_lines, refine_lines_centroid
 from lumicks.pylake.nb_widgets.kymotracker_widgets import KymoWidgetGreedy
 

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -6,7 +6,7 @@ from .fitting.models import *
 from .correlated_stack import CorrelatedStack
 from .fitting.fit import FdFit
 from lumicks.pylake.fitting.parameter_trace import parameter_trace
-from lumicks.pylake.nb_widgets.range_selector import FdRangeSelector
+from lumicks.pylake.nb_widgets.range_selector import FdRangeSelector, FdDistanceRangeSelector
 from lumicks.pylake.kymotracker.kymotracker import track_greedy, track_lines, filter_lines, refine_lines_centroid
 from lumicks.pylake.nb_widgets.kymotracker_widgets import KymoWidgetGreedy
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from .detail.timeindex import to_timestamp
 from .calibration import ForceCalibration
-from lumicks.pylake.nb_widgets.fd_selector import SliceRangeSelector
+from lumicks.pylake.nb_widgets.range_selector import SliceRangeSelectorWidget
 
 
 class Slice:
@@ -303,7 +303,7 @@ class Slice:
 
     @property
     def range_selector(self):
-        return SliceRangeSelector(self)
+        return SliceRangeSelectorWidget(self)
 
 
 def _downsample(data, factor, reduce):

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -301,9 +301,8 @@ class Slice:
         plt.ylabel(self.labels.get("y", "y"))
         plt.title(self.labels.get("title", "title"))
 
-    @property
-    def range_selector(self):
-        return SliceRangeSelectorWidget(self)
+    def range_selector(self, show=True):
+        return SliceRangeSelectorWidget(self, show=show)
 
 
 def _downsample(data, factor, reduce):

--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -38,7 +38,7 @@ def lighten_color(c, amount):
 
 def find_contiguous(mask):
     """Find [start,stop] indices and lengths of contiguous blocks where mask is True."""
-    padded = np.hstack((0, np.asarray(mask, dtype=bool) == True, 0))
+    padded = np.hstack((0, mask.astype(np.bool), 0))
     change_points = np.abs(np.diff(padded))
     ranges = np.argwhere(change_points == 1).reshape(-1,2)
     run_lengths = np.diff(ranges, axis=1).squeeze()

--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -35,3 +35,11 @@ def lighten_color(c, amount):
     hsv = mpl.colors.rgb_to_hsv(mpl.colors.to_rgb(c))
     hsv[2] = np.clip(hsv[2]+amount, 0.0, 1.0)
     return mpl.colors.hsv_to_rgb(hsv)
+
+def find_contiguous(mask):
+    """Find [start,stop] indices and lengths of contiguous blocks where mask is True."""
+    padded = np.hstack((0, np.asarray(mask, dtype=bool) == True, 0))
+    change_points = np.abs(np.diff(padded))
+    ranges = np.argwhere(change_points == 1).reshape(-1,2)
+    run_lengths = np.diff(ranges, axis=1).squeeze()
+    return ranges, np.atleast_1d(run_lengths)

--- a/lumicks/pylake/fdcurve.py
+++ b/lumicks/pylake/fdcurve.py
@@ -150,3 +150,9 @@ class FDCurve(DownsampledFD):
         plt.xlabel(self.d.labels.get("y", "distance"))
         plt.ylabel(self.f.labels.get("y", "force"))
         plt.title(self.name)
+
+    def range_selector(self, show=True):
+        return FdTimeRangeSelectorWidget(self, show=show)
+
+    def distance_range_selector(self, show=True, max_gap=0):
+        return FdDistanceRangeSelectorWidget(self, show=show, max_gap=max_gap)

--- a/lumicks/pylake/fdcurve.py
+++ b/lumicks/pylake/fdcurve.py
@@ -79,6 +79,14 @@ class FDCurve(DownsampledFD):
         new_curve.stop = new_curve.f._src.stop
         return new_curve
 
+    def _slice_by_distance(self, min_dist, max_dist):
+        """Return a subset of this FD curve within a selected distance range"""
+        # TODO => checking for one-way pass (no back and forth) variable time
+        # TODO => handle distance measurement noise in time channel
+        ix = np.logical_and(min_dist <= self.d.data, self.d.data <= max_dist)
+        timestamps = self.d.timestamps[ix]
+        return self[timestamps[0]:timestamps[-1]]
+
     def _get_downsampled_force(self, n, xy):
         return getattr(self.file, f"downsampled_force{n}{xy}")[self.start:self.stop]
 

--- a/lumicks/pylake/nb_widgets/range_selector.py
+++ b/lumicks/pylake/nb_widgets/range_selector.py
@@ -3,34 +3,53 @@ import numpy as np
 import time
 
 
-class SliceRangeSelector:
-    def __init__(self, channel_slice, axes=None, show=True):
+class BaseRangeSelectorWidget:
+    """ Base class for range selection widgets.
+        Takes care of setting up connections and internal event handling.
+
+        Parameters
+        __________
+        axes : matplotlib.axes.Axes
+            Axes instance used for plotting
+        show : bool
+            Controls if plot is rendered immediately
+        range_conversion_function : function
+            Function to convert from units of the underlying data to plotting units,
+            for example: timestamps -> seconds in the case of a Slice
+            default simply returns the value unchanged.
+    """
+    def __init__(self, axes=None, show=True, range_conversion_fcn=lambda point:point):
         self._axes = axes if axes else plt.axes(label=f"lk_slice_widget_{time.time()}")
-        self.slice = channel_slice
-        self.time = self.slice.timestamps
         self.connection_id = None
         self.current_range = []
         self._ranges = []
+        self.range_conversion_fcn = range_conversion_fcn
         self.open = show
 
         if show:
             self._axes.get_figure().canvas.mpl_connect('close_event', self.close)
             self.update_plot()
 
+    @property
+    def xdata(self):
+        raise NotImplementedError
+
+    @property
+    def ranges(self):
+        """Returns selected list of timestamp ranges"""
+        return np.copy(self._ranges)
+
     def close(self, event):
         self.open = False
 
     def wait_for_input(self):
         while self.open:
-            plt.pause(.0001)
+            plt.pause(0.0001)
 
-    def to_seconds(self, timestamp):
-        return (timestamp - self.time[0]) / 1e9
-
-    def _add_point(self, fd_timestamp):
+    def _add_point(self, point):
         """Adds a point intended to be a range endpoint. Once two points are selected the new range selection is
         committed and the range appended."""
-        self.current_range.append(fd_timestamp)
+        self.current_range.append(point)
 
         # We have a range selected. Append it to the list.
         if len(self.current_range) == 2:
@@ -39,12 +58,12 @@ class SliceRangeSelector:
             self.update_plot()
 
         # Draw a vertical line for some immediate visual feedback
-        self._axes.axvline(self.to_seconds(fd_timestamp))
+        self._axes.axvline(self.range_conversion_fcn(point))
         self._axes.get_figure().canvas.draw()
 
-    def _remove_range(self, fd_timestamp):
+    def _remove_range(self, point):
         """Removes a range if the provided timestamp falls inside it."""
-        in_range = [start < fd_timestamp < stop for start, stop in self._ranges]
+        in_range = [start < point < stop for start, stop in self._ranges]
         selected = np.nonzero(in_range)[0]
         if len(selected) > 0:
             selected_ranges = [self._ranges[x] for x in selected]
@@ -60,15 +79,14 @@ class SliceRangeSelector:
         if event.canvas.widgetlock.locked():
             return
 
-        event_timestamp = event.xdata * 1e9 + self.time[0]
         if event.button == 1:
             # Find the data point nearest to the event and determine its timestamp
-            fd_timestamp = self.time[np.argmin(np.abs(self.time - event_timestamp))]
-            if fd_timestamp:
-                self._add_point(fd_timestamp)
+            point = self.xdata[np.argmin(np.abs(self.xdata - event.xdata))]
+            if point:
+                self._add_point(point)
         elif event.button == 3:
             # Find whether we clicked an existing range
-            self._remove_range(event_timestamp)
+            self._remove_range(event.xdata)
 
     def connect_click_callback(self):
         """Connects a callback for clicking the axes"""
@@ -83,7 +101,7 @@ class SliceRangeSelector:
         self._axes.clear()
 
         for i, (t_start, t_end) in enumerate(self._ranges):
-            t_start, t_end = self.to_seconds(t_start), self.to_seconds(t_end)
+            t_start, t_end = self.range_conversion_fcn(t_start), self.range_conversion_fcn(t_end)
             self._axes.axvline(t_start)
             self._axes.axvline(t_end)
             self._axes.axvspan(t_start, t_end, alpha=0.15, color='blue')
@@ -91,17 +109,33 @@ class SliceRangeSelector:
 
         old_axis = plt.gca()
         plt.sca(self._axes)
-        self.slice.plot(linestyle='', marker='.', markersize=1)
+        self._plot_data()
         self.connect_click_callback()
-
-        plt.ylabel('Force [pN]')
-        plt.xlabel('Time [s]')
         plt.sca(old_axis)
 
+    def _plot_data(self):
+        raise NotImplementedError
+
+
+class SliceRangeSelectorWidget(BaseRangeSelectorWidget):
+    def __init__(self, channel_slice, axes=None, show=True):
+        self.slice = channel_slice
+        self.time = self.slice.timestamps
+        super().__init__(axes, show, self.to_seconds)
+
     @property
-    def ranges(self):
-        """Returns selected list of timestamp ranges"""
-        return np.copy(self._ranges)
+    def xdata(self):
+        return self.time
+
+    def to_seconds(self, timestamp):
+        return (timestamp - self.time[0]) / 1e9
+
+    def handle_button_event(self, event):
+        event.xdata = event.xdata * 1e9 + self.time[0] # convert seconds to timestamp
+        super().handle_button_event(event)
+
+    def _plot_data(self):
+        self.slice.plot(linestyle='', marker='.', markersize=1)
 
     @property
     def slices(self):
@@ -109,7 +143,7 @@ class SliceRangeSelector:
         return [self.slice[start:stop] for start, stop in self._ranges]
 
 
-class FdRangeSelectorWidget(SliceRangeSelector):
+class FdTimeRangeSelectorWidget(SliceRangeSelectorWidget):
     def __init__(self, fd_curve, axes=None, show=True):
         super().__init__(fd_curve.f, axes, show)
         self.fd_curve = fd_curve
@@ -120,8 +154,26 @@ class FdRangeSelectorWidget(SliceRangeSelector):
         return [self.fd_curve[start:stop] for start, stop in self._ranges]
 
 
+class FdDistanceRangeSelectorWidget(BaseRangeSelectorWidget):
+    def __init__(self, fd_curve, axes=None, show=True):
+        super().__init__(axes, show)
+        self.fd_curve = fd_curve        
+
+    @property
+    def xdata(self):
+        return self.fd_curve.d.data
+
+    def _plot_data(self):
+        self.fd_curve.plot_scatter(s=2)
+
+    @property
+    def fdcurves(self):
+        """Return list of selected fdcurves of data as `lumicks.pylake.FdCurve`"""
+        return [self.fd_curve._slice_by_distance(min_dist, max_dist) for min_dist, max_dist in self._ranges]
+
+
 class FdRangeSelector:
-    def __init__(self, fd_curves):
+    def __init__(self, fd_curves, select_by="time"):
         """Open widget to select regions in multiple F,d curves
 
         Parameters
@@ -141,10 +193,17 @@ class FdRangeSelector:
                                 "works. Please note that you may have to restart the notebook kernel for this to "
                                 "work."))
 
+        if select_by == "time":
+            widget = FdTimeRangeSelectorWidget
+        elif select_by == "distance":
+            widget = FdDistanceRangeSelectorWidget
+        else:
+            raise ValueError(f"selection by '{select_by}' is not recognized.")
+
         plt.figure()
         self.axes = plt.axes()
         self.active_plot = None
-        self.selectors = {key: FdRangeSelectorWidget(curve, self.axes, show=False) for key, curve in fd_curves.items()}
+        self.selectors = {key: widget(curve, self.axes, show=False) for key, curve in fd_curves.items()}
         keys = [key for key, curve in fd_curves.items()]
         ipywidgets.interact(self.update_plot, curve=ipywidgets.Dropdown(options=keys))
 

--- a/lumicks/pylake/nb_widgets/range_selector.py
+++ b/lumicks/pylake/nb_widgets/range_selector.py
@@ -155,7 +155,9 @@ class FdTimeRangeSelectorWidget(SliceRangeSelectorWidget):
 
 
 class FdDistanceRangeSelectorWidget(BaseRangeSelectorWidget):
-    def __init__(self, fd_curve, axes=None, show=True):
+    def __init__(self, fd_curve, axes=None, show=True, max_gap=0):
+        self.fd_curve = fd_curve        
+        self._max_gap = max_gap
         super().__init__(axes, show)
         self.fd_curve = fd_curve        
 
@@ -169,7 +171,7 @@ class FdDistanceRangeSelectorWidget(BaseRangeSelectorWidget):
     @property
     def fdcurves(self):
         """Return list of selected fdcurves of data as `lumicks.pylake.FdCurve`"""
-        return [self.fd_curve._slice_by_distance(min_dist, max_dist) for min_dist, max_dist in self._ranges]
+        return [self.fd_curve._sliced_by_distance(min_dist, max_dist, self._max_gap) for min_dist, max_dist in self._ranges]
 
 
 class FdRangeSelector:

--- a/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
+++ b/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
@@ -1,4 +1,5 @@
-from lumicks.pylake import FdRangeSelectorWidget, FdRangeSelector
+from lumicks.pylake import FdRangeSelector
+from lumicks.pylake.nb_widgets.range_selector import FdTimeRangeSelectorWidget
 from lumicks.pylake.fdcurve import FDCurve
 from lumicks.pylake.channel import TimeSeries, Slice
 from matplotlib.testing.decorators import cleanup
@@ -22,7 +23,7 @@ def test_selector_widget(mockevent):
     dt = int(600e9)
     fd_curve = make_mock_fd([0, 1, 2, 3], [0, 1, 2, 3], start=start_point, dt=dt)
 
-    selector = FdRangeSelectorWidget(fd_curve, show=False)
+    selector = FdTimeRangeSelectorWidget(fd_curve, show=False)
 
     assert selector.current_range == []
     selector._add_point(750)
@@ -38,7 +39,7 @@ def test_selector_widget(mockevent):
     assert selector.to_seconds(2500e9) == 0
     selector.update_plot()
 
-    selector = FdRangeSelectorWidget(fd_curve)
+    selector = FdTimeRangeSelectorWidget(fd_curve)
     lmb = 1
     rmb = 3
 

--- a/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
+++ b/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
@@ -1,5 +1,5 @@
 from lumicks.pylake import FdRangeSelector
-from lumicks.pylake.nb_widgets.range_selector import FdTimeRangeSelectorWidget
+from lumicks.pylake.nb_widgets.range_selector import FdTimeRangeSelectorWidget, FdDistanceRangeSelectorWidget
 from lumicks.pylake.fdcurve import FDCurve
 from lumicks.pylake.channel import TimeSeries, Slice
 from matplotlib.testing.decorators import cleanup
@@ -97,6 +97,84 @@ def test_selector_widget(mockevent):
 
 
 @cleanup
+def test_distance_selector_widget(mockevent):
+    start_point = int(2500e9)
+    dt = int(600e9)
+    fd_curve = make_mock_fd(np.arange(10), np.arange(10), start=start_point, dt=dt)
+
+    selector = FdDistanceRangeSelectorWidget(fd_curve, show=False)
+
+    assert selector.current_range == []
+    selector._add_point(2)
+    assert selector.current_range == [2]
+    selector._add_point(4)
+    assert selector.current_range == []
+    assert np.allclose(selector.ranges, [[2, 4]])
+    selector._add_point(6)
+    selector._add_point(9)
+    assert selector.current_range == []
+    assert np.allclose(selector.ranges, [[2, 4], [6, 9]])
+
+    selector.update_plot()
+
+    selector = FdDistanceRangeSelectorWidget(fd_curve, show=True)
+    lmb = 1
+    rmb = 3
+
+    # Remove a segment
+    event = mockevent(selector._axes, 3, 1, rmb, False)
+    selector.handle_button_event(event)
+    assert selector.current_range == []
+
+    # Add a point
+    event = mockevent(selector._axes, 2, 1, lmb, False)
+    selector.handle_button_event(event)
+    assert selector.current_range == [2]
+
+    # Widget is locked, do not add!
+    event = mockevent(selector._axes, 4, 1, lmb, True)
+    selector.handle_button_event(event)
+    assert selector.current_range == [2]
+
+    # Not the axis we own, do not add!
+    event = mockevent(5, 4, 1, lmb, False)
+    selector.handle_button_event(event)
+    assert selector.current_range == [2]
+
+    # Successful add
+    event = mockevent(selector._axes, 4, 1, lmb, False)
+    selector.handle_button_event(event)
+    assert selector.current_range == []
+    assert np.allclose(selector.ranges, [2, 4])
+
+    assert np.allclose(selector.fdcurves[0].f.data, fd_curve[start_point + 2*dt:start_point + 5*dt].f.data)
+
+    # Add another segment
+    selector.handle_button_event(mockevent(selector._axes, 6, 1, lmb, False))
+    selector.handle_button_event(mockevent(selector._axes, 9, 1, lmb, False))
+
+    # Remove a segment (fails since its outside)
+    event = mockevent(selector._axes, 10, 1, rmb, False)
+    selector.handle_button_event(event)
+    assert selector.current_range == []
+    assert np.allclose(selector.ranges, [[2, 4], [6, 9]])
+
+    # Remove a segment (inner segment, smallest segment gets removed first)
+    event = mockevent(selector._axes, 3, 1, rmb, False)
+    selector.handle_button_event(event)
+    assert selector.current_range == []
+    assert np.allclose(selector.ranges, [[6, 9]])
+
+    # Remove a segment (inner segment, smallest segment gets removed first)
+    event = mockevent(selector._axes, 7, 1, rmb, False)
+    selector.handle_button_event(event)
+    assert selector.current_range == []
+    assert np.allclose(selector.ranges, [[]])
+
+    assert selector.fdcurves == []
+
+
+@cleanup
 def test_multi_selector_widget():
     fd_curve1 = make_mock_fd([0, 1, 2, 3], [0, 1, 2, 3], start=int(2500e9))
     fd_curve2 = make_mock_fd([2, 3, 4, 5], [2, 3, 4, 5], start=int(2500e9))
@@ -106,6 +184,18 @@ def test_multi_selector_widget():
 
     with pytest.raises(RuntimeError):
         FdRangeSelector({"fd1": fd_curve1, "fd2": fd_curve2})
+
+
+@cleanup
+def test_multi_distance_selector_widget():
+    fd_curve1 = make_mock_fd(np.arange(10), np.arange(10), start=int(2500e9))
+    fd_curve2 = make_mock_fd(np.arange(3, 13), np.arange(3, 13), start=int(2500e9))
+
+    with pytest.raises(ValueError):
+        FdRangeSelector({})
+
+    with pytest.raises(RuntimeError):
+        FdRangeSelector({"fd1": fd_curve1, "fd2": fd_curve2})        
 
 
 @cleanup

--- a/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
+++ b/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
@@ -1,5 +1,7 @@
 from lumicks.pylake import FdRangeSelector
-from lumicks.pylake.nb_widgets.range_selector import FdTimeRangeSelectorWidget, FdDistanceRangeSelectorWidget
+from lumicks.pylake.nb_widgets.range_selector import (FdTimeRangeSelectorWidget, 
+                                                      FdDistanceRangeSelectorWidget, 
+                                                      BaseRangeSelectorWidget)
 from lumicks.pylake.fdcurve import FDCurve
 from lumicks.pylake.channel import TimeSeries, Slice
 from matplotlib.testing.decorators import cleanup
@@ -102,7 +104,7 @@ def test_distance_selector_widget(mockevent):
     dt = int(600e9)
     fd_curve = make_mock_fd(np.arange(10), np.arange(10), start=start_point, dt=dt)
 
-    selector = FdDistanceRangeSelectorWidget(fd_curve, show=False)
+    selector = fd_curve.distance_range_selector(show=False)
 
     assert selector.current_range == []
     selector._add_point(2)
@@ -117,7 +119,7 @@ def test_distance_selector_widget(mockevent):
 
     selector.update_plot()
 
-    selector = FdDistanceRangeSelectorWidget(fd_curve, show=True)
+    selector = fd_curve.distance_range_selector(show=True)
     lmb = 1
     rmb = 3
 
@@ -199,7 +201,14 @@ def test_multi_distance_selector_widget():
 
 
 @cleanup
-def test_slice_widget_opens():
+def test_selector_widgets_open():
     channel = Slice(TimeSeries([1, 2, 3, 4], [100, 200, 300, 400]))
+    widget = channel.range_selector()
+    assert isinstance(widget, BaseRangeSelectorWidget)
 
-    channel.range_selector
+    fd_curve = make_mock_fd(np.arange(10), np.arange(10), start=int(2500e9))
+    widget = fd_curve.range_selector()
+    assert isinstance(widget, BaseRangeSelectorWidget)
+
+    widget = fd_curve.distance_range_selector()
+    assert isinstance(widget, BaseRangeSelectorWidget)

--- a/lumicks/pylake/tests/test_dfcurve.py
+++ b/lumicks/pylake/tests/test_dfcurve.py
@@ -41,3 +41,73 @@ def test_slice():
     sliced = fd[101:102]
     assert id(fd.f) != id(sliced.f)
     assert id(fd.d) != id(sliced.d)
+
+
+def test_sliced_by_distance():
+    # test slicing
+    d = np.arange(10)
+    fd = make_mock_fd(force=np.ones(d.shape), distance=d)
+    # beginning
+    sub = fd._sliced_by_distance(0, 4, max_gap=0)
+    assert np.all(np.equal([0, 1, 2, 3, 4], sub.d.timestamps))
+    sub = fd._sliced_by_distance(-1, 4, max_gap=0)
+    assert np.all(np.equal([0, 1, 2, 3, 4], sub.d.timestamps))
+    # middle
+    sub = fd._sliced_by_distance(3, 6, max_gap=0)
+    assert np.all(np.equal([3, 4, 5, 6], sub.d.timestamps))
+    # end
+    sub = fd._sliced_by_distance(7, 9, max_gap=0)
+    assert np.all(np.equal([7, 8, 9], sub.d.timestamps))
+    sub = fd._sliced_by_distance(7, 11, max_gap=0)
+    assert np.all(np.equal([7, 8, 9], sub.d.timestamps))
+
+    # test noise handling
+    min_dist = 1.5
+    max_dist = 2
+    max_gap = 2
+
+    # "ideal" data
+    d0 = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 
+                   3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
+    f0 = np.ones(d0.shape)                   
+    fd0 = make_mock_fd(force=f0, distance=d0)
+
+    # find timestamps of proper slice
+    is_in_range = np.logical_and(min_dist <= d0, d0 <= max_dist)#.astype(np.int)
+    ts_in_range = fd0.d.timestamps[is_in_range]
+
+    # "blip" before changepoint - within gap limit
+    d1 = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.1, 2.0, 
+                   3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
+    # "blip" before changepoint - outside gap limit
+    d2 = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.1, 2.0, 2.0, 2.0, 2.0, 
+                   3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
+    # "blip" after changepoint - within gap limit
+    d3 = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 
+                   3.0, 1.9, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
+    # "blip" after changepoint - outside gap limit
+    d4 = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 
+                   3.0, 3.0, 3.0, 1.9, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
+    # "blip" before and after chanepoint - within gap limit
+    d5 = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.1, 2.0, 
+                   3.0, 1.9, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
+    # "blip" before and after changepoint - outside gap limit
+    d6 = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.1, 2.0, 2.0, 2.0, 2.0, 
+                   3.0, 3.0, 3.0, 1.9, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0])                   
+
+    # these types of noise can be handled  
+    # result should be identical to logical mask of ideal data
+    for d in (d0, d1, d2, d4, d6):                  
+        fd = make_mock_fd(force=f0, distance=d)
+        sub = fd._sliced_by_distance(min_dist=min_dist, max_dist=max_dist, max_gap=max_gap)
+        assert np.all(np.equal(ts_in_range, sub.d.timestamps))
+    
+    # these types of noise cannot be handled  
+    # result should be longer or shorter than expected
+    for d in (d3, d5):                  
+        fd = make_mock_fd(force=f0, distance=d)
+        sub = fd._sliced_by_distance(min_dist=min_dist, max_dist=max_dist, max_gap=max_gap)
+        with pytest.raises(ValueError) as exc:
+            assert np.all(np.equal(ts_in_range, sub.d.timestamps))
+        assert str(exc.value).strip() == ("operands could not be broadcast together with shapes " 
+                                          f"({ts_in_range.size},) ({sub.d.timestamps.size},)")

--- a/lumicks/pylake/tests/test_dfcurve.py
+++ b/lumicks/pylake/tests/test_dfcurve.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from lumicks.pylake.fdcurve import FDCurve
 from lumicks.pylake.channel import Slice, TimeSeries

--- a/lumicks/pylake/tests/test_utilities.py
+++ b/lumicks/pylake/tests/test_utilities.py
@@ -1,4 +1,4 @@
-from lumicks.pylake.detail.utilities import first, unique, get_color, lighten_color
+from lumicks.pylake.detail.utilities import first, unique, get_color, lighten_color, find_contiguous
 import pytest
 import matplotlib as mpl
 import numpy as np
@@ -22,3 +22,50 @@ def test_unique():
 def test_colors():
     [mpl.colors.to_rgb(get_color(k)) for k in range(30)]
     assert np.allclose(lighten_color([0.5, 0, 0], .2), [.7, 0, 0])
+
+
+def test_find_contiguous():
+    def check_blocks_are_true(mask, ranges):
+        for rng in ranges:
+            assert np.all(mask[slice(*rng)])
+
+    data = np.array([0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0])
+
+    mask = data
+    ranges, lengths = find_contiguous(mask)
+    assert np.all(np.equal(ranges, [[1, 10]]))
+    assert np.all(np.equal(lengths, [9]))
+    check_blocks_are_true(mask, ranges)
+    
+    mask = data < 10
+    ranges, lengths = find_contiguous(mask)
+    assert np.all(np.equal(ranges, [[0, 11]]))
+    assert np.all(np.equal(lengths, [11]))
+    check_blocks_are_true(mask, ranges)
+
+    mask = data > 10
+    ranges, lengths = find_contiguous(mask)
+    assert len(ranges) == 0
+    assert len(lengths) == 0
+    check_blocks_are_true(mask, ranges)
+
+    mask = data < 4
+    ranges, lengths = find_contiguous(mask)
+    assert np.all(np.equal(ranges, [[0, 4],
+                                    [7, 11]]))
+    assert np.all(np.equal(lengths, [4, 4]))
+    check_blocks_are_true(mask, ranges)
+
+    data = np.arange(10)
+
+    mask = data <= 5
+    ranges, lengths = find_contiguous(mask)
+    assert np.all(np.equal(ranges, [[0, 6]]))
+    assert np.all(np.equal(lengths, [6]))
+    check_blocks_are_true(mask, ranges)
+
+    mask = data >= 5
+    ranges, lengths = find_contiguous(mask)
+    assert np.all(np.equal(ranges, [[5, 10]]))
+    assert np.all(np.equal(lengths, [5]))
+    check_blocks_are_true(mask, ranges)


### PR DESCRIPTION
**Why this PR?**
User request for a notebook widget to select a range based on distance rather than time

**Key Points & Notes**
- `fd_selector.py` was renamed to `range_selector.py` (internal module)
- selector widgets code was refactored to make more general, easier to add new widgets
- some internal widget classes renamed to be more consistent
- noise in distance measurement can lead to premature truncation of the time channel if the longest contiguous block of data is selected from a pure logical mask (see figure, left and middle columns). An optional argument allows for small gaps caused by noise in the data (figure, right column)
![try_slicing_result](https://user-images.githubusercontent.com/61475504/105032484-1cfe1400-5a57-11eb-9dd6-c80538a10a71.png)
the desired distance threshold is displayed as the dashed black line in relevant plots

See the docs [here](https://lumicks-pylake.readthedocs.io/en/range_selector/tutorial/nbwidgets.html)
