### PR TITLE
Fd ensemble

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * Added `center_point_um` property to `PointScan`, `Kymo` and `Scan` classes.
 * Added `scan_width_um` property to `Kymo` and `Scan` classes.
 * Added `FDCurve.with_offset()` to `FDCurve` to add offsets to force and distance.
+* Added `FdEnsemble` to be able to process multiple `FDCurve` instances simultaneously.
 
 #### Bug fixes
 * Fixed `downsampled_over` to ignore gaps rather than result in an unhandled exception. Previously when you downsampled a `TimeSeries` channel which had a gap in its data, `downsampled_over` would try to compute the mean of an empty subsection, which raises an exception. Now this case is gracefully handled.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Added `FDCurve.range_selector()` and `FDCurve.distance_range_selector()`
 * Added `center_point_um` property to `PointScan`, `Kymo` and `Scan` classes.
 * Added `scan_width_um` property to `Kymo` and `Scan` classes.
+* Added `FDCurve.with_offset()` to `FDCurve` to add offsets to force and distance.
 
 #### Bug fixes
 * Fixed `downsampled_over` to ignore gaps rather than result in an unhandled exception. Previously when you downsampled a `TimeSeries` channel which had a gap in its data, `downsampled_over` would try to compute the mean of an empty subsection, which raises an exception. Now this case is gracefully handled.

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * Added `scan_width_um` property to `Kymo` and `Scan` classes.
 * Added `FDCurve.with_offset()` to `FDCurve` to add offsets to force and distance.
 * Added `FdEnsemble` to be able to process multiple `FDCurve` instances simultaneously.
+* Added `FdEnsemble.align_linear()` to align F,d curves in an ensemble by correcting for a constant offset in force and distance using two linear regressions. See [FD curves](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/fdcurves.html) for more information.
 
 #### Bug fixes
 * Fixed `downsampled_over` to ignore gaps rather than result in an unhandled exception. Previously when you downsampled a `TimeSeries` channel which had a gap in its data, `downsampled_over` would try to compute the mean of an empty subsection, which raises an exception. Now this case is gracefully handled.

--- a/docs/tutorial/fdcurves.rst
+++ b/docs/tutorial/fdcurves.rst
@@ -58,6 +58,15 @@ It's also possible to work with multiple FD curves as an ensemble::
 
     fd_ensemble = lk.FdEnsemble(file.fdcurves)
 
+We can align the FD curves using the align function::
+
+    fd_ensemble.align_linear(distance_range_low=0.02, distance_range_high=0.02)
+
+This aligns all the curves to the first and estimates an offset in force and distance, which is subtracted from the
+data. Force is aligned by taking the mean of the lowest distances, while distance is aligned by considering the last
+segment of each FD curve and regressing linear lines there, from which the offset is computed. Note that this requires
+the ends of the aligned F,d curves to be in a comparably folded state and obtained in the elastic range of the force,
+distance curve. If any of these assumptions are not met, this method should not be applied. We can obtain the force
 and distance from such an ensemble using::
 
     f = fd_ensemble.f

--- a/docs/tutorial/fdcurves.rst
+++ b/docs/tutorial/fdcurves.rst
@@ -50,3 +50,15 @@ The raw data can be accessed as well::
     plt.scatter(distance.data, force.data)
     # Plot manually: force timetrace
     plt.plot(force.timestamps, force.data)
+
+FD Ensembles
+------------
+
+It's also possible to work with multiple FD curves as an ensemble::
+
+    fd_ensemble = lk.FdEnsemble(file.fdcurves)
+
+and distance from such an ensemble using::
+
+    f = fd_ensemble.f
+    d = fd_ensemble.d

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -9,6 +9,7 @@ from lumicks.pylake.fitting.parameter_trace import parameter_trace
 from lumicks.pylake.nb_widgets.range_selector import FdRangeSelector, FdDistanceRangeSelector
 from lumicks.pylake.kymotracker.kymotracker import track_greedy, track_lines, filter_lines, refine_lines_centroid
 from lumicks.pylake.nb_widgets.kymotracker_widgets import KymoWidgetGreedy
+from lumicks.pylake.fdensemble import FdEnsemble
 
 
 def pytest(args=None, plugins=None):

