### PR TITLE
Ldat refactor (pt. 1)

### DIFF
--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -1,0 +1,84 @@
+import math
+import scipy
+from collections import namedtuple
+from .detail.power_models import passive_power_spectrum_model, sphere_friction_coefficient
+
+
+class CalibrationModel:
+    def __init__(self):
+        pass
+
+    def __call__(self):
+        raise NotImplementedError
+
+    def calibration_parameters(self, params):
+        raise NotImplementedError
+
+
+class PassiveCalibrationModel(CalibrationModel):
+    """Model to fit data acquired during passive calibration.
+
+    The power spectrum calibration algorithm implemented here is based on a number of publications
+    by the Flyvbjerg group at DTU [1]_ [2]_ [3]_ [4]_.
+
+    References
+    ----------
+    .. [1] Berg-Sørensen, K. & Flyvbjerg, H. Power spectrum analysis for optical tweezers. Rev. Sci.
+           Instrum. 75, 594 (2004).
+    .. [2] Tolić-Nørrelykke, I. M., Berg-Sørensen, K. & Flyvbjerg, H. MatLab program for precision
+           calibration of optical tweezers. Comput. Phys. Commun. 159, 225–240 (2004).
+    .. [3] Hansen, P. M., Tolic-Nørrelykke, I. M., Flyvbjerg, H. & Berg-Sørensen, K.
+           tweezercalib 2.1: Faster version of MatLab package for precise calibration of optical
+           tweezers. Comput. Phys. Commun. 175, 572–573 (2006).
+    .. [4] Berg-Sørensen, K., Peterman, E. J. G., Weber, T., Schmidt, C. F. & Flyvbjerg, H. Power
+           spectrum analysis for optical tweezers. II: Laser wavelength dependence of parasitic
+           filtering, and how to achieve high bandwidth. Rev. Sci. Instrum. 77, 063106 (2006).
+
+    Attributes
+    ----------
+    bead_diameter : float
+        Bead diameter [um].
+    viscosity : float, optional
+        Liquid viscosity [Pa*s]. Default: 1.002e-3 Pa*s.
+    temperature : float, optional
+        Liquid temperature [Celsius].
+    """
+    def __init__(self, bead_diameter, viscosity=1.002e-3, temperature=20):
+        self.bead_diameter = bead_diameter
+        self.viscosity = viscosity
+        self.temperature = temperature
+
+    def __call__(self, f, fc, diffusion_constant, f_diode, alpha):
+        return passive_power_spectrum_model(f, fc, diffusion_constant, f_diode, alpha)
+
+    def calibration_parameters(self, fc, diffusion_constant):
+        """Compute calibration parameters from cutoff frequency and diffusion constant.
+
+        Parameters
+        ----------
+        fc : float
+            Corner frequency, in Hz.
+        diffusion_constant : float
+            Diffusion constant, in (a.u.)^2/s
+
+        Returns
+        -------
+        namedtuple (Rd, kappa, Rf)
+            Attributes:
+                Rd : float
+                    Distance response [um/V]
+                kappa : float
+                    Trap stiffness [pN/nm]
+                Rf : float
+                    Force response [pN/V]
+            Note: returns None if the fit fails.
+        """
+        CalibrationParameters = namedtuple("PassiveCalibrationFitResults", ["Rd", "kappa", "Rf"])
+
+        gamma_0 = sphere_friction_coefficient(self.viscosity, self.bead_diameter * 1e-6)
+        temperature_k = scipy.constants.convert_temperature(self.temperature, "C", "K")
+        Rd = math.sqrt(scipy.constants.k * temperature_k / gamma_0 / diffusion_constant) * 1e6
+        kappa = 2 * math.pi * gamma_0 * fc * 1e3
+        Rf = Rd * kappa * 1e3
+
+        return CalibrationParameters(Rd, kappa, Rf)

