### PR TITLE
channel: fix lazy evaluation of Continuous.from_data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 
 #### Bug fixes
 * Fixed `downsampled_over` to ignore gaps rather than result in an unhandled exception. Previously when you downsampled a `TimeSeries` channel which had a gap in its data, `downsampled_over` would try to compute the mean of an empty subsection, which raises an exception. Now this case is gracefully handled.
+* Fixed bug in `Continuous` which lead to excessive memory usage and degraded performance.
 
 #### Breaking changes
 * `FdRangeSelectorWidget` is no longer public.

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -340,7 +340,7 @@ class Continuous:
     def from_dataset(dset, y_label="y", calibration=None):
         start = dset.attrs["Start time (ns)"]
         dt = int(1e9 / dset.attrs["Sample rate (Hz)"])
-        return Slice(Continuous(dset[()], start, dt),
+        return Slice(Continuous(dset, start, dt),
                      labels={"title": dset.name.strip("/"), "y": y_label}, calibration=calibration)
 
     @property
@@ -452,7 +452,7 @@ class TimeTags:
 
     @staticmethod
     def from_dataset(dset, y_label="y"):
-        return Slice(TimeTags(dset[()]))
+        return Slice(TimeTags(dset))
 
     @property
     def timestamps(self):

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -1,3 +1,4 @@
+import h5py
 import pytest
 import numpy as np
 from lumicks.pylake import channel
@@ -576,3 +577,8 @@ def test_channel_plot():
     mpl.pyplot.gca().clear()
     s.plot(start=100e9)
     testLine(np.arange(0, 230, 10) - 100 + 5, d)
+
+
+def test_regression_lazy_loading(h5_file):
+    ch = channel.Continuous.from_dataset(h5_file["Force HF"]["Force 1x"])
+    assert type(ch._src._src_data) == h5py.Dataset


### PR DESCRIPTION
**Why?**
It seems that the `Continuous` channel was no longer evaluated lazily and immediately pulled in all the data. This degraded performance and memory usage.

![image](https://user-images.githubusercontent.com/19836026/107649870-2fe2bd80-6c7e-11eb-96f8-a68ad8042697.png)

Note that `TimeTags` suffers from the same issue, but there it doesn't have a performance implication because it gets converted into a `numpy` array immediately in the constructor anyhow.