### PR TITLE
ci: test installation

### DIFF
--- a/.github/workflows/pylake_test.py
+++ b/.github/workflows/pylake_test.py
@@ -1,0 +1,7 @@
+import lumicks.pylake as lk
+import sys
+import os
+import pathlib
+
+os.chdir(str(pathlib.Path(lk.__file__).parent))
+sys.exit(lk.pytest(args=["--runslow", "--color=yes"]))

--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -24,6 +24,8 @@ jobs:
         pip install .
         pip install black==20.8b1
     - name: Pytest
-      run: pytest lumicks/pylake --color=yes --runslow
+      run: |
+        cd .github/workflows
+        python pylake_test.py
     - name: Black
       run: black --check --diff --color .

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,15 +5,3 @@ license_file = license.md
 minversion = 3.3
 addopts = --doctest-modules --ignore=setup.py --ignore=docs/conf.py
 norecursedirs = .* *.egg build cpp* dist docs/*
-filterwarnings =
-    # make warnings into errors but ignore certain third-party extension issues
-    error
-    # importing scipy submodules on some version of Python
-    ignore::ImportWarning
-    # bogus numpy ABI warning (see numpy/#432)
-    ignore:.*numpy.dtype size changed.*:RuntimeWarning
-    ignore:.*numpy.ufunc size changed.*:RuntimeWarning
-    # h5py triggers a numpy DeprecationWarning when accessing empty datasets (such as our json fields). Here they pass
-    # a None shape argument where () is expected by numpy. This will likely be fixed in next h5py release, see the
-    # following PR on h5py: https://github.com/h5py/h5py/pull/1780/files
-    ignore:.*None into shape arguments as an alias for \(\) is.*:DeprecationWarning


### PR DESCRIPTION
**Why this PR?**
Because I don't want to release a broken pylake again. During the v0.8.0 we had the problem that one of the files needed in the test wasn't being shipped. This wasn't picked up by CI, because CI doesn't actually test the installed package, but just whether pytest passes in the current working directory.

**Why this solution?**
This solution installs pylake using pip and runs the tests there.

Originally, I opted for the cleaner
`pytest --runslow --color=yes --pyargs lumicks.pylake`

But it wouldn't recognise our custom option `runslow`. Therefore this solution has the preference.

Note that I have moved the warning configuration from `setup.cfg` to `conftest.py`. The reason for this is that we want our testing configured when calling pytest in the imported module as well. This seems like a cleaner solution than adding a `pytest.ini` to the list of things installed with the package (which could be shadowed by an ini the user has).

There were two cases in which certain files were not packaged. Either leaving `include_package_data` out of `setup.py` or leaving the file out of the manifest). I have tested both cases that would lead to incorrect packaging and verified that both of them would now not pass the testing ci.