### PR TITLE
confocal: differentiate ui scan_width from actual scan_width

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,12 +4,17 @@
 
 #### New features
 
+* Added `Scan.size_um` and `Kymo.size_um` to return the scanned size along each dimension. Use these properties to access the scan sizes along each axis for [scans](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html) and [kymographs](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html).
 * Added force calibration functionality to Pylake. Please refer to [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html) for more information.
 
 #### Bug fixes
 
 * Fixed bug in kymotracker which could result in a line being extended one pixel too far in either direction. Reason for the bug was that a blurring step in the peak-finding routine was being applied on both axes, while it should have only been applied to one axis. Note that while this bug affects peak detection (finding one too many), it should not affect peak localization as that is performed in a separate step.
 * Fixed bug in kymotracker slicing which could result in one line too many or too few being included. The bug was caused by using the timestamp corresponding to one sample beyond the last pixel of the line as "start of the next line" without accounting for the dead time that may be there.
+
+#### Breaking changes
+
+* `Scan.scan_width_um` and `Kymo.scan_width_um` have been deprecated. Use `Scan.size_um` and `Kymo.size_um` to get the scan sizes. When performing a scan, Bluelake determines an appropriate scan width based on the desired pixel size and the scan width entered in the UI. The property `scan_width_um` returned the scan size entered by the user, rather than the actual scan size achieved. To obtain the achieved scan size, use `Scan.size_um` and `Kymo.size_um`.
 
 ## v0.8.1 | 2021-02-17
 

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -46,7 +46,7 @@ For an even lower-level look at data, the raw photon count samples can be access
 There are also several properties available for convenient access to the scan metadata:
 
 * `scan.center_point_um` provides a dictionary of the central x, y, and z coordinates of the scan in micrometers relative to the brightfield field of view
-* `scan.scan_width_um` provides a list of scan widths in micrometers along the axes of the scan
+* `scan.size_um` provides a list of scan sizes in micrometers along the axes of the scan
 * `scan.pixelsize_um` provides the pixel size in micrometers
 * `scan.lines_per_frame` provides the number scanned lines in each frame (number of rows in the raw data array)
 * `scan.pixels_per_line` provides the number of pixels in each line of the scan (number of columns in the raw data array)

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -43,7 +43,7 @@ For example, one can plot the region of the kymograph between 175 and 180 second
 There are also several properties available for convenient access to the kymograph metadata:
 
 * `kymo.center_point_um` provides a dictionary of the central x, y, and z coordinates of the scan in micrometers relative to the brightfield field of view
-* `kymo.scan_width_um` provides a list of scan widths in micrometers along the axes of the scan
+* `kymo.size_um` provides a list of scan sizes in micrometers along the axes of the scan
 * `kymo.pixelsize_um` provides the pixel size in micrometers
 * `kymo.pixels_per_line` provides the number of pixels in each line of the kymograph
 * `kymo.fast_axis` provides the axis that was scanned (x or y)

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -265,12 +265,33 @@ class ConfocalImage(BaseScan):
 
     @property
     def pixelsize_um(self):
-        """Returns a `List` of axes dimensions in um. The length of the list corresponds to the number of scan axes."""
+        """Returns a `List` of axes dimensions in um. The length of the list corresponds to the
+        number of scan axes."""
         return [axes["pixel size (nm)"] / 1000 for axes in self._ordered_axes()]
 
     @property
+    def size_um(self):
+        """Returns a `List` of scan sizes in um along axes. The length of the list corresponds to
+        the number of scan axes."""
+        return [
+            axes["pixel size (nm)"] * axes["num of pixels"] / 1000 for axes in self._ordered_axes()
+        ]
+
+    @property
+    @deprecated(
+        reason=(
+            "The property `scan_width_um` has been deprecated. Use `size_um` to get the actual "
+            "size of the scan. When performing a scan, Bluelake determines an appropriate scan "
+            "width based on the desired pixel size and the desired scan width. This means that the "
+            "size of the performed scan could deviate from the width provided in this property."
+        ),
+        action="always",
+        version="0.8.2",
+    )
     def scan_width_um(self):
-        """Returns a `List` of scan widths in um along axes. The length of the list corresponds to the number of scan axes."""
+        """Returns a `List` of scan widths as configured in the Bluelake UI. The length of the list
+        corresponds to the number of scan axes. Note that these widths can deviate from the actual
+        scan widths performed in practice"""
         return [axes["scan width (um)"] for axes in self._ordered_axes()]
 
     @property

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -103,7 +103,7 @@ class Kymo(ConfocalImage):
     def _plot(self, image, **kwargs):
         import matplotlib.pyplot as plt
 
-        width_um = self.scan_width_um[0]
+        size_um = self.size_um[0]
         ts = self.timestamps
         duration = (ts[0, -1] - ts[0, 0]) / 1e9
         linetime = (ts[0, 1] - ts[0, 0]) / 1e9
@@ -111,8 +111,8 @@ class Kymo(ConfocalImage):
         default_kwargs = dict(
             # With origin set to upper (default) bounds should be given as (0, n, n, 0)
             # pixel center aligned with mean time per line
-            extent=[-0.5 * linetime, duration + 0.5 * linetime, width_um, 0],
-            aspect=(image.shape[0] / image.shape[1]) * (duration / width_um),
+            extent=[-0.5 * linetime, duration + 0.5 * linetime, size_um, 0],
+            aspect=(image.shape[0] / image.shape[1]) * (duration / size_um),
         )
 
         plt.imshow(image, **{**default_kwargs, **kwargs})

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -100,7 +100,7 @@ class Scan(ConfocalImage):
         if self.num_frames != 1:
             image = image[frame - 1]
 
