### PR TITLE
Handle Numpy FutureWarning

### DIFF
--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -41,7 +41,7 @@ def test_attributes(h5_file):
     assert type(f.experiment) is str
     assert type(f.description) is str
     assert type(f.guid) is str
-    assert np.issubdtype(f.export_time, int)
+    assert np.issubdtype(f.export_time, np.dtype(int).type)
 
 
 def test_channels(h5_file):


### PR DESCRIPTION
**Why this PR?**
numpy < v1.20 raises FutureWarning with `np.issubdtype(np.int, int)`

**What's in this PR?**
change offending line according to warning suggestion