### PR TITLE
Return cropped reference channel from downsampled_like

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,9 @@
 * `KymoLineGroup.save()` and `KymoWidgetGreedy.save_lines()` no longer take `dx` and `dt` arguments. 
   Instead, the correct time and position calibration is now passed automatically to these functions. See [kymographs](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html) for more information.
 
+#### Breaking changes
+* `Slice.downsampled_like()` now returns both the downsampled `Slice` and a copy of the low frequency reference `Slice` cropped such that both instances have exactly the same timestamps.
+
 ## v0.8.2 | 2021-04-30
 
 #### New features

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -171,23 +171,23 @@ To downsample to a specific frequency use `downsampled_to` with the desired freq
     ds_channel = channel.downsampled_to(3125)
     ds_timestep = np.diff(ds_channel.timestamps[:2]) * 1e-9  # timestep 320 us
 
-By default, this method will take the mean of every N samples where N is defined as the ratio between the two sampling times. 
-This can cause issues when N isn't an integer, leading to an unequal number of points contributing to each point in the 
+By default, this method will take the mean of every N samples where N is defined as the ratio between the two sampling times.
+This can cause issues when N isn't an integer, leading to an unequal number of points contributing to each point in the
 downsampled channel. To automatically find the nearest higher frequency that will fulfill this requirement, use the `method="ceil"`::
 
     ds_channel2 = channel.downsampled_to(3126, method="ceil")
     ds_timestep2 = np.diff(ds_channel2.timestamps[:2]) * 1e-9  # timestep 307.2 us
 
-For data that is recorded with variable sampling frequencies, it is usually not possible to downsample to a 
-single sample rate, while maintaining an equal number of samples per downsampled sample. To force downsampling 
+For data that is recorded with variable sampling frequencies, it is usually not possible to downsample to a
+single sample rate, while maintaining an equal number of samples per downsampled sample. To force downsampling
 to a single frequency in the case of variable sample rates, use `method="force"`::
 
-    variable_channel = file.downsampled_force1x 
+    variable_channel = file.downsampled_force1x
     variable_ds_channel = variable_channel.downsampled_to(3125, method="force")
 
 Note that this same flag can also be used to force a specific downsampling rate for non-integer downsampling rates.
 
-A slice can also be downsampled over arbitrary time segments by using `downsampled_over` and supplying a 
+A slice can also be downsampled over arbitrary time segments by using `downsampled_over` and supplying a
 list of `(start, stop)` tuples indicating over which ranges to apply the function.
 
 A slice that contains equally spaced timestamps can be downsampled by a specific factor using `downsampled_by`
@@ -203,10 +203,14 @@ Sometimes, one may want to downsample a high frequency channel in exactly the sa
 channel is sampled. For this purpose you can use `downsampled_like`::
 
     lf_data = file["Force LF"]["Force 1x"]
-    downsampled = file["Force HF"]["Force 1x"].downsampled_like(lf_data)
+    downsampled, lf_cropped = file["Force HF"]["Force 1x"].downsampled_like(lf_data)
 
-    lf_data.plot()
-    downsampled.plot(start=lf_data.start)
+    lf_cropped.plot()
+    downsampled.plot()
+
+Generally, it is not possible to reconstruct the first 1-2 timepoints of the reference low frequency channel from the high frequency
+channel input. Therefore, this method returns the downsampled channel and a copy of the reference channel that is cropped such that
+both channels have exactly the same timestamps.
 
 Calibrations
 ------------

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -304,7 +304,8 @@ class Slice:
             ]
         )
 
-        return self._with_data_source(TimeSeries(downsampled, timestamps))
+        new_slice = self._with_data_source(TimeSeries(downsampled, timestamps))
+        return new_slice, other_slice[new_slice._src.start : new_slice._src.stop]
 
     def plot(self, start=None, **kwargs):
         """A simple line plot to visualize the data over time

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -546,7 +546,8 @@ def test_downsampling_like():
     y_downsampled = np.array([0, 1, 2, 3, 4, 6, 7, 8, 9, 10])
     reference = channel.Slice(channel.TimeSeries(y_downsampled, t_downsampled))
 
-    ds = s.downsampled_like(reference)
+    ds, ref_out = s.downsampled_like(reference)
+    assert np.all(np.equal(ds.timestamps, ref_out.timestamps))
     assert np.allclose(t_downsampled[1:-1], ds.timestamps)
     assert np.allclose(y_downsampled[1:-1], ds.data)
 


### PR DESCRIPTION
**Why this PR?**

When using `Slice.downsampled_like()` to downsample a high frequency channel to the same timestamps as a low frequency channel output from Bluelake, the first 1-2 time points cannot be constructed due to missing HF data.

This PR introduces a breaking change where `downsampled_like()` now returns both the downsampled channel and a copy of the reference LF channel that is cropped such that the timestamps of both instances are exactly the same. 