### PR TITLE
Refactor

### DIFF
--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -287,6 +287,9 @@ class ScannedImage(BaseScan):
 
     @property
     def lines_per_frame(self):
+        if len(self._shape) == 1:
+            raise NotImplementedError("This method is not defined for 1D scans")
+
         return self._json["scan volume"]["scan axes"][1]["num of pixels"]
 
     @property

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -1,14 +1,75 @@
 import json
 import numpy as np
 import cachetools
+import warnings
 from deprecated.sphinx import deprecated
 
 from .mixin import PhotonCounts
 from .mixin import ExcitationLaserPower
-from .image import reconstruct_image_sum, reconstruct_image, save_tiff, ImageMetadata
+from .image import (
+    reconstruct_image_sum,
+    reconstruct_image,
+    reconstruct_num_frames,
+    seek_timestamp_next_line,
+    line_timestamps_image,
+    save_tiff,
+    ImageMetadata,
+)
 
 
-class BaseScan(PhotonCounts, ExcitationLaserPower):
+class DeprecatedBooleanProperties:
+    @property
+    @deprecated(
+        reason="By definition, confocal images always have fluorescence data.",
+        version="0.8.0",
+        action="always",
+    )
+    def has_fluorescence(self) -> bool:
+        return True
+
+    @property
+    @deprecated(
+        reason="This property is always False and therefore not needed.",
+        version="0.8.0",
+        action="always",
+    )
+    def has_force(self) -> bool:
+        return False
+
+
+class ConfocalPlotting:
+    def plot_red(self, **kwargs):
+        """Plot an image of the red photon channel
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to :func:`matplotlib.pyplot.imshow`.
+        """
+        return self._plot_color("red", **kwargs)
+
+    def plot_green(self, **kwargs):
+        """Plot an image of the green photon channel
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to :func:`matplotlib.pyplot.imshow`.
+        """
+        return self._plot_color("green", **kwargs)
+
+    def plot_blue(self, **kwargs):
+        """Plot an image of the blue photon channel
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to :func:`matplotlib.pyplot.imshow`.
+        """
+        return self._plot_color("blue", **kwargs)
+
+
+class BaseScan(PhotonCounts, DeprecatedBooleanProperties):
     """Base class for confocal scans
 
     Parameters
@@ -43,7 +104,7 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
         h5py_dset : h5py.Dataset
             The original HDF5 dataset containing confocal scan information
         file : lumicks.pylake.File
-            The parent file. Used to loop up channel data
+            The parent file. Used to look up channel data
         """
         start = h5py_dset.attrs["Start time (ns)"]
         stop = h5py_dset.attrs["Stop time (ns)"]
@@ -55,26 +116,14 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
 
         return cls(name, file, start, stop, json_data)
 
-    @property
-    @deprecated(
-        reason=(
-            "Access to raw metadata will be removed in a future release. "
-            "Use accessor properties instead. (see docs)"
-        ),
-        action="always",
-        version="0.8.0",
-    )
-    def json(self):
-        return self._json
-
     def _get_photon_count(self, name):
         """Grab the portion of the photon count that overlaps with the scan."""
         photon_count = getattr(self.file, f"{name}_photon_count".lower())[self.start : self.stop]
         timeline_start = photon_count._src.start
         timeline_dt = photon_count._src.dt
 
-        # Workaround for a bug in the STED delay mechanism which could result in scan start times ending up within
-        # the sample time.
+        # Workaround for a bug in the STED delay mechanism which could result in scan start times
+        # ending up within the sample time.
         if timeline_start - timeline_dt < self.start < timeline_start:
             self.start = timeline_start
 
@@ -93,85 +142,101 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
         """Resolve error when confocal scan starts before the timeline information."""
         raise NotImplementedError
 
