### PR TITLE
force_calibration: drop compatibility mode

### DIFF
--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -139,7 +139,7 @@ def guess_f_diode_initial_value(ps, guess_fc, guess_D):
 
 
 def calculate_power_spectrum(
-    data, sample_rate, fit_range=(1e2, 23e3), num_points_per_block=2000, compatibility_mode=False
+    data, sample_rate, fit_range=(1e2, 23e3), num_points_per_block=2000
 ):
     """Compute power spectrum and returns it as a :class:`~.PowerSpectrum`.
 
@@ -155,15 +155,6 @@ def calculate_power_spectrum(
     num_points_per_block : int, optional
         The spectrum is first block averaged by this number of points per block.
         Default: 2000.
-    compatibility_mode : bool
-        The force calibration routine used in Bluelake 1.6.x and older had a bug which resulted in
-        a different downsampling factor being used than specified, but then using the wrong
-        downsampling factor in subsequent computations (leading to a slightly different weighting
-        of the data when calibrating). Enabling this flag computes a Power Spectrum which has the
-        same error when used for calibration. Note that this difference only resulted in small
-        deviations (starting from the third significant digit of most calibration properties for
-        a typical calibration spectrum). The only parameter that was largely effect was the
-        `chi_squared_per_deg`, which could be about 20% off.
 
     Returns
     -------
@@ -175,16 +166,7 @@ def calculate_power_spectrum(
 
     power_spectrum = PowerSpectrum(data, sample_rate)
     power_spectrum = power_spectrum.in_range(*fit_range)
-
-    if compatibility_mode:
-        # The original code ended up applying the following rounding to the down-sampling
-        factor = power_spectrum.frequency.size // (
-            power_spectrum.frequency.size // num_points_per_block
-        )
-        power_spectrum = power_spectrum.downsampled_by(factor)
-        power_spectrum.num_points_per_block = num_points_per_block  # Different actual factor!
-    else:
-        power_spectrum = power_spectrum.downsampled_by(num_points_per_block)
+    power_spectrum = power_spectrum.downsampled_by(num_points_per_block)
 
     return power_spectrum
 

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -51,22 +51,6 @@ def test_calibration_result():
         psc.CalibrationResults(invalid=5)
 
 
-def test_compatibility_mode():
-    d = np.arange(0.0, 50.0, 1.0)
-    spectrum = psc.calculate_power_spectrum(
-        d, 4000, fit_range=(0, np.inf), num_points_per_block=7, compatibility_mode=False
-    )
-    spectrum_compat = psc.calculate_power_spectrum(
-        d, 4000, fit_range=(0, np.inf), num_points_per_block=7, compatibility_mode=True
-    )
-
-    # Despite actually having been downsampled with different ratios, they seemingly have the same
-    # down-sampling ratio.
-    assert np.allclose(spectrum.power, [0.17201502, 0.00841408, 0.00392077])
-    assert np.allclose(spectrum_compat.power, [0.15219624, 0.00682399, 0.00347977])
-    assert np.allclose(spectrum.num_points_per_block, spectrum_compat.num_points_per_block)
-
-
 @pytest.mark.parametrize(
     "corner_frequency,diffusion_constant,alpha,f_diode,num_samples,viscosity,bead_diameter,temperature,err_fc,err_d,"
     "err_f_diode,err_alpha,",


### PR DESCRIPTION
**Why this PR?**
Since the differences between the old and new force calibration were so small, it was decided to drop the compatibility mode with the old version (since it only adds more code to maintain).

![image](https://user-images.githubusercontent.com/19836026/112181309-9c959400-8bfc-11eb-861a-48c38af027e0.png)

If someone _really really_ needs it, it'll still be in the git history.