### PR TITLE
Deprecate confocal json public attribute

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,8 @@
 * `FdRangeSelectorWidget` is no longer public.
 * Renamed `fd_selector.py` to `range_selector.py`
 * `Slice.range_selector()` is now a method instead of a property
+* Deprecated `json` attribute in confocal classes `PointScan`, `Scan`, and `Kymo`. **Note: The format of the raw metadata exported from Bluelake is likely to change in future releases and therefore should not be accessed directly. Instead, use the accessor properties, as documented for [scans](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html) and [kymographs](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html).**
+* Deprecated `has_force` and `has_fluorescence` properties in confocal classes `PointScan`, `Scan`, and `Kymo`.
 
 #### Other
 * Added documentation for the Kymotracker widget. See the [Cas9 kymotracking example](https://lumicks-pylake.readthedocs.io/en/latest/examples/cas9_kymotracking/cas9_kymotracking.html) or the [kymotracking tutorial](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -47,17 +47,17 @@ class Kymo(ConfocalImage):
         i_max = np.searchsorted(line_timestamps, stop, side='left')
 
         if i_min >= len(line_timestamps):
-            return EmptyKymo(self.name, self.file, line_timestamps[-1], line_timestamps[-1], self.json)
+            return EmptyKymo(self.name, self.file, line_timestamps[-1], line_timestamps[-1], self._json)
 
         if i_min >= i_max:
-            return EmptyKymo(self.name, self.file, line_timestamps[i_min], line_timestamps[i_min], self.json)
+            return EmptyKymo(self.name, self.file, line_timestamps[i_min], line_timestamps[i_min], self._json)
 
         if i_max < len(line_timestamps):
             stop = line_timestamps[i_max]
 
         start = line_timestamps[i_min]
 
-        return Kymo(self.name, self.file, start, stop, self.json)
+        return Kymo(self.name, self.file, start, stop, self._json)
 
     def _fix_incorrect_start(self):#, timeline_start, timeline_dt):
         """ Resolve error when confocal scan starts before the timeline information.
@@ -135,18 +135,18 @@ class Kymo(ConfocalImage):
 
         import matplotlib.pyplot as plt
         _, (ax1, ax2) = plt.subplots(2, 1)
-        
+
         # plot kymo
         plt.sca(ax1)
         getattr(self, f"plot_{color_channel}")()
         ax1.set_xlabel(None)
-        
+
         # plot force channel
         plt.sca(ax2)
         force = self._downsample_channel(force_channel[-2], force_channel[-1], reduce=reduce)
         force.plot(**kwargs)
         ax2.set_xlim(ax1.get_xlim())
-        
+
         set_aspect_ratio(ax1, aspect_ratio)
         set_aspect_ratio(ax2, aspect_ratio)
 

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -26,8 +26,8 @@ class Scan(ConfocalImage):
     """
     def __init__(self, name, file, start, stop, json):
         super().__init__(name, file, start, stop, json)
-        self._num_frames = self.json["scan count"]
-        if len(self.json["scan volume"]["scan axes"]) > 2:
+        self._num_frames = self._json["scan count"]
+        if len(self._json["scan volume"]["scan axes"]) > 2:
             raise RuntimeError("3D scans are not supported")
 
     def __repr__(self):
@@ -46,7 +46,7 @@ class Scan(ConfocalImage):
 
     @property
     def lines_per_frame(self):
-        return self.json["scan volume"]["scan axes"][1]["num of pixels"]
+        return self._json["scan volume"]["scan axes"][1]["num of pixels"]
 
     @property
     def _shape(self):
@@ -67,7 +67,7 @@ class Scan(ConfocalImage):
         Here X, Y, Z correspond to axis number 0, 1 and 2. So for an YZ scan, we'd want Y on the X axis."""
         data = data.squeeze()
 
-        physical_axis = [axis["axis"] for axis in self.json["scan volume"]["scan axes"]]
+        physical_axis = [axis["axis"] for axis in self._json["scan volume"]["scan axes"]]
         if physical_axis[0] > physical_axis[1]:
             new_axis_order = np.arange(len(data.shape), dtype=int)
             new_axis_order[-1], new_axis_order[-2] = new_axis_order[-2], new_axis_order[-1]

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -18,8 +18,12 @@ def test_kymo_properties(h5_file):
                                         [2.084375e+10, 2.187500e+10, 2.284375e+10, 2.387500e+10]], np.int64)
 
         assert repr(kymo) == "Kymo(pixels=5)"
-        assert kymo.has_fluorescence
-        assert not kymo.has_force
+        with pytest.deprecated_call():
+            kymo.json
+        with pytest.deprecated_call():
+            assert kymo.has_fluorescence
+        with pytest.deprecated_call():
+            assert not kymo.has_force
         assert kymo.pixels_per_line == 5
         assert len(kymo.infowave) == 64
         assert kymo.rgb_image.shape == (5, 4, 3)
@@ -103,8 +107,12 @@ def test_kymo_slicing(h5_file):
             empty_kymograph.plot_rgb()
 
         assert empty_kymograph.red_image.shape == (5, 0)
