### PR TITLE
kymo: fix slicing bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## v0.8.2 | t.b.d.
 
 * Fixed bug in kymotracker which could result in a line being extended one pixel too far in either direction. Reason for the bug was that a blurring step in the peak-finding routine was being applied on both axes, while it should have only been applied to one axis. Note that while this bug affects peak detection (finding one too many), it should not affect peak localization as that is performed in a separate step.
+* Fixed bug in kymotracker slicing which could result in one line too many or too few being included. The bug was caused by using the timestamp corresponding to one sample beyond the last pixel of the line as "start of the next line" without accounting for the dead time that may be there.
 
 ## v0.8.1 | 2021-02-17
 

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -114,10 +114,8 @@ def line_timestamps_image(time_stamps, infowave, pixels_per_line):
     pixels_per_line : int
         The number of pixels on the fast axis of the scan.
     """
-    pixel_start_idx = np.flatnonzero(infowave == InfowaveCode.pixel_boundary)
-    pixel_start_idx = np.concatenate(([0], pixel_start_idx + 1))
-
-    return time_stamps[pixel_start_idx[0:-1:pixels_per_line]]
+    min_stamps = reconstruct_image(time_stamps, infowave, shape=(pixels_per_line,), reduce=np.min)
+    return min_stamps.astype(np.int64)[:, 0]
 
 
 def seek_timestamp_next_line(infowave):


### PR DESCRIPTION
**Why this PR?**
While fixing something else, I noticed that this behaviour is unexpected.

When slicing a kymo, the intended behaviour was to use the starting timestamps of each line as a determinant of whether that line should be included. Instead, it was using the one beyond the end.

**Why not use `self.timestamps`**?
`self.timestamps` provides means of the timestamps of samples corresponding to each pixel. This can lead to strange issues with a partial pixel being cut off when slicing that way. You really want the first sample of each line.

**How could this one slip through the tests?**
The overarching test of the slicing is not precise enough. This is part of bigger problem which we hope to address soon, but which requires a bit of refactoring.

The test on the actual function grabbing the timestamps was bad. The reference data always had one "ignored" sample which meant that for that particular test it passed. It was not representative of the type of data you'd encounter in a real case. I've made the test a bit more robust by including different `scan settings`. The old code would not pass this test.