### PR TITLE
docs: update conda instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,6 +1,9 @@
 Installation
 ============
 
+Installation instructions
+-------------------------
+
 .. _Python: https://www.python.org/
 .. _SciPy: http://www.scipy.org/
 
@@ -13,11 +16,7 @@ If you're already familiar with Python and have the above prerequisites, install
 
     pip install lumicks.pylake
 
-Alternatively, if you're using Anaconda::
-
-    conda install lumicks.pylake -c conda-forge
-
-If you are new to Python/SciPy, more detailed installation instructions are available below.
+Alternatively, if you're using Anaconda, please see the more detailed instructions below.
 
 
 Anaconda
@@ -30,62 +29,121 @@ The easiest way to install Python and SciPy is with `Anaconda`_, a free scientif
 
 .. rubric:: Windows
 
-#. Go to the `Anaconda`_ website and download the Python 3.6 installer.
+#. Go to the `Anaconda`_ website and download the Python 3.8 (or newer) installer.
 
 #. Run it and accept the default options during the installation.
 
-#. Open `Anaconda Prompt` from the `Start` menu. Enter the following command a press enter. This will enable the `conda-forge`::
+#. Open `Anaconda Prompt` from the `Start` menu.
+
+#. Create a new environment for Pylake named pylake by invoking the following command::
+
+    conda create -n pylake
+
+#. The environment can then be activated::
+
+    conda activate pylake
+
+#. The line where you enter your next command should now start with the text `(pylake)` instead of `(base)`, to indicate you're in the pylake environment you just created.
+
+#. Pylake can be found on `conda-forge`_. Add `conda-forge`_ to the list of sources as follows::
 
     conda config --add channels conda-forge
 
-#. Finally, enter the following command to install Pylake::
+#. We can install Pylake in this environment by invoking the following commands::
 
     conda install lumicks.pylake
+
+#. To make sure Jupyter notebook can find the ipykernel, we invoke::
+
+    python -m ipykernel install --user
+
+#. It should be possible to open a jupyter notebook in this environment by calling::
+
+    jupyter notebook
+
+Note that if you are used to starting Jupyter notebook from the Anaconda Navigator, you will have to set the environment to `pylake` for it to have access to the environment where you just installed Pylake.
+
+You can do this in the drop down menu that normally defaults to the environment `base`.
+
+If you are used to starting Jupyter from the Anaconda prompt, then remember to activate the correct environment (pylake) prior to starting the notebook.
+You can activate this environment by calling::
+
+    conda activate pylake
 
 That's it, all done. Check out the :doc:`Tutorial </tutorial/index>` for some example code and Jupyter notebooks to get started.
 
 
 .. rubric:: Linux
 
-#. Go to the `Anaconda`_ website and download the Python 3.6 installer.
+#. Go to the `Anaconda`_ website and download the Python 3.8 (or newer) installer.
 
 #. Open a terminal window and run::
 
     bash Anaconda3-x.x.x-Linux-x86_64.sh
 
-   Follow the installation steps. You can accept most of the default values, but make sure
-   that you type `yes` to add Anaconda to `PATH`::
+#. Follow the installation steps. Make sure that you type `yes` when prompted with the question whether to run conda init::
 
-       Do you wish the installer to prepend the Anaconda3 install location
-       to PATH in your /home/<user_name>/.bashrc ? [yes|no]
-       [no] >>> yes
+    Do you wish the installer to initialize Anaconda 3 by running conda init? [yes|no]
+    [no] >>> yes
 
-   Now, close your terminal window and open a new one for the changes to take effect.
+#. Now, close your terminal window and open a new one for the changes to take effect.
 
-#. Next, enable `conda-forge`::
+#. Using the terminal, we will create a new environment for Pylake named pylake by invoking the following command::
+
+    conda create -n pylake
+
+#. The environment can then be activated::
+
+    conda activate pylake
+
+#. Pylake can be found on `conda-forge`_. Add `conda-forge`_ to the list of sources as follows::
 
     conda config --add channels conda-forge
 
-#. Finally, install Pylake with the following command::
+#. We can install Pylake in this environment by invoking the following commands::
 
     conda install lumicks.pylake
+
+#. It should be possible to open a Jupyter notebook in this environment by calling `jupyter notebook` from the terminal.
+
+#. It should also be possible to now start the Anaconda Navigator by calling `anaconda-navigator` from the terminal.
+
+Note that if you are used to starting Jupyter notebook from the Anaconda Navigator, you will have to set the environment to `pylake` for it to have access to the environment where you just installed Pylake.
+You can do this in the drop down menu that normally defaults to the environment `base`.
+If you are used to starting Jupyter notebook from the terminal, then remember to activate the correct environment (pylake) prior to starting the notebook.
 
 That's it, all done. Check out the :doc:`Tutorial </tutorial/index>` for some example code and Jupyter notebooks to get started.
 
 
 .. rubric:: macOS
 