--- a/lumicks/pylake/force_calibration/detail/power_models.py
+++ b/lumicks/pylake/force_calibration/detail/power_models.py
@@ -26,7 +26,8 @@ def fit_analytical_lorentzian(ps):
 
         Note: returns None if the fit fails.
     """
-    FitResults = namedtuple("AnalyticalLorentzianFitResults", ["fc", "D", "sigma_fc", "sigma_D", "ps_fit"])
+    FitResults = namedtuple("AnalyticalLorentzianFitResults",
+                            ["fc", "D", "sigma_fc", "sigma_D", "ps_fit"])
 
     # Calculate S[p,q] elements (Ref. 1, Eq. 13-14).
     Spq = np.zeros((3, 3))

--- a/lumicks/pylake/force_calibration/detail/power_models.py
+++ b/lumicks/pylake/force_calibration/detail/power_models.py
@@ -1,0 +1,143 @@
+import math
+import numpy as np
+from collections import namedtuple
+from .power_spectrum import PowerSpectrum
+
+
+def fit_analytical_lorentzian(ps):
+    """Performs an analytical least-squares fit of a Lorentzian Power Spectrum.
+
+    Based on Section IV from ref. 1.
+
+    Parameters
+    ----------
+    ps : PowerSpectrum
+        Power spectrum data. Should generally be block-averaged, before passing
+        into this function.
+
+    Returns
+    -------
+    namedtuple (fc, D, sigma_fc, sigma_D, ps_fit)
+        Attributes:
+        - `fc` : corner frequency [Hz]
+        - `D`: diffusion constant [V^2/s]
+        - `sigma_fc`, `sigma_D`: 1-sigma confidence intervals for `fc` and `D`
+        - `ps_fit`: `PowerSpectrum` object with model fit
+
+        Note: returns None if the fit fails.
+    """
+    FitResults = namedtuple("AnalyticalLorentzianFitResults", ["fc", "D", "sigma_fc", "sigma_D", "ps_fit"])
+
+    # Calculate S[p,q] elements (Ref. 1, Eq. 13-14).
+    Spq = np.zeros((3, 3))
+    for p in range(3):
+        for q in range(3):
+            Spq[p, q] = np.sum(np.power(ps.f, 2 * p) * np.power(ps.P, q))
+    try:
+        # Calculate a and b parameters (Ref. 1, Eq. 13-14).
+        a = (Spq[0, 1] * Spq[2, 2] - Spq[1, 1] * Spq[1, 2]) / (Spq[0, 2] * Spq[2, 2] - Spq[1, 2] * Spq[1, 2])
+        b = (Spq[1, 1] * Spq[0, 2] - Spq[0, 1] * Spq[1, 2]) / (Spq[0, 2] * Spq[2, 2] - Spq[1, 2] * Spq[1, 2])
+
+        # Having a and b, calculating fc and D is trivial.
+        fc = math.sqrt(a / b)  # corner frequency [Hz]
+        D = (1 / b) * 2 * (math.pi ** 2)  # diffusion constant [V^2/s]
+
+        # Fitted power spectrum values.
+        ps_fit = PowerSpectrum()
+        ps_fit.f = ps.f
+        ps_fit.P = 1 / (a + b * np.power(ps.f, 2))
+        ps_fit.sampling_rate = ps.sampling_rate
+        ps_fit.T_measure = ps.T_measure
+
+        # Error propagation (Ref. 1, Eq. 25-28).
+        x_min = ps.f.min() / fc
+        x_max = ps.f.max() / fc
+
+        u = (
+            (2 * x_max) / (1 + x_max ** 2)
+            - (2 * x_min) / (1 + x_min ** 2)
+            + 2 * math.atan((x_max - x_min) / (1 + x_min * x_max))
+        )
+        v = (4 / (x_max - x_min)) * (math.atan((x_max - x_min) / (1 + x_min * x_max))) ** 2
+        s_fc = math.sqrt(math.pi / (u - v))
+        sigma_fc = fc * s_fc / math.sqrt(math.pi * fc * ps.T_measure)
+
+        s_D = math.sqrt(u / ((1 + math.pi / 2) * (x_max - x_min))) * s_fc
+        sigma_D = D * math.sqrt((1 + math.pi / 2) / (math.pi * fc * ps.T_measure)) * s_D
+
+        return FitResults(fc, D, sigma_fc, sigma_D, ps_fit)
+    except ValueError:
+        return None
+
+
+def _alpha(a):
+    return 1 / math.sqrt(1 + a ** 2)
+
+
+def _a(alpha):
+    return math.sqrt(1 / alpha ** 2 - 1)
+
+
+class FullPSFitModel:
+    """Callable wrapper around our model function for the full power spectrum.
+
+    Takes care of fit parameter rescaling, before calling into the core model
+    function `P`.
+    """
+
+    def __init__(self, scale_factors):
+        self.scale_factors = scale_factors
+
+    def __call__(self, f, p1, p2, p3, p4):
+        """This method gets called when we try to call a FullPSFitModel object"""
+        return self.P(f, *self.get_params_from_rescaled_params((p1, p2, p3, p4)))
+
+    @staticmethod
+    def P(f, fc, D, f_diode, alpha):
+        """Theoretical model for the full power spectrum.
+
+        See ref. 1, Eq. (10), and ref. 2, Eq. (11).
+
+        Parameters
+        ----------
+        f : numpy.ndarray
+            Frequency values, in Hz.
+        fc : float
+            Corner frequency, in Hz.
+        D : float
+            Diffusion constant, in (a.u.)^2/s
+        f_diode : float
+            Diode fall-off frequency, in Hz.
+        alpha : float
+            Diode parameter, between 0 and 1.
+        """
+        return (D / (2 * math.pi ** 2)) / (f ** 2 + fc ** 2) * FullPSFitModel.g_diode(f, f_diode, alpha)
+
+    @staticmethod
+    def g_diode(f, f_diode, alpha):
+        """Theoretical model for the low-pass filtering by the PSD.
+
+        See ref. 2, Eq. (11).
+        """
+        return alpha ** 2 + (1 - alpha ** 2) / (1 + (f / f_diode) ** 2)
+
+    def get_params_from_rescaled_params(self, rescaled_params):
+        return (
+            rescaled_params[0] * self.scale_factors[0],
+            rescaled_params[1] * self.scale_factors[1],
+            rescaled_params[2] * self.scale_factors[2],
+            _alpha(rescaled_params[3] * self.scale_factors[3]),
+        )
+
+
+def sphere_friction_coefficient(eta, d):
+    """Friction coefficient of a sphere with diameter `d` in a liquid with viscosity `eta`
+
+    Parameters
+    ----------
+    eta : float
+        Dynamic / shear viscosity [Pa*s]
+    d : float
+        Sphere diameter [m]
+    """
+    return 3.0 * math.pi * eta * d

--- a/lumicks/pylake/force_calibration/detail/power_models.py
+++ b/lumicks/pylake/force_calibration/detail/power_models.py
@@ -33,41 +33,39 @@ def fit_analytical_lorentzian(ps):
     for p in range(3):
         for q in range(3):
             Spq[p, q] = np.sum(np.power(ps.f, 2 * p) * np.power(ps.P, q))
-    try:
-        # Calculate a and b parameters (Ref. 1, Eq. 13-14).
-        a = (Spq[0, 1] * Spq[2, 2] - Spq[1, 1] * Spq[1, 2]) / (Spq[0, 2] * Spq[2, 2] - Spq[1, 2] * Spq[1, 2])
-        b = (Spq[1, 1] * Spq[0, 2] - Spq[0, 1] * Spq[1, 2]) / (Spq[0, 2] * Spq[2, 2] - Spq[1, 2] * Spq[1, 2])
 
-        # Having a and b, calculating fc and D is trivial.
-        fc = math.sqrt(a / b)  # corner frequency [Hz]
-        D = (1 / b) * 2 * (math.pi ** 2)  # diffusion constant [V^2/s]
+    # Calculate a and b parameters (Ref. 1, Eq. 13-14).
+    a = (Spq[0, 1] * Spq[2, 2] - Spq[1, 1] * Spq[1, 2]) / (Spq[0, 2] * Spq[2, 2] - Spq[1, 2] * Spq[1, 2])
+    b = (Spq[1, 1] * Spq[0, 2] - Spq[0, 1] * Spq[1, 2]) / (Spq[0, 2] * Spq[2, 2] - Spq[1, 2] * Spq[1, 2])
 
-        # Fitted power spectrum values.
-        ps_fit = PowerSpectrum()
-        ps_fit.f = ps.f
-        ps_fit.P = 1 / (a + b * np.power(ps.f, 2))
-        ps_fit.sampling_rate = ps.sampling_rate
-        ps_fit.T_measure = ps.T_measure
+    # Having a and b, calculating fc and D is trivial.
+    fc = math.sqrt(a / b)  # corner frequency [Hz]
+    D = (1 / b) * 2 * (math.pi ** 2)  # diffusion constant [V^2/s]
 
-        # Error propagation (Ref. 1, Eq. 25-28).
-        x_min = ps.f.min() / fc
-        x_max = ps.f.max() / fc
+    # Fitted power spectrum values.
+    ps_fit = PowerSpectrum()
+    ps_fit.f = ps.f
+    ps_fit.P = 1 / (a + b * np.power(ps.f, 2))
+    ps_fit.sampling_rate = ps.sampling_rate
+    ps_fit.T_measure = ps.T_measure
 
-        u = (
-            (2 * x_max) / (1 + x_max ** 2)
-            - (2 * x_min) / (1 + x_min ** 2)
-            + 2 * math.atan((x_max - x_min) / (1 + x_min * x_max))
-        )
-        v = (4 / (x_max - x_min)) * (math.atan((x_max - x_min) / (1 + x_min * x_max))) ** 2
-        s_fc = math.sqrt(math.pi / (u - v))
-        sigma_fc = fc * s_fc / math.sqrt(math.pi * fc * ps.T_measure)
+    # Error propagation (Ref. 1, Eq. 25-28).
+    x_min = ps.f.min() / fc
+    x_max = ps.f.max() / fc
 
-        s_D = math.sqrt(u / ((1 + math.pi / 2) * (x_max - x_min))) * s_fc
-        sigma_D = D * math.sqrt((1 + math.pi / 2) / (math.pi * fc * ps.T_measure)) * s_D
+    u = (
+        (2 * x_max) / (1 + x_max ** 2)
+        - (2 * x_min) / (1 + x_min ** 2)
+        + 2 * math.atan((x_max - x_min) / (1 + x_min * x_max))
+    )
+    v = (4 / (x_max - x_min)) * (math.atan((x_max - x_min) / (1 + x_min * x_max))) ** 2
+    s_fc = math.sqrt(math.pi / (u - v))
+    sigma_fc = fc * s_fc / math.sqrt(math.pi * fc * ps.T_measure)
 
-        return FitResults(fc, D, sigma_fc, sigma_D, ps_fit)
-    except ValueError:
-        return None
+    s_D = math.sqrt(u / ((1 + math.pi / 2) * (x_max - x_min))) * s_fc
+    sigma_D = D * math.sqrt((1 + math.pi / 2) / (math.pi * fc * ps.T_measure)) * s_D
+
+    return FitResults(fc, D, sigma_fc, sigma_D, ps_fit)
 
 
 def _alpha(a):

--- a/lumicks/pylake/force_calibration/detail/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/detail/power_spectrum.py
@@ -100,8 +100,9 @@ class PowerSpectrum:
     def in_range(self, f_min, f_max):
         """Returns part of the power spectrum within a given frequency range."""
         ir = PowerSpectrum()
-        ir.f = self.f[(self.f > f_min) & (self.f <= f_max)]
-        ir.P = self.P[(self.f > f_min) & (self.f <= f_max)]
+        mask = (self.f > f_min) & (self.f <= f_max)
+        ir.f = self.f[mask]
+        ir.P = self.P[mask]
         ir.sampling_rate = self.sampling_rate
         ir.T_measure = self.T_measure
         return ir

--- a/lumicks/pylake/force_calibration/detail/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/detail/power_spectrum.py
@@ -1,0 +1,110 @@
+import numpy as np
+import math
+
+
+def block_average(data, n_blocks):
+    """Calculates the block average of a dataset.
+
+    For an array ``A`` of length ``N``, returns an array ``B`` of length
+    ``M``, where each element of ``B`` is the average of ``q`` neighboring
+    elements. ``q`` is equal to ``floor(N/M)``. This implies that if ``N*q``
+    is not exactly equal to ``M``, the last partially complete window is
+    thrown away by this function.
+    """
+    block_size = math.floor(data.size / n_blocks)
+    length = block_size * n_blocks
+    return np.mean(np.reshape(data[:length], (-1, block_size)), axis=1)
+
+
+def block_average_std(data, n_blocks):
+    """Calculates the block standard deviation of a dataset.
+
+    Works as `block_average`, but calculates the standard deviation
+    instead of the average.
+
+    See Also
+    --------
+    block_average
+    """
+    block_size = math.floor(data.size / n_blocks)
+    length = block_size * n_blocks
+    return np.std(np.reshape(data[:length], (-1, block_size)), axis=1)
+
+
+class PowerSpectrum:
+    """Power spectrum data for a time series.
+
+    Attributes
+    ----------
+    f : numpy.ndarray
+        Frequency values for the power spectrum. [Hz]
+    P : numpy.ndarray
+        Power values for the power spectrum (typically in V^2/s).
+    sampling_rate : float
+        The sampling rate for the original data. [Hz]
+    T_measure : float
+        The total duration of the original data. [seconds]
+    """
+
+    def __init__(self, data=None, sampling_rate=None):
+        """Constructor
+
+        If neither parameter is given, an empty object is created.
+
+        Parameters
+        ----------
+        data : numpy.ndarray, optional
+            Data from which to calculate a power spectrum.
+        sampling_rate : float, optional
+        """
+        if data is not None:
+            # Initialize from raw sensor data.
+            assert sampling_rate is not None
+
+            # Subtract average position.
+            data = data - np.mean(data)
+
+            # Calculate power spectrum.
+            fft = np.fft.rfft(data)
+            self.f = np.fft.rfftfreq(data.size, 1.0 / sampling_rate)
+            self.P = (1.0 / sampling_rate) * np.square(np.abs(fft)) / data.size
+
+            # Store metadata
+            self.sampling_rate = sampling_rate
+            self.T_measure = data.size / sampling_rate
+        else:
+            # Initialize empty object.
+            self.f = None
+            self.P = None
+            self.sampling_rate = None
+            self.T_measure = None
+
+    def as_dict(self):
+        """"Returns a representation of the PowerSpectrum suitable for serialization"""
+        return {"f": self.f.tolist(), "P": self.P.tolist()}
+
+    def block_averaged(self, n_blocks=2000):
+        """Returns a block-averaged power spectrum.
+
+        See Also
+        --------
+        block_average
+        """
+        ba = PowerSpectrum()
+        ba.f = block_average(self.f, n_blocks)
+        ba.P = block_average(self.P, n_blocks)
+        ba.sampling_rate = self.sampling_rate
+        ba.T_measure = self.T_measure
+        return ba
+
+    def in_range(self, f_min, f_max):
+        """Returns part of the power spectrum within a given frequency range."""
+        ir = PowerSpectrum()
+        ir.f = self.f[(self.f > f_min) & (self.f <= f_max)]
+        ir.P = self.P[(self.f > f_min) & (self.f <= f_max)]
+        ir.sampling_rate = self.sampling_rate
+        ir.T_measure = self.T_measure
+        return ir
+
+    def n_samples(self):
+        return self.f.size