--- a/lumicks/pylake/detail/alignment.py
+++ b/lumicks/pylake/detail/alignment.py
@@ -1,0 +1,65 @@
+import numpy as np
+from lumicks.pylake.detail.utilities import first
+
+
+def align_force_simple(fd_curves, distance_range=1):
+    """Aligns F,d curves to the first F,d curves in the ensemble by force
+
+    It evaluates the difference in offset by considering the mean of the early data points. The underlying assumption
+    is that the force does not increase substantially for the first part of the pulling curve and that curves have
+    been acquired starting from the same F,d point."""
+    assert len(fd_curves) > 1, "Alignment only makes sense for more than 1 curve"
+
+    def get_offset(fd):
+        force, distance = fd._sliced(distance_max=np.min(fd.d.data[fd.d.data > 0]) + distance_range)
+        return np.mean(force)
+
+    reference_offset = get_offset(first(fd_curves.values()))
+    return {key: fd.with_offset(force_offset=reference_offset - get_offset(fd)) for key, fd in fd_curves.items()}
+
+
+def align_distance_simple(fd_curves, distance_range=1):
+    """Aligns F,d curves to the first F,d curve in the ensemble by distance. Note that force has to be aligned first.
+
+    This method regresses a line to the last segment of each F,d curve and aligns the curves based on this regressed
+    line. Note that this requires the ends of the aligned F,d curves to be in a comparably folded state and obtained
+    in the elastic range of the force, distance curve. If any of these assumptions are not met, this method should not
+    be applied."""
+    assert len(fd_curves) > 1, "Alignment only makes sense for more than 1 curve"
+
+    def linear_fit(fd):
+        force, distance = fd._sliced(distance_min=np.max(fd.d.data) - distance_range)
+        poly_coefficients = np.polyfit(distance, force, 1)
+        return poly_coefficients[1], poly_coefficients[0]
+
+    ref_offset, ref_slope = linear_fit(first(fd_curves.values()))
+
+    def get_offset(fd):
+        force, distance = fd._sliced(distance_min=np.max(fd.d.data) - distance_range)
+        force_sim = ref_offset + ref_slope * distance
+        dx = np.mean(force - force_sim) / ref_slope
+        return dx
+
+    return {key: fd.with_offset(distance_offset=get_offset(fd)) for key, fd in fd_curves.items()}
+
+
+def align_fd_simple(fd_curves, distance_range_low, distance_range_high):
+    """Aligns F,d curves to the first F,d curve in the ensemble.
+
+    Force is aligned by taking the mean of the lowest distances. Distance is aligned by considering the last segment
+    of each F,d curve. This method regresses a line to the last segment of each F,d curve and aligns the curves based
+    on this regressed line. Note that this requires the ends of the aligned F,d curves to be in a comparably folded
+    state and obtained in the elastic range of the force, distance curve. If any of these assumptions are not met, this
+    method should not be applied.
+
+    Parameters
+    ----------
+    fd_curves : Dict[lumicks.pylake.FDCurve]
+        List of F,d curves to apply the method to.
+    distance_range_low : float
+        Range of distances to use for the force alignment. Distances in the range [smallest_distance,
+        smallest_distance + distance_range_low) are used to determine the force offsets.
+    distance_range_high : float
+        Upper range of distances to use. Distances in the range [largest_distance - distance_range_high,
+        largest_distance] are used for the distance alignment."""
+    return align_distance_simple(align_force_simple(fd_curves, distance_range_low), distance_range_high)

--- a/lumicks/pylake/fdensemble.py
+++ b/lumicks/pylake/fdensemble.py
@@ -1,0 +1,68 @@
+from lumicks.pylake.detail.alignment import align_fd_simple
+import numpy as np
+
+
+class FdEnsemble:
+    """An ensemble of FD curves exported from Bluelake.
+
+    This class provides a way to handle an ensemble of FD and perform procedures such as curve alignment on them.
+
+    Attributes
+    ----------
+    fd_curves : Dict[lumicks.pylake.FDCurve]
+        Dictionary of unprocessed FD curves.
+    fd_curves_processed : Dict[lumicks.pylake.FDCurve]
+        Dictionary of FD curves that were processed by the ensemble.
+
+    Methods
+    -------
+    align_linear(distance_range_low, distance_range_high)
+        Aligns F,d curves to the first F,d curve in the ensemble using two linear regressions.
+
+    Examples
+    --------
+    ::
+
+        import lumicks.pylake as lk
+
+        file = lk.File("example.h5")
+        fd_ensemble = lk.FdEnsemble(file.fdcurves)  # Create the ensemble
+
+        # Use the first 0.02 and last 0.04 um of data to align the data
+        fd_ensemble.align_linear(distance_range_low=0.02, distance_range_low=0.04)
+
+        # Plot the aligned Fd curves
+        for fd in fd_ensemble.values():
+            fd.plot_scatter()
+    """
+    def __init__(self, fd_curves):
+        self.fd_curves = fd_curves
+        self.fd_curves_processed = fd_curves
+
+    def __getitem__(self, item):
+        return self.fd_curves_processed[item]
+
+    def __iter__(self):
+        return self.fd_curves_processed.__iter__()
+
+    def items(self):
+        return self.fd_curves_processed.items()
+
+    def values(self):
+        return self.fd_curves_processed.values()
+
+    def keys(self):
+        return self.fd_curves_processed.keys()
+
+    @property
+    def raw(self):
+        return self.fd_curves
+
+    @property
+    def f(self):
+        return np.hstack([fd.f.data for fd in self.values()])
+
+    @property
+    def d(self):
+        return np.hstack([fd.d.data for fd in self.values()])
+

