### PR TITLE
force_calibration: remove extra downsample factor conversions

### DIFF
--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -1,6 +1,6 @@
-import math
 import numpy as np
 
+from .detail.utilities import downsample
 from .detail.timeindex import to_timestamp
 from .calibration import ForceCalibration
 from lumicks.pylake.nb_widgets.range_selector import SliceRangeSelectorWidget
@@ -328,15 +328,6 @@ class Slice:
         return SliceRangeSelectorWidget(self, show=show)
 
 
-def _downsample(data, factor, reduce):
-    def round_down(size, n):
-        """Round down `size` to the nearest multiple of `n`"""
-        return int(math.floor(size / n)) * n
-
-    data = data[: round_down(data.size, factor)]
-    return reduce(data.reshape(-1, factor), axis=1)
-
-
 class Continuous:
     """A source of continuous data for a timeline slice
 
@@ -402,7 +393,7 @@ class Continuous:
 
     def downsampled_by(self, factor, reduce):
         return self.__class__(
-            _downsample(self.data, factor, reduce),
+            downsample(self.data, factor, reduce),
             start=self.start + self.dt * (factor - 1) // 2,
             dt=self.dt * factor,
         )

--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -1,6 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mpl
+import math
 
 
 def first(iterable, condition=lambda x: True):
@@ -44,3 +45,27 @@ def find_contiguous(mask):
     ranges = np.argwhere(change_points == 1).reshape(-1, 2)
     run_lengths = np.diff(ranges, axis=1).squeeze()
     return ranges, np.atleast_1d(run_lengths)
+
+
+def downsample(data, factor, reduce):
+    """This function is used to downsample data in blocks of size `factor`.
+
+    This function downsamples blocks of size `factor` using the function specified in reduce. If
+    there are insufficient points to fill a final block, this last block is discarded.
+
+    Parameters
+    ----------
+    data : array_like
+        Input data
+    factor : int
+        Factor to downsample by
+    reduce : callable
+        Function to use for reducing the data
+    """
+
+    def round_down(size, n):
+        """Round down `size` to the nearest multiple of `n`"""
+        return int(math.floor(size / n)) * n
+
+    data = data[: round_down(data.size, factor)]
+    return reduce(data.reshape(-1, factor), axis=1)

--- a/lumicks/pylake/force_calibration/detail/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/detail/power_spectrum.py
@@ -1,21 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
-import math
 from copy import copy
-
-
-def block_reduce(data, n_blocks, reduce=np.mean):
-    """Calculates the block average of a dataset.
-
-    For an array ``A`` of length ``N``, returns an array ``B`` of length
-    ``M``, where each element of ``B`` is the average of ``q`` neighboring
-    elements. ``q`` is equal to ``floor(N/M)``. This implies that if ``N*q``
-    is not exactly equal to ``M``, the last partially complete window is
-    thrown away by this function.
-    """
-    block_size = math.floor(data.size / n_blocks)
-    length = block_size * n_blocks
-    return reduce(np.reshape(data[:length], (-1, block_size)), axis=1)
+from lumicks.pylake.detail.utilities import downsample
 
 
 class PowerSpectrum:
@@ -62,17 +48,12 @@ class PowerSpectrum:
         """"Returns a representation of the PowerSpectrum suitable for serialization"""
         return {"f": self.f.tolist(), "P": self.P.tolist()}
 
-    def block_averaged(self, num_blocks=2000):
-        """Returns a block-averaged power spectrum.
-
-        See Also
-        --------
-        block_average
-        """
+    def downsampled_by(self, factor, reduce=np.mean):
+        """Returns a spectrum downsampled by a given factor."""
         ba = copy(self)
-        ba.f = block_reduce(self.f, num_blocks)
-        ba.P = block_reduce(self.P, num_blocks)
-        ba.num_points_per_block = self.num_points_per_block * math.floor(self.P.size / num_blocks)
+        ba.f = downsample(self.f, factor, reduce)
+        ba.P = downsample(self.P, factor, reduce)
+        ba.num_points_per_block = self.num_points_per_block * factor
 
         return ba
 

