### PR TITLE
Fixes for deprecated functionalities in numpy

### DIFF
--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -359,7 +359,7 @@ class Continuous:
 
     @property
     def _timesteps(self):
-        return np.asarray([self.dt], dtype=np.int)
+        return np.asarray([self.dt], dtype=int)
 
     def slice(self, start, stop):
         def to_index(t):
@@ -418,7 +418,7 @@ class TimeSeries:
 
     @property
     def _timesteps(self):
-        return np.unique(np.diff(self.timestamps)).astype(np.int)
+        return np.unique(np.diff(self.timestamps)).astype(int)
 
     def slice(self, start, stop):
         idx = np.logical_and(start <= self.timestamps, self.timestamps < stop)

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -99,7 +99,7 @@ class TiffFrame:
             return self.data
 
         if channel.lower() == "rgb":
-            data = (self.data / (2**self.bit_depth - 1)).astype(np.float)
+            data = (self.data / (2**self.bit_depth - 1)).astype(float)
             if vmax is None:
                 return data/data.max()
             else:

--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -38,7 +38,7 @@ def lighten_color(c, amount):
 
 def find_contiguous(mask):
     """Find [start,stop] indices and lengths of contiguous blocks where mask is True."""
-    padded = np.hstack((0, mask.astype(np.bool), 0))
+    padded = np.hstack((0, mask.astype(bool), 0))
     change_points = np.abs(np.diff(padded))
     ranges = np.argwhere(change_points == 1).reshape(-1,2)
     run_lengths = np.diff(ranges, axis=1).squeeze()

--- a/lumicks/pylake/fitting/parameters.py
+++ b/lumicks/pylake/fitting/parameters.py
@@ -196,7 +196,7 @@ class Params:
 
     @property
     def fitted(self):
-        return np.asarray([not param.fixed for param in self._src.values()], dtype=np.bool)
+        return np.asarray([not param.fixed for param in self._src.values()], dtype=bool)
 
     @property
     def lower_bounds(self):

--- a/lumicks/pylake/kymotracker/detail/peakfinding.py
+++ b/lumicks/pylake/kymotracker/detail/peakfinding.py
@@ -41,7 +41,7 @@ class KymoPeaks:
             self.unassigned = []
 
         def reset_assignment(self):
-            self.unassigned = np.ones(self.time_points.shape, dtype=np.bool)
+            self.unassigned = np.ones(self.time_points.shape, dtype=bool)
 
     def __init__(self, coordinates, time_points, peak_amplitudes):
         assert len(coordinates) == len(time_points)
