### PR TITLE
force_calibration: docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## v0.8.2 | t.b.d.
 
+#### New features
+
+* Added force calibration functionality to Pylake. Please refer to [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html) for more information.
+
+#### Bug fixes
+
 * Fixed bug in kymotracker which could result in a line being extended one pixel too far in either direction. Reason for the bug was that a blurring step in the peak-finding routine was being applied on both axes, while it should have only been applied to one axis. Note that while this bug affects peak detection (finding one too many), it should not affect peak localization as that is performed in a separate step.
 * Fixed bug in kymotracker slicing which could result in one line too many or too few being included. The bug was caused by using the timestamp corresponding to one sample beyond the last pixel of the line as "start of the next line" without accounting for the dead time that may be there.
 

--- a/docs/_ext/nbexport.py
+++ b/docs/_ext/nbexport.py
@@ -189,11 +189,11 @@ class NBTranslator(nodes.NodeVisitor):
         self.visit_literal_block(node)
 
     def visit_math(self, node):
-        self.write_markdown("${}$".format(node["latex"]))
+        self.write_markdown("${}$".format(node.astext()))
         raise nodes.SkipNode
 
-    def visit_displaymath(self, node):
-        self.write_markdown("$$\n{}\n$$\n\n".format(node["latex"].strip()))
+    def visit_math_block(self, node):
+        self.write_markdown("$$\n{}\n$$\n\n".format(node.astext().strip()))
         raise nodes.SkipNode
 
     def unknown_visit(self, node):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,7 +27,10 @@ Force calibration
 
     calculate_power_spectrum
     fit_power_spectrum
+    CalibrationSettings
     PassiveCalibrationModel
+    force_calibration.power_spectrum.PowerSpectrum
+    force_calibration.power_spectrum_calibration.CalibrationResults
 
 
 FD Fitting

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,6 +18,18 @@ If you are just looking to get started, read the :doc:`/tutorial/index` first.
     correlated_stack.CorrelatedStack
 
 