-        x_um, y_um = self.scan_width_um
+        x_um, y_um = self.size_um
         default_kwargs = dict(
             # With origin set to upper (default) bounds should be given as (0, n, n, 0)
             extent=[0, x_um, y_um, 0],

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -197,7 +197,7 @@ def h5_file(tmpdir_factory, request):
                             "num of pixels": 5,
                             "pixel size (nm)": 10,
                             "scan time (ms)": 0,
-                            "scan width (um)": 5 * 0.010
+                            "scan width (um)": 5 * 0.010 + .5
                         }
                     ]
                 }
@@ -246,7 +246,7 @@ def h5_file(tmpdir_factory, request):
                                 "num of pixels": n_pixels_1,
                                 "pixel size (nm)": 191,
                                 "scan time (ms)": 0,
-                                "scan width (um)": .191 * n_pixels_1
+                                "scan width (um)": .191 * n_pixels_1 + .5
                             },
                             {
                                 "axis": axis_2,
@@ -254,7 +254,7 @@ def h5_file(tmpdir_factory, request):
                                 "num of pixels": n_pixels_2,
                                 "pixel size (nm)": 197,
                                 "scan time (ms)": 0,
-                                "scan width (um)": .197 * n_pixels_2
+                                "scan width (um)": .197 * n_pixels_2 + .5
                             }
                         ]
                     }
@@ -353,7 +353,7 @@ def h5_file_missing_meta(tmpdir_factory, request):
                                 "num of pixels": n_pixels_1,
                                 "pixel size (nm)": 191,
                                 "scan time (ms)": 0,
-                                "scan width (um)": .191 * n_pixels_1
+                                "scan width (um)": .191 * n_pixels_1 + .5
                             },
                             {
                                 "axis": axis_2,
@@ -361,7 +361,7 @@ def h5_file_missing_meta(tmpdir_factory, request):
                                 "num of pixels": n_pixels_2,
                                 "pixel size (nm)": 197,
                                 "scan time (ms)": 0,
-                                "scan width (um)": .197 * n_pixels_2
+                                "scan width (um)": .197 * n_pixels_2 + .5
                             }
                         ]
                     }

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -37,7 +37,7 @@ def test_kymo_properties(h5_file):
         assert np.allclose(kymo.center_point_um["x"], 58.075877109272604)
         assert np.allclose(kymo.center_point_um["y"], 31.978375270573267)
         assert np.allclose(kymo.center_point_um["z"], 0)
-        assert np.allclose(kymo.scan_width_um, [0.050])
+        assert np.allclose(kymo.size_um, [0.050])
 
 
 def test_kymo_slicing(h5_file):

--- a/lumicks/pylake/tests/test_scan.py
+++ b/lumicks/pylake/tests/test_scan.py
@@ -38,7 +38,9 @@ def test_scans(h5_file):
         assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
         assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
         assert np.allclose(scan.center_point_um["z"], 0)
-        assert np.allclose(scan.scan_width_um, [0.197*5, 0.191*4])
+        assert np.allclose(scan.size_um, [0.197*5, 0.191*4])
+        with pytest.warns(DeprecationWarning):
+            assert np.allclose(scan.scan_width_um, [[0.197*5 + .5, 0.191*4 + .5]])
 
         with pytest.raises(NotImplementedError):
             scan["1s":"2s"]
@@ -68,7 +70,7 @@ def test_scans(h5_file):
         assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
         assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
         assert np.allclose(scan.center_point_um["z"], 0)
-        assert np.allclose(scan.scan_width_um, [0.197*3, 0.191*4])
+        assert np.allclose(scan.size_um, [0.197*3, 0.191*4])
 
         scan = f.scans["fast X slow Z multiframe"]
         reference_timestamps2 = np.zeros((2, 4, 3))
@@ -96,7 +98,7 @@ def test_scans(h5_file):
         assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
         assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
         assert np.allclose(scan.center_point_um["z"], 0)
-        assert np.allclose(scan.scan_width_um, [0.191*4, 0.197*3])
+        assert np.allclose(scan.size_um, [0.191*4, 0.197*3])
 
         scan = f.scans["fast Y slow Z multiframe"]
         reference_timestamps2 = np.zeros((2, 4, 3))
@@ -124,7 +126,7 @@ def test_scans(h5_file):
         assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
         assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
         assert np.allclose(scan.center_point_um["z"], 0)
-        assert np.allclose(scan.scan_width_um, [0.191*4, 0.197*3])
+        assert np.allclose(scan.size_um, [0.191*4, 0.197*3])
 
 
 def test_damaged_scan(h5_file):


### PR DESCRIPTION
**Why this PR?**
In pylake, the scan width the user entered was available through `scan_width_um`. While a user may be lured into believing that this is the actual scan width of the scan they're dealing with, it is actually not because Bluelake will round the scan to a fixed number of pixels multiplied by the pixel width. It would be better to reserve this property for the actually obtained scan width and have a separate property for the scan width as entered in the UI.