### PR TITLE
Export (aligned) tiff files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * Added `FDCurve.with_offset()` to `FDCurve` to add offsets to force and distance.
 * Added `FdEnsemble` to be able to process multiple `FDCurve` instances simultaneously.
 * Added `FdEnsemble.align_linear()` to align F,d curves in an ensemble by correcting for a constant offset in force and distance using two linear regressions. See [FD curves](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/fdcurves.html) for more information.
+* Added `CorrelatedStack.export_tiff()` for exporting aligned image stacks.
 
 #### Bug fixes
 * Fixed `downsampled_over` to ignore gaps rather than result in an unhandled exception. Previously when you downsampled a `TimeSeries` channel which had a gap in its data, `downsampled_over` would try to compute the mean of an empty subsection, which raises an exception. Now this case is gracefully handled.

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -32,3 +32,14 @@ using timestamps obtained from the `CorrelatedStack`::
 
     # Determine the force trace averaged over frame 2...9.
     file.force1x.downsampled_over(stack[2:10].timestamps)
+
+The aligned image stack can also be exported to tiff format::
+
+    stack.export_tiff("aligned_stack.tiff")
+    stack[5:20].export_tiff("aligned_short_stack.tiff") # export a slice of the CorrelatedStack
+
+Generally, the edges of an aligned image can become corrupted due interopolation artefacts. 
+In this case, we can export a cropped region of interest by supplying the `roi` kwarg in the form
+`[min_x_pixel, max_x_pixel, min_y_pixel, max_y_pixel]`::
+
+    stack.export_tiff("aligned_cropped_stack.tiff", roi=[20, 280, 20, 180])

--- a/lumicks/pylake/tests/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_correlated_stack.py
@@ -46,8 +46,9 @@ class MockTiffFile:
         return len(self._src.pages)
 
 
