### PR TITLE
kymotracker: estimate diffusion constant from MSD (1 of N)

### DIFF
--- a/lumicks/pylake/kymotracker/detail/msd_estimation.py
+++ b/lumicks/pylake/kymotracker/detail/msd_estimation.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 
 
 def calculate_msd(frame_idx, position, max_lag):
@@ -34,3 +35,147 @@ def calculate_msd(frame_idx, position, max_lag):
     msd = [np.mean(summand[frame_diff == delta_frame]) for delta_frame in frame_lags]
 
     return frame_lags, msd
+
+
+def estimate_diffusion_constant_simple(frame_idx, coordinate, time_step, max_lag):
+    """Perform an unweighted fit to the MSD estimates to obtain a diffusion constant.
+
+    The estimator for the MSD (rho) is defined as:
+
+      rho_n = (1 / (N-n)) sum_{i=1}^{N-n}(r_{i+n} - r_{i})^2
+
+    In a diffusion problem, the MSD can be fitted to a linear curve.
+
+        intercept = 2 * d * (sigma**2 - 2 * R * D * delta_t)
+        slope = 2 * d * D * delta_t
+
+    Here d is the dimensionality of the problem (in this case, d is set to 1). D is the diffusion
+    constant. R is a motion blur constant. delta_t is the time step and sigma represents the dynamic
+    localization error (which is not necessarily the same as the static localization error).
+
+    One aspect that is import to consider is that this estimator uses every data point multiple
+    times. As a consequence the elements of rho_n are highly correlated. This means that including
+    more points doesn't necessarily make the estimates better and can actually make the estimate
+    worse. It is therefore a good idea to estimate an appropriate number of MSD estimates to use.
+    See [1] for more information on this.
+
+    Note that this estimation procedure should only be used for Brownian motion in isotropic
+    media (meaning no cellular or structured environments) in the absence of drift.
+
+    1) Michalet, X., & Berglund, A. J. (2012). Optimal diffusion coefficient estimation in
+    single-particle tracking. Physical Review E, 85(6), 061916.
+
+    Parameters
+    ----------
+    frame_idx : array_like
+        Frame indices of the observations.
+    coordinate : array_like
+        Positional coordinates.
+    time_step : float
+        Time step between each frame.
+    max_lag : int
+        Maximum delay to include in the estimate (must be larger than 1).
+    """
+    if not np.issubdtype(frame_idx.dtype, np.integer):
+        raise TypeError("Frame indices need to be integer")
+
+    if max_lag < 2:
+        raise ValueError("You need at least two lags to estimate a diffusion constant")
+
+    frame_lags, msd = calculate_msd(frame_idx, coordinate, max_lag)
+    coefficients = np.polyfit(frame_lags, msd, 1)
+    return coefficients[0] / (2.0 * time_step)
+
+
+def calculate_localization_error(frame_lags, msd):
+    """Determines the localization error, a metric used in the computation of the optimal number
+    of points to include in the ordinary least squares estimate. The localization error is defined
+    as:
+
+        localization_error = intercept / slope = sigma**2 / (D * delta_t) - 2 * R
+
+    Parameters
+    ----------
+    frame_lags : array_like
+        frame lags to include.
+    msd : array_like
+        (Correlated) Mean Squared Distance estimates as obtained by `calculate_msd`.
+    """
+    assert len(frame_lags) == len(msd), "Need to supply an MSD estimate per lag time"
+    coefficients = np.polyfit(frame_lags, msd, 1)
+    slope, intercept = coefficients[0], coefficients[1]
+
+    if intercept < 0:
+        return 0
+    elif slope < 0:
+        return np.inf
+    else:
+        return intercept / slope
+
+
+def optimal_points(localization_error, num_points):
+    """Empirical relationship described in Michalet et al for determining optimal number of points
+    to estimate slope or intercept. These equations minimize the relative error. See [1] for more
+    information.
+
+    1) Michalet, X., & Berglund, A. J. (2012). Optimal diffusion coefficient estimation in
+    single-particle tracking. Physical Review E, 85(6), 061916.
+    """
+    fa = 2.0 + 1.6 * localization_error ** 0.51
+    limit_a = 3 + (4.5 * num_points ** 0.4 - 8.5) ** 1.2
+
+    fb = 2 + 1.35 * localization_error ** 0.6
+    limit_b = 0.8 + 0.564 * num_points
+
+    if np.isinf(localization_error):
+        num_points_intercept, num_points_slope = np.floor(limit_a), np.floor(limit_b)
+    else:
+        num_points_intercept = np.floor(fa * limit_a / (fa ** 3 + limit_a ** 3) ** (1.0 / 3.0))
+        num_points_slope = min(
+            np.floor(limit_b), np.floor(fb * limit_b / (fb ** 3 + limit_b ** 3) ** (1.0 / 3.0))
+        )
+
+    return max(2, int(num_points_slope)), max(2, int(num_points_intercept))
+
+
+def determine_optimal_points(frame_idx, coordinate, max_iterations=100):
+    """Calculate optimal number of points to include in the diffusion estimate according to [1].
+
+    Including more lags than necessary in an ordinary least squares estimate leads to excessive
+    variance in the estimator due to the samples going into the MSD being highly correlated. The
+    equations in [1] provide a heuristic for determining the optimal number of points for different
+    diffusion constants based on theoretical considerations. For more information, please refer
+    to the paper.
+
+    1) Michalet, X., & Berglund, A. J. (2012). Optimal diffusion coefficient estimation in
+    single-particle tracking. Physical Review E, 85(6), 061916.
+    """
+    if not np.issubdtype(frame_idx.dtype, np.integer):
+        raise TypeError("Frame indices need to be integer")
+
+    num_slope = max(2, len(coordinate) // 10)  # Need at least two points for a linear regression!
+    num_intercept = max(2, len(coordinate) // 10)
+    number_computed = 0
+
+    num_slopes = set()
+    for _ in np.arange(max_iterations):
+        # Only evaluate what we need
+        required_points = max(num_intercept, num_slope)
+        if required_points > number_computed:
+            frame_lags, msd = calculate_msd(frame_idx, coordinate, required_points)
+            number_computed = required_points
+
+        num_slopes.add(num_slope)
+
+        # Determine the number of points to include in the next fit
+        num_slope, num_intercept = optimal_points(
+            calculate_localization_error(frame_lags[:num_slope], msd[:num_slope]), len(coordinate)
+        )
+
+        if num_slope in num_slopes:
+            return num_slope, num_intercept
+
+    warnings.warn(
+        RuntimeWarning("Warning, maximum number of iterations exceeded. Returning best solution.")
+    )
+    return num_slope, num_intercept

--- a/lumicks/pylake/kymotracker/detail/msd_estimation.py
+++ b/lumicks/pylake/kymotracker/detail/msd_estimation.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+
+def calculate_msd(frame_idx, position, max_lag):
+    """Estimate the Mean Square Displacement (MSD) for various time lags.
+
+    The estimator for the MSD (rho) is defined as:
+
+      rho_n = (1 / (N-n)) sum_{i=1}^{N-n}(r_{i+n} - r_{i})^2
+
+    here N refers to the total frames, n to the lag time and r_i the spatial position at lag i.
+    This function produces a list of lag times and mean squared displacements for those lag times.
+
+    Parameters
+    ----------
+    frame_idx : array_like
+        List of frame indices (note that these have to be of integral type to prevent rounding
+        errors).
+    position : array_like
+        List of positions.
+    max_lag : float
+        Maximum lag to include (note that MSD estimates generally do not get better by including
+        several lag steps).
+    """
+    frame_mesh_1, frame_mesh_2 = np.meshgrid(frame_idx, frame_idx)
+    frame_diff = frame_mesh_1 - frame_mesh_2
+    frame_lags = np.unique(frame_diff)
+
+    position_mesh_1, position_mesh_2 = np.meshgrid(position, position)
+    summand = (position_mesh_1 - position_mesh_2) ** 2
+
+    # Look up only the rho elements we need
+    frame_lags = frame_lags[frame_lags > 0][:max_lag]
+    msd = [np.mean(summand[frame_diff == delta_frame]) for delta_frame in frame_lags]
+
+    return frame_lags, msd

--- a/lumicks/pylake/kymotracker/tests/test_msd.py
+++ b/lumicks/pylake/kymotracker/tests/test_msd.py
@@ -1,5 +1,38 @@
 from lumicks.pylake.kymotracker.detail.msd_estimation import *
+import contextlib
 import pytest
+
+
+@contextlib.contextmanager
+def temp_seed(seed):
+    np.random.seed(seed)
+    try:
+        yield
+    finally:
+        np.random.seed(None)
+
+
+def simulate_diffusion_1d(diffusion, steps, dt, observation_noise):
+    """Simulate from a Wiener process
+
+    Parameters
+    ----------
+    diffusion : float
+        Diffusion constant.
+    steps : int
+        Number of steps to simulate.
+    dt : float
+        Time step.
+    observation_noise : float
+        Standard deviation of the observation noise.
+    """
+
+    def simulate_wiener(sigma, num_steps, time_step):
+        return np.cumsum(np.random.normal(0, sigma * np.sqrt(time_step), size=(num_steps,)))
+
+    return simulate_wiener(np.sqrt(2.0 * diffusion), steps, dt) + np.random.normal(
+        0, observation_noise, (steps,)
+    )
 
 
 @pytest.mark.parametrize(
@@ -18,3 +51,99 @@ def test_msd_estimation(time, position, max_lag, lag, msd):
     lag_est, msd_est = calculate_msd(time, position, max_lag)
     assert np.allclose(lag_est, lag)
     assert np.allclose(msd_est, msd)
+
+
+@pytest.mark.parametrize(
+    "frame_idx, coordinate, time_step, max_lag, diffusion_const",
+    [
+        (np.array([1, 2, 3, 4, 5]), np.array([-1.0, 1.0, -1.0, -3.0, -5.0]), 0.5, 50, 4.53333333),
+        (np.array([1, 2, 3, 4, 5]), np.array([-1.0, 1.0, -1.0, -3.0, -5.0]), 1.0, 50, 2.26666667),
+        (np.array([1, 2, 3, 4, 5]), np.array([-1.0, 1.0, -1.0, -3.0, -5.0]), 1.0, 2, 3.33333333),
+    ],
+)
+def test_estimate(frame_idx, coordinate, time_step, max_lag, diffusion_const):
+    diffusion_est = estimate_diffusion_constant_simple(frame_idx, coordinate, time_step, max_lag)
+    assert np.allclose(diffusion_est, diffusion_const)
+
+
+def test_maxlag_asserts():
+    # Max_lag has to be bigger than 2
+    with pytest.raises(ValueError):
+        estimate_diffusion_constant_simple(np.array([1]), None, None, 1)
+
+    with pytest.raises(ValueError):
+        estimate_diffusion_constant_simple(np.array([1]), None, None, -1)
+
+
+@pytest.mark.parametrize(
+    "intercept, slope, result",
+    [(1, 1, 1), (2, 1, 2), (1, 2, 0.5), (-1, 1, 0), (-1, -1, 0), (1, -1, np.inf)],
+)
+def test_localization_error_calculation(intercept, slope, result):
+    calculate_localization_error(np.arange(10), intercept + slope * np.arange(10))
+
+
+def test_localization_eq():
+    with pytest.raises(AssertionError):
+        calculate_localization_error(np.array([1, 2, 3]), np.array([1, 2]))
+
+
+@pytest.mark.parametrize(
+    "N, ref_slopes, ref_intercepts",
+    [
+        (
+            10,
+            np.array([2, 2, 2, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6]),
+            np.array([2, 2, 2, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6]),
+        ),
+        (
+            100,
+            np.array([2, 2, 2, 2, 3, 4, 7, 12, 22, 39, 52, 56, 57, 57, 57, 57, 57, 57, 57]),
+            np.array([2, 2, 2, 2, 3, 4, 7, 11, 18, 27, 35, 38, 39, 39, 39, 39, 39, 39, 39]),
+        ),
+        (
+            1000,
+            np.array([2, 2, 2, 2, 3, 4, 7, 12, 23, 44, 87, 170, 319, 485, 551, 563, 564, 564, 564]),
+            np.array([2, 2, 2, 2, 3, 4, 7, 11, 18, 32, 55, 90, 126, 142, 145, 146, 146, 146, 146]),
+        ),
+    ],
+)
+def test_optimal_points(N, ref_slopes, ref_intercepts):
+    test_values = np.hstack((np.arange(-2, 7, 0.5), np.inf))
+    assert np.allclose(ref_slopes, [optimal_points(10 ** x, N)[0] for x in test_values])
+    assert np.allclose(ref_intercepts, [optimal_points(10 ** x, N)[1] for x in test_values])
+
+
+@pytest.mark.parametrize(
+    "diffusion, num_steps, step, noise, n_optimal",
+    [
+        (0.1, 30, 1, 0, 2),
+        (0.1, 30, 1, 0.1, 2),
+        (0.1, 30, 1, 0.5, 3),
+        (0.1, 30, 1, 1.0, 4),
+        (0.1, 50, 1, 1.0, 7),
+        (1, 50, 1, 1.0, 3),
+    ],
+)
+def test_determine_points_from_data(diffusion, num_steps, step, noise, n_optimal):
+    with temp_seed(0):
+        coordinate = simulate_diffusion_1d(diffusion, num_steps, step, noise)
+        assert np.allclose(
+            determine_optimal_points(np.arange(num_steps), coordinate, max_iterations=100),
+            n_optimal,
+        )
+
+
+def test_integer_frame_indices():
+    # It is important that these diffusion methods take integers as frame indices, because otherwise
+    # round-off errors can occur. This test checks whether this criterion is actively checked.
+    with pytest.raises(TypeError):
+        estimate_diffusion_constant_simple(np.array([1.5]), None, None, -1)
+
+    with pytest.raises(TypeError):
+        determine_optimal_points(np.arange(0.0, 5.0, 1.0), np.arange(0.0, 5.0, 1.0))
+
+
+def test_max_iterations():
+    with pytest.warns(RuntimeWarning):
+        determine_optimal_points(np.arange(0, 5, 1), np.arange(0.0, 5.0, 1.0), max_iterations=0)

--- a/lumicks/pylake/kymotracker/tests/test_msd.py
+++ b/lumicks/pylake/kymotracker/tests/test_msd.py
@@ -1,0 +1,20 @@
+from lumicks.pylake.kymotracker.detail.msd_estimation import *
+import pytest
+
+
+@pytest.mark.parametrize(
+    "time,position,max_lag,lag,msd",
+    [
+        (np.arange(25), np.arange(25) * 2, 3, [1, 2, 3], [4.0, 16.0, 36.0]),
+        (np.arange(25), np.arange(25) * 2, 1000, np.arange(1, 25), (np.arange(1, 25) * 2) ** 2),
+        (np.arange(25), -np.arange(25) * 2, 3, [1, 2, 3], [4.0, 16.0, 36.0]),
+        (np.arange(25), np.arange(25) * 3, 3, [1, 2, 3], [9.0, 36.0, 81.0]),
+        (np.arange(25), np.arange(25) * 3, 2, [1, 2], [9.0, 36.0]),
+        ([1, 3, 4], [0, 6, 9], 3, [1, 2, 3], [9.0, 36.0, 81.0]),
+        ([1, 4, 6], [0, 9, 15], 3, [2, 3, 5], [36.0, 81.0, 225.0]),
+    ],
+)
+def test_msd_estimation(time, position, max_lag, lag, msd):
+    lag_est, msd_est = calculate_msd(time, position, max_lag)
+    assert np.allclose(lag_est, lag)
+    assert np.allclose(msd_est, msd)


### PR DESCRIPTION
**Why this PR?**
Users would like to estimate diffusion constants from their single particle traces. This PR adds some back-end for doing MSD estimation. It implements methods from.

**What is in this PR?**
Essentially, it computes the MSD statistic and regresses a line through it. The optimal number of points to include depends on the localization uncertainty and to determine this the heuristic from [1] was implemented.

[1]. Michalet, X., & Berglund, A. J. (2012). Optimal diffusion coefficient estimation in single-particle tracking. Physical Review E, 85(6), 061916.
[2]. Michalet, X. (2010). Mean square displacement analysis of single-particle trajectories with localization error: Brownian motion in an isotropic medium. Physical Review E, 82(4), 041914.

![image](https://user-images.githubusercontent.com/19836026/110443394-26e9de00-80bc-11eb-8add-e1118603be31.png)

**Why 1 of N?**
This PR merely has the back-end calls for one of the methods for estimating diffusion. While implementing this, it became clear that we need to incorporate the calibration structure, or this workflow is going to be very error prone for users (since otherwise they'd be getting their values in pixel units).

**Why not MLE?**
All methods for estimating the diffusion constants have pros and cons. This one seems to be widely known and easy to understand. In the future, we may add the spectral MLE (good for long traces), GLS or covariance based diffusion estimators. These estimates can be more optimal, but have longer run times, can encounter numerical issues and require more work. For simple diffusion, the second Michalet paper shows however that simple OLS is equivalent to WLS if the optimal number of points are chosen.