--- a/lumicks/pylake/force_calibration/detail/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/detail/power_spectrum.py
@@ -1,4 +1,5 @@
 import numpy as np
+import matplotlib.pyplot as plt
 import math
 
 
@@ -31,7 +32,7 @@ class PowerSpectrum:
         The total duration of the original data. [seconds]
     """
 
-    def __init__(self, data=None, sampling_rate=None):
+    def __init__(self, data=None, sampling_rate=None, unit="V"):
         """Constructor
 
         If neither parameter is given, an empty object is created.
@@ -41,7 +42,9 @@ class PowerSpectrum:
         data : numpy.ndarray, optional
             Data from which to calculate a power spectrum.
         sampling_rate : float, optional
+        unit : str, optional
         """
+        self.unit = unit
         if data is not None:
             # Initialize from raw sensor data.
             assert sampling_rate is not None
@@ -99,3 +102,15 @@ class PowerSpectrum:
 
     def n_samples(self):
         return self.f.size
+
+    def plot(self):
+        """Plot power spectrum"""
+        plt.plot(self.f, self.P)
+        plt.xlabel("Frequency [Hz]")
+        plt.ylabel(f"Power [{self.unit}^2/Hz]")
+        plt.xscale('log')
+        plt.yscale('log')
+        if self.num_points_per_block:
+            plt.title(f"Blocked Power spectrum (N={self.num_points_per_block})")
+        else:
+            plt.title("Power spectrum")

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -239,11 +239,7 @@ def fit_power_spectrum(power_spectrum, model, settings=CalibrationSettings()):
     backing = (1 - scipy.special.gammainc(chi_squared / 2, n_degrees_of_freedom / 2)) * 100
 
     # Fitted power spectrum values.
-    ps_model_fit = PowerSpectrum()
-    ps_model_fit.f = power_spectrum.f
-    ps_model_fit.P = model(power_spectrum.f, *solution_params)
-    ps_model_fit.sampling_rate = power_spectrum.sampling_rate
-    ps_model_fit.T_measure = power_spectrum.T_measure
+    ps_model_fit = power_spectrum.with_spectrum(model(power_spectrum.f, *solution_params))
 
     return CalibrationResults(
         model=model,

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -22,258 +22,18 @@ References
 """
 
 import numpy as np
+import math
 import scipy
 import scipy.optimize
 import scipy.constants
