### PR TITLE
channel: add arithmetic operators

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * Added option to stitch Kymograph lines via the Jupyter notebook widget.
 * Added Mean Square Displacement (MSD) and diffusion constant estimation to `KymoLine`. For more information, please refer to [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html)
 * Added `FdCurve.with_baseline_corrected_x()` to return a baseline corrected version of the FD curve if the corrected data is available. **Note: currently the baseline is only calculated for the x-component of the force channel in Bluelake. Therefore baseline corrected `FdCurve` instances use only the x-component of the force channel, unlike default `FdCurve`s which use the full magnitude of the force channel by default.**
+* Added ability to perform arithmetic on `Slice` (e.g. `(f.force1x - f.force2x) / 2`). For more information see [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#exporting-h5-files) for more information.
 
 #### Breaking changes
 

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -158,6 +158,17 @@ Plotting is typically performed with the origin of the plot set to the timestamp
     first_slice.plot()
     second_slice.plot(start=first_slice.start)  # we want to use the start of first_slice as time point "zero"
 
+Arithmetic
+^^^^^^^^^^
+
+Simple arithmetic operations can be performed directly on slices::
+
+    >>> diff_force = (file.force1x - file.force2x) / 2
+    <lumicks.pylake.channel.Slice at 0x2954d3016d0>
+
+    >>> force_magnitude = (file.force1x ** 2 + file.force1y ** 2) ** 0.5
+    <lumicks.pylake.channel.Slice at 0x2954d3016d0>
+
 Downsampling
 ^^^^^^^^^^^^
 

--- a/lumicks/pylake/tests/test_arithmetic.py
+++ b/lumicks/pylake/tests/test_arithmetic.py
@@ -1,0 +1,148 @@
+import pytest
+import numpy as np
+from lumicks.pylake.channel import Slice, Continuous, TimeSeries, TimeTags
+
+t_start = 1 + int(1e18)
+time_series = np.array([1, 2, 3, 4, 5], dtype=np.int64) + int(1e18)
+slice_continuous_1 = Slice(Continuous([1, 2, 3, 4, 5], start=t_start, dt=1))
+slice_continuous_2 = Slice(Continuous([2, 2, 2, 2, 2], start=t_start, dt=1))
+slice_timeseries_1 = Slice(TimeSeries([1, 2, 3, 4, 5], time_series))
+slice_timeseries_2 = Slice(TimeSeries([2, 2, 2, 2, 2], time_series))
+
+operators = [
+    "__add__",
+    "__sub__",
+    "__truediv__",
+    "__mul__",
+    "__pow__",
+    "__radd__",
+    "__rsub__",
+    "__rtruediv__",
+    "__rmul__",
+    "__rpow__",
+]
+
+
+@pytest.mark.parametrize(
+    "slice1, slice2",
+    [
+        (slice_continuous_1, slice_continuous_2),
+        (slice_timeseries_1, slice_timeseries_2),
+        (slice_continuous_1, slice_timeseries_2),
+        (slice_timeseries_1, slice_continuous_2),
+    ],
+)
+def test_operations_slice(slice1, slice2):
+    def test_operator(first_slice, second_slice, operation):
+        # Operations in the containers must give the same result as operating on the data directly.
+        assert np.array_equal(
+            getattr(first_slice, operation)(second_slice).data,
+            getattr(first_slice.data, operation)(second_slice.data),
+        )
+
+        # Operations shouldn't modify the timestamps.
+        assert np.array_equal(
+            getattr(first_slice, operation)(second_slice).timestamps, first_slice.timestamps
+        )
+
+    for operator in operators:
+        test_operator(slice1, slice2, operator)
+
+
+@pytest.mark.parametrize(
+    "slice1, scalar",
+    [
+        (slice_continuous_1, 2.0),
+        (slice_timeseries_1, 2.0),
+    ],
+)
+def test_operations_scalar(slice1, scalar):
+    def test_operator(current_slice, scalar_val, operation):
+        # Operations in the containers must give the same result as operating on the data directly.
+        assert np.array_equal(
+            getattr(current_slice, operation)(scalar_val).data,
+            getattr(current_slice.data, operation)(scalar_val),
+        )
+
+        # Operations shouldn't modify the timestamps.
+        assert np.array_equal(
+            getattr(current_slice, operation)(scalar_val).timestamps, current_slice.timestamps
+        )
+
+    for operator in operators:
+        test_operator(slice1, scalar, operator)
+
+
+slice_continuous_different_timestamps = Slice(Continuous([2, 2, 2, 2, 2], start=t_start + 1, dt=1))
+slice_timeseries_different_timestamps = Slice(TimeSeries([2, 2, 2, 2, 2], time_series + 1))
+
+
+@pytest.mark.parametrize(
+    "slice1, slice2",
+    [
+        (slice_continuous_1, slice_continuous_different_timestamps),
+        (slice_timeseries_1, slice_timeseries_different_timestamps),
+        (slice_continuous_1, slice_timeseries_different_timestamps),
+        (slice_timeseries_1, slice_continuous_different_timestamps),
+    ],
+)
+def test_incompatible_timestamps(slice1, slice2):
+    # Test whether the timestamps are correctly compared
+    for operator in operators:
+        with pytest.raises(RuntimeError):
+            getattr(slice1, operator)(slice2)
+
+
+slice_continuous_different_length = Slice(Continuous([2, 2, 2, 2], start=t_start, dt=1))
+slice_timeseries_different_length = Slice(TimeSeries([2, 2, 2, 2], [1, 2, 3, 4]))
+
+
+@pytest.mark.parametrize(
+    "slice1, slice2",
+    [
+        (slice_continuous_1, slice_continuous_different_length),
+        (slice_timeseries_1, slice_timeseries_different_length),
+        (slice_continuous_1, slice_timeseries_different_length),
+        (slice_timeseries_1, slice_continuous_different_length),
+    ],
+)
+def test_incompatible_length(slice1, slice2):
+    # The data sets need to be the same length. We explicitly raise an exception when they are not.
+    for operator in operators:
+        with pytest.raises(RuntimeError):
+            getattr(slice1, operator)(slice2)
+
+
+@pytest.mark.parametrize(
+    "slice1, slice2",
+    [
+        (slice_continuous_1, [2, 2, 2, 2, 2]),
+        (slice_timeseries_1, [2, 2, 2, 2, 2]),
+        (slice_continuous_1, np.array([2, 2, 2, 2, 2])),
+        (slice_timeseries_1, np.array([[2, 2, 2, 2, 2]])),
+    ],
+)
+def test_incompatible_types(slice1, slice2):
+    for operator in operators:
+        with pytest.raises(TypeError):
+            getattr(slice1, operator)(slice2)
+
+
+timetags = Slice(TimeTags(time_series))
+
+
+@pytest.mark.parametrize(
+    "data1, data2",
+    [
+        (slice_continuous_1, timetags),
+        (slice_timeseries_1, timetags),
+        (timetags, slice_continuous_2),
+        (timetags, slice_timeseries_2),
+    ],
+)
+def test_timetags_not_implemented(data1, data2):
+    # This is not implemented for time tags at this point (we need to determine what are sensible
+    # operations on those first).
+    for operator in operators:
+        with pytest.raises(NotImplementedError):
+            getattr(data1, operator)(data2)

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -583,3 +583,16 @@ def test_channel_plot():
 def test_regression_lazy_loading(h5_file):
     ch = channel.Continuous.from_dataset(h5_file["Force HF"]["Force 1x"])
     assert type(ch._src._src_data) == h5py.Dataset
+
+
+@pytest.mark.parametrize(
+    "data, new_data",
+    [
+        (channel.Continuous([1, 2, 3, 4, 5], start=1, dt=1), np.array([5, 6, 7, 8, 9])),
+        (channel.TimeSeries([1, 2, 3, 4, 5], [2, 3, 4, 5, 6]), np.array([5, 6, 7, 8, 9])),
+    ],
+)
+def test_with_data(data, new_data):
+    assert np.allclose(data._with_data(new_data).data, new_data)
+    old_timestamps = data.timestamps
+    assert np.allclose(data._with_data(new_data).timestamps, old_timestamps)


### PR DESCRIPTION
**What is this PR?**
It adds arithmetic operations on `Continuous` and `TimeSeries` slices.

**Why this PR?**
Because it makes performing basic mathematical operations on slices a lot less cumbersome and will likely lead to people not immediately pulling their data out of our slice class all the time.

Note that we explicitly verify that the timestamps of the two channels in question are the same. There is still a performance improvement that could be done by specializing this for `Continuous` channel data, but I left that for another day.

![image](https://user-images.githubusercontent.com/19836026/114904453-2c9fb580-9e18-11eb-9ec5-6015ece370b2.png)
