### PR TITLE
Handle baseline corrected FD curves

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,15 +7,16 @@
 * Added `Kymo.downsampled_by()` for downsampling Kymographs. See [kymographs](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html) for more information.
 * Added option to stitch Kymograph lines via the Jupyter notebook widget.
 * Added Mean Square Displacement (MSD) and diffusion constant estimation to `KymoLine`. For more information, please refer to [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html)
+* Added `FdCurve.with_baseline_corrected_x()` to return a baseline corrected version of the FD curve if the corrected data is available. **Note: currently the baseline is only calculated for the x-component of the force channel in Bluelake. Therefore baseline corrected `FdCurve` instances use only the x-component of the force channel, unlike default `FdCurve`s which use the full magnitude of the force channel by default.**
 
 #### Breaking changes
 
 * Dropped support for Python 3.6.
 * The attribute `image_data` in `KymoLine` is now private.
-* Make kymotracker functions `track_greedy()`, `track_lines()`, and class `KymoWidgetGreedy` take `Kymo` and a channel (e.g. "red") as their input. 
-  The advantage of this is that now units of time (seconds) and space (microns) are propagated automatically to the tracked `KymoLine`s. 
+* Make kymotracker functions `track_greedy()`, `track_lines()`, and class `KymoWidgetGreedy` take `Kymo` and a channel (e.g. "red") as their input.
+  The advantage of this is that now units of time (seconds) and space (microns) are propagated automatically to the tracked `KymoLine`s.
   See the [Cas9 kymotracking example](https://lumicks-pylake.readthedocs.io/en/latest/examples/cas9_kymotracking/cas9_kymotracking.html) or the [kymotracking tutorial](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
-* `KymoLineGroup.save()` and `KymoWidgetGreedy.save_lines()` no longer take `dx` and `dt` arguments. 
+* `KymoLineGroup.save()` and `KymoWidgetGreedy.save_lines()` no longer take `dx` and `dt` arguments.
   Instead, the correct time and position calibration is now passed automatically to these functions. See [kymographs](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html) for more information.
 
 #### Breaking changes

--- a/docs/tutorial/fdcurves.rst
+++ b/docs/tutorial/fdcurves.rst
@@ -71,3 +71,21 @@ and distance from such an ensemble using::
 
     f = fd_ensemble.f
     d = fd_ensemble.d
+
+Baseline Correction
+-------------------
+
+.. note::
+    By default, FD curves are constructed using the force magnitude :math:`F = \sqrt{F_x^2 + F_y^2}`. However, baseline
+    correction in Bluelake is only calculated for the x-component :math:`F_x`. Therefore, FD curves with baseline
+    correction applied are constructed with only the x-component rather than the full magnitude and may not be directly
+    comparable to the corresponding uncorrected FD curve.
+
+    Additionally, baseline-corrected FD curves are read directly from the source HDF5 file. Therefore, any data processing previously
+    applied to the FD curve used to obtain the baseline corrected curve is lost.
+
+FD curves can also be constructed from baseline corrected force data if the channel was exported from Bluelake with a baseline correction applied::
+
+    file = lk.File("example.h5")
+    fd = file.fdcurves["baseline"]          # low frequency, uncorrected force magnitude
+    fd_bl = fd.with_baseline_corrected_x() # low frequency, baseline corrected force x-component

--- a/lumicks/pylake/detail/mixin.py
+++ b/lumicks/pylake/detail/mixin.py
@@ -115,6 +115,21 @@ class DownsampledFD:
         return _try_get_or_empty(self._get_distance, 2)
 
 
+class BaselineCorrectedForce:
+    """Full frequency, baseline-corrected force channels"""
+
+    def _get_corrected_force(self, n, xy):
+        raise NotImplementedError
+
+    @property
+    def corrected_force1x(self) -> Slice:
+        return _try_get_or_empty(self._get_corrected_force, 1, "x")
+
+    @property
+    def corrected_force2x(self) -> Slice:
+        return _try_get_or_empty(self._get_corrected_force, 2, "x")
+
+
 class PhotonCounts:
     """Red, green and blue photon channels"""
 

--- a/lumicks/pylake/fdcurve.py
+++ b/lumicks/pylake/fdcurve.py
@@ -159,6 +159,24 @@ class FdCurve(DownsampledFD):
 
         return new_curve
 
+    def with_baseline_corrected_x(self):
+        """Return a copy of this F,d curve with baseline correction applied to force channel.
+        Note: only the x component is available with baseline correction.
+        Note: All previous data manipulations (eg. subtraction of another curve) will be lost."""
+        new_curve = self.__copy__()
+
+        # get high-frequency, baseline-corrected data
+        corrected_force_hf = getattr(self.file, f"corrected_force{self._primary_force_channel}x")
+        if len(corrected_force_hf) == 0:
+            raise ValueError("baseline correction not found.")
+
+        # downsample to match distance data
+        force, distance = corrected_force_hf.downsampled_like(self.d)
+        new_curve._force_cache = force
+        new_curve._distance_cache = distance
+
+        return new_curve
+
     @property
     def f(self):
         """The primary force channel associated with this FD curve"""

--- a/lumicks/pylake/tests/data/mock_fdcurve.py
+++ b/lumicks/pylake/tests/data/mock_fdcurve.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+def generate_fdcurve_with_baseline_offset():
+    # generate high frequency data
+    distance_hf = np.linspace(1, 10, 500)                       # distance, HF
+    time_hf = np.arange(0, 3*distance_hf.size, 3) + 100         # timestamps, HF
+    true_f_hf = np.exp(0.5 * distance_hf)                       # true force, HF
+
+    # make baseline
+    p = [-1e-5, 1e-4, 1e-3, 0.005, 0.3, -5, 30] # baseline polynomial coefficients
+    bl = np.polyval(p, distance_hf)                             # baseline
+    obs_f_hf = true_f_hf + bl                                   # observed force, HF
+
+    # manually downsample to low frequency like BL
+    win = 5
+    rng = range(0, distance_hf.size-win, win)
+    downsample = lambda r, w, hf: np.array([np.mean(hf[start:start+w]) for start in r])
+
+    time_lf = np.array([time_hf[start+win] for start in rng])   # timestamps, LF
+    distance_lf = downsample(rng, win, distance_hf)             # distance, LF
+    true_f_lf = downsample(rng, win, true_f_hf)                 # true force, LF
+    obs_f_lf = downsample(rng, win, obs_f_hf)                   # observed force, LF
+
+    data = {
+        "HF": {
+            "time": time_hf,
+            "true_force": true_f_hf,
+            "obs_force": obs_f_hf,
+        },
+        "LF": {
+            "time": time_lf,
+            "true_force": true_f_lf,
+            "obs_force": obs_f_lf,
+            "distance": distance_lf
+        }
+    }
+
+    return p, data


### PR DESCRIPTION
## Why this PR?
Allow users to access FD curves exported with baseline correction from Bluelake.

## Notes
Currently in Bluelake, the baseline is only calculated for the x-component `Fx`. However, as currently implemented in pylake, `FdCurves` by default are constructed using the channel magnitude `sqrt(Fx**2 + Fy**2)`. There are also future considerations (like piezotracking as the distance channel) which are not yet clearly defined. So it seemed most reasonable to add the `FdCurve.with_baseline_correction()` method to return a new instance using the corrected data rather than messing around with object construction from `File`.

~~I chose to add a `FdCurve._baseline_corrected` attribute to keep track of which data is used for each instance. However, I also considered making a separate `BaselineCorrectedFdCurve` subclass. Both options have pros and cons as far as future maintenance and feature extendibility, so any discussion on this is welcome!~~

## Update
After the original PR was opened, found out that BL will not directly export corrected LF data, only corrected HF data. Therefore, the corrected HF data needs to be downsampled like the LF distance channel. In order to do this efficiently, we need functionality from PR #139 .

## Not included  
The following features were originally part of this ticket, however it seemed like the PR would be too large for manageable review. So these will be separate PRs after this one is merged:
- plotting baseline and raw data 
- applying correction to non-corrected data if coefficients are available 
- accessing polynomial coefficients
