### PR TITLE
kymotracker: fix bug in peakfinding routine

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.8.2 | t.b.d.
+
+* Fixed bug in kymotracker which could result in a line being extended one pixel too far in either direction. Reason for the bug was that a blurring step in the peak-finding routine was being applied on both axes, while it should have only been applied to one axis. Note that while this bug affects peak detection (finding one too many), it should not affect peak localization as that is performed in a separate step.
+
 ## v0.8.1 | 2021-02-17
 
 #### New features

--- a/lumicks/pylake/kymotracker/detail/peakfinding.py
+++ b/lumicks/pylake/kymotracker/detail/peakfinding.py
@@ -22,7 +22,7 @@ def peak_estimate(data, half_width, thresh):
         Threshold for accepting something as a peak.
     """
     dilation_factor = int(math.ceil(half_width)) * 2 + 1
-    data = gaussian_filter(data, [0.5, 0.5])
+    data = gaussian_filter(data, [0.5, 0])
     dilated = grey_dilation(data, (dilation_factor, 0))
     dilated[dilated < thresh] = -1
     coordinates, time_points = np.where(data == dilated)

--- a/lumicks/pylake/kymotracker/tests/test_peakfinding.py
+++ b/lumicks/pylake/kymotracker/tests/test_peakfinding.py
@@ -18,6 +18,18 @@ def test_peak_estimation(location):
     assert np.abs(peaks.frames[0].coordinates[0] - location) < 1e-3
 
 
+def test_regression_peak_estimation():
+    # This test tests a regression where a peak could be found adjacent to a very bright structure.
+    # The error originated from the blurring used to get rid of pixelation noise being applied
+    # in two directions rather than only one.
+    data = np.array([[0, 0, 0, 0, 0],
+                     [255, 255, 255, 0, 0],
+                     [0, 0, 0, 0, 0]])
+
+    position, time = peak_estimate(data, 1, thresh=10)
+    assert len(position) == 3
+
+
 def test_kymopeaks():
     # First time frame we choose the right one first, then the second one. Second time frame vice versa.
     coordinates = np.array([3.2, 4.1, 6.4, 8.2])


### PR DESCRIPTION
**Why this PR?**
It fixes a bug in the Kymotracker that could occur when a bright structure suddenly ends.

The reason for this bug was that a filter that was being applied to reduce pixelation noise was being applied in two directions rather than just along the scan axis. This meant that the pixel could bleed through to the next column of pixels.

![image](https://user-images.githubusercontent.com/19836026/109709828-35586700-7b9d-11eb-9c6a-861d263af7d3.png)

Note that while this bug affects peak _detection_, it should not affect peak localization, since this step is followed by a centroid estimation step.

![image](https://user-images.githubusercontent.com/19836026/109710743-54a3c400-7b9e-11eb-87be-aead2b3f3439.png)