+Force calibration
+-----------------
+
+.. autosummary::
+    :toctree: _api
+
+
+    calculate_power_spectrum
+    fit_power_spectrum
+    PassiveCalibrationModel
+
+
 FD Fitting
 ----------
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,3 +1,47 @@
+@article{berg2004power,
+  title={Power spectrum analysis for optical tweezers},
+  author={Berg-Sørensen, Kirstine and Flyvbjerg, Henrik},
+  journal={Review of Scientific Instruments},
+  volume={75},
+  number={3},
+  pages={594--612},
+  year={2004},
+  publisher={American Institute of Physics}
+}
+
+@article{tolic2004matlab,
+  title={MatLab program for precision calibration of optical tweezers},
+  author={Tolić-Nørrelykke, Iva Marija and Berg-Sørensen, Kirstine and Flyvbjerg, Henrik},
+  journal={Computer physics communications},
+  volume={159},
+  number={3},
+  pages={225--240},
+  year={2004},
+  publisher={Elsevier}
+}
+
+@article{hansen2006tweezercalib,
+  title={tweezercalib 2.0: Faster version of MatLab package for precise calibration of optical tweezers},
+  author={Hansen, Poul Martin and Tolić-Nørrelykke, Iva Marija and Flyvbjerg, Henrik and Berg-Sørensen, Kirstine},
+  journal={Computer physics communications},
+  volume={174},
+  number={6},
+  pages={518--520},
+  year={2006},
+  publisher={Elsevier}
+}
+
+@article{berg2006power,
+  title={Power spectrum analysis for optical tweezers. II: Laser wavelength dependence of parasitic filtering, and how to achieve high bandwidth},
+  author={Berg-Sørensen, Kirstine and Peterman, Erwin JG and Weber, Tom and Schmidt, Christoph F and Flyvbjerg, Henrik},
+  journal={Review of scientific instruments},
+  volume={77},
+  number={6},
+  pages={063106},
+  year={2006},
+  publisher={American Institute of Physics}
+}
+
 @article{broekmans2016dna,
   title={DNA twist stability changes with magnesium (2+) concentration},
   author={Broekmans, Onno D and King, Graeme A and Stephens, Greg J and Wuite, Gijs JL},

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -1,0 +1,95 @@
+Force calibration
+=================
+
+.. only:: html
+
+    :nbexport:`Download this page as a Jupyter notebook <self>`
+
+Force calibration is used to convert the raw voltages that Bluelake records to actual forces.
+In this tutorial, we will be redoing a calibration that we already performed in Bluelake, to provide an example of using the force calibration module::
+
+    f = lk.File("calibration.h5")
+
+In this tutorial, we want to reproduce calibration item 1.
+We grab the chunk of data that was used for the calibration last time::
+
+    start = f.force1x.calibration[1]["Start time (ns)"]
+    stop = f.force1x.calibration[1]["Stop time (ns)"]
+    force_slice = f.force1x[start:stop]
+
+To be able to calibrate our forces, we first convert back our data to raw voltages.
+We can do this using the previous calibration performed in Bluelake (in this case, the first one in the file)::
+
+    volts = force_slice.data / f.force1x.calibration[0]["Rf (pN/V)"]
+
+Force calibration models are fit to power spectra. To compute a power spectrum from our data::
+
+    power_spectrum = lk.calculate_power_spectrum(volts, sample_rate=force_slice.sample_rate)
+
+This function returns a power_spectrum which we can plot::
+
+    power_spectrum.plot()
+
+.. image:: force_calibration_blocked_spectrum.png
+
+Note that the computation of the power spectrum involves some downsampling.
+If you wish to change the amount of downsampling applied or which range to compute the spectrum for, you can specify these as additional arguments::
+
+    lk.calculate_power_spectrum(volts, sample_rate=force_slice.sample_rate, fit_range=(1e2, 23e3), num_points_per_block=350)
+
+To fit the passive calibration data, we will use a model based on a number of publications by the Flyvbjerg group :cite:`berg2004power,tolic2004matlab,hansen2006tweezercalib,berg2006power`.
+This model can be found in `PassiveCalibrationModel`. It is calibrated by fitting the following equation to the power spectrum:
+
+.. math::
+
+    P(f) = \frac{D}{2 \pi ^ 2 \left(f^2 + f_c ^ 2\right)} g(f, f_{diode}, \alpha)
+
+where :math:`D` corresponds to the diffusion constant, :math:`f` the frequency and :math:`f_c` the fitted cutoff. The second term :math:`g` takes into account the slower response of the position detection system and is given by:
+
+.. math::
+
+    g(f, f_{diode}, \alpha) = \alpha^2 + \frac{1 - \alpha ^ 2}{1 + (f / f_{diode})^2}
+
+Here :math:`\alpha` corresponds to the fraction of the signal response that is instantaneous, while :math:`f_{diode}` characterizes the frequency response of the diode.
+
+To convert the parameters obtained from this spectral fit to a trap stiffness, the following is computed:
+
+.. math::
+
+    \kappa = 2 \pi \gamma f_c
+
+Here :math:`\kappa` then represents the final trap stiffness. The parameter :math:`\gamma` corresponds to the friction coefficient of a sphere, which is given by:
+
+.. math::
+
+    \gamma = 3 \pi \eta d
+
+where :math:`\eta` corresponds to the dynamic viscosity and :math:`d` represents the bead diameter.
+
+We use the bead diameter found in the calibration performed in Bluelake.
+You can optionally also provide a viscosity (in Pa/s) and temperature (in degrees Celsius)::
+
+    bead_diameter = f.force1x.calibration[1]["Bead diameter (um)"]
+    force_model = lk.PassiveCalibrationModel(bead_diameter, viscosity=0.001002, temperature=20)
+
+To fit this model to the data, you can now invoke::
+
+    calibration = lk.fit_power_spectrum(power_spectrum, force_model)
+    calibration
+
+This will produce a table with your fitted calibration parameters.
+
+.. image:: force_calibration_table.png
+
+These parameters can be accessed analogously to the calibrations in Bluelake files::
+
+    >>> print(calibration["kappa (pN/nm)"])
+    >>> print(f.force1x.calibration[1]["kappa (pN/nm)"])
+    0.17432391259341345
+    0.17431947810792106
+
+We can plot the calibration by calling::
+
+    calibration.plot()
+
+.. image:: force_calibration_fit.png

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -37,7 +37,7 @@ This function returns a power_spectrum which we can plot::
 Note that the computation of the power spectrum involves some downsampling.
 If you wish to change the amount of downsampling applied or which range to compute the spectrum for, you can specify these as additional arguments::
 
-    lk.calculate_power_spectrum(volts, sample_rate=force_slice.sample_rate, fit_range=(1e2, 23e3), num_points_per_block=350)
+    lk.calculate_power_spectrum(volts, sample_rate=force_slice.sample_rate, fit_range=(1e2, 23e3), num_points_per_block=2000)
 
 To fit the passive calibration data, we will use a model based on a number of publications by the Flyvbjerg group :cite:`berg2004power,tolic2004matlab,hansen2006tweezercalib,berg2006power`.
 This model can be found in :class:`~.PassiveCalibrationModel`. It is calibrated by fitting the following equation to the power spectrum:

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -20,7 +20,9 @@ We grab the chunk of data that was used for the calibration last time::
 To be able to calibrate our forces, we first convert back our data to raw voltages.
 We can do this using the previous calibration performed in Bluelake (in this case, the first one in the file)::
 
-    volts = force_slice.data / f.force1x.calibration[0]["Rf (pN/V)"]
+    offset = f.force1x.calibration[0]["Offset (pN)"]
+    response = f.force1x.calibration[0]["Rf (pN/V)"]
+    volts = (force_slice.data - offset) / response
 
 Force calibration models are fit to power spectra. To compute a power spectrum from our data::
 
@@ -38,7 +40,7 @@ If you wish to change the amount of downsampling applied or which range to compu
     lk.calculate_power_spectrum(volts, sample_rate=force_slice.sample_rate, fit_range=(1e2, 23e3), num_points_per_block=350)
 
 To fit the passive calibration data, we will use a model based on a number of publications by the Flyvbjerg group :cite:`berg2004power,tolic2004matlab,hansen2006tweezercalib,berg2006power`.
-This model can be found in `PassiveCalibrationModel`. It is calibrated by fitting the following equation to the power spectrum:
+This model can be found in :class:`~.PassiveCalibrationModel`. It is calibrated by fitting the following equation to the power spectrum:
 
 .. math::
 

--- a/docs/tutorial/force_calibration_blocked_spectrum.png
+++ b/docs/tutorial/force_calibration_blocked_spectrum.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e860ebd27bcae50720abba94927a52297339029d164f379f75a2a311a2364341
+size 13349

--- a/docs/tutorial/force_calibration_fit.png
+++ b/docs/tutorial/force_calibration_fit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ce6c3712ff7efd41e3cd7488c6f662c762383fcaf577c69455d840d618c267e
+size 14449

--- a/docs/tutorial/force_calibration_table.png
+++ b/docs/tutorial/force_calibration_table.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27645d1656caba52f27ba83afea8a53f03272d4024ae0e7310aeb460b2de39ad
+size 44156

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -30,3 +30,4 @@ These import conventions are used consistently in the tutorial.
     fdfitting
     nbwidgets
     kymotracking
+    force_calibration

--- a/docs/zrefs.rst
+++ b/docs/zrefs.rst
@@ -1,6 +1,11 @@
 This page lists references used for implementing specific functionality into Pylake. Please see below for more
 information on these topics.
 
+Force Calibration
+-----------------
+
+The passive force calibration method was based on a number of publications by the Flyvbjerg group :cite:`berg2004power,tolic2004matlab,hansen2006tweezercalib,berg2006power`.
+
 F,d Fitting
 -----------
 

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -23,6 +23,7 @@ from .force_calibration.calibration_models import PassiveCalibrationModel
 from .force_calibration.power_spectrum_calibration import (
     calculate_power_spectrum,
     fit_power_spectrum,
+    CalibrationSettings,
 )
 
 

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -19,6 +19,11 @@ from .nb_widgets.range_selector import FdRangeSelector, FdDistanceRangeSelector
 from .kymotracker.kymotracker import *
 from .nb_widgets.kymotracker_widgets import KymoWidgetGreedy
 from .fdensemble import FdEnsemble
+from .force_calibration.calibration_models import PassiveCalibrationModel
+from .force_calibration.power_spectrum_calibration import (
+    calculate_power_spectrum,
+    fit_power_spectrum,
+)
 
 
 def pytest(args=None, plugins=None):

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -49,6 +49,7 @@ class PassiveCalibrationModel(CalibrationModel):
     temperature : float, optional
         Liquid temperature [Celsius].
     """
+
     def __name__(self):
         return "PassiveCalibrationModel"
 

--- a/lumicks/pylake/force_calibration/detail/power_models.py
+++ b/lumicks/pylake/force_calibration/detail/power_models.py
@@ -2,7 +2,7 @@ import math
 import numpy as np
 from collections import namedtuple
 from itertools import product
-from .power_spectrum import PowerSpectrum
+from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
 
 
 def fit_analytical_lorentzian(ps):
@@ -33,7 +33,7 @@ def fit_analytical_lorentzian(ps):
     # Calculate S[p,q] elements (Ref. 1, Eq. 13-14).
     Spq = np.zeros((3, 3))
     for p, q in product(range(3), range(3)):
-        Spq[p, q] = np.sum(np.power(ps.f, 2 * p) * np.power(ps.P, q))
+        Spq[p, q] = np.sum(np.power(ps.frequency, 2 * p) * np.power(ps.power, q))
 
     # Calculate a and b parameters (Ref. 1, Eq. 13-14).
     a = (Spq[0, 1] * Spq[2, 2] - Spq[1, 1] * Spq[1, 2]) / (Spq[0, 2] * Spq[2, 2] - Spq[1, 2] * Spq[1, 2])
@@ -44,11 +44,11 @@ def fit_analytical_lorentzian(ps):
     D = (1 / b) * 2 * (math.pi ** 2)  # diffusion constant [V^2/s]
 
     # Fitted power spectrum values.
-    ps_fit = ps.with_spectrum(1 / (a + b * np.power(ps.f, 2)))
+    ps_fit = ps.with_spectrum(1 / (a + b * np.power(ps.frequency, 2)))
 
     # Error propagation (Ref. 1, Eq. 25-28).
-    x_min = ps.f.min() / fc
-    x_max = ps.f.max() / fc
+    x_min = ps.frequency.min() / fc
+    x_max = ps.frequency.max() / fc
 
     u = (
         (2 * x_max) / (1 + x_max ** 2)

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -139,7 +139,7 @@ def guess_f_diode_initial_value(ps, guess_fc, guess_D):
 
 
 def calculate_power_spectrum(
-    data, sample_rate, fit_range=(1e2, 23e3), num_points_per_block=350, compatibility_mode=False
+    data, sample_rate, fit_range=(1e2, 23e3), num_points_per_block=2000, compatibility_mode=False
 ):
     """Compute power spectrum and returns it as a :class:`~.PowerSpectrum`.
 
@@ -154,7 +154,7 @@ def calculate_power_spectrum(
         full model fit. Default: (1e2, 23e3) [Hz]
     num_points_per_block : int, optional
         The spectrum is first block averaged by this number of points per block.
-        Default: 350.
+        Default: 2000.
     compatibility_mode : bool
         The force calibration routine used in Bluelake 1.6.x and older had a bug which resulted in
         a different downsampling factor being used than specified, but then using the wrong

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -1,6 +1,6 @@
 import pytest
 from lumicks.pylake.force_calibration.detail.power_models import *
-from lumicks.pylake.force_calibration.detail.power_spectrum import PowerSpectrum
+from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
 
 
 def test_friction_coefficient():
@@ -72,5 +72,5 @@ def test_fit_analytic_curve():
     ps = PowerSpectrum([3, 3, 4, 5, 1, 3, 2, 4, 5, 2], 100)
     ref = [0.0396382, 0.0389208, 0.03691641, 0.03399826, 0.03061068, 0.02713453]
     fit = fit_analytical_lorentzian(ps)
-    assert np.allclose(fit.ps_fit.f, np.arange(0, 60, 10))
-    assert np.allclose(fit.ps_fit.P, ref)
+    assert np.allclose(fit.ps_fit.frequency, np.arange(0, 60, 10))
+    assert np.allclose(fit.ps_fit.power, ref)

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -62,8 +62,8 @@ def test_compatibility_mode():
 
     # Despite actually having been downsampled with different ratios, they seemingly have the same
     # down-sampling ratio.
-    assert np.allclose(spectrum.P, [0.17201502, 0.00841408, 0.00392077])
-    assert np.allclose(spectrum_compat.P, [0.15219624, 0.00682399, 0.00347977])
+    assert np.allclose(spectrum.power, [0.17201502, 0.00841408, 0.00392077])
+    assert np.allclose(spectrum_compat.power, [0.15219624, 0.00682399, 0.00347977])
     assert np.allclose(spectrum.num_points_per_block, spectrum_compat.num_points_per_block)
 
 
@@ -134,7 +134,7 @@ def test_bad_data():
     model = PassiveCalibrationModel(1, temperature=20, viscosity=0.0001)
     power_spectrum = psc.PowerSpectrum(data, num_samples)
 
-    with pytest.raises(psc.CalibrationError):
+    with pytest.raises(RuntimeError):
         psc.fit_power_spectrum(power_spectrum, model=model)
 
 


### PR DESCRIPTION
**Why this PR?**
To illustrate how to use the Force Calibration functions.

**Open issues**
- How should we deal with the fact that the calibration is slightly different now? Should we document it? Should I redo the reference calibration in the docs such that the two agree (assuming BL will be updated)?

The reason for the difference is that the original Force Calibration used `num_points_per_block` from the `CalibrationSettings` class even though the actual downsampling provided him with a different actual downsampling. The refactored version fixes this bug leading to differences in the calibration. For the important parameters the differences are very small (fourth digit), but for the `chi_squared_per_deg` the difference can be more than 10%.

See also: https://github.com/lumicks/pylake/pull/120 to see how the erroneous behaviour can be reproduced.

- The default for `num_points` was 350 in the original Force Calibration settings struct, however I see in most bluelake calibrations a `num_points` of 2000 (the function default in the original Force Calibration). Which one should be used as default?

Docs build here: https://lumicks-pylake.readthedocs.io/en/ldat_docs/