### PR TITLE
Kymo.downsampled_by(#) [MSD 2a of N]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.9.0 | t.b.d.
+
+#### New features
+
+* Added `Kymo.downsampled_by()` for downsampling Kymographs. See [kymographs](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html) for more information.
+
 ## v0.8.2 | 2021-04-30
 
 #### New features

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -49,6 +49,20 @@ There are also several properties available for convenient access to the kymogra
 * `kymo.fast_axis` provides the axis that was scanned (x or y)
 * `kymo.line_time_seconds` provides the time between successive lines
 
+Downsampling kymograph
+----------------------
+
+We can downsample a kymograph by invoking::
+
+    kymo_ds = kymo.downsampled_by(time_factor=2)
+
+Note however, that not all functionalities are present anymore when downsampling a kymograph. For
+example, we can no longer access the per pixel timestamps::
+
+    >>> kymo_ds.timestamps
+    AttributeError: Per pixel timestamps are no longer available after downsampling a kymograph since they are not well defined (the downsampling occurs over a non contiguous time window).
+    Line timestamps are still available however. See: `Kymo.line_time_seconds`.
+
 Plotting and exporting
 ----------------------
 

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -104,14 +104,13 @@ class Kymo(ConfocalImage):
         import matplotlib.pyplot as plt
 
         size_um = self.size_um[0]
-        ts = self.timestamps
-        duration = (ts[0, -1] - ts[0, 0]) / 1e9
-        linetime = (ts[0, 1] - ts[0, 0]) / 1e9
+        duration = self.line_time_seconds * image.shape[1]
+        linetime = self.line_time_seconds
 
         default_kwargs = dict(
             # With origin set to upper (default) bounds should be given as (0, n, n, 0)
             # pixel center aligned with mean time per line
-            extent=[-0.5 * linetime, duration + 0.5 * linetime, size_um, 0],
+            extent=[-0.5 * linetime, duration - 0.5 * linetime, size_um, 0],
             aspect=(image.shape[0] / image.shape[1]) * (duration / size_um),
         )
 

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -140,7 +140,11 @@ def test_plotting(h5_file):
         kymo = f.kymos["Kymo1"]
 
         kymo.plot_red()
-        assert np.allclose(np.sort(plt.xlim()), [-0.5, 3.5], atol=0.05)
+        # The following assertion fails because of unequal line times in the test data. These
+        # unequal line times are not typical for BL data. Kymo nowadays assumes equal line times
+        # which is why the old version of this test fails.
+        # assert np.allclose(np.sort(plt.xlim()), [-0.5, 3.5], atol=0.05)
+        assert np.allclose(plt.xlim(), [-0.515625, 3.609375])
         assert np.allclose(np.sort(plt.ylim()), [0, 0.05])
 
 
@@ -155,7 +159,12 @@ def test_plotting_with_force(h5_file):
         assert np.all(np.equal(ds.timestamps, kymo.timestamps[2]))
 
         kymo.plot_with_force(force_channel="2x", color_channel="red")
-        assert np.allclose(np.sort(plt.xlim()), [-0.5, 3.5], atol=0.05)
+
+        # The following assertion fails because of unequal line times in the test data. These
+        # unequal line times are not typical for BL data. Kymo nowadays assumes equal line times
+        # which is why the old version of this test fails.
+        # assert np.allclose(np.sort(plt.xlim()), [-0.5, 3.5], atol=0.05)
+        assert np.allclose(plt.xlim(), [-0.515625, 3.609375])
         assert np.allclose(np.sort(plt.ylim()), [10, 30])
 
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "cachetools>=3.1",
         "deprecated>=1.2.8",
         "scikit-learn>=0.18.0",
+        "scikit-image>=0.17.2",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
## Why this PR?
One of the issues with MSD 2 of N was that we spun out a separate class because we needed to handle downsampling. This is undesirable because it makes things more complex for the user (yet another object to think about).

Instead, this PR attempts to add downsampling to `Kymo` itself. To not make the same mess as before, I have also developed a small mocking setup, which allows us to mock Kymos.

One advantage of this setup is that the downsampling can be done lazily.

One alternative to this is to do something similar to https://github.com/lumicks/pylake/pull/132 and abstract the image in the `Kymo`. Then this `DownsampledKymo` could be a regular `Kymo` but with a different image as source. You'd lose the connection to the original though.

## Notes
To enable this feature, and still be able to plot, I had to "break" one of the existing tests. Essentially, what that test was testing were plot limits for the Kymograph. However, the reason these plot limits were as they were was because of the unequal line times in the test data. I have compared that for typical BL kymographs, the new plot setup actually produces the same result.

Updating the test data would've required fixes in more than 50 tests, therefore I have left that exercise for a future PR.