--- a/lumicks/pylake/fdensemble.py
+++ b/lumicks/pylake/fdensemble.py
@@ -66,3 +66,21 @@ class FdEnsemble:
     def d(self):
         return np.hstack([fd.d.data for fd in self.values()])
 
+    def align_linear(self, distance_range_low, distance_range_high):
+        """Aligns F,d curves to the first F,d curve in the ensemble.
+
+        Force is aligned by taking the mean of the lowest distances. Distance is aligned by considering the last segment
+        of each F,d curve. This method regresses a line to the last segment of each F,d curve and aligns the curves
+        based on this regressed line. Note that this requires the ends of the aligned F,d curves to be in a comparably
+        folded state and obtained in the elastic range of the force, distance curve. If any of these assumptions are not
+        met, this method should not be applied.
+
+        Parameters
+        ----------
+        distance_range_low : float
+            Range of distances to use for the force alignment. Distances in the range [smallest_distance,
+            smallest_distance + distance_range_low) are used to determine the force offsets.
+        distance_range_high : float
+            Upper range of distances to use. Distances in the range [largest_distance - distance_range_high,
+            largest_distance] are used for the distance alignment."""
+        self.fd_curves_processed = align_fd_simple(self.fd_curves, distance_range_low, distance_range_high)

--- a/lumicks/pylake/tests/test_dfcurve.py
+++ b/lumicks/pylake/tests/test_dfcurve.py
@@ -155,6 +155,21 @@ def test_subtract_too_much_distance():
         fd1.with_offset(distance_offset=-4.0)
 
 
+@pytest.mark.parametrize("slice_parameters,f,d", [
+    ({}, np.arange(-0.5, 3, 0.5), np.arange(0.5, 4, .5)),
+    ({"force_max": 1}, np.arange(-0.5, 1, 0.5), np.arange(0.5, 2.0, .5)),
+    ({"force_min": 0}, np.arange(0, 3, 0.5), np.arange(1.0, 4, .5)),
+    ({"distance_min": 1}, np.arange(0.0, 3, 0.5), np.arange(1.0, 4, .5)),
+    ({"distance_max": 3}, np.arange(-0.5, 2, 0.5), np.arange(0.5, 3, .5)),
+])
+def test_fd_slice(slice_parameters, f, d):
+    fd1 = make_mock_fd(force=np.arange(-2, 3, .5), distance=np.arange(-1, 4, .5), start=0)
+
+    fdr = fd1._sliced(**slice_parameters)
+    assert np.allclose(fdr.f, f)
+    assert np.allclose(fdr.d, d)
+
+
 def test_copy_behaviour_with_offset(h5_file):
     """Test whether with_offset is successful when there's an actual file attached. The reason this is tested explicitly
     is because with_offset may not deepcopy the handle it holds to the parent file."""