-from math import floor, sqrt, pi, atan
-from collections import namedtuple
-
-
-def block_average(data, n_blocks):
-    """Calculates the block average of a dataset.
-
-    For an array ``A`` of length ``N``, returns an array ``B`` of length
-    ``M``, where each element of ``B`` is the average of ``q`` neighboring
-    elements. ``q`` is equal to ``floor(N/M)``. This implies that if ``N*q``
-    is not exactly equal to ``M``, the last partially complete window is
-    thrown away by this function.
-    """
-    block_size = floor(data.size / n_blocks)
-    length = block_size * n_blocks
-    return np.mean(np.reshape(data[:length], (-1, block_size)), axis=1)
-
-
-def block_average_std(data, n_blocks):
-    """Calculates the block standard deviation of a dataset.
-
-    Works as `block_average`, but calculates the standard deviation
-    instead of the average.
-
-    See Also
-    --------
-    block_average
-    """
-    block_size = floor(data.size / n_blocks)
-    length = block_size * n_blocks
-    return np.std(np.reshape(data[:length], (-1, block_size)), axis=1)
-
-
-class PowerSpectrum:
-    """Power spectrum data for a time series.
-
-    Attributes
-    ----------
-    f : numpy.ndarray
-        Frequency values for the power spectrum. [Hz]
-    P : numpy.ndarray
-        Power values for the power spectrum (typically in V^2/s).
-    sampling_rate : float
-        The sampling rate for the original data. [Hz]
-    T_measure : float
-        The total duration of the original data. [seconds]
-    """
-
-    def __init__(self, data=None, sampling_rate=None):
-        """Constructor
-
-        If neither parameter is given, an empty object is created.
-
-        Parameters
-        ----------
-        data : numpy.ndarray, optional
-            Data from which to calculate a power spectrum.
-        sampling_rate : float, optional
-        """
-        if data is not None:
-            # Initialize from raw sensor data.
-            assert sampling_rate is not None
-
-            # ... have to subtract average position first.
-            data = data - np.mean(data)
-
-            # ... use FFT to calculate power spectrum.
-            fft = np.fft.rfft(data)
-            self.f = np.fft.rfftfreq(data.size, 1./sampling_rate)
-            self.P = (1./sampling_rate) * np.square(np.abs(fft)) / data.size
-
-            # ... store metadata.
-            self.sampling_rate = sampling_rate
-            self.T_measure = data.size / sampling_rate
-        else:
-            # Initialize empty object.
-            self.f = None
-            self.P = None
-            self.sampling_rate = None
-            self.T_measure = None
-
-    def as_dict(self):
-        """"Returns a representation of the PowerSpectrum suitable for serialization"""
-        return {'f': self.f.tolist(), 'P': self.P.tolist()}
-
-    def block_averaged(self, n_blocks=2000):
-        """Returns a block-averaged power spectrum.
-
-        See Also
-        --------
-        block_average
-        """
-        ba = PowerSpectrum()
-        ba.f = block_average(self.f, n_blocks)
-        ba.P = block_average(self.P, n_blocks)
-        ba.sampling_rate = self.sampling_rate
-        ba.T_measure = self.T_measure
-        return ba
-
-    def in_range(self, f_min, f_max):
-        """Returns part of the power spectrum within a given frequency range."""
-        ir = PowerSpectrum()
-        ir.f = self.f[(self.f > f_min) & (self.f <= f_max)]
-        ir.P = self.P[(self.f > f_min) & (self.f <= f_max)]
-        ir.sampling_rate = self.sampling_rate
-        ir.T_measure = self.T_measure
-        return ir
-
-    def n_samples(self):
-        return self.f.size
-
-
-def fit_analytical_lorentzian(ps):
-    """Performs an analytical least-squares fit of a Lorentzian Power Spectrum.
-
-    Based on Section IV from ref. 1.
-
-    Parameters
-    ----------
-    ps : PowerSpectrum
-        Power spectrum data. Should generally be block-averaged, before passing
-        into this function.
-
-    Returns
-    -------
-    namedtuple (fc, D, sigma_fc, sigma_D, ps_fit)
-        Attributes:
-        - `fc` : corner frequency [Hz]
-        - `D`: diffusion constant [V^2/s]
-        - `sigma_fc`, `sigma_D`: 1-sigma confidence intervals for `fc` and `D`
-        - `ps_fit`: `PowerSpectrum` object with model fit
-
-        Note: returns None if the fit fails.
-    """
-    FitResults = namedtuple('AnalyticalLorentzianFitResults',
-                            ['fc', 'D', 'sigma_fc', 'sigma_D', 'ps_fit'])
-
-    # Calculate S[p,q] elements (Ref. 1, Eq. 13-14).
-    Spq = np.zeros((3,3))
-    for p in range(3):
-        for q in range(3):
-            Spq[p,q] = np.sum( np.power(ps.f, 2*p) * np.power(ps.P, q) )
-
-    try:
-        # Calculate a and b parameters (Ref. 1, Eq. 13-14).
-        a = (Spq[0,1] * Spq[2,2] - Spq[1,1] * Spq[1,2]) / (Spq[0,2] * Spq[2,2] - Spq[1,2] * Spq[1,2])
-        b = (Spq[1,1] * Spq[0,2] - Spq[0,1] * Spq[1,2]) / (Spq[0,2] * Spq[2,2] - Spq[1,2] * Spq[1,2])
-
-        # Having a and b, calculating fc and D is trivial.
-        fc = sqrt(a/b)              # corner frequency [Hz]
-        D  = (1/b) * 2 * (pi**2)    # diffusion constant [V^2/s]
-
-        # Fitted power spectrum values.
-        ps_fit = PowerSpectrum()
-        ps_fit.f = ps.f
-        ps_fit.P = 1 / (a + b * np.power(ps.f, 2))
-        ps_fit.sampling_rate = ps.sampling_rate
-        ps_fit.T_measure = ps.T_measure
-
-        # Error propagation (Ref. 1, Eq. 25-28).
-        x_min = ps.f.min() / fc
-        x_max = ps.f.max() / fc
-
-        u = (2*x_max)/(1+x_max**2) - (2*x_min)/(1+x_min**2) \
-            + 2*atan((x_max-x_min) / (1 + x_min*x_max))
-        v = (4/(x_max-x_min)) * (atan( (x_max-x_min)/(1+x_min*x_max) ))**2
-        s_fc = sqrt( pi / (u - v) )
-        sigma_fc = fc * s_fc / sqrt( pi * fc * ps.T_measure )
-
-        s_D = sqrt( u / ( (1+pi/2)*(x_max-x_min) ) ) * s_fc
-        sigma_D = D * sqrt( (1 + pi/2) / (pi * fc * ps.T_measure) ) * s_D
-
-        return FitResults(fc, D, sigma_fc, sigma_D, ps_fit)
-
-    except ValueError:
-        return None
-
-
-def _alpha(a):
-    return 1/sqrt(1+a**2)
-
-
-def _a(alpha):
-    return sqrt(1/alpha**2 - 1)
-
-
-class FullPSFitModel:
-    """Callable wrapper around our model function for the full power spectrum.
-
-    Takes care of fit parameter rescaling, before calling into the core model
-    function `P`.
-    """
-
-    def __init__(self, scale_factors):
-        self.scale_factors = scale_factors
-
-    def __call__(self, f, p1, p2, p3, p4):
-        """This method gets called when we try to call a FullPSFitModel object"""
-        return self.P(f, *self.get_params_from_rescaled_params((p1, p2, p3, p4)))
-
-    @staticmethod
-    def P(f, fc, D, f_diode, alpha):
-        """Theoretical model for the full power spectrum.
-
-        See ref. 1, Eq. (10), and ref. 2, Eq. (11).
-
-        Parameters
-        ----------
-        f : numpy.ndarray
-            Frequency values, in Hz.
-        fc : float
-            Corner frequency, in Hz.
-        D : float
-            Diffusion constant, in (a.u.)^2/s
-        f_diode : float
-            Diode fall-off frequency, in Hz.
-        alpha : float
-            Diode parameter, between 0 and 1.
-        """
-        return (D/(2*pi**2)) / (f**2 + fc**2) * FullPSFitModel.g_diode(f, f_diode, alpha)
-
-    @staticmethod
-    def g_diode(f, f_diode, alpha):
-        """Theoretical model for the low-pass filtering by the PSD.
-
-        See ref. 2, Eq. (11).
-        """
-        return alpha**2 + (1-alpha**2) / (1 + (f/f_diode)**2)
-
-    def get_params_from_rescaled_params(self, rescaled_params):
-        return (
-            rescaled_params[0] * self.scale_factors[0],
-            rescaled_params[1] * self.scale_factors[1],
-            rescaled_params[2] * self.scale_factors[2],
-            _alpha(rescaled_params[3] * self.scale_factors[3])
-        )
-
-
-def sphere_friction_coefficient(eta, d):
-    """Friction coefficient of a sphere with diameter `d` in a liquid with viscosity `eta`
-
-    Parameters
-    ----------
-    eta : float
-        Dynamic / shear viscosity [Pa*s]
-    d : float
-        Sphere diameter [m]
-    """
-    return 3*pi*eta*d
+from lumicks.pylake.force_calibration.detail.power_spectrum import PowerSpectrum
+from lumicks.pylake.force_calibration.detail.power_models import (
+    fit_analytical_lorentzian,
+    FullPSFitModel,
+    _a,
+    _alpha,
+    sphere_friction_coefficient,
+)
 
 
 class CalibrationParameters:
@@ -290,18 +50,18 @@ class CalibrationParameters:
     """
 
     def __init__(self, bead_diameter, **kwargs):
-        self.bead_diameter  = bead_diameter
-        self.viscosity      = 1.002e-3
-        self.temperature    = 20
+        self.bead_diameter = bead_diameter
+        self.viscosity = 1.002e-3
+        self.temperature = 20
 
         for k, v in kwargs.items():
             if k in self.__dict__:
                 setattr(self, k, v)
             else:
-                raise TypeError('Unknown argument %s' % k)
+                raise TypeError("Unknown argument %s" % k)
 
     def temperature_K(self):
-        return scipy.constants.convert_temperature(self.temperature, 'C', 'K')
+        return scipy.constants.convert_temperature(self.temperature, "C", "K")
 
 
 class CalibrationSettings:
@@ -326,17 +86,17 @@ class CalibrationSettings:
     """
 
     def __init__(self, **kwargs):
-        self.n_points_per_block         = 350
-        self.fit_range                  = (1e2, 23e3)
-        self.analytical_fit_range       = (1e1, 1e4)
-        self.ftol                       = 1e-7
-        self.maxfev                     = 10000
+        self.n_points_per_block = 350
+        self.fit_range = (1e2, 23e3)
+        self.analytical_fit_range = (1e1, 1e4)
+        self.ftol = 1e-7
+        self.maxfev = 10000
 
         for k, v in kwargs.items():
             if k in self.__dict__:
                 setattr(self, k, v)
             else:
