### PR TITLE
force_calibration: Add compatibility mode

### DIFF
--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -51,6 +51,22 @@ def test_calibration_result():
         psc.CalibrationResults(invalid=5)
 
 
+def test_compatibility_mode():
+    d = np.arange(0.0, 50.0, 1.0)
+    spectrum = psc.calculate_power_spectrum(
+        d, 4000, fit_range=(0, np.inf), num_points_per_block=7, compatibility_mode=False
+    )
+    spectrum_compat = psc.calculate_power_spectrum(
+        d, 4000, fit_range=(0, np.inf), num_points_per_block=7, compatibility_mode=True
+    )
+
+    # Despite actually having been downsampled with different ratios, they seemingly have the same
+    # down-sampling ratio.
+    assert np.allclose(spectrum.P, [0.17201502, 0.00841408, 0.00392077])
+    assert np.allclose(spectrum_compat.P, [0.15219624, 0.00682399, 0.00347977])
+    assert np.allclose(spectrum.num_points_per_block, spectrum_compat.num_points_per_block)
+
+
 @pytest.mark.parametrize(
     "corner_frequency,diffusion_constant,alpha,f_diode,num_samples,viscosity,bead_diameter,temperature,err_fc,err_d,"
     "err_f_diode,err_alpha,",


### PR DESCRIPTION
**Why this PR?**
The old Force Calibration had a bug in the data weighting that lead to subtle differences. This mode reproduces the old (incorrect) behaviour in case someone wants to compare their results.

The reason for the difference is that the original Force Calibration used `num_points_per_block` from the `CalibrationSettings` class even though the actual downsampling provided him with a different actual downsampling. The refactored version fixes this bug leading to differences in the calibration. For the important parameters the differences are very small (fourth digit), but for the chi_squared_per_deg the difference can be more than 10%.


```
Bead diameter (um)  | BL:                            4.4 New:                            4.4	Compatibility (wrong):                            4.4
D (V^2/s)           | BL:          0.0018185011277037587 New:          0.0018204810302284427	Compatibility (wrong):          0.0018185011277037587
Fit tolerance       | BL:                          1e-07 New:                          1e-07	Compatibility (wrong):                          1e-07
Max iterations      | BL:                        10000.0 New:                          10000	Compatibility (wrong):                          10000
Points per block    | BL:                         2000.0 New:                           2000	Compatibility (wrong):                           2000
Rd (um/V)           | BL:              7.318701602991308 New:              7.314720716210157	Compatibility (wrong):              7.318701602991308
Rf (pN/V)           | BL:               1275.79224386105 New:              1276.426226913255	Compatibility (wrong):               1275.79224386105
Sample rate (Hz)    | BL:                        78125.0 New:                          78125	Compatibility (wrong):                          78125
Temperature (C)     | BL:                           20.0 New:                             20	Compatibility (wrong):                             20
Viscosity (Pa*s)    | BL:                       0.001002 New:                       0.001002	Compatibility (wrong):                       0.001002
alpha               | BL:             0.5207129123532122 New:             0.5209656253809163	Compatibility (wrong):             0.5207129123532122
backing (%)         | BL:              99.99999970439725 New:              99.99719492386868	Compatibility (wrong):              99.99999970439725
chi_squared_per_deg | BL:             1.8874095716385406 New:             1.5962673874158098	Compatibility (wrong):             1.8874095716385406
err_D               | BL:          1.481160885810113e-05 New:         1.4841756956587979e-05	Compatibility (wrong):         1.4811608858101084e-05
err_alpha           | BL:           0.002724460718956656 New:          0.0027288899064591976	Compatibility (wrong):           0.002724460718956656
err_f_diode         | BL:             124.43453375745366 New:             124.30850926826882	Compatibility (wrong):             124.43453375745321
err_fc              | BL:               7.39008100935111 New:              7.389270245078325	Compatibility (wrong):              7.390081009351098
f_diode (Hz)        | BL:              7558.898142552784 New:             7538.8871916782755	Compatibility (wrong):              7558.898142552784
fc (Hz)             | BL:              667.6894640192777 New:              668.3848177104585	Compatibility (wrong):              667.6894640192777
kappa (pN/nm)       | BL:            0.17431947810792106 New:            0.17450102012569887	Compatibility (wrong):            0.17431947810792106
```