--- a/lumicks/pylake/tests/test_fdensemble.py
+++ b/lumicks/pylake/tests/test_fdensemble.py
@@ -1,0 +1,55 @@
+import pytest
+import numpy as np
+from lumicks.pylake.detail.alignment import align_force_simple, align_distance_simple, align_fd_simple
+from lumicks.pylake.fdcurve import FDCurve
+from lumicks.pylake.channel import Slice, TimeSeries
+from lumicks.pylake.fdensemble import FdEnsemble
+
+
+def make_mock_fd(force, distance, start=0):
+    """Mock FD curve which is not attached to an actual file, timestamps start at `start`"""
+    assert len(force) == len(distance)
+    fd = FDCurve(file=None, start=None, stop=None, name="")
+    timestamps = np.arange(len(force)) + start
+    fd._force_cache = Slice(TimeSeries(force, timestamps))
+    fd._distance_cache = Slice(TimeSeries(distance, timestamps))
+    return fd
+
+
+def test_iteration_fd_ensemble():
+    """Test whether we can iterate over the ensemble"""
+    force = np.hstack((np.ones(50), np.arange(1, 52)))
+    distance = np.hstack((np.arange(1, 102)))
+    fds = {
+        "fd1": make_mock_fd(force=force, distance=distance, start=0),
+        "fd2": make_mock_fd(force=force + 5, distance=distance, start=0),
+        "fd3": make_mock_fd(force=force + 15, distance=distance, start=0),
+    }
+    fd_ensemble = FdEnsemble(fds)
+
+    for key1, key2 in zip(fds, fd_ensemble):
+        assert key1 == key2
+
+    for key1, key2 in zip(fds.items(), fd_ensemble.items()):
+        assert key1 == key2
+
+    # The curves should be the same
+    for fd_a, fd_b in zip(fds.values(), fd_ensemble.values()):
+        assert id(fd_a) == id(fd_b)
+
+    for fd_a, fd_b in zip(fds.values(), fd_ensemble.raw.values()):
+        assert id(fd_a) == id(fd_b)
+
+
+def test_fd_ensemble_accessors():
+    force = np.arange(3)
+    distance = np.arange(3)
+    fds = {
+        "fd1": make_mock_fd(force=force, distance=distance, start=0),
+        "fd2": make_mock_fd(force=force + 5, distance=distance, start=0),
+        "fd3": make_mock_fd(force=force + 15, distance=distance, start=0),
+    }
+    fd_ensemble = FdEnsemble(fds)
+
+    assert np.allclose(fd_ensemble.f, np.array([0, 1, 2, 5, 6, 7, 15, 16, 17]))
+    assert np.allclose(fd_ensemble.d, np.array([0, 1, 2, 0, 1, 2, 0, 1, 2]))

--- a/lumicks/pylake/tests/test_fdensemble.py
+++ b/lumicks/pylake/tests/test_fdensemble.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 from lumicks.pylake.detail.alignment import align_force_simple, align_distance_simple, align_fd_simple
 from lumicks.pylake.fdcurve import FDCurve
@@ -14,6 +13,94 @@ def make_mock_fd(force, distance, start=0):
     fd._force_cache = Slice(TimeSeries(force, timestamps))
     fd._distance_cache = Slice(TimeSeries(distance, timestamps))
     return fd