--- a/lumicks/pylake/force_calibration/detail/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/detail/power_spectrum.py
@@ -27,20 +27,20 @@ class PowerSpectrum:
         Frequency values for the power spectrum. [Hz]
     P : numpy.ndarray
         Power values for the power spectrum (typically in V^2/s).
-    sampling_rate : float
+    sample_rate : float
         The sampling rate for the original data. [Hz]
     total_duration : float
         The total duration of the original data. [seconds]
     """
 
-    def __init__(self, data, sampling_rate, unit="V"):
+    def __init__(self, data, sample_rate, unit="V"):
         """Power spectrum
 
         Parameters
         ----------
         data : numpy.ndarray
             Data from which to calculate a power spectrum.
-        sampling_rate : float
+        sample_rate : float
             Sampling rate at which this data was acquired.
         unit : str
             Units the data is in (default: V).
@@ -50,12 +50,12 @@ class PowerSpectrum:
 
         # Calculate power spectrum.
         fft = np.fft.rfft(data)
-        self.f = np.fft.rfftfreq(data.size, 1.0 / sampling_rate)
-        self.P = (1.0 / sampling_rate) * np.square(np.abs(fft)) / data.size
+        self.f = np.fft.rfftfreq(data.size, 1.0 / sample_rate)
+        self.P = (1.0 / sample_rate) * np.square(np.abs(fft)) / data.size
 
         # Store metadata
-        self.sampling_rate = sampling_rate
-        self.total_duration = data.size / sampling_rate
+        self.sample_rate = sample_rate
+        self.total_duration = data.size / sample_rate
         self.num_points_per_block = 1
 
     def as_dict(self):

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -131,7 +131,7 @@ def guess_f_diode_initial_value(ps, guess_fc, guess_D):
         A good initial value for the parameter `f_diode`, for fitting the full
         power spectrum.
     """
-    f_nyquist = ps.sampling_rate / 2
+    f_nyquist = ps.sample_rate / 2
     P_aliased_nyq = (guess_D / (2 * math.pi ** 2)) / (f_nyquist ** 2 + guess_fc ** 2)
     if ps.P[-1] < P_aliased_nyq:
         dif = ps.P[-1] / P_aliased_nyq
@@ -140,14 +140,14 @@ def guess_f_diode_initial_value(ps, guess_fc, guess_D):
         return 2 * f_nyquist
 
 
-def calculate_power_spectrum(data, sampling_rate, fit_range=(1e2, 23e3), num_points_per_block=350):
+def calculate_power_spectrum(data, sample_rate, fit_range=(1e2, 23e3), num_points_per_block=350):
     """Compute power spectrum.
 
     Parameters
     ----------
     data : np.array
         Data used for calibration.
-    sampling_rate : float
+    sample_rate : float
         Sampling rate [Hz]
     fit_range : tuple (f_min, f_max), optional
         Tuple of two floats, indicating the frequency range to use for the