-    def _plot_color(self, color, **kwargs):
-        """Implementation of plotting for selected color."""
-        raise NotImplementedError
-
-    def plot_red(self, **kwargs):
-        """Plot an image of the red photon channel
-
-        Parameters
-        ----------
-        **kwargs
-            Forwarded to :func:`matplotlib.pyplot.imshow`.
-        """
-        return self._plot_color("red", **kwargs)
-
-    def plot_green(self, **kwargs):
-        """Plot an image of the green photon channel
-
-        Parameters
-        ----------
-        **kwargs
-            Forwarded to :func:`matplotlib.pyplot.imshow`.
-        """
-        return self._plot_color("green", **kwargs)
-
-    def plot_blue(self, **kwargs):
-        """Plot an image of the blue photon channel
-
-        Parameters
-        ----------
-        **kwargs
-            Forwarded to :func:`matplotlib.pyplot.imshow`.
-        """
-        return self._plot_color("blue", **kwargs)
-
-    def plot_rgb(self, **kwargs):
-        """Plot all color channels
-
-        Parameters
-        ----------
-        **kwargs
-            Forwarded to `~matplotlib.pyplot.plot`.
-        """
-        raise NotImplementedError
-
-    @property
-    @deprecated(
-        reason="By definition, confocal images always have fluorescence data.",
-        version="0.8.0",
-        action="always",
-    )
-    def has_fluorescence(self) -> bool:
-        return True
-
-    @property
-    @deprecated(
-        reason="This property is always False and therefore not needed.",
-        version="0.8.0",
-        action="always",
-    )
-    def has_force(self) -> bool:
-        return False
-
     @property
     def center_point_um(self):
-        """Returns a dictionary of the x/y/z center coordinates of the scan (w.r.t. brightfield field of view) """
+        """Returns a dictionary of the x/y/z center coordinates of the scan (w.r.t. brightfield
+        field of view)"""
         return self._json["scan volume"]["center point (um)"]
 
+    @property
+    @deprecated(
+        reason=(
+            "Access to raw metadata will be removed in a future release. "
+            "Use accessor properties instead. (see docs)"
+        ),
+        action="always",
+        version="0.8.0",
+    )
+    def json(self):
+        return self._json
 
-class ConfocalImage(BaseScan):
+
+class ScannedImage(BaseScan):
+    def __init__(self, name, file, start, stop, json):
+        super().__init__(name, file, start, stop, json)
+        self._num_frames = self._json["scan count"]
+        if len(self._json["scan volume"]["scan axes"]) > 2:
+            raise RuntimeError("3D scans are not supported")
+
+    @cachetools.cachedmethod(lambda self: self._cache)
+    def _line_start_timestamps(self):
+        """Compute starting timestamp of each line (first DAQ sample corresponding to that line),
+        not the first pixel timestamp."""
+        timestamps = self.infowave.timestamps
+        line_timestamps = line_timestamps_image(
+            timestamps, self.infowave.data, self.pixels_per_line
+        )
+        return np.append(line_timestamps, timestamps[-1])
+
+    def slice(self, start, stop):
+        """All indexing is in timestamp units (ns)"""
+        line_timestamps = self._line_start_timestamps()
+        i_min = np.searchsorted(line_timestamps, start, side="left")
+        i_max = np.searchsorted(line_timestamps, stop, side="left")
+
+        if i_min >= len(line_timestamps) or i_min >= i_max:
+            return None
+
+        if i_max < len(line_timestamps):
+            stop = line_timestamps[i_max]
+
+        start = line_timestamps[i_min]
+        return ScannedImage(self.name, self.file, start, stop, self._json)
+
     def _ordered_axes(self):
         """Returns axis indices in spatial order"""
         return sorted(self._json["scan volume"]["scan axes"], key=lambda x: x["axis"])
 
     def _to_spatial(self, data):
