### PR TITLE
force_calibration: don't catch and rethrow exception

### DIFF
--- a/lumicks/pylake/force_calibration/detail/power_models.py
+++ b/lumicks/pylake/force_calibration/detail/power_models.py
@@ -27,8 +27,9 @@ def fit_analytical_lorentzian(ps):
 
         Note: returns None if the fit fails.
     """
-    FitResults = namedtuple("AnalyticalLorentzianFitResults",
-                            ["fc", "D", "sigma_fc", "sigma_D", "ps_fit"])
+    FitResults = namedtuple(
+        "AnalyticalLorentzianFitResults", ["fc", "D", "sigma_fc", "sigma_D", "ps_fit"]
+    )
 
     # Calculate S[p,q] elements (Ref. 1, Eq. 13-14).
     Spq = np.zeros((3, 3))
@@ -36,8 +37,12 @@ def fit_analytical_lorentzian(ps):
         Spq[p, q] = np.sum(np.power(ps.frequency, 2 * p) * np.power(ps.power, q))
 
     # Calculate a and b parameters (Ref. 1, Eq. 13-14).
-    a = (Spq[0, 1] * Spq[2, 2] - Spq[1, 1] * Spq[1, 2]) / (Spq[0, 2] * Spq[2, 2] - Spq[1, 2] * Spq[1, 2])
-    b = (Spq[1, 1] * Spq[0, 2] - Spq[0, 1] * Spq[1, 2]) / (Spq[0, 2] * Spq[2, 2] - Spq[1, 2] * Spq[1, 2])
+    a = (Spq[0, 1] * Spq[2, 2] - Spq[1, 1] * Spq[1, 2]) / (
+        Spq[0, 2] * Spq[2, 2] - Spq[1, 2] * Spq[1, 2]
+    )
+    b = (Spq[1, 1] * Spq[0, 2] - Spq[0, 1] * Spq[1, 2]) / (
+        Spq[0, 2] * Spq[2, 2] - Spq[1, 2] * Spq[1, 2]
+    )
 
     # Having a and b, calculating fc and D is trivial.
     fc = math.sqrt(a / b)  # corner frequency [Hz]
@@ -75,6 +80,7 @@ def _convert_to_a(alpha):
 
 class ScaledModel:
     """Callable wrapper around a model function to handle scaling"""
+
     def __init__(self, model, initial_guess):
         scale_factors = (
             *initial_guess[0:3],
@@ -101,10 +107,13 @@ class ScaledModel:
         # interval into an 'alpha' confidence interval. Note that this also seems
         # to give us different results for the alpha confidence interval than the
         # original tweezercalib-2.1 code from ref. 3.
-        perr[3] = abs(
+        perr[3] = (
+            abs(
                 _convert_to_alpha(rescaled_params[3] * self._scale_factors[3] + perr[3])
                 - _convert_to_alpha(rescaled_params[3] * self._scale_factors[3] - perr[3])
-            ) / 2
+            )
+            / 2
+        )
         return perr
 
     def __call__(self, f, p1, p2, p3, p4):

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -187,8 +187,10 @@ def fit_power_spectrum(power_spectrum, model, settings=CalibrationSettings()):
         Parameters obtained from the calibration procedure.
     """
     if len(power_spectrum.frequency) < 4:
-        raise RuntimeError("Insufficient number of points to fit power spectrum. Check whether"
-                           "you are using the correct frequency range and sampling rate.")
+        raise RuntimeError(
+            "Insufficient number of points to fit power spectrum. Check whether"
+            "you are using the correct frequency range and sampling rate."
+        )
     if not isinstance(power_spectrum, PowerSpectrum):
         raise TypeError('Argument "power_spectrum" must be of type PowerSpectrum')
     if not isinstance(settings, CalibrationSettings):