-#. Go to the `Anaconda`_ website and download the Python 3.6 installer.
+#. Go to the `Anaconda`_ website and download the Python 3.8 (or newer) installer.
 
 #. Run it and accept the default options during the installation.
 
-#. Open `Terminal` and run the following command to enable `conda-forge`::
+#. Open `Terminal`. First, we will create a new environment for Pylake named pylake by invoking the following command::
+
+    conda create -n pylake
+
+#. The environment can then be activated by invoking the following::
+
+    conda activate pylake
+
+#. Pylake can be found on `conda-forge`_. We can add `conda-forge`_ to the list of sources as follows::
 
     conda config --add channels conda-forge
 
-#. Finally, install Pylake with the following command::
+#. Install Pylake in this environment by invoking the following commands::
 
     conda install lumicks.pylake
+
+#. It should be possible to open a jupyter notebook in this environment by calling::
+
+    jupyter notebook
+
+Note that if you are used to starting Jupyter notebook from the Anaconda Navigator, you will have to set the environment to `pylake` for it to have access to the environment where you just installed pylake.
+You can do this in the drop down menu that normally defaults to the environment `base`.
+If you are used to starting Jupyter from `Terminal`, then remember to activate the correct environment (pylake) prior to starting the notebook.
 
 That's it, all done. Check out the :doc:`Tutorial </tutorial/index>` for some example code and Jupyter notebooks to get started.
 
@@ -96,6 +154,20 @@ Updating
 If you already have Pylake installed and you want to update to the latest version, just run::
 
     conda update lumicks.pylake
+
+Note that this updates the package to the latest version that is compatible with your environment.
+It will also attempt to update any dependencies that require an update in order to be compatible with the updated version of pylake.
+You can check which version of pylake you have after this procedure by checking the pylake version
+from the command prompt (windows) or terminal (macOS/linux)::
+
+    conda list pylake
+
+If for some reason conda fails to update pylake to the latest version, it is usually easier to just remove the pylake environment and reinstall from scratch.
+To do this, open a new Anaconda prompt and type::
+
+    conda env remove -n pylake
+
+After which you can re-install pylake using the regular installation instructions above.
 
 
 .. _ffmpeg_installation:
@@ -109,6 +181,103 @@ Exporting to compressed video formats requires an additional dependency named ff
 When using conda, ffmpeg can be installed as follows::
 
     conda install -c conda-forge ffmpeg