+
+
+def test_align_force_simple():
+    """Test whether alignment of curves with a constant offset in force produces aligned curves"""
+
+    force = np.hstack((np.ones(50), np.arange(1, 50)))
+    distance = np.arange(1, 100)
+    fd1 = make_mock_fd(force=force, distance=distance, start=0)
+    fd2 = make_mock_fd(force=force + 5, distance=distance, start=0)
+    fd3 = make_mock_fd(force=force + 15, distance=distance, start=0)
+    aligned = align_force_simple({"fd1": fd1, "fd2": fd2, "fd3": fd3}, distance_range=50)
+
+    for fd in aligned.values():
+        assert np.allclose(fd.d.data, distance)
+        assert np.allclose(fd.f.data, force)
+
+
+def test_align_distance_simple():
+    """Test whether alignment of curves with a constant offset in distance produces aligned curves"""
+
+    force = np.hstack((np.ones(50), np.arange(1, 52)))
+    distance = np.arange(1.0, 102.0)
+    fd1 = make_mock_fd(force=force, distance=distance, start=0)
+    fd2 = make_mock_fd(force=force, distance=distance + 4.0, start=0)
+    fd3 = make_mock_fd(force=force, distance=distance + 2.0, start=0)
+    aligned = align_distance_simple({"fd1": fd1, "fd2": fd2, "fd3": fd3}, distance_range=50)
+
+    for fd in aligned.values():
+        assert np.allclose(fd.d.data, distance)
+        assert np.allclose(fd.f.data, force)
+
+
+def test_align_fd_simple():
+    """Test whether alignment of curves with a constant offset in both force and distance produces aligned curves"""
+
+    force = np.hstack((np.ones(50), np.arange(1, 52)))
+    distance = np.arange(1.0, 102.0)
+    fd1 = make_mock_fd(force=force, distance=distance, start=0)
+    fd2 = make_mock_fd(force=force + 5.0, distance=distance + 4.0, start=0)
+    fd3 = make_mock_fd(force=force + 15.0, distance=distance + 2.0, start=0)
+    aligned = align_fd_simple({"fd1": fd1, "fd2": fd2, "fd3": fd3}, 50, 50)
+
+    for fd in aligned.values():
+        assert np.allclose(fd.f.data, force)
+        assert np.allclose(fd.d.data, distance)
+
+
+def test_non_constant_rate_fd_alignment_simple():
+    """Tests what happens when we try to align an Fd curve with a non-constant pulling rate. A non-constant pulling rate
+    would lead to a non-linear relation when just looking at either force or distance, rather than looking at them
+    at the same time. Here we test whether the alignment actually operates on f,d rather than on channels
+    independently"""
+
+    distance = np.hstack((np.arange(150) * np.arange(150)) / 2500)
+    force = np.copy(distance)
+    force[force < 2] = 2
+
+    def generate_data(num_shortened):
+        return make_mock_fd(force=force[:-num_shortened], distance=distance[:-num_shortened], start=0)
+
+    shortening = [10, 20, 33, 48, 14, 60]
+    fds = {f"f_{idx}": generate_data(num_shortened) for idx, num_shortened in enumerate(shortening)}
+    aligned = align_fd_simple(fds, 1.5, 1.2)
+
+    for fd, num_shortened in zip(aligned.values(), shortening):
+        assert np.allclose(fd.f.data, force[:-num_shortened])
+        assert np.allclose(fd.d.data, distance[:-num_shortened])
+
+
+def test_back_and_forth_rate_fd_alignment_simple():
+    """Test what happens when we align an F,d curve that keeps going back and forth (non monotonic distance). The reason
+    we want to test this specific case is because there may be F,d curves that go back and forth. If the code merely
+    takes the last and first N samples, then this test would fail."""
+    
+    distance = 2.0 + np.sin(np.arange(1000))
+    force = np.copy(distance)
+    force[force < 2.0] = 2
+
+    def generate_data(num_shortened):
+        return make_mock_fd(force=force[:-num_shortened], distance=distance[:-num_shortened], start=0)
+
+    shortening = [100, 200, 330]
+    fds = {f"fd_{idx}": generate_data(num_shortened) for idx, num_shortened in enumerate(shortening)}
+    aligned = align_fd_simple(fds, 1, 1)
+
+    for fd, num_shortened in zip(aligned.values(), shortening):
+        assert np.allclose(fd.f.data, force[:-num_shortened])
+        assert np.allclose(fd.d.data, distance[:-num_shortened])
 
 
 def test_iteration_fd_ensemble():
@@ -37,8 +124,11 @@ def test_iteration_fd_ensemble():
     for fd_a, fd_b in zip(fds.values(), fd_ensemble.values()):
         assert id(fd_a) == id(fd_b)
 
-    for fd_a, fd_b in zip(fds.values(), fd_ensemble.raw.values()):
-        assert id(fd_a) == id(fd_b)
+    # Test that alignment leads to new objects and that the originals weren't modified
+    fd_ensemble.align_linear(1, 1)
+    for fd_a, fd_new, fd_unchanged in zip(fds.values(), fd_ensemble.values(), fd_ensemble.raw.values()):
+        assert id(fd_a) != id(fd_new)
+        assert id(fd_a) == id(fd_unchanged)
 
 
 def test_fd_ensemble_accessors():
@@ -53,3 +143,6 @@ def test_fd_ensemble_accessors():
 
     assert np.allclose(fd_ensemble.f, np.array([0, 1, 2, 5, 6, 7, 15, 16, 17]))
     assert np.allclose(fd_ensemble.d, np.array([0, 1, 2, 0, 1, 2, 0, 1, 2]))
+
+    fd_ensemble.align_linear(20, 20)
+    assert np.allclose(fd_ensemble.f, np.array([0, 1, 2, 0, 1, 2, 0, 1, 2]))


### PR DESCRIPTION
**Why this PR?**
While we do provide a workflow for dealing with offsets by means of fitting in the F,d curves, some labs prefer doing analyses on ensembles of F,d curves. One thing they often do is align the curves prior to analysis, after which they classify different parts of the curves (many curves at the same time). This PR is the first towards enabling that type of workflow.

**What's in this PR?**
It introduces the `FdEnsemble` which is essentially a collection of processed F,d curves. It also includes the most basic alignment method, which is based on two regressions (one constant, one linear) at the start and end of each curve.

It works quite well for data generated by some of our collaborators. For some of our own data, the conditions that the measurements were taken in are often not standardized enough, leading to misalignment when this method is applied. I've tried to make the preconditions for using this method clear in the docstring.

Future work will go into implementing a more robust alignment method as well (Bosshart et al).