@@ -197,9 +199,11 @@ def fit_power_spectrum(power_spectrum, model, settings=CalibrationSettings()):
     # Fit analytical Lorentzian to get initial guesses for the full power spectrum model.
     analytical_power_spectrum = power_spectrum.in_range(*settings.analytical_fit_range)
     if len(analytical_power_spectrum.frequency) < 1:
-        raise RuntimeError("An empty power spectrum was passed to fit_analytical_lorentzian. Check"
-                           "whether you are using the correct sample rate and frequency range"
-                           "for the analytical fit.")
+        raise RuntimeError(
+            "An empty power spectrum was passed to fit_analytical_lorentzian. Check"
+            "whether you are using the correct sample rate and frequency range"
+            "for the analytical fit."
+        )
     anl_fit_res = fit_analytical_lorentzian(analytical_power_spectrum)
 
     initial_params = (

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -8,8 +8,10 @@ def test_friction_coefficient():
 
 
 def test_spectrum(reference_models):
-    assert np.allclose(passive_power_spectrum_model(np.arange(10000), 1000, 1e9, 10000, 0.5),
-                       reference_models.lorentzian_filtered(np.arange(10000), 1000, 1e9, 0.5, 10000))
+    assert np.allclose(
+        passive_power_spectrum_model(np.arange(10000), 1000, 1e9, 10000, 0.5),
+        reference_models.lorentzian_filtered(np.arange(10000), 1000, 1e9, 0.5, 10000),
+    )
 
 
 def test_spectrum_parameter_scaling(reference_models):
@@ -50,8 +52,12 @@ def test_spectrum_parameter_scaling(reference_models):
         [1000, 1e-9, 30000, 21.113382377506746, 1.1763968470146817e-11],
     ],
 )
-def test_fit_analytic(reference_models, corner_frequency, diffusion_constant, num_samples, sigma_fc, sigma_diffusion):
-    power_spectrum = reference_models.lorentzian(np.arange(0, num_samples), corner_frequency, diffusion_constant)
+def test_fit_analytic(
+    reference_models, corner_frequency, diffusion_constant, num_samples, sigma_fc, sigma_diffusion
+):
+    power_spectrum = reference_models.lorentzian(
+        np.arange(0, num_samples), corner_frequency, diffusion_constant
+    )
     data = np.fft.irfft(np.sqrt(np.abs(power_spectrum))) * (num_samples - 1) * 2
 
     num_points_per_block = 20

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -118,6 +118,23 @@ def test_bad_data():
     model = PassiveCalibrationModel(1, temperature=20, viscosity=0.0001)
     power_spectrum = psc.PowerSpectrum(data, num_samples)
 
+    with pytest.raises(ValueError):
+        psc.fit_power_spectrum(power_spectrum, model=model)
+
+
+def test_no_data_in_range():
+    model = PassiveCalibrationModel(1, temperature=20, viscosity=0.0001)
+
+    # Here the range slices off all the data and we are left with an empty spectrum
+    power_spectrum = psc.PowerSpectrum(np.arange(100), sample_rate=100).in_range(47, 100)
+
+    with pytest.raises(RuntimeError):
+        psc.fit_power_spectrum(power_spectrum, model=model)
+
+    # Check whether a failure to get a sufficient number of points in the analytical fit is
+    # detected.
+    power_spectrum = psc.PowerSpectrum(np.arange(100), sample_rate=1e-3)
+
     with pytest.raises(RuntimeError):
         psc.fit_power_spectrum(power_spectrum, model=model)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ exclude = '''
     | build
     | dist
     | tests  # ignore test directories until we have a better solution for test datasets
-    | force_calibration  # ignore it for now since a big refactoring effort is ongoing
   )/
 )
 '''


### PR DESCRIPTION
**Why this PR?**
We currently catch and lump all errors that can happen during the analytical part of the force calibration. This is not helpful when debugging issues.

This PR handles two known preconditions explicitly (and provides more useful information) and lets the others bubble up.