-        assert empty_kymograph.has_fluorescence
-        assert not empty_kymograph.has_force
+        with pytest.deprecated_call():
+            empty_kymograph.json
+        with pytest.deprecated_call():
+            assert empty_kymograph.has_fluorescence
+        with pytest.deprecated_call():
+            assert not empty_kymograph.has_force
         assert empty_kymograph.infowave.data.size == 0
         assert empty_kymograph.pixels_per_line == 5
         assert empty_kymograph.red_image.size == 0
@@ -130,13 +138,13 @@ def test_plotting(h5_file):
     f = pylake.File.from_h5py(h5_file)
     if f.format_version == 2:
         kymo = f.kymos["Kymo1"]
-        
+
         kymo.plot_red()
         assert np.allclose(np.sort(plt.xlim()), [-0.5, 3.5], atol=0.05)
         assert np.allclose(np.sort(plt.ylim()), [0, 0.05])
 
 
-@cleanup        
+@cleanup
 def test_plotting_with_force(h5_file):
     f = pylake.File.from_h5py(h5_file)
     if f.format_version == 2:
@@ -151,7 +159,7 @@ def test_plotting_with_force(h5_file):
         assert np.allclose(np.sort(plt.ylim()), [10, 30])
 
 
-@cleanup        
+@cleanup
 def test_plotting_with_histograms(h5_file):
     def get_rectangle_data():
         widths = [p.get_width() for p in plt.gca().patches]
@@ -193,8 +201,8 @@ def test_plotting_with_histograms(h5_file):
 
         with pytest.raises(ValueError):
             kymo.plot_with_time_histogram(color_channel="red", pixels_per_bin=6)
-        
-        
+
+
 def test_save_tiff(tmpdir_factory, h5_file):
     from os import stat
 

--- a/lumicks/pylake/tests/test_point_scan.py
+++ b/lumicks/pylake/tests/test_point_scan.py
@@ -19,9 +19,13 @@ def test_point_scans(h5_file):
                                    0, 1, 0, 0, 0, 8, 0])
         assert np.allclose(ps_red.timestamps, reference_timestamps)
         assert np.allclose(ps_red.data, reference_data)
-        
-        assert ps.has_fluorescence
-        assert not ps.has_force
+
+        with pytest.deprecated_call():
+            ps.json
+        with pytest.deprecated_call():
+            assert ps.has_fluorescence
+        with pytest.deprecated_call():
+            assert not ps.has_force
 
 
 @cleanup

--- a/lumicks/pylake/tests/test_scan.py
+++ b/lumicks/pylake/tests/test_scan.py
@@ -20,8 +20,12 @@ def test_scans(h5_file):
 
         assert np.allclose(scan.timestamps, np.transpose(reference_timestamps))
         assert scan.num_frames == 1
-        assert scan.has_fluorescence
-        assert not scan.has_force
+        with pytest.deprecated_call():
+            scan.json
+        with pytest.deprecated_call():
+            assert scan.has_fluorescence
+        with pytest.deprecated_call():
+            assert not scan.has_force
         assert scan.pixels_per_line == 4
         assert scan.lines_per_frame == 5
         assert len(scan.infowave) == 64
@@ -46,8 +50,12 @@ def test_scans(h5_file):
 
         assert np.allclose(scan.timestamps, reference_timestamps2)
         assert scan.num_frames == 2
-        assert scan.has_fluorescence
-        assert not scan.has_force
+        with pytest.deprecated_call():
+            scan.json
+        with pytest.deprecated_call():
+            assert scan.has_fluorescence
+        with pytest.deprecated_call():
+            assert not scan.has_force
         assert scan.pixels_per_line == 4
         assert scan.lines_per_frame == 3
         assert len(scan.infowave) == 64
@@ -70,8 +78,12 @@ def test_scans(h5_file):
 
         assert np.allclose(scan.timestamps, reference_timestamps2)
         assert scan.num_frames == 2
-        assert scan.has_fluorescence
-        assert not scan.has_force
+        with pytest.deprecated_call():
+            scan.json
+        with pytest.deprecated_call():
+            assert scan.has_fluorescence
+        with pytest.deprecated_call():
+            assert not scan.has_force
         assert scan.pixels_per_line == 4
         assert scan.lines_per_frame == 3
         assert len(scan.infowave) == 64
@@ -94,8 +106,12 @@ def test_scans(h5_file):
 
         assert np.allclose(scan.timestamps, reference_timestamps2)
         assert scan.num_frames == 2
-        assert scan.has_fluorescence
-        assert not scan.has_force
+        with pytest.deprecated_call():
+            scan.json
+        with pytest.deprecated_call():
+            assert scan.has_fluorescence
+        with pytest.deprecated_call():
+            assert not scan.has_force
         assert scan.pixels_per_line == 4
         assert scan.lines_per_frame == 3
         assert len(scan.infowave) == 64

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "opencv-python-headless>=3.0",
         "ipywidgets>=7.0.0",
         "cachetools>=3.1",
+        "deprecated>=1.2.8",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
**Why this PR?**
Currently the public `json` attribute in `confocal.BaseScan` is a regular Python dict read from the json metadata exported by Bluelake. This attribute should be deprecated so users are warned not to use it.

**What changed?**
* `BaseScan.json` is now a property decorated with `@deprecated`
* internal access to the metadata is still available as before through `BaseScan._json` 
* deprecated `BaseScan.has_force` and `BaseScan.has_fluorescence`. These fields were never really useful, now return hard-coded boolean values