-                raise TypeError('Unknown argument %s' % k)
+                raise TypeError("Unknown argument %s" % k)
 
 
 class CalibrationResults:
@@ -380,20 +140,33 @@ class CalibrationResults:
     """
 
     def __init__(self, **kwargs):
-        _valid_attr = ['fc', 'D', 'f_diode', 'alpha',
-                       'err_fc', 'err_D', 'err_f_diode', 'err_alpha',
-                       'chi_squared_per_deg', 'backing',
-                       'ps_fitted', 'ps_model_fit',
-                       'Rd', 'kappa', 'Rf', 'error']
+        _valid_attr = [
+            "fc",
+            "D",
+            "f_diode",
+            "alpha",
+            "err_fc",
+            "err_D",
+            "err_f_diode",
+            "err_alpha",
+            "chi_squared_per_deg",
+            "backing",
+            "ps_fitted",
+            "ps_model_fit",
+            "Rd",
+            "kappa",
+            "Rf",
+            "error",
+        ]
 
         for k, v in kwargs.items():
             if k in _valid_attr:
                 setattr(self, k, v)
             else:
-                raise TypeError('Unknown argument/attribute %s' % k)
+                raise TypeError("Unknown argument/attribute %s" % k)
 
     def is_success(self):
-        return not hasattr(self, 'error')
+        return not hasattr(self, "error")
 
 
 class CalibrationError(Exception):
@@ -430,7 +203,6 @@ class PowerSpectrumCalibration:
             self.settings = settings
         else:
             self.settings = CalibrationSettings()
-
         self.results = None
 
     @staticmethod
@@ -452,18 +224,14 @@ class PowerSpectrumCalibration:
         float:
             A good initial value for the parameter `f_diode`, for fitting the full
             power spectrum.
-
-        See Also
-        --------
-        fit_full_powerspectrum
         """
-        f_nyquist = ps.sampling_rate/2
-        P_aliased_nyq = (guess_D/(2*pi**2)) / (f_nyquist**2 + guess_fc**2)
+        f_nyquist = ps.sampling_rate / 2
+        P_aliased_nyq = (guess_D / (2 * math.pi ** 2)) / (f_nyquist ** 2 + guess_fc ** 2)
         if ps.P[-1] < P_aliased_nyq:
             dif = ps.P[-1] / P_aliased_nyq
-            return sqrt(dif * f_nyquist**2 / (1. - dif))
+            return math.sqrt(dif * f_nyquist ** 2 / (1.0 - dif))
         else:
-            return 2*f_nyquist
+            return 2 * f_nyquist
 
     def run_fit(self, print_diagnostics=False):
         """Runs the actual fitting procedure
@@ -475,7 +243,7 @@ class PowerSpectrumCalibration:
         """
         # Filter and block the power spectrum.
         ps = self.ps.in_range(*self.settings.fit_range)