+
+
+Conda environments
+------------------
+.. _PyCharm: https://www.jetbrains.com/pycharm/download/#section=windows
+.. _PyCharm documentation: https://www.jetbrains.com/help/pycharm/conda-support-creating-conda-virtual-environment.html
+.. _Jupyter: https://jupyter.org/
+.. _uninstall instructions: https://docs.anaconda.com/anaconda/install/uninstall/
+.. _VS Code: https://code.visualstudio.com/download
+.. _VS Code Environment Instructions: https://code.visualstudio.com/docs/python/environments#_conda-environments
+.. _numpy discussion: https://github.com/numpy/numpy/issues/15183#issuecomment-603575874
+
+If you have installed Pylake according to the Installation Instructions for Anaconda, then you should now have a separate environment for your Pylake work.
+You may be wondering why we needed to create a new environment for Pylake, and what an environment is.
+
+When using Python, you will quickly find that several packages that you can install depend on each other.
+For example, when installing Pylake, you could see that the installation of Pylake required numerous other packages to be installed as well.
+Most Python packages are continuously updated by their authors. Sometimes, these authors decide that certain existing functionalities need to be changed.
+This means that not all of them will be completely backwards compatible.
+Therefore, it can be challenging to find a set of packages and package versions that all work together.
+
+One pragmatic solution to this is to maintain separate Python environments for different projects.
+This means that you create independent "copies" of Python and its installed packages, so that the different projects you're working on don't interfere with each other.
+Anaconda is one solution to this problem. With Anaconda, you can have multiple installations of Python (with all their installed modules) installed on your computer.
+These installations are referred to as environments.
+
+**Why do we install Pylake in a separate environment by default?**
+
+Conda sources the packages it uses from a channel, these are locations where conda and the Anaconda Navigator search for packages.
+The default one is called Anaconda, but Pylake is available on a channel named `conda-forge`_.
+Conda forge and Anaconda both have different versions of different packages.
+Some of these are not compatible with each other.
+This is why it is wise to install Pylake into its own environment, and only source packages from the channel `conda-forge`_ in that environment.
+This helps prevent difficulties when trying to come up with a plan to install a package you request.
+
+**How do I set up my other tools to use the correct environment?**
+
+For most programs, it is just a matter of pointing them to the correct environment.
+If you prefer using the Anaconda Navigator, you can activate the environment by selecting it from the drop down menu `Applications on`.
+By default, the selected environment is `base`.
+
+*PyCharm*
+
+For small data analysis scripts, `Jupyter`_ notebooks can be quite helpful.
+For larger projects you may want to switch to an integrated development environment (IDE).
+Our recommended tool for working on larger Python projects is `PyCharm`_.
+You can install PyCharm by following the default installation instructions.
+Next, we have to set up PyCharm so that it finds the correct Conda environment.
+For information on how to do this, please refer to the `PyCharm documentation`_.
+
+*Spyder*
+
+If you have installed `Spyder` with the `pylake` environment active, you should also have a start menu entry that reads `Spyder (pylake)`.
+Note how Conda typically installs shortcuts indicating the relevant environment between brackets.
+
+*VS Code*
+
+#. Download `VS Code`_ and install it following the default installation instructions.
+
+#. Start it when the installer finishes.
+
+#. Go to the extensions tab (CTRL + SHIFT + X)
+
+#. Enter Python in the search field.
+
+#. Click on the Python plugin (by Microsoft) and install it.
+
+#. Restart VS Code.
+
+#. Open the Command Palette (CTRL + SHIFT + P) and type "Python: Select Interpreter". Here you should choose the pylake environment.
+
+#. Close VS Code.
+
+VS Code should now appear in your Anaconda Navigator list.
+Make sure that you selected the pylake environment when starting VS Code from the Anaconda Navigator.
+It should now be possible to use pylake in VS Code.
+
+Under Windows, you will need to start VS Code from the Anaconda Navigator for it to use the correct environment.
+For more information on how to get it to run without Anaconda Navigator on Windows see the `VS Code Environment Instructions`_ and this `numpy discussion`_.
+
+**Can I use pip with Anaconda?**
+
+`Pip` is a different package manager.
+While `conda` does allow you to install `pip` inside a conda environment, there is no guarantee that `pip` packages will be compatible with `conda-forge` packages.
+It is therefore wise to choose one package manager as your go-to package manager and only switch when a package you need can only be found on the other package manager.
+
+While using `pip` within conda is perfectly possible, note that if you do decide to go down this route, you should install all packages in that environment via `pip` and none via `conda`.
+If you decide to use this configuration then you have to make sure that you install it using the version of `pip` inside your conda environment.
+You can get problematic incompatibilities if you use a system-wide install of `pip` in conjunction with an active `conda` environment.
+
+On Windows, the easiest way to find out which `pip` you are using is to invoke `where pip` on the anaconda prompt that you are using.
+The `pip` executable that will be called when you invoke it from the command prompt will be at the top and should be located in your conda environment.
+You can verify this by checking whether the path contains your currently active environment in it.
+
+If you see that `pip` is either not on your path or it is being sourced from a different location, double check whether you have activated the correct conda environment.
+You can activate an environment by invoking `conda activate <environment name>`, where `<environment name>` should be replaced with the environment you want to activate.
+If you have already activated the correct environment, but you still don't see `pip` being sourced from there then you can install it into this environment by invoking `conda install pip`.
 
 
 Troubleshooting
@@ -149,24 +318,8 @@ the only backend that provides interactive plots with Pylake.
 **Conda takes a long time to resolve the environment and then fails. What can I do?**
 
 Several packages depend on each other. Sometimes, finding a suitable collection of packages that is compatible can be
-problematic. One way to work around this is to make a separate environment for working with `pylake`. You can create a
-new environment named `pylake` by invoking the following in the anaconda prompt::
-
-    conda create -n pylake
-
-The environment can then be activated by calling `activate`::
-
-    conda activate pylake
-
-You can see that it is activated, because `pylake` should now be prefixed to the path in your anaconda prompt. We can
-install `pylake` and `jupyter notebook` in this environment by invoking the following commands::
-
-    conda install -c conda-forge lumicks.pylake
-    conda install -c conda-forge jupyter notebook
-
-It should be possible to open a jupyter notebook in this environment by calling `jupyter notebook`. Note that if you
-are used to starting Jupyter from the anaconda navigator, you will have to set the environment to `pylake` for it to
-have access to the pylake package.
+problematic. One way to work around this is to make a new environment for working with Pylake. See the installation
+instructions for more information.
 
 
 **How do I check which version of pylake I have?**
@@ -187,3 +340,11 @@ You can run the test suite as follows::
     lk.pytest()
 
 If all tests pass (except for the slow ones which are skipped) then your installation of `pylake` is good to go.
+
+
+**I tried the installation instructions but conda still won't install pylake**
+
+If creating a new environment doesn't work then it may be time to uninstall and reinstall conda.
+Note that this means you will lose all the environments you have created.
+Please follow these `uninstall instructions`_ to uninstall conda.
+After uninstalling, you should be able to reinstall using the regular installation instructions.


### PR DESCRIPTION
**Why this PR?**
We're still having a lot of support originating from anaconda breakage. The default installation instructions have to be amended to reflect that we do rely on always creating a new environment for Pylake now. On Windows, we also need to set the correct path for Jupyter notebook to find the IPython kernel. This was also added to the list of installation instructions.

These installation instructions were tested on Windows and Linux.

Proposed docs can be found here: https://lumicks-pylake.readthedocs.io/en/conda_instructions/install.html