@@ -158,7 +158,7 @@ def calculate_power_spectrum(data, sampling_rate, fit_range=(1e2, 23e3), num_poi
     """
     if not isinstance(data, np.ndarray) or (data.ndim != 1):
         raise TypeError('Argument "data" must be a numpy vector')
-    power_spectrum = PowerSpectrum(data, sampling_rate)
+    power_spectrum = PowerSpectrum(data, sample_rate)
     power_spectrum = power_spectrum.in_range(*fit_range)
     power_spectrum = power_spectrum.block_averaged(
         num_blocks=power_spectrum.P.size // num_points_per_block
@@ -274,7 +274,7 @@ def fit_power_spectrum(power_spectrum, model, settings=CalibrationSettings()):
                 "Number of points per block", power_spectrum.num_points_per_block, "-"
             ),
             "Sample rate (Hz)": CalibrationParameter(
-                "Sample rate", power_spectrum.sampling_rate, "Hz"
+                "Sample rate", power_spectrum.sample_rate, "Hz"
             ),
         },
     )

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -153,16 +153,14 @@ def calculate_power_spectrum(data, sample_rate, fit_range=(1e2, 23e3), num_point
         Tuple of two floats, indicating the frequency range to use for the
         full model fit. Default: (1e2, 23e3) [Hz]
     num_points_per_block : int, optional
-        The spectrum is first block averaged with approximately this number of points per block.
+        The spectrum is first block averaged by this number of points per block.
         Default: 350.
     """
     if not isinstance(data, np.ndarray) or (data.ndim != 1):
         raise TypeError('Argument "data" must be a numpy vector')
     power_spectrum = PowerSpectrum(data, sample_rate)
     power_spectrum = power_spectrum.in_range(*fit_range)
-    power_spectrum = power_spectrum.block_averaged(
-        num_blocks=power_spectrum.P.size // num_points_per_block
-    )
+    power_spectrum = power_spectrum.downsampled_by(num_points_per_block)
     return power_spectrum
 
 

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 from lumicks.pylake.force_calibration.detail.power_models import *
 from lumicks.pylake.force_calibration.detail.power_spectrum import PowerSpectrum
 
@@ -59,7 +58,7 @@ def test_fit_analytic(reference_models, corner_frequency, diffusion_constant, nu
     fit_range = (0, 15000)
     ps = PowerSpectrum(data, sample_rate=len(data))
     ps = ps.in_range(*fit_range)
-    ps = ps.block_averaged(num_blocks=ps.P.size // num_points_per_block)
+    ps = ps.downsampled_by(num_points_per_block)
 
     fit = fit_analytical_lorentzian(ps.in_range(1e1, 1e4))
 

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -57,7 +57,7 @@ def test_fit_analytic(reference_models, corner_frequency, diffusion_constant, nu
 
     num_points_per_block = 20
     fit_range = (0, 15000)
-    ps = PowerSpectrum(data, sampling_rate=len(data))
+    ps = PowerSpectrum(data, sample_rate=len(data))
     ps = ps.in_range(*fit_range)
     ps = ps.block_averaged(num_blocks=ps.P.size // num_points_per_block)
 

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
@@ -19,7 +19,7 @@ def test_blocking_separate(data, num_blocks, avg, std):
 
 
 @pytest.mark.parametrize(
-    "frequency, num_data, sampling_rate",
+    "frequency, num_data, sample_rate",
     [
         [200, 50, 2000],
         [400, 50, 2000],
@@ -27,13 +27,13 @@ def test_blocking_separate(data, num_blocks, avg, std):
         [400, 50, 4000],
     ],
 )
-def test_power_spectrum_attrs(frequency, num_data, sampling_rate):
+def test_power_spectrum_attrs(frequency, num_data, sample_rate):
     """Testing the attributes of power spectra"""
-    data = np.sin(2.0 * np.pi * frequency / sampling_rate * np.arange(num_data))
-    power_spectrum = PowerSpectrum(data, sampling_rate)
+    data = np.sin(2.0 * np.pi * frequency / sample_rate * np.arange(num_data))
+    power_spectrum = PowerSpectrum(data, sample_rate)
 
-    df = sampling_rate / num_data
-    frequency_axis = np.arange(0, .5 * sampling_rate + 1, df)
+    df = sample_rate / num_data
+    frequency_axis = np.arange(0, .5 * sample_rate + 1, df)
     assert np.allclose(power_spectrum.f, frequency_axis)
     assert np.allclose(power_spectrum.num_samples(), len(frequency_axis))
 
@@ -43,7 +43,7 @@ def test_power_spectrum_attrs(frequency, num_data, sampling_rate):
 
     # Is all the power at this frequency? (Valid when dealing with multiples of the sample rate)
     assert np.allclose(power_spectrum.P[np.argmax(power_spectrum.P)], np.sum(power_spectrum.P))
-    assert np.allclose(power_spectrum.total_duration, num_data / sampling_rate)
+    assert np.allclose(power_spectrum.total_duration, num_data / sample_rate)
 
     # Check serialized properties
     assert np.allclose(power_spectrum.as_dict()["f"], power_spectrum.f)
@@ -51,7 +51,7 @@ def test_power_spectrum_attrs(frequency, num_data, sampling_rate):
 
 
 @pytest.mark.parametrize(
-    "frequency, num_data, sampling_rate, num_blocks, f_blocked, p_blocked",
+    "frequency, num_data, sample_rate, num_blocks, f_blocked, p_blocked",
     [
         [200, 50, 2000, 4, [100, 340, 580, 820], [1.04166667e-3, 0, 0, 0]],
         [400, 50, 2000, 4, [100, 340, 580, 820], [0, 1.04166667e-3, 0, 0]],
@@ -60,10 +60,10 @@ def test_power_spectrum_attrs(frequency, num_data, sampling_rate):
         [400, 50, 4000, 7, [80, 320, 560, 800, 1040, 1280, 1520], [0, 1.04166667e-03, 0, 0, 0, 0, 0]],
     ],
 )
-def test_power_spectrum_blocking(frequency, num_data, sampling_rate, num_blocks, f_blocked, p_blocked):
+def test_power_spectrum_blocking(frequency, num_data, sample_rate, num_blocks, f_blocked, p_blocked):
     """Functional test whether the results of blocking the power spectrum are correct"""
-    data = np.sin(2.0 * np.pi * frequency / sampling_rate * np.arange(num_data))
-    power_spectrum = PowerSpectrum(data, sampling_rate)
+    data = np.sin(2.0 * np.pi * frequency / sample_rate * np.arange(num_data))
+    power_spectrum = PowerSpectrum(data, sample_rate)
 
     blocked = power_spectrum.block_averaged(num_blocks)
     assert np.allclose(blocked.f, f_blocked)
@@ -78,7 +78,7 @@ def test_power_spectrum_blocking(frequency, num_data, sampling_rate, num_blocks,
 
 
 @pytest.mark.parametrize(
-    "frequency, num_data, sampling_rate, num_blocks, f_min, f_max",
+    "frequency, num_data, sample_rate, num_blocks, f_min, f_max",
     [
         [200, 50, 2000, 4, 0, 10000],
         [400, 50, 2000, 4, 0, 10000],
@@ -88,9 +88,9 @@ def test_power_spectrum_blocking(frequency, num_data, sampling_rate, num_blocks,
         [400, 50, 4000, 8, 0, 100],
     ],
 )
-def test_in_range(frequency, num_data, sampling_rate, num_blocks, f_min, f_max):
-    data = np.sin(2.0 * np.pi * frequency / sampling_rate * np.arange(num_data))
-    power_spectrum = PowerSpectrum(data, sampling_rate)
+def test_in_range(frequency, num_data, sample_rate, num_blocks, f_min, f_max):
+    data = np.sin(2.0 * np.pi * frequency / sample_rate * np.arange(num_data))
+    power_spectrum = PowerSpectrum(data, sample_rate)
 
     power_subset = power_spectrum.in_range(f_min, f_max)
     assert id(power_subset) != id(power_spectrum)
@@ -102,7 +102,7 @@ def test_in_range(frequency, num_data, sampling_rate, num_blocks, f_min, f_max):
     assert np.allclose(power_subset.f, power_spectrum.f[mask])
     assert np.allclose(power_subset.P, power_spectrum.P[mask])
     assert np.allclose(power_spectrum.total_duration, power_subset.total_duration)
-    assert np.allclose(power_spectrum.sampling_rate, power_subset.sampling_rate)
+    assert np.allclose(power_spectrum.sample_rate, power_subset.sample_rate)
 
 
 @cleanup
@@ -119,5 +119,5 @@ def test_replace_spectrum():
     assert np.allclose(power_spectrum.f, replaced.f)
     assert np.allclose(replaced.P, np.arange(6))
     assert np.allclose(replaced.num_points_per_block, 1)
-    assert np.allclose(replaced.sampling_rate, power_spectrum.sampling_rate)
+    assert np.allclose(replaced.sample_rate, power_spectrum.sample_rate)
     assert np.allclose(replaced.total_duration, power_spectrum.total_duration)

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -33,17 +33,17 @@ def test_input_validation_power_spectrum_calibration():
 
     # Wrong dimensions
     with pytest.raises(TypeError):
-        psc.fit_power_spectrum(data=np.array([[1, 2, 3], [1, 2, 3]]), sampling_rate=78125, model=model)
+        psc.fit_power_spectrum(data=np.array([[1, 2, 3], [1, 2, 3]]), sample_rate=78125, model=model)
 
     # Wrong type
     with pytest.raises(TypeError):
-        psc.fit_power_spectrum(data="bloop", sampling_rate=78125, model=model)
+        psc.fit_power_spectrum(data="bloop", sample_rate=78125, model=model)
 
     with pytest.raises(TypeError):
-        psc.fit_power_spectrum(data=np.array([1, 2, 3]), sampling_rate=78125, model="invalid")
+        psc.fit_power_spectrum(data=np.array([1, 2, 3]), sample_rate=78125, model="invalid")
 
     with pytest.raises(TypeError):
-        psc.fit_power_spectrum(data=np.array([1, 2, 3]), sampling_rate=78125, model=model, settings="invalid")
+        psc.fit_power_spectrum(data=np.array([1, 2, 3]), sample_rate=78125, model=model, settings="invalid")
 
 
 def test_calibration_result():
@@ -127,7 +127,7 @@ def reference_calibration_result():
     data = np.load(os.path.join(os.path.dirname(__file__), "reference_spectrum.npz"))
     reference_spectrum = data["arr_0"]
     model = PassiveCalibrationModel(4.4, temperature=20, viscosity=0.001002)
-    reference_spectrum = psc.calculate_power_spectrum(reference_spectrum, sampling_rate=78125,
+    reference_spectrum = psc.calculate_power_spectrum(reference_spectrum, sample_rate=78125,
                                                       num_points_per_block=100,
                                                       fit_range=(100.0, 23000.0))
     ps_calibration = psc.fit_power_spectrum(power_spectrum=reference_spectrum, model=model)

--- a/lumicks/pylake/tests/test_utilities.py
+++ b/lumicks/pylake/tests/test_utilities.py
@@ -1,4 +1,4 @@
-from lumicks.pylake.detail.utilities import first, unique, get_color, lighten_color, find_contiguous
+from lumicks.pylake.detail.utilities import *
 import pytest
 import matplotlib as mpl
 import numpy as np
@@ -69,3 +69,17 @@ def test_find_contiguous():
     assert np.all(np.equal(ranges, [[5, 10]]))
     assert np.all(np.equal(lengths, [5]))
     check_blocks_are_true(mask, ranges)
+
+
+@pytest.mark.parametrize(
+    "data,factor,avg,std",
+    [
+        [np.arange(10), 2, [0.5, 2.5, 4.5, 6.5, 8.5], [0.5, 0.5, 0.5, 0.5, 0.5]],
+        [np.arange(0, 10, 2), 1, [0.0, 2.0, 4.0, 6.0, 8.0], [0.0, 0.0, 0.0, 0.0, 0.0]],
+        [np.arange(0, 10, 2), 2, [1.0, 5.0], [1.0, 1.0]],
+        [np.arange(0, 11, 2), 2, [1.0, 5.0, 9.0], [1.0, 1.0, 1.0]],
+    ],
+)
+def test_downsample(data, factor, avg, std):
+    assert np.allclose(avg, downsample(data, factor, reduce=np.mean))
+    assert np.allclose(std, downsample(data, factor, reduce=np.std))


### PR DESCRIPTION
**Why this PR?**
While writing the docs I noticed two things that needed fixups. One, we  use `sample_rate` instead of `sampling_rate`.

The second is that how you specify how much the spectra need to be downsampled is a bit strange. The API takes a number of points to use for averaging. That is then converted to a number of blocks, which is then converted back to a number of points. By changing the API, we get more predictable behaviour.

It also deduplicates some code between channel and force calibration (and allows both to be covered by the same test of the basic functionality).

One thing that's worth noting is that this is part of the reason the original LDAT was using the wrong `n_points_per_block` in the actual fit (since it usually wasn't what you actually got and it was used straight from `self.settings.n_points_per_block` rather than from `PowerSpectrum`, which at the time didn't keep track of how often things had been downsampled).

**Why did the test change?**
When specifying a number of blocks, you can end up with a nearest downsampling factor that would allow more blocks than you asked for. They are then just dropped.

The test in question has 50 data points at a samplerate of 4000, where we request 7 blocks from the API. 50 datapoints leads to a frequency spectrum that is 26 long. We want 7 blocks, so that's a downsampling factor of 3 (floor of 3.71). At that downsampling factor we can actually get 8 blocks, so specifying a number of blocks would end up throwing away data we could have had. This way, it's also more consistent with the rest of the Pylake API.