@@ -110,7 +110,7 @@ def refine_peak_based_on_moment(data, coordinates, time_points, half_kernel_size
     for iteration in range(max_iter):
         offsets = subpixel_offset[coordinates, time_points]
         out_of_bounds, = np.nonzero(abs(offsets) > 0.5)
-        coordinates[out_of_bounds] += np.sign(offsets[out_of_bounds]).astype(np.int)
+        coordinates[out_of_bounds] += np.sign(offsets[out_of_bounds]).astype(int)
 
         # Edge cases (literally)
         low = coordinates < 0
@@ -151,7 +151,7 @@ def merge_close_peaks(peaks, minimum_distance):
         right_lower = peak_amplitudes[too_close + 1] < peak_amplitudes[too_close]
         too_close[right_lower] += 1
 
-        mask = np.ones(current_frame.coordinates.shape, dtype=np.bool)
+        mask = np.ones(current_frame.coordinates.shape, dtype=bool)
         mask[sort_order[too_close]] = False  # too_close was in sorted ordering.
 
         current_frame.coordinates = current_frame.coordinates[mask]

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -193,8 +193,8 @@ def refine_lines_centroid(lines, line_width):
         Line width
     """
     interpolated_lines = [line.interpolate() for line in lines]
-    time_idx = np.round(np.array(np.hstack([line.time_idx for line in interpolated_lines]))).astype(np.int)
-    coordinate_idx = np.round(np.array(np.hstack([line.coordinate_idx for line in interpolated_lines]))).astype(np.int)
+    time_idx = np.round(np.array(np.hstack([line.time_idx for line in interpolated_lines]))).astype(int)
+    coordinate_idx = np.round(np.array(np.hstack([line.coordinate_idx for line in interpolated_lines]))).astype(int)
 
     coordinate_idx, time_idx, _ = refine_peak_based_on_moment(interpolated_lines[0].image_data,
                                                               coordinate_idx,

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -69,7 +69,7 @@ class Scan(ConfocalImage):
 
         physical_axis = [axis["axis"] for axis in self.json["scan volume"]["scan axes"]]
         if physical_axis[0] > physical_axis[1]:
-            new_axis_order = np.arange(len(data.shape), dtype=np.int)
+            new_axis_order = np.arange(len(data.shape), dtype=int)
             new_axis_order[-1], new_axis_order[-2] = new_axis_order[-2], new_axis_order[-1]
             return np.transpose(data, new_axis_order)
         else:

--- a/lumicks/pylake/tests/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_correlated_stack.py
@@ -413,17 +413,17 @@ def test_image_reconstruction_rgb():
 
     assert fr.is_rgb
     max_signal = np.max(np.hstack([fr._get_plot_data("green"), fr._get_plot_data("red")]))
-    diff = np.abs(fr._get_plot_data('green').astype(np.float)-fr._get_plot_data("red").astype(np.float))
+    diff = np.abs(fr._get_plot_data('green').astype(float)-fr._get_plot_data("red").astype(float))
     assert np.all(diff/max_signal < 0.05)
     max_signal = np.max(np.hstack([fr._get_plot_data("green"), fr._get_plot_data("blue")]))
-    diff = np.abs(fr._get_plot_data('green').astype(np.float)-fr._get_plot_data("blue").astype(np.float))
+    diff = np.abs(fr._get_plot_data('green').astype(float)-fr._get_plot_data("blue").astype(float))
     assert np.all(diff/max_signal < 0.05)
 
-    original_data = (img0 / (2**img_args["bit_depth"] - 1)).astype(np.float)
+    original_data = (img0 / (2**img_args["bit_depth"] - 1)).astype(float)
     assert np.allclose(original_data, fr._get_plot_data(), atol=0.05)
     assert np.allclose(original_data / 0.5, fr._get_plot_data(vmax=0.5), atol=0.10)
     max_signal = np.max(np.hstack([img0[:, :, 0], fr._get_plot_data("red")]))
-    diff = np.abs(img0[:, :, 0].astype(np.float)-fr._get_plot_data("red").astype(np.float))
+    diff = np.abs(img0[:, :, 0].astype(float)-fr._get_plot_data("red").astype(float))
     assert np.all(diff/max_signal < 0.05)
 
     with pytest.raises(ValueError):
@@ -449,7 +449,7 @@ def test_image_reconstruction_rgb():
     stack = CorrelatedStack.from_data(fake_tiff)        
     fr = stack._get_frame(0)
 
-    original_data = (img0 / (2**img_args["bit_depth"] - 1)).astype(np.float)
+    original_data = (img0 / (2**img_args["bit_depth"] - 1)).astype(float)
     assert np.allclose(original_data, fr._get_plot_data(), atol=0.05)
 
 
@@ -476,7 +476,7 @@ def test_image_reconstruction_rgb_multiframe():
     fr = stack._get_frame(2)
 
     assert fr.is_rgb
-    original_data = (img0 / (2**img_args["bit_depth"] - 1)).astype(np.float)
+    original_data = (img0 / (2**img_args["bit_depth"] - 1)).astype(float)
     assert np.allclose(original_data, fr._get_plot_data(), atol=0.05)
 
 

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -876,19 +876,19 @@ def test_parameter_slicing():
 
 
 def test_analytic_roots():
-    a = np.array([0])
-    b = np.array([-3])
-    c = np.array([1])
+    a = np.array([0.0])
+    b = np.array([-3.0])
+    c = np.array([1.0])
 
     assert np.allclose(
-        np.sort(np.roots(np.array([np.array(1.0), a, b, c], dtype=np.float64))),
+        np.sort(np.roots(np.hstack((np.array([1.0]), a, b, c)))),
         np.sort(
             np.array(
                 [
                     solve_cubic_wlc(a, b, c, 0)[0],
                     solve_cubic_wlc(a, b, c, 1)[0],
                     solve_cubic_wlc(a, b, c, 2)[0],
-                ],
+                ]
             )
         ),
     )

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -283,11 +283,9 @@ def test_invalid_access(h5_file):
 def test_missing_metadata(h5_file_missing_meta):
     f = pylake.File.from_h5py(h5_file_missing_meta)
     if f.format_version == 2:
-        with pytest.warns(UserWarning) as record:
+        with pytest.warns(UserWarning, match="Scan 'fast Y slow X no meta' is missing metadata and cannot be loaded"):
             scans = f.scans
             assert len(scans) == 1
-            assert len(record) == 1
-            assert record[0].message.args[0] == "Scan 'fast Y slow X no meta' is missing metadata and cannot be loaded"
 
 
 def _internal_h5_export_api(file, *args, **kwargs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,5 +13,7 @@ filterwarnings =
     # bogus numpy ABI warning (see numpy/#432)
     ignore:.*numpy.dtype size changed.*:RuntimeWarning
     ignore:.*numpy.ufunc size changed.*:RuntimeWarning
-    # h5py triggers numpy's FutureWarning
-    ignore::FutureWarning
+    # h5py triggers a numpy DeprecationWarning when accessing empty datasets (such as our json fields). Here they pass
+    # a None shape argument where () is expected by numpy. This will likely be fixed in next h5py release, see the
+    # following PR on h5py: https://github.com/h5py/h5py/pull/1780/files
+    ignore:.*None into shape arguments as an alias for \(\) is.*:DeprecationWarning


### PR DESCRIPTION
**Why this PR?**
Some functionalities were deprecated in numpy. We'd like to stay up to date.

**Why the addition to setup.cfg?**
h5py is still using some deprecated behaviour. They already have a fix for this (see: https://github.com/h5py/h5py/pull/1780/files ) but until that's out there, it would be nice to silence this one error.