-        """Implements any necessary post-processing actions after image reconstruction from infowave """
-        raise NotImplementedError
+        """If the first axis of the reconstruction has a higher physical axis number than the second, we flip the axes.
+
+        Checks whether the axes should be flipped w.r.t. the reconstruction. Reconstruction always produces images
+        with the slow axis first, and the fast axis second. Depending on the order of axes scanned, this may not
+        coincide with physical axes. The axes should always be ordered from the lowest physical axis number to higher.
+        Here X, Y, Z correspond to axis number 0, 1 and 2. So for an YZ scan, we'd want Y on the X axis."""
+        physical_axis = [axis["axis"] for axis in self._json["scan volume"]["scan axes"]]
+        if len(physical_axis) == 1:
+            return data.T
+
+        data = data.squeeze()
+
+        if physical_axis[0] > physical_axis[1]:
+            new_axis_order = np.arange(len(data.shape), dtype=int)
+            new_axis_order[-1], new_axis_order[-2] = new_axis_order[-2], new_axis_order[-1]
+            print(new_axis_order)
+            return np.transpose(data, new_axis_order)
+        else:
+            return data
+
+    def _fix_incorrect_start(self):
+        """Resolve error when confocal scan starts before the timeline information.
+
+        For 1D scans this is recoverable by omitting the first line."""
+        if len(self._shape) > 1:
+            raise RuntimeError(
+                "Start of the scan was truncated. Reconstruction cannot proceed. Did you export the "
+                "entire scan time in Bluelake?"
+            )
+
+        self.start = seek_timestamp_next_line(self.infowave[self.start :])
+        self._cache = {}
+        warnings.warn(
+            "Start of the kymograph was truncated. Omitting the truncated first line.",
+            RuntimeWarning,
+        )
 
     @cachetools.cachedmethod(lambda self: self._cache)
-    def _image(self, channel):
+    def image(self, channel):
         channel_data = getattr(self, f"{channel}_photon_count").data
         raw_image = reconstruct_image_sum(channel_data, self.infowave.data, self._shape)
         return self._to_spatial(raw_image)
@@ -188,6 +253,83 @@ class ConfocalImage(BaseScan):
             raise RuntimeError("Can't get pixel timestamps if there are no pixels")
         raw_image = reconstruct_image(channel_data, self.infowave.data, self._shape, reduce=np.mean)
         return self._to_spatial(raw_image)
+
+    @property
+    def timestamps(self) -> np.ndarray:
+        """Timestamps for image pixels, not for samples
+
+        The returned array has the same shape as the `*_image` arrays.
+        """
+        return self._timestamps("timestamps")
+
+    @property
+    def infowave(self):
+        return self.file["Info wave"]["Info wave"][self.start : self.stop]
+
+    @property
+    def _fast_axis_metadata(self):
+        return self._json["scan volume"]["scan axes"][0]
+
+    @property
+    def fast_axis(self):
+        return "X" if self._fast_axis_metadata["axis"] == 0 else "Y"
+
+    @property
+    def pixels_per_line(self):
+        return self._fast_axis_metadata["num of pixels"]
+
+    @property
+    def num_frames(self):
+        if self._num_frames == 0:
+            self._num_frames = reconstruct_num_frames(
+                self.infowave.data, self.pixels_per_line, self.lines_per_frame
+            )
+        return self._num_frames
+
+    @property
+    def lines_per_frame(self):
+        return self._json["scan volume"]["scan axes"][1]["num of pixels"]
+
+    @property
+    def _shape(self):
+        return tuple(ax["num of pixels"] for ax in reversed(self._json["scan volume"]["scan axes"]))
+
+    @property
+    def pixelsize_um(self):
+        """Returns a `List` of axes dimensions in um. The length of the list corresponds to the
+        number of scan axes."""
+        return [axes["pixel size (nm)"] / 1000 for axes in self._ordered_axes()]
+
+    @property
+    def size_um(self):
+        """Returns a `List` of scan sizes in um along axes. The length of the list corresponds to
+        the number of scan axes."""
+        return [
+            axes["pixel size (nm)"] * axes["num of pixels"] / 1000 for axes in self._ordered_axes()
+        ]
+
+    @property
+    @deprecated(
+        reason=(
+            "The property `scan_width_um` has been deprecated. Use `size_um` to get the actual "
+            "size of the scan. When performing a scan, Bluelake determines an appropriate scan "
+            "width based on the desired pixel size and the desired scan width. This means that the "
+            "size of the performed scan could deviate from the width provided in this property."
+        ),
+        action="always",
+        version="0.8.2",
+    )
+    def scan_width_um(self):
+        """Returns a `List` of scan widths as configured in the Bluelake UI. The length of the list
+        corresponds to the number of scan axes. Note that these widths can deviate from the actual
+        scan widths performed in practice"""
+        return [axes["scan width (um)"] for axes in self._ordered_axes()]
+
+
+class ConfocalImageAPI(DeprecatedBooleanProperties, ConfocalPlotting, ExcitationLaserPower):
+    def __init__(self, image):
+        self._src = image
+        self._cache = {}
 
     def _plot_color(self, color, **kwargs):
         from matplotlib.colors import LinearSegmentedColormap