-        ps = ps.block_averaged(n_blocks=ps.P.size//self.settings.n_points_per_block)
+        ps = ps.block_averaged(n_blocks=ps.P.size // self.settings.n_points_per_block)
 
         try:
             # First do an analytical simple Lorentzian fit, to get some initial
@@ -483,14 +251,16 @@ class PowerSpectrumCalibration:
             anl_fit_ps = ps.in_range(*self.settings.analytical_fit_range)
             anl_fit_res = fit_analytical_lorentzian(anl_fit_ps)
             if not anl_fit_res:
-                raise ValueError('Analytical fit failed')
-            initial_params = (anl_fit_res.fc, anl_fit_res.D,
-                              self.guess_f_diode_initial_value(ps, anl_fit_res.fc, anl_fit_res.D),
-                              0.3)
+                raise ValueError("Analytical fit failed")
+            initial_params = (
+                anl_fit_res.fc,
+                anl_fit_res.D,
+                self.guess_f_diode_initial_value(ps, anl_fit_res.fc, anl_fit_res.D),
+                0.3,
+            )
 
             if print_diagnostics:
-                print('Initial fit parameters:   fc = %.2e  D = %.2f  f_diode = %.2e  alpha = %.2f' % initial_params)
-
+                print("Initial fit parameters:   fc = %.2e  D = %.2f  f_diode = %.2e  alpha = %.2f" % initial_params)
             # Then do a Levenberg-Marquardt weighted least-squares fit on the full model.
             #
             # Technical notes:
@@ -514,33 +284,38 @@ class PowerSpectrumCalibration:
             #   "np.sum( ((f(xdata, *popt) - ydata) / sigma)**2 )" into the expression
             #   in Eq. 39 of ref. 1.
 
-            model = FullPSFitModel(scale_factors=(*initial_params[0:3], _a(initial_params[3]),))
-            sigma = (1/ps.P) / sqrt(self.settings.n_points_per_block)
-            (solution_params_rescaled, pcov) = \
-                    scipy.optimize.curve_fit(
-                        lambda f, fc, D, f_diode, a: 1/model(f, fc, D, f_diode, a),
-                        ps.f, 1/ps.P,
-                        p0=np.ones(4),
-                        sigma=sigma,
-                        absolute_sigma=True,
-                        method='lm',
-                        ftol=self.settings.ftol,
-                        maxfev=self.settings.maxfev,
-                    )
+            model = FullPSFitModel(
+                scale_factors=(
+                    *initial_params[0:3],
+                    _a(initial_params[3]),
+                )
+            )
+            sigma = (1 / ps.P) / math.sqrt(self.settings.n_points_per_block)
+            (solution_params_rescaled, pcov) = scipy.optimize.curve_fit(
+                lambda f, fc, D, f_diode, a: 1 / model(f, fc, D, f_diode, a),
+                ps.f,
+                1 / ps.P,
+                p0=np.ones(4),
+                sigma=sigma,
+                absolute_sigma=True,
+                method="lm",
+                ftol=self.settings.ftol,
+                maxfev=self.settings.maxfev,
+            )
             solution_params_rescaled = np.abs(solution_params_rescaled)
             # the model function is symmetric in alpha and f_diode...
             solution_params = model.get_params_from_rescaled_params(solution_params_rescaled)
 
             # Calculate goodness-of-fit, in terms of the statistical backing (see ref. 1).
-            chi_squared = np.sum( ( (1/model(ps.f, *solution_params_rescaled) - 1/ps.P) / sigma)**2 )
+            chi_squared = np.sum(((1 / model(ps.f, *solution_params_rescaled) - 1 / ps.P) / sigma) ** 2)
             n_degrees_of_freedom = ps.P.size - len(solution_params)
             chi_squared_per_deg = chi_squared / n_degrees_of_freedom
-            backing = (1 - scipy.special.gammainc(chi_squared/2, n_degrees_of_freedom/2)) * 100
+            backing = (1 - scipy.special.gammainc(chi_squared / 2, n_degrees_of_freedom / 2)) * 100
 
             # We also have to un-rescale the covariance matrix.
             # There's actually a rescaling factor *squared* in there, as the Jacobian
             # appears twice in the equation for the covariance matrix.
-            perr = np.sqrt(np.diag(pcov) * (np.array(model.scale_factors)**2))
+            perr = np.sqrt(np.diag(pcov) * (np.array(model.scale_factors) ** 2))
 
             # TODO Fix calculation of alpha confidence interval.
             # The previous step calculated the confidence interval in the transformed
@@ -549,8 +324,13 @@ class PowerSpectrumCalibration:
             # interval into an 'alpha' confidence interval. Note that this also seems
             # to give us different results for the alpha confidence interval than the
             # original tweezercalib-2.1 code from ref. 3.
-            perr[3] = abs(  _alpha(solution_params_rescaled[3]*model.scale_factors[3] + perr[3])
-                          - _alpha(solution_params_rescaled[3]*model.scale_factors[3] - perr[3]))/2
+            perr[3] = (
+                abs(
+                    _alpha(solution_params_rescaled[3] * model.scale_factors[3] + perr[3])
+                    - _alpha(solution_params_rescaled[3] * model.scale_factors[3] - perr[3])
+                )
+                / 2
+            )
 
             # Fitted power spectrum values.
             ps_model_fit = PowerSpectrum()
@@ -560,37 +340,35 @@ class PowerSpectrumCalibration:
             ps_model_fit.T_measure = ps.T_measure
 
             if print_diagnostics:
-                print('Solution:   fc = %.2e  D = %.2f  f_diode = %.2e  alpha = %.2f' % solution_params)
-                print('Errors:     fc = %.2e  D = %.2f  f_diode = %.2e  alpha = %.2f' % tuple(perr))
-                print('Units:      fc : Hz        D : V^2/s f_diode : Hz')
-                print('Chi^2 per degree of freedom = %.2f' % chi_squared_per_deg)
-                print('Statistical backing = %.1f%%' % backing)
-
+                print("Solution:   fc = %.2e  D = %.2f  f_diode = %.2e  alpha = %.2f" % solution_params)
+                print("Errors:     fc = %.2e  D = %.2f  f_diode = %.2e  alpha = %.2f" % tuple(perr))
+                print("Units:      fc : Hz        D : V^2/s f_diode : Hz")
+                print("Chi^2 per degree of freedom = %.2f" % chi_squared_per_deg)
+                print("Statistical backing = %.1f%%" % backing)
             # Calculate additional calibration constants.
-            gamma_0 = sphere_friction_coefficient(self.params.viscosity, self.params.bead_diameter*1e-6)
-            Rd = sqrt(scipy.constants.k * self.params.temperature_K() / gamma_0 / solution_params[1]) * 1e6
-            kappa = 2 * pi * gamma_0 * solution_params[0] * 1e3
+            gamma_0 = sphere_friction_coefficient(self.params.viscosity, self.params.bead_diameter * 1e-6)
+            Rd = math.sqrt(scipy.constants.k * self.params.temperature_K() / gamma_0 / solution_params[1]) * 1e6
+            kappa = 2 * math.pi * gamma_0 * solution_params[0] * 1e3
             Rf = Rd * kappa * 1e3
 
             # Return fit results.
             self.results = CalibrationResults(
-                                fc=solution_params[0],
-                                D=solution_params[1],
-                                f_diode=solution_params[2],
-                                alpha=solution_params[3],
-                                err_fc=perr[0],
-                                err_D=perr[1],
-                                err_f_diode=perr[2],
-                                err_alpha=perr[3],
-                                chi_squared_per_deg=chi_squared_per_deg,
-                                backing=backing,
-                                ps_fitted=ps,
-                                ps_model_fit=ps_model_fit,
-                                Rd=Rd,
-                                kappa=kappa,
-                                Rf=Rf
+                fc=solution_params[0],
+                D=solution_params[1],
+                f_diode=solution_params[2],
+                alpha=solution_params[3],
+                err_fc=perr[0],
+                err_D=perr[1],
+                err_f_diode=perr[2],
+                err_alpha=perr[3],
+                chi_squared_per_deg=chi_squared_per_deg,
+                backing=backing,
+                ps_fitted=ps,
+                ps_model_fit=ps_model_fit,
+                Rd=Rd,
+                kappa=kappa,
+                Rf=Rf,
             )
         except (ValueError, RuntimeError) as e:
-            self.results = CalibrationResults(
-                                ps_fitted=ps)
+            self.results = CalibrationResults(ps_fitted=ps)
             raise CalibrationError(str(e))

--- a/lumicks/pylake/force_calibration/tests/conftest.py
+++ b/lumicks/pylake/force_calibration/tests/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+import numpy as np
+
+
+class ReferenceModels:
+    @staticmethod
+    def lorentzian(f, fc, diffusion_constant):
+        return diffusion_constant / (2.0 * np.pi ** 2) / (fc ** 2 + f ** 2)
+
+    @staticmethod
+    def lorentzian_filtered(f, fc, diffusion_constant, alpha, f_diode):
+        return ReferenceModels.lorentzian(f, fc, diffusion_constant) * \
+               (alpha ** 2 + (1.0 - alpha ** 2) / (1.0 + (f / f_diode) ** 2))
+
+    @staticmethod
+    def lorentzian_td(corner_frequency, diffusion_constant, alpha, f_diode, num_samples):
+        f = np.arange(0, num_samples)
+        power_spectrum = ReferenceModels.lorentzian_filtered(f, corner_frequency, diffusion_constant, alpha, f_diode)
+        data = np.fft.irfft(np.sqrt(np.abs(power_spectrum))) * (num_samples - 1) * 2
+        return data, len(data)
+
+
+@pytest.fixture
+def reference_models():
+    return ReferenceModels()

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -67,3 +67,11 @@ def test_fit_analytic(reference_models, corner_frequency, diffusion_constant, nu
     assert np.allclose(fit.D, diffusion_constant)
     assert np.allclose(fit.sigma_fc, sigma_fc)
     assert np.allclose(fit.sigma_D, sigma_diffusion)
+
+
+def test_fit_analytic_curve():
+    ps = PowerSpectrum([3, 3, 4, 5, 1, 3, 2, 4, 5, 2], 100)
+    ref = [0.0396382, 0.0389208, 0.03691641, 0.03399826, 0.03061068, 0.02713453]
+    fit = fit_analytical_lorentzian(ps)
+    assert np.allclose(fit.ps_fit.f, np.arange(0, 60, 10))
+    assert np.allclose(fit.ps_fit.P, ref)

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -43,13 +43,13 @@ def test_fit_analytic(reference_models, corner_frequency, diffusion_constant, nu
     power_spectrum = reference_models.lorentzian(np.arange(0, num_samples), corner_frequency, diffusion_constant)
     data = np.fft.irfft(np.sqrt(np.abs(power_spectrum))) * (num_samples - 1) * 2
 
+    num_points_per_block = 20
+    fit_range = (0, 15000)
     ps = PowerSpectrum(data, sampling_rate=len(data))
-    settings = CalibrationSettings(fit_range=(0, 15000), n_points_per_block=20)
+    ps = ps.in_range(*fit_range)
+    ps = ps.block_averaged(num_blocks=ps.P.size // num_points_per_block)
 
-    ps = ps.in_range(0, 15000)
-    ps = ps.block_averaged(n_blocks=ps.P.size // settings.n_points_per_block)
-
-    fit = fit_analytical_lorentzian(ps.in_range(*settings.analytical_fit_range))
+    fit = fit_analytical_lorentzian(ps.in_range(1e1, 1e4))
 
     assert np.allclose(fit.fc, corner_frequency)
     assert np.allclose(fit.D, diffusion_constant)

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -1,0 +1,57 @@
+import pytest
+import numpy as np
+from lumicks.pylake.force_calibration.detail.power_models import *
+from lumicks.pylake.force_calibration.power_spectrum_calibration import CalibrationSettings
+from lumicks.pylake.force_calibration.detail.power_spectrum import PowerSpectrum
+
+
+def test_friction_coefficient():
+    assert np.allclose(sphere_friction_coefficient(5, 1), 3 * np.pi * 5 * 1)
+
+
+def test_spectrum(reference_models):
+    assert np.allclose(FullPSFitModel.P(np.arange(10000), 1000, 1e9, 10000, 0.5),
+                       reference_models.lorentzian_filtered(np.arange(10000), 1000, 1e9, 0.5, 10000))
+
+
+def test_spectrum_parameter_scaling(reference_models):
+    f = np.arange(10000)
+    scaling = [2.0, 3.0, 4.0, 5.0]
+    scaled_psc = FullPSFitModel(scaling)
+
+    alpha = 0.5
+    inverted_alpha = np.sqrt(((1.0 / alpha) ** 2.0 - 1.0) / scaling[3]**2)
+
+    assert np.allclose(scaled_psc(f, 1000 / scaling[0], 1e9 / scaling[1], 10000 / scaling[2], inverted_alpha),
+                       reference_models.lorentzian_filtered(np.arange(10000), 1000, 1e9, 0.5, 10000))
+
+
+@pytest.mark.parametrize(
+    "corner_frequency,diffusion_constant,num_samples,sigma_fc,sigma_diffusion",
+    [
+        [1000, 1e-9, 30000, 21.113382377506746, 1.1763968470146817e-11],
+        [1500, 1.2e-9, 50000, 28.054469036154266, 1.5342555193009045e-11],
+        [1500, 1.2e-9, 10000, 28.068761746382837, 1.5365711725327977e-11],
+        [1500, 1.2e-9, 10000, 28.068761746382837, 1.5365711725327977e-11],
+        [1500, 1.2e-9, 10000, 28.068761746382837, 1.5365711725327977e-11],
+        [1500, 1.2e-9, 10000, 28.068761746382837, 1.5365711725327977e-11],
+        [1000, 1e-9, 30000, 21.113382377506746, 1.1763968470146817e-11],
+        [1000, 1e-9, 30000, 21.113382377506746, 1.1763968470146817e-11],
+    ],
+)
+def test_fit_analytic(reference_models, corner_frequency, diffusion_constant, num_samples, sigma_fc, sigma_diffusion):
+    power_spectrum = reference_models.lorentzian(np.arange(0, num_samples), corner_frequency, diffusion_constant)
+    data = np.fft.irfft(np.sqrt(np.abs(power_spectrum))) * (num_samples - 1) * 2
+
+    ps = PowerSpectrum(data, sampling_rate=len(data))
+    settings = CalibrationSettings(fit_range=(0, 15000), n_points_per_block=20)
+
+    ps = ps.in_range(0, 15000)
+    ps = ps.block_averaged(n_blocks=ps.P.size // settings.n_points_per_block)
+
+    fit = fit_analytical_lorentzian(ps.in_range(*settings.analytical_fit_range))
+
+    assert np.allclose(fit.fc, corner_frequency)
+    assert np.allclose(fit.D, diffusion_constant)
+    assert np.allclose(fit.sigma_fc, sigma_fc)
+    assert np.allclose(fit.sigma_D, sigma_diffusion)

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
@@ -1,4 +1,5 @@
 from lumicks.pylake.force_calibration.detail.power_spectrum import block_reduce, PowerSpectrum
+from matplotlib.testing.decorators import cleanup
 import numpy as np
 import pytest
 
@@ -109,3 +110,9 @@ def test_in_range(frequency, num_data, sampling_rate, num_blocks, f_min, f_max):
     assert np.allclose(power_subset.P, power_spectrum.P[mask])
     assert np.allclose(power_spectrum.T_measure, power_subset.T_measure)
     assert np.allclose(power_spectrum.sampling_rate, power_subset.sampling_rate)
+
+
+@cleanup
+def test_plot():
+    ps = PowerSpectrum(np.sin(2.0 * np.pi * 100 / 78125 * np.arange(100)), 78125)
+    ps.plot()

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
@@ -1,4 +1,4 @@
-from lumicks.pylake.force_calibration.power_spectrum_calibration import PowerSpectrum, block_average, block_average_std
+from lumicks.pylake.force_calibration.detail.power_spectrum import block_average, block_average_std, PowerSpectrum
 import numpy as np
 import pytest
 

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -1,5 +1,7 @@
 from lumicks.pylake.force_calibration import power_spectrum_calibration as psc
 from lumicks.pylake.force_calibration.calibration_models import PassiveCalibrationModel, sphere_friction_coefficient
+from matplotlib.testing.decorators import cleanup
+from textwrap import dedent
 import numpy as np
 import scipy as sp
 import os
@@ -48,11 +50,6 @@ def test_calibration_result():
     with pytest.raises(TypeError):
         psc.CalibrationResults(invalid=5)
 
-    calibration_result = psc.CalibrationResults(fc=5)
-    assert calibration_result.is_success() is True
-    setattr(calibration_result, "error", "error!")
-    assert calibration_result.is_success() is False
-
 
 @pytest.mark.parametrize(
     "corner_frequency,diffusion_constant,alpha,f_diode,num_samples,viscosity,bead_diameter,temperature,err_fc,err_d,"
@@ -88,10 +85,10 @@ def test_good_fit_integration_test(
     power_spectrum = psc.calculate_power_spectrum(data, f_sample, fit_range=(0, 15000), num_points_per_block=20)
     ps_calibration = psc.fit_power_spectrum(power_spectrum=power_spectrum, model=model)
 
-    assert np.allclose(ps_calibration.fc, corner_frequency, rtol=1e-4)
-    assert np.allclose(ps_calibration.D, diffusion_constant, rtol=1e-5)
-    assert np.allclose(ps_calibration.alpha, alpha, rtol=1e-4)
-    assert np.allclose(ps_calibration.f_diode, f_diode, rtol=1e-4)
+    assert np.allclose(ps_calibration["fc (Hz)"], corner_frequency, rtol=1e-4)
+    assert np.allclose(ps_calibration["D (V^2/s)"], diffusion_constant, rtol=1e-5)
+    assert np.allclose(ps_calibration["alpha"], alpha, rtol=1e-4)
+    assert np.allclose(ps_calibration["f_diode (Hz)"], f_diode, rtol=1e-4)
 
     gamma = sphere_friction_coefficient(viscosity, bead_diameter * 1e-6)
     kappa_true = 2.0 * np.pi * gamma * corner_frequency * 1e3
@@ -99,21 +96,15 @@ def test_good_fit_integration_test(
         np.sqrt(sp.constants.k * sp.constants.convert_temperature(temperature, "C", "K") / gamma / diffusion_constant)
         * 1e6
     )
-    assert np.allclose(ps_calibration.kappa, kappa_true, rtol=1e-4)
-    assert np.allclose(ps_calibration.Rd, rd_true, rtol=1e-4)
-    assert np.allclose(ps_calibration.Rf, rd_true * kappa_true * 1e3, rtol=1e-4)
-    assert np.allclose(ps_calibration.chi_squared_per_deg, 0)  # Noise free
+    assert np.allclose(ps_calibration["kappa (pN/nm)"], kappa_true, rtol=1e-4)
+    assert np.allclose(ps_calibration["Rd (um/V)"], rd_true, rtol=1e-4)
+    assert np.allclose(ps_calibration["Rf (pN/V)"], rd_true * kappa_true * 1e3, rtol=1e-4)
+    assert np.allclose(ps_calibration["chi_squared_per_deg"], 0)  # Noise free
 
-    assert np.allclose(ps_calibration.err_fc, err_fc)
-    assert np.allclose(ps_calibration.err_D, err_d)
-    assert np.allclose(ps_calibration.err_f_diode, err_f_diode)
-    assert np.allclose(ps_calibration.err_alpha, err_alpha)
-
-    assert ps_calibration.is_success() is True
-
-    # This field actually never gets set, which is very strange. But for exact parity, we keep it.
-    setattr(ps_calibration, "error", "Error!")
-    assert ps_calibration.is_success() is False
+    assert np.allclose(ps_calibration["err_fc"], err_fc)
+    assert np.allclose(ps_calibration["err_D"], err_d)
+    assert np.allclose(ps_calibration["err_f_diode"], err_f_diode)
+    assert np.allclose(ps_calibration["err_alpha"], err_alpha)
 
 
 def test_bad_calibration_result_arg():
@@ -131,22 +122,74 @@ def test_bad_data():
         psc.fit_power_spectrum(power_spectrum, model=model)
 
 
-def test_actual_spectrum():
+@pytest.fixture(scope="module")
+def reference_calibration_result():
     data = np.load(os.path.join(os.path.dirname(__file__), "reference_spectrum.npz"))
     reference_spectrum = data["arr_0"]
     model = PassiveCalibrationModel(4.4, temperature=20, viscosity=0.001002)
     reference_spectrum = psc.calculate_power_spectrum(reference_spectrum, sampling_rate=78125,
-                                                      num_points_per_block=100, fit_range=(100.0, 23000.0))
+                                                      num_points_per_block=100,
+                                                      fit_range=(100.0, 23000.0))
     ps_calibration = psc.fit_power_spectrum(power_spectrum=reference_spectrum, model=model)
 
-    assert np.allclose(ps_calibration.D, 0.0018512665210876748, rtol=1e-4)
-    assert np.allclose(ps_calibration.Rd, 7.253645956145265, rtol=1e-4)
-    assert np.allclose(ps_calibration.Rf, 1243.9711315478219, rtol=1e-4)
-    assert np.allclose(ps_calibration.kappa, 0.17149598134079505, rtol=1e-4)
-    assert np.allclose(ps_calibration.alpha, 0.5006103727942776, rtol=1e-4)
-    assert np.allclose(ps_calibration.backing, 66.4331056392512, rtol=1e-4)
-    assert np.allclose(ps_calibration.chi_squared_per_deg, 1.063783302378645, rtol=1e-4)
-    assert np.allclose(ps_calibration.err_fc, 32.23007993226726, rtol=1e-4)
-    assert np.allclose(ps_calibration.err_D, 6.43082000774291e-05, rtol=1e-4)
-    assert np.allclose(ps_calibration.err_alpha, 0.013141463933316694, rtol=1e-4)
-    assert np.allclose(ps_calibration.err_f_diode, 561.6377089699399, rtol=1e-4)
+    return ps_calibration, model, reference_spectrum
+
+
+def test_actual_spectrum(reference_calibration_result):
+    ps_calibration, model, reference_spectrum = reference_calibration_result
+
+    assert np.allclose(ps_calibration["D (V^2/s)"], 0.0018512665210876748, rtol=1e-4)
+    assert np.allclose(ps_calibration["Rd (um/V)"], 7.253645956145265, rtol=1e-4)
+    assert np.allclose(ps_calibration["Rf (pN/V)"], 1243.9711315478219, rtol=1e-4)
+    assert np.allclose(ps_calibration["kappa (pN/nm)"], 0.17149598134079505, rtol=1e-4)
+    assert np.allclose(ps_calibration["alpha"], 0.5006103727942776, rtol=1e-4)
+    assert np.allclose(ps_calibration["backing (%)"], 66.4331056392512, rtol=1e-4)
+    assert np.allclose(ps_calibration["chi_squared_per_deg"], 1.063783302378645, rtol=1e-4)
+    assert np.allclose(ps_calibration["err_fc"], 32.23007993226726, rtol=1e-4)
+    assert np.allclose(ps_calibration["err_D"], 6.43082000774291e-05, rtol=1e-4)
+    assert np.allclose(ps_calibration["err_alpha"], 0.013141463933316694, rtol=1e-4)
+    assert np.allclose(ps_calibration["err_f_diode"], 561.6377089699399, rtol=1e-4)
+
+
+@cleanup
+def test_result_plot(reference_calibration_result):
+    ps_calibration, model, reference_spectrum = reference_calibration_result
+    ps_calibration.plot()
+
+
+def test_attributes_ps_calibration(reference_calibration_result):
+    ps_calibration, model, reference_spectrum = reference_calibration_result
+    assert id(ps_calibration.model) == id(model)
+    assert id(ps_calibration.ps_fitted) == id(reference_spectrum)
+
+    with pytest.raises(RuntimeError):
+        psc.CalibrationResults(model=None, ps_model_fit=None, ps_fitted=None, params={"test": 5})
+
+
+def test_repr(reference_calibration_result):
+    ps_calibration, model, reference_spectrum = reference_calibration_result
+    print(str(ps_calibration))
+    assert str(ps_calibration) == dedent("""\
+        Name                 Description                                               Value
+        -------------------  --------------------------------------------------------  -----------------------
+        Bead diameter (um)   Bead diameter (um)                                        4.4
+        Viscosity (Pa*s)     Liquid viscosity (Pa*s)                                   0.001002
+        Temperature (C)      Liquid temperature (C)                                    20
+        Rd (um/V)            Distance response (um/V)                                  7.25365
+        kappa (pN/nm)        Trap stiffness (pN/nm)                                    0.171496
+        Rf (pN/V)            Force response (pN/V)                                     1243.97
+        fc (Hz)              Corner frequency (Hz)                                     656.875
+        D (V^2/s)            Diffusion constant (V^2/s)                                0.00185127
+        f_diode (Hz)         Diode low-pass filtering roll-off frequency (Hz)          7936.4
+        alpha                Diode 'relaxation factor' (-)                             0.50061
+        err_fc               Corner frequency Std Err (Hz)                             32.2301
+        err_D                Diffusion constant Std Err (V^2/s)                        6.43082e-05
+        err_f_diode          Diode low-pass filtering roll-off frequency Std Err (Hz)  561.638
+        err_alpha            Diode 'relaxation factor' Std Err (-)                     0.0131415
+        chi_squared_per_deg  Chi squared per degree of freedom (-)                     1.06378
+        backing (%)          Statistical backing (%)                                   66.4331
+        Max iterations       Maximum number of function evaluations (-)                10000
+        Model                Calibration model (-)                                     PassiveCalibrationModel
+        Fit tolerance        Fitting tolerance (-)                                     1e-07
+        Points per block     Number of points per block (-)                            100
+        Sample rate (Hz)     Sample rate (Hz)                                          78125""")


### PR DESCRIPTION
**Why?**
Would be nice to allow different `ForceCalibration` models to be used.

![ldat2](https://user-images.githubusercontent.com/19836026/107555818-e9d31e80-6bd7-11eb-9b7f-e5262a6fdf30.gif)

**What is all in this PR?**
`PowerSpectrum` is in its own file, with its own tests. I have moved keeping track of how much averaging has taken place into `PowerSpectrum`, since this guy owns that information.

Instead of a stateful class, the calibration is now a function that raises an exception when things go awry. You do however want access to the `PowerSpectrum` used for fitting if it fails. Instead, you now compute the `PowerSpectrum` with its own API, and pass it and an appropriate model to the calibration function. I've added some plotting functionality to it as well, which is probably not so relevant for automation/Bluelake, but nice to have in Pylake when adding new `ForceCalibration` models.

In the future, we want to add additional models which do additional things. I have defined a `CalibrationModel` interface of functions which should be implemented for that to work. This meant modifying the class with fixed attributes named `CalibrationResults`. Instead, I have replaced it with a class which uses `__getitem__` to provide dictionary-like access (akin to `ForceCalibration` items in Pylake). If these need to be attributes for some reason, we could change this.

I have wrapped parameters into a little tuple with their description. Initially, I had a std error inside this tuple, because I think it would be nice to pack these two elements of data together. While I think that would be nicer, unfortunately, this is not how the force calibration structure we have in Pylake is set up at the moment. Instead, I went with a parameter layout that for static calibration produces exactly the same fields as what we have in Pylake now (except for one exception listed below). Hopefully, this will lead to users being instantly familiar with the new API.

Some things I shuffled back and forth a bit.

One thing I was unsure about is the duplicate field:
```
     'Response (pN/V)': 1265.2669140456192,
     'Rf (pN/V)': 1265.2669140456192,
```

Do we need both of them?

I have moved the parameter scaling that was happening into its own class so that it is separated from the actual model. This is a (mostly) feature parity PR, so I have not yet removed the non-linear rescaling used to introduce parameter bounds yet (as this PR is already pretty chunky). Since `curve_fit` supports bounds natively nowadays, I'd prefer to use this in pt 2 of this refactor.

There's a few items of information that do not make it to the CalibrationResults, which Bluelake probably fills. These are:
```
    {'Fit range (max.) (Hz)': 23000.0,
     'Fit range (min.) (Hz)': 100.0,
     'Kind': 'Full calibration',
     'Number of samples': 781250.0,
     'Offset (pN)': 0.0,
     'Sign': 1.0,
     'Start time (ns)': 1611320223633490800,
     'Stop time (ns)': 1611320233633490800,
     }
```

Also worth nothing is that the field `Max iterations` in Calibration fields seems to be incorrect and is actually maximum function evaluations. I kept this naming mishap for now, but maybe we should fix that name.

One thing I doubted about was in `CalibrationResults` and the way it interacts with the model. One thing I notice is that all of the calibration models have a different post-processing step. Here they calculate values (which may be interesting to keep in the calibration) from the parameters obtained in the power spectrum fit. I pass these along to `CalibrationResults` to be presented to the user.

When `CalibrationResults` is created, I check whether the mandatory parameters exist in the params field (the ones required to use the calibration (kappa for instance)). This is to make sure that new models actually expose these parameters in the correct form. Alternatively, one thing we could do is have a regular (mandatory) named parameter `kappa` (and whichever other mandatory parameters exist) for `CalibrationResults`, along with a `get_kappa()` on the models. It would mean storing mutable state in `CalibrationModels` though. I'm not entirely sure how much we want to enforce the structure of these parameters at this point already. We'll probably be the only ones writing these `CalibrationModels`. We'd know the consequences of exposing different things.
