### PR TITLE
Rename FDCurve to FdCurve

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,12 +3,12 @@
 ## v0.8.0 | t.b.d.
 
 #### New features
-* Added widget to graphically slice `FDCurve` by distance in Jupyter Notebooks. It can be opened by calling `pylake.FdDistanceRangeSelector(fdcurves)`. For more information, see the tutorials section on [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
-* Added `FDCurve.range_selector()` and `FDCurve.distance_range_selector()`
+* Added widget to graphically slice `FdCurve` by distance in Jupyter Notebooks. It can be opened by calling `pylake.FdDistanceRangeSelector(fdcurves)`. For more information, see the tutorials section on [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
+* Added `FdCurve.range_selector()` and `FdCurve.distance_range_selector()`
 * Added `center_point_um` property to `PointScan`, `Kymo` and `Scan` classes.
 * Added `scan_width_um` property to `Kymo` and `Scan` classes.
-* Added `FDCurve.with_offset()` to `FDCurve` to add offsets to force and distance.
-* Added `FdEnsemble` to be able to process multiple `FDCurve` instances simultaneously.
+* Added `FdCurve.with_offset()` to `FdCurve` to add offsets to force and distance.
+* Added `FdEnsemble` to be able to process multiple `FdCurve` instances simultaneously.
 * Added `FdEnsemble.align_linear()` to align F,d curves in an ensemble by correcting for a constant offset in force and distance using two linear regressions. See [FD curves](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/fdcurves.html) for more information.
 * Added `CorrelatedStack.export_tiff()` for exporting aligned image stacks.
 
@@ -22,6 +22,7 @@
 * `Slice.range_selector()` is now a method instead of a property
 * Deprecated `json` attribute in confocal classes `PointScan`, `Scan`, and `Kymo`. **Note: The format of the raw metadata exported from Bluelake is likely to change in future releases and therefore should not be accessed directly. Instead, use the accessor properties, as documented for [scans](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html) and [kymographs](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html).**
 * Deprecated `has_force` and `has_fluorescence` properties in confocal classes `PointScan`, `Scan`, and `Kymo`.
+* Renamed `FDCurve` and `FDSlice` to `FdCurve` and `FdSlice`.
 
 #### Other
 * Added documentation for the Kymotracker widget. See the [Cas9 kymotracking example](https://lumicks-pylake.readthedocs.io/en/latest/examples/cas9_kymotracking/cas9_kymotracking.html) or the [kymotracking tutorial](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
@@ -87,8 +88,8 @@
 ## v0.6.2 | 2020-09-21
 
 * Support plotting Z-axis scans. Z-axis scans would previously throw an exception due to how the physical dimensions were fetched. This issue is now resolved.
-* Add slicing (by time) for `FDCurve`.
-* Add widget to graphically slice `FDCurve` in Jupyter Notebooks. It can be opened by calling `pylake.FdRangeSelector(fdcurves)`. For more information, see the tutorials section on [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
+* Add slicing (by time) for `FdCurve`.
+* Add widget to graphically slice `FdCurve` in Jupyter Notebooks. It can be opened by calling `pylake.FdRangeSelector(fdcurves)`. For more information, see the tutorials section on [notebook widgets](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html).
 * Fixed bug in `FdRangeSelectorWidget` that prevented drawing to the correct axes when other axes has focus.
 * Fixed displayed coordinates to correctly reflect position in `Kymo.plot_red()`, `Kymo.plot_green()`, `Kymo.plot_blue()` and `Kymo.plot_rgb()`. The data origin (e.g. `kymo.red_image[0, 0]`) is displayed on the top left of the image in these plots, whereas previously this was not reflected correctly in the coordinates displayed on the plot axes (placing the coordinate origin at the bottom left).
 
@@ -146,7 +147,7 @@
 ## v0.2.0 | 2018-07-27
 
 * Channel slices can be downsampled: `lf_force = hf_force.downsampled_by(factor=20)`
-* `FDCurve`s now support subtraction, e.g. `fd = f.fdcurves["measured"] - f.fdcurves["baseline"]`
+* `FdCurve`s now support subtraction, e.g. `fd = f.fdcurves["measured"] - f.fdcurves["baseline"]`
 * Scans and kymos now have a `.timestamps` property with per-pixel timestamps with the same shape as the image arrays
 * Added Matlab compatibility examples to the repository in `examples/matlab`
 * `h5py` >= v2.8 is now required

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,7 +11,7 @@ If you are just looking to get started, read the :doc:`/tutorial/index` first.
 
     File
     channel.Slice
-    fdcurve.FDCurve
+    fdcurve.FdCurve
     kymo.Kymo
     scan.Scan
     point_scan.PointScan

--- a/docs/examples/reca_fitting/reca_fitting.rst
+++ b/docs/examples/reca_fitting/reca_fitting.rst
@@ -25,8 +25,8 @@ Let's first load our data and see which curves are present in these files::
     >>> print(control_file.fdcurves)
     >>> print(reca_file.fdcurves)
 
-    {'FD_5_control_forw': <lumicks.pylake.fdcurve.FDCurve object at 0x0000022C8514E780>}
-    {'FD_5_3_RecA_forw_after_2_quick_manual_FD': <lumicks.pylake.fdcurve.FDCurve object at 0x0000022C8514E860>}
+    {'FD_5_control_forw': <lumicks.pylake.fdcurve.FdCurve object at 0x0000022C8514E780>}
+    {'FD_5_3_RecA_forw_after_2_quick_manual_FD': <lumicks.pylake.fdcurve.FdCurve object at 0x0000022C8514E860>}
 
 Plot the data
 -------------

--- a/lumicks/pylake/detail/alignment.py
+++ b/lumicks/pylake/detail/alignment.py
@@ -54,7 +54,7 @@ def align_fd_simple(fd_curves, distance_range_low, distance_range_high):
 
     Parameters
     ----------
-    fd_curves : Dict[lumicks.pylake.FDCurve]
+    fd_curves : Dict[lumicks.pylake.FdCurve]
         List of F,d curves to apply the method to.
     distance_range_low : float
         Range of distances to use for the force alignment. Distances in the range [smallest_distance,

--- a/lumicks/pylake/fdcurve.py
+++ b/lumicks/pylake/fdcurve.py
@@ -1,3 +1,4 @@
+import deprecated
 import numpy as np
 from copy import copy, deepcopy
 from .channel import Slice, TimeSeries
@@ -7,14 +8,14 @@ from .nb_widgets.range_selector import FdTimeRangeSelectorWidget, FdDistanceRang
 from collections import namedtuple
 
 
-FDSlice = namedtuple("FDSlice", "f d")
+FdSlice = namedtuple("FdSlice", "f d")
 
 
-class FDCurve(DownsampledFD):
+class FdCurve(DownsampledFD):
     """An FD curve exported from Bluelake
 
     By default, the primary force and distance channels are `downsampled_force2`
-    and `distance1`. Alternatives can be selected using `FDCurve.with_channels()`.
+    and `distance1`. Alternatives can be selected using `FdCurve.with_channels()`.
     Note that it does not modify the FD curve in place but returns a copy.
 
     Attributes
@@ -170,7 +171,7 @@ class FDCurve(DownsampledFD):
         """
         f, d = self.f.data, self.d.data
         valid_idx = np.logical_and.reduce((d > 0, d >= distance_min, d < distance_max, f >= force_min, f < force_max))
-        return FDSlice(f[valid_idx], d[valid_idx])
+        return FdSlice(f[valid_idx], d[valid_idx])
 
     def with_channels(self, force, distance):
         """Return a copy of this FD curve with difference primary force and distance channels"""
@@ -199,3 +200,8 @@ class FDCurve(DownsampledFD):
 
     def distance_range_selector(self, show=True, max_gap=0):
         return FdDistanceRangeSelectorWidget(self, show=show, max_gap=max_gap)
+
+
+@deprecated.deprecated(version='0.8.0', reason="The class FDCurve was renamed to FdCurve.")
+class FDCurve(FdCurve):
+    pass

--- a/lumicks/pylake/fdensemble.py
+++ b/lumicks/pylake/fdensemble.py
@@ -9,9 +9,9 @@ class FdEnsemble:
 
     Attributes
     ----------
-    fd_curves : Dict[lumicks.pylake.FDCurve]
+    fd_curves : Dict[lumicks.pylake.FdCurve]
         Dictionary of unprocessed FD curves.
-    fd_curves_processed : Dict[lumicks.pylake.FDCurve]
+    fd_curves_processed : Dict[lumicks.pylake.FdCurve]
         Dictionary of FD curves that were processed by the ensemble.
 
     Methods

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -8,7 +8,7 @@ from .calibration import ForceCalibration
 from .channel import Slice, Continuous, TimeSeries, TimeTags
 from .detail.mixin import Force, DownsampledFD, PhotonCounts, PhotonTimeTags
 from .detail.h5_helper import write_h5
-from .fdcurve import FDCurve
+from .fdcurve import FdCurve
 from .group import Group
 from .kymo import Kymo
 from .point_scan import PointScan
@@ -219,8 +219,8 @@ class File(Group, Force, DownsampledFD, PhotonCounts, PhotonTimeTags):
         return self._get_object_dictionary("Scan", Scan)
 
     @property
-    def fdcurves(self) -> Dict[str, FDCurve]:
-        return self._get_object_dictionary("FD Curve", FDCurve)
+    def fdcurves(self) -> Dict[str, FdCurve]:
+        return self._get_object_dictionary("FD Curve", FdCurve)
 
     @property
     def markers(self) -> Dict[str, Marker]:

--- a/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
+++ b/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
@@ -2,7 +2,7 @@ from lumicks.pylake import FdRangeSelector
 from lumicks.pylake.nb_widgets.range_selector import (FdTimeRangeSelectorWidget, 
                                                       FdDistanceRangeSelectorWidget, 
                                                       BaseRangeSelectorWidget)
-from lumicks.pylake.fdcurve import FDCurve
+from lumicks.pylake.fdcurve import FdCurve
 from lumicks.pylake.channel import TimeSeries, Slice
 from matplotlib.testing.decorators import cleanup
 import pytest
@@ -12,7 +12,7 @@ import numpy as np
 def make_mock_fd(force, distance, start=0, dt=600e9):
     """Mock FD curve which is not attached to an actual file, timestamps start at `start`"""
     assert len(force) == len(distance)
-    fd = FDCurve(file=None, start=None, stop=None, name="")
+    fd = FdCurve(file=None, start=None, stop=None, name="")
     timestamps = int(dt) * np.arange(len(force)) + start
     fd._force_cache = Slice(TimeSeries(force, timestamps))
     fd._distance_cache = Slice(TimeSeries(distance, timestamps))

--- a/lumicks/pylake/tests/test_fdcurve.py
+++ b/lumicks/pylake/tests/test_fdcurve.py
@@ -1,14 +1,14 @@
 import numpy as np
 import pytest
 
-from lumicks.pylake.fdcurve import FDCurve
+from lumicks.pylake.fdcurve import FdCurve
 from lumicks.pylake.channel import Slice, TimeSeries
 
 
 def make_mock_fd(force, distance, start=0, file=None):
     """Mock FD curve which is not attached to an actual file, timestamps start at `start`"""
     assert len(force) == len(distance)
-    fd = FDCurve(file=file, start=None, stop=None, name="")
+    fd = FdCurve(file=file, start=None, stop=None, name="")
     timestamps = np.arange(len(force)) + start
     fd._force_cache = Slice(TimeSeries(force, timestamps))
     fd._distance_cache = Slice(TimeSeries(distance, timestamps))

--- a/lumicks/pylake/tests/test_fdensemble.py
+++ b/lumicks/pylake/tests/test_fdensemble.py
@@ -1,6 +1,6 @@
 import numpy as np
 from lumicks.pylake.detail.alignment import align_force_simple, align_distance_simple, align_fd_simple
-from lumicks.pylake.fdcurve import FDCurve
+from lumicks.pylake.fdcurve import FdCurve
 from lumicks.pylake.channel import Slice, TimeSeries
 from lumicks.pylake.fdensemble import FdEnsemble
 
@@ -8,7 +8,7 @@ from lumicks.pylake.fdensemble import FdEnsemble
 def make_mock_fd(force, distance, start=0):
     """Mock FD curve which is not attached to an actual file, timestamps start at `start`"""
     assert len(force) == len(distance)
-    fd = FDCurve(file=None, start=None, stop=None, name="")
+    fd = FdCurve(file=None, start=None, stop=None, name="")
     timestamps = np.arange(len(force)) + start
     fd._force_cache = Slice(TimeSeries(force, timestamps))
     fd._distance_cache = Slice(TimeSeries(distance, timestamps))


### PR DESCRIPTION
**Why?**
Considering the relatively large number of breaking changes in the next release, let's make names a bit more consistent across the board first.

This PR renames `FDCurve` and `FDSlice` to `FdCurve` and `FdSlice` respectively.