@@ -230,30 +372,28 @@ class ConfocalImage(BaseScan):
             This option is disabled by default: an error will be raise if the data does not fit.
         """
         if self.rgb_image.size > 0:
-            save_tiff(self.rgb_image, filename, dtype, clip, ImageMetadata.from_dataset(self._json))
+            save_tiff(
+                self.rgb_image, filename, dtype, clip, ImageMetadata.from_dataset(self._src._json)
+            )
         else:
             raise RuntimeError("Can't export TIFF if there are no pixels")
 
     @property
     def infowave(self):
-        return self.file["Info wave"]["Info wave"][self.start : self.stop]
+        return self._src.infowave
 
     @property
     def _shape(self):
         """The shape of the image ([optional: pixels on slow axis], pixels on fast axis)"""
-        raise NotImplementedError
-
-    @property
-    def pixels_per_line(self):
-        return self._fast_axis_metadata["num of pixels"]
-
-    @property
-    def _fast_axis_metadata(self):
-        return self._json["scan volume"]["scan axes"][0]
+        return self._src._shape
 
     @property
     def fast_axis(self):
-        return "X" if self._fast_axis_metadata["axis"] == 0 else "Y"
+        return self._src.fast_axis
+
+    @property
+    def pixels_per_line(self):
+        return self._src.pixels_per_line
 
     @property
     def timestamps(self) -> np.ndarray:
@@ -261,21 +401,19 @@ class ConfocalImage(BaseScan):
 
         The returned array has the same shape as the `*_image` arrays.
         """
-        return self._timestamps("timestamps")
+        return self._src.timestamps
 
     @property
     def pixelsize_um(self):
         """Returns a `List` of axes dimensions in um. The length of the list corresponds to the
         number of scan axes."""
-        return [axes["pixel size (nm)"] / 1000 for axes in self._ordered_axes()]
+        return self._src.pixelsize_um
 
     @property
     def size_um(self):
         """Returns a `List` of scan sizes in um along axes. The length of the list corresponds to
         the number of scan axes."""
