### PR TITLE
Document access to scan metadata

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
 #### New features
 * Added widget to graphically slice `FDCurve` by distance in Jupyter Notebooks. It can be opened by calling `pylake.FdDistanceRangeSelector(fdcurves)`. For more information, see the tutorials section on [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
 * Added `FDCurve.range_selector()` and `FDCurve.distance_range_selector()`
+* Added `center_point_um` property to `PointScan`, `Kymo` and `Scan` classes.
+* Added `scan_width_um` property to `Kymo` and `Scan` classes.
 
 #### Bug fixes
 * Fixed `downsampled_over` to ignore gaps rather than result in an unhandled exception. Previously when you downsampled a `TimeSeries` channel which had a gap in its data, `downsampled_over` would try to compute the mean of an empty subsection, which raises an exception. Now this case is gracefully handled.

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -26,12 +26,10 @@ Or just pick a single one::
     scan = file.scans["name"]
     scan.plot_red()
 
-If a few pixels dominate the image, one might want to set the scale by hand. We can pass an extra argument to `plot_red`
-named `vmax` to accomplish this. This parameter gets forwarded to :func:`matplotlib.pyplot.imshow`::
+Scan data and details
+---------------------
 
-    scan.plot_red(vmax=5)
-
-Access the raw image data::
+You can access the raw image data::
 
     rgb = scan.rgb_image  # matrix with `shape == (h, w, 3)`
     blue = scan.blue_image  # single color so `shape == (h, w)`
@@ -39,15 +37,31 @@ Access the raw image data::
     # Plot manually
     plt.imshow(rgb)
 
-The images contain pixel data where each pixel is made up a multiple photon count samples collected by the scanner.
+The images contain pixel data where each pixel represents summed photon counts.
 For an even lower-level look at data, the raw photon count samples can be accessed::
 
     photons = scan.red_photons
     plt.plot(photons.timestamps, photons.data)
 
-The images can also be exported in the TIFF format::
+There are also several properties available for convenient access to the scan metadata:
 
-    scan.save_tiff("image.tiff")
+* `scan.center_point_um` provides a dictionary of the central x, y, and z coordinates of the scan in micrometers relative to the brightfield field of view
+* `scan.scan_width_um` provides a list of scan widths in micrometers along the axes of the scan
+* `scan.pixelsize_um` provides the pixel size in micrometers
+* `scan.lines_per_frame` provides the number scanned lines in each frame (number of rows in the raw data array)
+* `scan.pixels_per_line` provides the number of pixels in each line of the scan (number of columns in the raw data array)
+* `scan.fast_axis` provides the fastest axis that was scanned (x or y)
+* `scan.num_frames` provides the number of frames available
+
+
+Plotting and Exporting
+----------------------
+
+As shown above, there are convenience functions for plotting either the full RGB image or a single color channel.
+If a few pixels dominate the image, one might want to set the scale by hand. We can pass an extra argument to `plot_red`
+named `vmax` to accomplish this. This parameter gets forwarded to :func:`matplotlib.pyplot.imshow`::
+
+    scan.plot_red(vmax=5)
 
 Multi-frame scans are also supported::
 
@@ -56,6 +70,10 @@ Multi-frame scans are also supported::
     print(scan.rgb_image.shape)  # (self.num_frames, h, w, 3) -> three color channels
 
     scan.plot(frame=3)  # plot the third frame -- defaults to the first frame if no argument is given
+
+The images can also be exported in the TIFF format::
+
+    scan.save_tiff("image.tiff")
 
 Scans can also be exported to video formats.
 Exporting the red channel of a multi-scan GIF can be done as follows for example::

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -24,6 +24,9 @@ Or just pick a single one::
     kymo = file.kymos["name"]
     kymo.plot_red()
 
+Kymo data and details
+---------------------
+
 Access the raw image data::
 
     rgb = kymo.rgb_image  # matrix with `shape == (h, w, 3)`
@@ -31,6 +34,23 @@ Access the raw image data::
 
     # Plot manually
     plt.imshow(rgb)
+
+Kymographs can also be sliced in order to obtain a specific time range.
+For example, one can plot the region of the kymograph between 175 and 180 seconds using::
+
+    kymo["175s":"180s"].plot_red()
+
+There are also several properties available for convenient access to the kymograph metadata:
+
+* `kymo.center_point_um` provides a dictionary of the central x, y, and z coordinates of the scan in micrometers relative to the brightfield field of view
+* `kymo.scan_width_um` provides a list of scan widths in micrometers along the axes of the scan
+* `kymo.pixelsize_um` provides the pixel size in micrometers
+* `kymo.pixels_per_line` provides the number of pixels in each line of the kymograph
+* `kymo.fast_axis` provides the axis that was scanned (x or y)
+* `kymo.line_time_seconds` provides the time between successive lines
+
+Plotting and exporting
+----------------------
 
 There are also convenience functions to plot individual color channels and the full RGB image::
 
@@ -42,8 +62,3 @@ There are also convenience functions to plot individual color channels and the f
 The images can also be exported in the TIFF format::
 
     kymo.save_tiff("image.tiff")
-
-Kymographs can also be sliced in order to obtain a specific time range.
-For example, one can plot the region of the kymograph between 175 and 180 seconds using::
-
-    kymo["175s":"180s"].plot_red()

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -130,6 +130,11 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
     def has_force(self) -> bool:
         return self.json["force"]
 
+    @property
+    def center_point_um(self):
+        """Returns a dictionary of the x/y/z center coordinates of the scan (w.r.t. brightfield field of view) """
+        return self.json["scan volume"]["center point (um)"]
+
 
 class ConfocalImage(BaseScan):
 
@@ -238,6 +243,11 @@ class ConfocalImage(BaseScan):
     def pixelsize_um(self):
         """Returns a `List` of axes dimensions in um. The length of the list corresponds to the number of scan axes."""
         return [axes["pixel size (nm)"] / 1000 for axes in self._ordered_axes()]
+
+    @property
+    def scan_width_um(self):
+        """Returns a `List` of scan widths in um along axes. The length of the list corresponds to the number of scan axes."""
+        return [axes["scan width (um)"] for axes in self._ordered_axes()]
 
     @property
     def red_image(self):

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -86,7 +86,7 @@ class Kymo(ConfocalImage):
     def _plot(self, image, **kwargs):
         import matplotlib.pyplot as plt
 
-        width_um = self._ordered_axes()[0]["scan width (um)"]
+        width_um = self.scan_width_um[0]
         ts = self.timestamps
         duration = (ts[0, -1] - ts[0, 0]) / 1e9
         linetime = (ts[0, 1] - ts[0, 0]) / 1e9

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -96,9 +96,7 @@ class Scan(ConfocalImage):
         if self.num_frames != 1:
             image = image[frame - 1]
 
-        axes = self._ordered_axes()
-        x_um = axes[0]["scan width (um)"]
-        y_um = axes[1]["scan width (um)"]
+        x_um, y_um = self.scan_width_um
         default_kwargs = dict(
             # With origin set to upper (default) bounds should be given as (0, n, n, 0)
             extent=[0, x_um, y_um, 0],
@@ -111,6 +109,7 @@ class Scan(ConfocalImage):
             # Updating the image data in an existing plot is a lot faster than re-plotting with `imshow`.
             image_handle.set_data(image)
 
+        axes = self._ordered_axes()
         plt.xlabel(f"{axis_label[axes[0]['axis']]} ($\\mu m$)")
         plt.ylabel(f"{axis_label[axes[1]['axis']]} ($\\mu m$)")
         if self.num_frames == 1:

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -30,6 +30,10 @@ def test_kymo_properties(h5_file):
         assert kymo.fast_axis == "X"
         assert np.allclose(kymo.pixelsize_um, 10/1000)
         assert np.allclose(kymo.line_time_seconds, 1.03125)
+        assert np.allclose(kymo.center_point_um["x"], 58.075877109272604)
+        assert np.allclose(kymo.center_point_um["y"], 31.978375270573267)
+        assert np.allclose(kymo.center_point_um["z"], 0)
+        assert np.allclose(kymo.scan_width_um, [0.050])
 
 
 def test_kymo_slicing(h5_file):

--- a/lumicks/pylake/tests/test_scan.py
+++ b/lumicks/pylake/tests/test_scan.py
@@ -31,6 +31,10 @@ def test_scans(h5_file):
         assert scan.green_image.shape == (4, 5)
         assert scan.fast_axis == "Y"
         assert np.allclose(scan.pixelsize_um, [197/1000, 191/1000])
+        assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
+        assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
+        assert np.allclose(scan.center_point_um["z"], 0)
+        assert np.allclose(scan.scan_width_um, [0.197*5, 0.191*4])
 
         with pytest.raises(NotImplementedError):
             scan["1s":"2s"]
@@ -53,6 +57,10 @@ def test_scans(h5_file):
         assert scan.green_image.shape == (2, 4, 3)
         assert scan.fast_axis == "Y"
         assert np.allclose(scan.pixelsize_um, [197 / 1000, 191 / 1000])
+        assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
+        assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
+        assert np.allclose(scan.center_point_um["z"], 0)
+        assert np.allclose(scan.scan_width_um, [0.197*3, 0.191*4])
 
         scan = f.scans["fast X slow Z multiframe"]
         reference_timestamps2 = np.zeros((2, 4, 3))
@@ -73,6 +81,10 @@ def test_scans(h5_file):
         assert scan.green_image.shape == (2, 3, 4)
         assert scan.fast_axis == "X"
         assert np.allclose(scan.pixelsize_um, [191 / 1000, 197 / 1000])
+        assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
+        assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
+        assert np.allclose(scan.center_point_um["z"], 0)
+        assert np.allclose(scan.scan_width_um, [0.191*4, 0.197*3])
 
         scan = f.scans["fast Y slow Z multiframe"]
         reference_timestamps2 = np.zeros((2, 4, 3))
@@ -93,6 +105,10 @@ def test_scans(h5_file):
         assert scan.green_image.shape == (2, 3, 4)
         assert scan.fast_axis == "Y"
         assert np.allclose(scan.pixelsize_um, [191 / 1000, 197 / 1000])
+        assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
+        assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
+        assert np.allclose(scan.center_point_um["z"], 0)
+        assert np.allclose(scan.scan_width_um, [0.191*4, 0.197*3])
 
 
 def test_damaged_scan(h5_file):


### PR DESCRIPTION
**Why this PR?**
Let users know what type of metadata is available for scans and kymos

**What's in this PR?**

* added `center_point_um` and `scan_width_um` properties
* added documentation for all public properties in `Scan` and `Kymo` classes. This should hopefully avoid many users from directly accessing the `.json` metadata
* cleaned up documenation for Confocal Images and Kymographs

Updated docs for [Scan](https://lumicks-pylake.readthedocs.io/en/scan_props/tutorial/images.html) and [Kymo](https://lumicks-pylake.readthedocs.io/en/scan_props/tutorial/kymographs.html)