-def test_correlated_stack():
-    fake_tiff = TiffStack(MockTiffFile(data=[np.ones((3,3))]*6,
+@pytest.mark.parametrize("shape", [(3,3), (5,4,3)])
+def test_correlated_stack(shape):
+    fake_tiff = TiffStack(MockTiffFile(data=[np.ones(shape)]*6,
                                        times=[["10", "18"], ["20", "28"], ["30", "38"], ["40", "48"], ["50", "58"], ["60", "68"]]),
                           align=True)
     stack = CorrelatedStack.from_data(fake_tiff)
@@ -94,119 +95,19 @@ def test_correlated_stack():
     assert (np.allclose([x.start for x in stack[2]], [30]))
 
 
-def test_rgb_correlated_stack():
-    fake_tiff = TiffStack(MockTiffFile(data=[np.ones((5,4,3))]*6,
-                                       times=[["10", "18"], ["20", "28"], ["30", "38"], ["40", "48"], ["50", "58"], ["60", "68"]]),
-                          align=True)
-    stack = CorrelatedStack.from_data(fake_tiff)
-
-    assert (stack[0].start == 10)
-    assert (stack[1].start == 20)
-    assert (stack[-1].start == 60)
-    assert (stack[0].num_frames == 1)
-
-    assert (stack[0].stop == 18)
-    assert (stack[-1].stop == 68)
-
-    assert (stack[1:2].stop == 28)
-    assert (stack[1:3].stop == 38)
-    assert (stack[1:2].num_frames == 1)
-    assert (stack[1:3].num_frames == 2)
-
-    assert (stack[3:5][0].start == 40)
-    assert (stack[3:5][1].start == 50)
-    assert (stack[3:5][0].num_frames == 1)
-
-    with pytest.raises(IndexError):
-        stack[3:5][2]
-
-    assert(stack[2:5][3:5].num_frames == 0)
-    assert(stack[2:5][1:2].start == 40)
-    assert(stack[2:5][1:3]._get_frame(1).start == 50)
-
-    with pytest.raises(IndexError):
-        stack[::2]
-
-    with pytest.raises(IndexError):
-        stack[1:2]._get_frame(1).stop
-
-    # Integration test whether slicing from the stack object actually provides you with correct slices
-    assert (np.allclose(stack[2:5].start, 30))
-    assert (np.allclose(stack[2:5].stop, 58))
-
-    # Test iterations
-    assert (np.allclose([x.start for x in stack], [10, 20, 30, 40, 50, 60]))
-    assert (np.allclose([x.start for x in stack[1:]], [20, 30, 40, 50, 60]))
-    assert (np.allclose([x.start for x in stack[:-1]], [10, 20, 30, 40, 50]))
-    assert (np.allclose([x.start for x in stack[2:4]], [30, 40]))
-    assert (np.allclose([x.start for x in stack[2]], [30]))
-
-
-def test_correlation():
+@pytest.mark.parametrize("shape", [(3,3), (5,4,3)])
+def test_correlation(shape):
     cc = channel.Slice(channel.Continuous(np.arange(10, 80, 2), 10, 2))
 
     # Test image stack without dead time
-    fake_tiff = TiffStack(MockTiffFile(data=[np.ones((3,3))]*6,
+    fake_tiff = TiffStack(MockTiffFile(data=[np.ones(shape)]*6,
                                        times=[["10", "20"], ["20", "30"], ["30", "40"], ["40", "50"], ["50", "60"], ["60", "70"]]),
                           align=True)
     stack = CorrelatedStack.from_data(fake_tiff)
     assert (np.allclose(np.hstack([cc[x.start:x.stop].data for x in stack[2:4]]), np.arange(30, 50, 2)))
 
     # Test image stack with dead time
-    fake_tiff = TiffStack(MockTiffFile(data=[np.ones((3,3))]*6,
-                                       times=[["10", "18"], ["20", "28"], ["30", "38"], ["40", "48"], ["50", "58"], ["60", "68"]]),
-                          align=True)
-    stack = CorrelatedStack.from_data(fake_tiff)
-
-    assert (np.allclose(np.hstack([cc[x.start:x.stop].data for x in stack[2:4]]),
-                        np.hstack([np.arange(30, 38, 2), np.arange(40, 48, 2)])))
-
-    # Unit test which tests whether we obtain an appropriately downsampled time series when ask for downsampling of a
-    # slice based on a stack.
-    ch = cc.downsampled_over(stack[0:3].timestamps)
-    assert(np.allclose(ch.data, [np.mean(np.arange(10, 18, 2)), np.mean(np.arange(20, 28, 2)), np.mean(np.arange(30, 38, 2))]))
-    assert (np.allclose(ch.timestamps, [(10 + 16) / 2, (20 + 26) / 2, (30 + 36) / 2]))
-
-    ch = cc.downsampled_over(stack[1:4].timestamps)
-    assert (np.allclose(ch.data, [np.mean(np.arange(20, 28, 2)), np.mean(np.arange(30, 38, 2)), np.mean(np.arange(40, 48, 2))]))
-    assert (np.allclose(ch.timestamps, [(20 + 26) / 2, (30 + 36) / 2, (40 + 46) / 2]))
-
-    with pytest.raises(TypeError):
-        cc.downsampled_over(stack[1:4])
-
-    with pytest.raises(ValueError):
-        cc.downsampled_over(stack[1:4].timestamps, where='up')
-
-    with pytest.raises(AssertionError):
-        cc["0ns":"20ns"].downsampled_over(stack[3:4].timestamps)
-
-    with pytest.raises(AssertionError):
-        cc["40ns":"70ns"].downsampled_over(stack[0:1].timestamps)
-
-    assert (stack[0].raw.start == 10)
-    assert (stack[1].raw.start == 20)
-    assert (stack[1:3][0].raw.start == 20)
-    assert (stack[1:3].raw[0].start == 20)
-    assert (stack[1:3].raw[1].start == 30)
-
-    # Regression test downsampled_over losing precision due to reverting to double rather than int64.
-    cc = channel.Slice(channel.Continuous(np.arange(10, 80, 2), 1588267266006287100, 1000))
-    ch = cc.downsampled_over([(1588267266006287100, 1588267266006287120)], where='left')
-    assert int(ch.timestamps[0]) == 1588267266006287100
-
-
-def test_rgb_correlation():
-    cc = channel.Slice(channel.Continuous(np.arange(10, 80, 2), 10, 2))
-
-    # Test image stack without dead time
-    fake_tiff = TiffStack(MockTiffFile(data=[np.ones((5,4,3))]*6,
-                                       times=[["10", "20"], ["20", "30"], ["30", "40"], ["40", "50"], ["50", "60"], ["60", "70"]]),
-                          align=True)
-    stack = CorrelatedStack.from_data(fake_tiff)
-    assert (np.allclose(np.hstack([cc[x.start:x.stop].data for x in stack[2:4]]), np.arange(30, 50, 2)))
-
-    # Test image stack with dead time
-    fake_tiff = TiffStack(MockTiffFile(data=[np.ones((5,4,3))]*6,
+    fake_tiff = TiffStack(MockTiffFile(data=[np.ones(shape)]*6,
                                        times=[["10", "18"], ["20", "28"], ["30", "38"], ["40", "48"], ["50", "58"], ["60", "68"]]),
                           align=True)
     stack = CorrelatedStack.from_data(fake_tiff)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "numpy>=1.14, <2",
         "scipy>=1.1, <2",
         "matplotlib>=2.2",
-        "tifffile>=2018.11.6",
+        "tifffile>=2019.7.26",
         "tabulate==0.8.6",
         "opencv-python-headless>=3.0",
         "ipywidgets>=7.0.0",


### PR DESCRIPTION
**Why this PR?**
Users would like to export the aligned images for use in other software or presentation

**What's in this PR?**
* added `CorrelatedStack.export_tiff()` method. `roi` kwarg allows for exporting a specific region
* some refactoring of the tests, adding fixtures to deal with test image and file generation
* works with either RGB or grayscale stacks, single- or multi-frame stacks