-        return [
-            axes["pixel size (nm)"] * axes["num of pixels"] / 1000 for axes in self._ordered_axes()
-        ]
+        return self._src.size_um
 
     @property
     @deprecated(
@@ -292,21 +430,65 @@ class ConfocalImage(BaseScan):
         """Returns a `List` of scan widths as configured in the Bluelake UI. The length of the list
         corresponds to the number of scan axes. Note that these widths can deviate from the actual
         scan widths performed in practice"""
-        return [axes["scan width (um)"] for axes in self._ordered_axes()]
+        return self._src.scan_width_um
 
     @property
     def red_image(self):
-        return self._image("red")
+        return self._src.image("red")
 
     @property
     def green_image(self):
-        return self._image("green")
+        return self._src.image("green")
 
     @property
     def blue_image(self):
-        return self._image("blue")
+        return self._src.image("blue")
+
+    @property
+    def red_photon_count(self):
+        return self._src.red_photon_count
+
+    @property
+    def green_photon_count(self):
+        return self._src.green_photon_count
+
+    @property
+    def blue_photon_count(self):
+        return self._src.blue_photon_count
 
     @property
     def rgb_image(self):
         color_channels = [getattr(self, f"{color}_image").T for color in ("red", "green", "blue")]
         return np.stack(color_channels).T
+
+    @classmethod
+    def from_dataset(cls, h5py_dset, file):
+        return cls(ScannedImage.from_dataset(h5py_dset, file))
+
+    @property
+    @deprecated(
+        reason=(
+            "Access to raw metadata will be removed in a future release. "
+            "Use accessor properties instead. (see docs)"
+        ),
+        action="always",
+        version="0.8.0",
+    )
+    def json(self):
+        return self._src.json
+
+    @property
+    def center_point_um(self):
+        return self._src.center_point_um
+
+    @property
+    def start(self):
+        return self._src.start
+
+    @property
+    def stop(self):
+        return self._src.stop
+
+    @property
+    def name(self):
+        return self._src.name

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -326,8 +326,9 @@ class ScannedImage(BaseScan):
 
 
 class ConfocalImageAPI(DeprecatedBooleanProperties, ConfocalPlotting, ExcitationLaserPower):
-    def __init__(self, image):
+    def __init__(self, image, file):
         self._src = image
+        self.file = file
         self._cache = {}
 
     def _plot_color(self, color, **kwargs):
@@ -462,7 +463,7 @@ class ConfocalImageAPI(DeprecatedBooleanProperties, ConfocalPlotting, Excitation
 
     @classmethod
     def from_dataset(cls, h5py_dset, file):
-        return cls(ScannedImage.from_dataset(h5py_dset, file))
+        return cls(ScannedImage.from_dataset(h5py_dset, file), file)
 
     @property
     @deprecated(

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -308,6 +308,10 @@ class ScannedImage(BaseScan):
         ]
 
     @property
+    def pixel_time_ms(self):
+        return self._json["scan volume"]["pixel time (ms)"]
+
+    @property
     @deprecated(
         reason=(
             "The property `scan_width_um` has been deprecated. Use `size_um` to get the actual "
@@ -371,9 +375,16 @@ class ConfocalImageAPI(DeprecatedBooleanProperties, ConfocalPlotting, Excitation
             If enabled, the photon count data will be clipped to fit into the desired `dtype`.
             This option is disabled by default: an error will be raise if the data does not fit.
         """
+        pixelsize_um = self._src.pixelsize_um
+        pixelsize_x_nm = pixelsize_um[0] * 1000
+        pixelsize_y_nm = pixelsize_um[-1] * 1000
         if self.rgb_image.size > 0:
             save_tiff(
-                self.rgb_image, filename, dtype, clip, ImageMetadata.from_dataset(self._src._json)
+                self.rgb_image,
+                filename,
+                dtype,
+                clip,
+                ImageMetadata(pixelsize_x_nm, pixelsize_y_nm, self._src.pixel_time_ms),
             )
         else:
             raise RuntimeError("Can't export TIFF if there are no pixels")

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -213,7 +213,6 @@ class ScannedImage(BaseScan):
         if physical_axis[0] > physical_axis[1]:
             new_axis_order = np.arange(len(data.shape), dtype=int)
             new_axis_order[-1], new_axis_order[-2] = new_axis_order[-2], new_axis_order[-1]
-            print(new_axis_order)
             return np.transpose(data, new_axis_order)
         else:
             return data

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -1,7 +1,4 @@
 import numpy as np
-import warnings
-import cachetools
-
 from .channel import empty_slice
 from .detail.confocal import ConfocalImageAPI
 from .detail.image import histogram_rows

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -42,9 +42,9 @@ class Kymo(ConfocalImageAPI):
 
         sliced_scan = self._src.slice(start, stop)
         if not sliced_scan:
-            return EmptyKymo(self._src)
+            return EmptyKymo(self._src, self.file)
         else:
-            return Kymo(sliced_scan)
+            return Kymo(sliced_scan, self.file)
 
     @property
     def line_time_seconds(self):

--- a/lumicks/pylake/point_scan.py
+++ b/lumicks/pylake/point_scan.py
@@ -1,7 +1,8 @@
-from .detail.confocal import BaseScan
+from .detail.confocal import BaseScan, ConfocalPlotting
+from .detail.mixin import ExcitationLaserPower
 
 
-class PointScan(BaseScan):
+class PointScan(BaseScan, ConfocalPlotting, ExcitationLaserPower):
     """A confocal point scan exported from Bluelake
 
     Parameters

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -1,14 +1,13 @@
 import numpy as np
 
-from .detail.confocal import ConfocalImage
-from .detail.image import reconstruct_image_sum, reconstruct_image, reconstruct_num_frames
+from .detail.confocal import ConfocalImageAPI
 
 
 """Axis label used for plotting"""
 axis_label = ("x", "y", "z")
 
 
-class Scan(ConfocalImage):
+class Scan(ConfocalImageAPI):
     """A confocal scan exported from Bluelake
 
     Parameters
@@ -25,12 +24,6 @@ class Scan(ConfocalImage):
         Dictionary containing scan-specific metadata.
     """
 
-    def __init__(self, name, file, start, stop, json):
-        super().__init__(name, file, start, stop, json)
-        self._num_frames = self._json["scan count"]
-        if len(self._json["scan volume"]["scan axes"]) > 2:
-            raise RuntimeError("3D scans are not supported")
-
     def __repr__(self):
         name = self.__class__.__name__
         return f"{name}(pixels=({self.pixels_per_line}, {self.lines_per_frame}))"
@@ -40,44 +33,11 @@ class Scan(ConfocalImage):
 
     @property
     def num_frames(self):
-        if self._num_frames == 0:
-            self._num_frames = reconstruct_num_frames(
-                self.infowave.data, self.pixels_per_line, self.lines_per_frame
-            )
-        return self._num_frames
+        return self._src.num_frames
 
     @property
     def lines_per_frame(self):
-        return self._json["scan volume"]["scan axes"][1]["num of pixels"]
-
-    @property
-    def _shape(self):
-        return (self.lines_per_frame, self.pixels_per_line)
-
-    def _fix_incorrect_start(self):
-        """Resolve error when confocal scan starts before the timeline information.
-        For scans, this is currently unrecoverable."""
-        raise RuntimeError(
-            "Start of the scan was truncated. Reconstruction cannot proceed. Did you export the "
-            "entire scan time in Bluelake?"
-        )
-
-    def _to_spatial(self, data):
-        """If the first axis of the reconstruction has a higher physical axis number than the second, we flip the axes.
-
-        Checks whether the axes should be flipped w.r.t. the reconstruction. Reconstruction always produces images
-        with the slow axis first, and the fast axis second. Depending on the order of axes scanned, this may not
-        coincide with physical axes. The axes should always be ordered from the lowest physical axis number to higher.
-        Here X, Y, Z correspond to axis number 0, 1 and 2. So for an YZ scan, we'd want Y on the X axis."""
-        data = data.squeeze()
-
-        physical_axis = [axis["axis"] for axis in self._json["scan volume"]["scan axes"]]
-        if physical_axis[0] > physical_axis[1]:
-            new_axis_order = np.arange(len(data.shape), dtype=int)
-            new_axis_order[-1], new_axis_order[-2] = new_axis_order[-2], new_axis_order[-1]
-            return np.transpose(data, new_axis_order)
-        else:
-            return data
+        return self._src.lines_per_frame
 
     def _plot(self, image, frame=1, image_handle=None, **kwargs):
         """Plot a scan frame.
@@ -113,7 +73,7 @@ class Scan(ConfocalImage):
             # Updating the image data in an existing plot is a lot faster than re-plotting with `imshow`.
             image_handle.set_data(image)
 
-        axes = self._ordered_axes()
+        axes = self._src._ordered_axes()
         plt.xlabel(f"{axis_label[axes[0]['axis']]} ($\\mu m$)")
         plt.ylabel(f"{axis_label[axes[1]['axis']]} ($\\mu m$)")
         if self.num_frames == 1:

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -283,7 +283,8 @@ def test_invalid_access(h5_file):
 def test_missing_metadata(h5_file_missing_meta):
     f = pylake.File.from_h5py(h5_file_missing_meta)
     if f.format_version == 2:
-        with pytest.warns(UserWarning, match="Scan 'fast Y slow X no meta' is missing metadata and cannot be loaded"):
+        with pytest.warns(UserWarning, match="ScannedImage 'fast Y slow X no meta' is "
+                                             "missing metadata and cannot be loaded"):
             scans = f.scans
             assert len(scans) == 1
 

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -5,23 +5,7 @@ from lumicks.pylake.detail.image import reconstruct_image, reconstruct_image_sum
 
 
 def test_metadata_from_json():
-    json = { 'cereal_class_version': 1,
-             'fluorescence': True,
-             'force': False,
-             'scan count': 0,
-             'scan volume': {'center point (um)': {'x': 58.075877109272604,
-                                                   'y': 31.978375270573267,
-                                                   'z': 0},
-                             'cereal_class_version': 1,
-                             'pixel time (ms)': 0.5,
-                             'scan axes': [{'axis': 0,
-                                            'cereal_class_version': 1,
-                                            'num of pixels': 240,
-                                            'pixel size (nm)': 150,
-                                            'scan time (ms)': 0,
-                                            'scan width (um)': 36.07468112612217}]}}
-
-    image_metadata = ImageMetadata.from_dataset(json)
+    image_metadata = ImageMetadata(150, 150, 0.5)
 
     res = image_metadata.resolution
     assert np.isclose(res[0], 1e7 / 150)

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -127,7 +127,7 @@ def test_damaged_kymo(h5_file):
         kymo_reference = np.transpose([[2, 0, 0, 0, 2], [0, 0, 0, 0, 0], [1, 0, 0, 0, 1], [0, 1, 1, 1, 0]])
 
         # Assume the user incorrectly exported only a partial Kymo
-        kymo.start = kymo.red_photon_count.timestamps[0] - 62500000
+        kymo._src.start = kymo.red_photon_count.timestamps[0] - 62500000
         with pytest.warns(RuntimeWarning):
             assert kymo.red_image.shape == (5, 3)
         assert np.allclose(kymo.red_image.data, kymo_reference[:, 1:])

--- a/lumicks/pylake/tests/test_scan.py
+++ b/lumicks/pylake/tests/test_scan.py
@@ -12,11 +12,15 @@ def test_scans(h5_file):
 
         assert repr(scan) == "Scan(pixels=(4, 5))"
 
-        reference_timestamps = np.array([[2.006250e+10, 2.025000e+10, 2.043750e+10, 2.062500e+10],
-                                        [2.084375e+10, 2.109375e+10, 2.128125e+10, 2.146875e+10],
-                                        [2.165625e+10, 2.187500e+10, 2.206250e+10, 2.225000e+10],
-                                        [2.243750e+10, 2.262500e+10, 2.284375e+10, 2.309375e+10],
-                                        [2.328125e+10, 2.346875e+10, 2.365625e+10, 2.387500e+10]])
+        reference_timestamps = np.array(
+            [
+                [2.006250e10, 2.025000e10, 2.043750e10, 2.062500e10],
+                [2.084375e10, 2.109375e10, 2.128125e10, 2.146875e10],
+                [2.165625e10, 2.187500e10, 2.206250e10, 2.225000e10],
+                [2.243750e10, 2.262500e10, 2.284375e10, 2.309375e10],
+                [2.328125e10, 2.346875e10, 2.365625e10, 2.387500e10],
+            ]
+        )
 
         assert np.allclose(scan.timestamps, np.transpose(reference_timestamps))
         assert scan.num_frames == 1
@@ -34,13 +38,13 @@ def test_scans(h5_file):
         assert scan.blue_image.shape == (4, 5)
         assert scan.green_image.shape == (4, 5)
         assert scan.fast_axis == "Y"
-        assert np.allclose(scan.pixelsize_um, [197/1000, 191/1000])
+        assert np.allclose(scan.pixelsize_um, [197 / 1000, 191 / 1000])
         assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
         assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
         assert np.allclose(scan.center_point_um["z"], 0)
-        assert np.allclose(scan.size_um, [0.197*5, 0.191*4])
+        assert np.allclose(scan.size_um, [0.197 * 5, 0.191 * 4])
         with pytest.warns(DeprecationWarning):
-            assert np.allclose(scan.scan_width_um, [[0.197*5 + .5, 0.191*4 + .5]])
+            assert np.allclose(scan.scan_width_um, [[0.197 * 5 + 0.5, 0.191 * 4 + 0.5]])
 
         with pytest.raises(NotImplementedError):
             scan["1s":"2s"]
@@ -70,7 +74,7 @@ def test_scans(h5_file):
         assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
         assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
         assert np.allclose(scan.center_point_um["z"], 0)
-        assert np.allclose(scan.size_um, [0.197*3, 0.191*4])
+        assert np.allclose(scan.size_um, [0.197 * 3, 0.191 * 4])
 
         scan = f.scans["fast X slow Z multiframe"]
         reference_timestamps2 = np.zeros((2, 4, 3))
@@ -98,7 +102,7 @@ def test_scans(h5_file):
         assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
         assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
         assert np.allclose(scan.center_point_um["z"], 0)
-        assert np.allclose(scan.size_um, [0.191*4, 0.197*3])
+        assert np.allclose(scan.size_um, [0.191 * 4, 0.197 * 3])
 
         scan = f.scans["fast Y slow Z multiframe"]
         reference_timestamps2 = np.zeros((2, 4, 3))
@@ -126,7 +130,7 @@ def test_scans(h5_file):
         assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
         assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
         assert np.allclose(scan.center_point_um["z"], 0)
-        assert np.allclose(scan.size_um, [0.191*4, 0.197*3])
+        assert np.allclose(scan.size_um, [0.191 * 4, 0.197 * 3])
 
 
 def test_damaged_scan(h5_file):
@@ -136,7 +140,7 @@ def test_damaged_scan(h5_file):
         scan = f.scans["fast Y slow X"]
 
         # Assume the user incorrectly exported only a partial scan (62500000 is the time step)
-        scan.start = scan.red_photon_count.timestamps[0] - 62500000
+        scan._src.start = scan.red_photon_count.timestamps[0] - 62500000
         with pytest.raises(RuntimeError):
             scan.red_image.shape
 
@@ -145,7 +149,7 @@ def test_damaged_scan(h5_file):
         scan = f.scans["fast Y slow X"]
 
         middle = scan.red_photon_count.timestamps[5]
-        scan.start = middle - 62400000
+        scan._src.start = middle - 62400000
         scan.red_image.shape  # should not raise, but change the start appropriately to work around sted bug
         assert np.allclose(scan.start, middle)
 
@@ -156,18 +160,18 @@ def test_plotting(h5_file):
     if f.format_version == 2:
         scan = f.scans["fast Y slow X multiframe"]
         scan.plot_blue()
-        assert np.allclose(np.sort(plt.xlim()), [0, .197 * 3])
-        assert np.allclose(np.sort(plt.ylim()), [0, .191 * 4])
+        assert np.allclose(np.sort(plt.xlim()), [0, 0.197 * 3])
+        assert np.allclose(np.sort(plt.ylim()), [0, 0.191 * 4])
 
         scan = f.scans["fast X slow Z multiframe"]
         scan.plot_rgb()
-        assert np.allclose(np.sort(plt.xlim()), [0, .191 * 4])
-        assert np.allclose(np.sort(plt.ylim()), [0, .197 * 3])
+        assert np.allclose(np.sort(plt.xlim()), [0, 0.191 * 4])
+        assert np.allclose(np.sort(plt.ylim()), [0, 0.197 * 3])
 
         scan = f.scans["fast Y slow Z multiframe"]
         scan.plot_rgb()
-        assert np.allclose(np.sort(plt.xlim()), [0, .191 * 4])
-        assert np.allclose(np.sort(plt.ylim()), [0, .197 * 3])
+        assert np.allclose(np.sort(plt.xlim()), [0, 0.191 * 4])
+        assert np.allclose(np.sort(plt.ylim()), [0, 0.197 * 3])
 
 
 def test_save_tiff(tmpdir_factory, h5_file):


### PR DESCRIPTION
Rough draft PR to investigate whether we can abstract some implementational details of `Scan` and `Kymo`. The idea is to make them more agnostic to where the data is coming from and contain everything related to reconstruction in its own class. This will hopefully allow us to make WIT kymos and treat them through the same API.

Note it's very rough. It's more an exploration to see what would happen if we put the abstraction at this level.

Aims:
- Make it clear what data we expect from an image, see `ScannedImage`. Essentially new "images" should implement this interface (we could formalize this by a base class).
- Being able to provide another class providing image data would make testing new functionalities easier.
- Being able to generate Kymos from other data sources.

Questions:
- Is the abstraction desirable to be at this level? The advantage is that `Scan` and `Kymo` are treated more uniformly and that `Scan` could also benefit from easier testing.
- Is `BaseScan` still worth it given that it actually doesn't deduplicate that much, but makes the hierarchy more complex.
- Do we really want Kymo deriving from a method that collects `Scan` API calls? This introduces coupling that may be hard to get rid of later (An alternative could be to have Kymo construct a `Scan`, and "hold" a `Scan` internally)?