### PR TITLE
Use a dataclass for KymolineData [MSD 2c]

### DIFF
--- a/.github/workflows/pylake_release.yml
+++ b/.github/workflows/pylake_release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.7'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 build:
   image: latest
 python:
-  version: 3.6
+  version: 3.7
   pip_install: true
 requirements_file: docs/requirements.txt

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 
 #### Breaking changes
 
+* Dropped support for Python 3.6.
 * The attribute `image_data` in `KymoLine` is now private.
 * Make kymotracker functions `track_greedy()`, `track_lines()`, and class `KymoWidgetGreedy` take `Kymo` and a channel (e.g. "red") as their input. 
   The advantage of this is that now units of time (seconds) and space (microns) are propagated automatically to the tracked `KymoLine`s. 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,7 @@ Installation instructions
 
 Pylake can be installed on Windows, Linux or Mac, with the following prerequisites:
 
-* `Python`_ 3.6 or newer (Python 2.x is not supported)
+* `Python`_ 3.7 or newer (Python 2.x is not supported)
 * The `SciPy`_ stack of scientific packages
 
 If you're already familiar with Python and have the above prerequisites, installing Pylake is just a simple case of using `pip`, Python's usual package manager::

--- a/lumicks/pylake/kymotracker/detail/trace_line_2d.py
+++ b/lumicks/pylake/kymotracker/detail/trace_line_2d.py
@@ -182,7 +182,7 @@ def _traverse_line_direction(
     return nodes
 
 
-@dataclass(frozen=True)
+@dataclass()
 class KymoLineData:
     """Uncalibrated kymograph lines coming from low-level kymotracker functions.
 
@@ -192,21 +192,19 @@ class KymoLineData:
 
     Parameters
     ----------
-    time_idx : List[float]
+    time_idx : np.ndarray
         List of time indices on the tracked image [pixels]
-    coordinate_idx : List[float]
+    coordinate_idx : np.ndarray
         List of coordinate indices on the tracked image [pixels]
+    """
 
-    Note: Some of the kymotracker functions return numpy arrays. Appending too many small numpy
-    arrays was a bottleneck and therefore we explicitly use lists."""
-
-    time_idx: List[float]
-    coordinate_idx: List[float]
+    time_idx: np.ndarray
+    coordinate_idx: np.ndarray
 
     def append(self, time_idx, coordinate_idx):
         """Append time [pixels], coordinate pair [pixels] to the KymoLine"""
-        self.time_idx.append(time_idx)
-        self.coordinate_idx.append(coordinate_idx)
+        self.time_idx = np.append(self.time_idx, time_idx)
+        self.coordinate_idx = np.append(self.coordinate_idx, coordinate_idx)
 
     def __len__(self):
         return len(self.coordinate_idx)
@@ -250,7 +248,7 @@ def traverse_line(
     line = np.array(indices_bwd + indices_fwd[1:])
 
     if len(line) > 0:
-        return KymoLineData(time_idx=line[:, 1].tolist(), coordinate_idx=line[:, 0].tolist())
+        return KymoLineData(time_idx=line[:, 1], coordinate_idx=line[:, 0])
 
 
 def detect_lines_from_geometry(
@@ -484,7 +482,8 @@ def points_to_line_segments(peaks, prediction_model, window=10, sigma_cutoff=2):
         for starting_point in np.argsort(-frame.peak_amplitudes * frame.unassigned):
             if frame.unassigned[starting_point]:
                 line = KymoLineData(
-                    [frame.time_points[starting_point]], [frame.coordinates[starting_point]]
+                    np.array([frame.time_points[starting_point]]),
+                    np.array([frame.coordinates[starting_point]]),
                 )
                 frame.unassigned[starting_point] = False
 

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -82,8 +82,8 @@ class KymoLine:
     __slots__ = ["time_idx", "coordinate_idx", "_image"]
 
     def __init__(self, time_idx, coordinate_idx, image):
-        self.time_idx = list(time_idx)
-        self.coordinate_idx = list(coordinate_idx)
+        self.time_idx = np.asarray(time_idx)
+        self.coordinate_idx = np.asarray(coordinate_idx)
         self._image = image
 
     @classmethod
@@ -97,16 +97,16 @@ class KymoLine:
         coordinate_pixel_offset = self._image.from_position(coordinate_offset)
 
         return KymoLine(
-            [time_idx + time_pixel_offset for time_idx in self.time_idx],
-            [coordinate_idx + coordinate_pixel_offset for coordinate_idx in self.coordinate_idx],
+            self.time_idx + time_pixel_offset,
+            self.coordinate_idx + coordinate_pixel_offset,
             self._image,
         )
 
     def __add__(self, other):
         """Concatenate two KymoLines"""
         return KymoLine(
-            self.time_idx + other.time_idx,
-            self.coordinate_idx + other.coordinate_idx,
+            np.hstack((self.time_idx, other.time_idx)),
+            np.hstack((self.coordinate_idx, other.coordinate_idx)),
             self._image,
         )
 
@@ -117,11 +117,11 @@ class KymoLine:
 
     @property
     def seconds(self):
-        return np.array([self._image.to_seconds(t) for t in self.time_idx])
+        return self._image.to_seconds(self.time_idx)
 
     @property
     def position(self):
-        return np.array([self._image.to_position(x) for x in self.coordinate_idx])
+        return self._image.to_position(self.coordinate_idx)
 
     def in_rect(self, rect):
         """Check whether any point of this KymoLine falls in the rect given in rect.

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -86,6 +86,10 @@ class KymoLine:
         self.coordinate_idx = list(coordinate_idx)
         self._image = image
 
+    @classmethod
+    def _from_kymolinedata(cls, kymolinedata, image):
+        return cls(kymolinedata.time_idx, kymolinedata.coordinate_idx, image)
+
     def with_offset(self, time_offset, coordinate_offset):
         """Returns an offset version of the KymoLine"""
         # Convert from image units to pixels

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -234,8 +234,8 @@ def refine_lines_centroid(lines, line_width):
     current = 0
     for line in interpolated_lines:
         line_length = len(line.time_idx)
-        line.time_idx = list(time_idx[current : current + line_length])
-        line.coordinate_idx = list(coordinate_idx[current : current + line_length])
+        line.time_idx = time_idx[current : current + line_length]
+        line.coordinate_idx = coordinate_idx[current : current + line_length]
         current += line_length
 
     return KymoLineGroup(interpolated_lines)

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -234,8 +234,8 @@ def refine_lines_centroid(lines, line_width):
     current = 0
     for line in interpolated_lines:
         line_length = len(line.time_idx)
-        line.time_idx = time_idx[current : current + line_length]
-        line.coordinate_idx = coordinate_idx[current : current + line_length]
+        line.time_idx = list(time_idx[current : current + line_length])
+        line.coordinate_idx = list(coordinate_idx[current : current + line_length])
         current += line_length
 
     return KymoLineGroup(interpolated_lines)

--- a/lumicks/pylake/kymotracker/tests/test_io.py
+++ b/lumicks/pylake/kymotracker/tests/test_io.py
@@ -9,10 +9,10 @@ def kymolinegroup_io_data():
     test_data = np.zeros((8, 8))
 
     test_img = CalibratedKymographChannel("test", data=test_data, time_step_ns=100e9, pixel_size=2)
-    k1 = KymoLine([1, 2, 3], [2, 3, 4], test_img)
-    k2 = KymoLine([2, 3, 4], [3, 4, 5], test_img)
-    k3 = KymoLine([3, 4, 5], [4, 5, 6], test_img)
-    k4 = KymoLine([4, 5, 6], [5, 6, 7], test_img)
+    k1 = KymoLine([1, 2, 3], np.array([2, 3, 4]), test_img)
+    k2 = KymoLine([2, 3, 4], np.array([3, 4, 5]), test_img)
+    k3 = KymoLine([3, 4, 5], np.array([4, 5, 6]), test_img)
+    k4 = KymoLine([4, 5, 6], np.array([5, 6, 7]), test_img)
     lines = KymoLineGroup([k1, k2, k3, k4])
 
     for k in lines:

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -6,11 +6,20 @@ import pytest
 
 
 def test_kymoline_interpolation():
-    time_idx = [1.0, 3.0, 5.0]
-    coordinate_idx = [1.0, 3.0, 3.0]
-    interpolated = KymoLine(time_idx, coordinate_idx, []).interpolate()
+    time_idx = np.array([1.0, 3.0, 5.0])
+    coordinate_idx = np.array([1.0, 3.0, 3.0])
+    kymoline = KymoLine(time_idx, coordinate_idx, [])
+    interpolated = kymoline.interpolate()
     assert np.allclose(interpolated.time_idx, [1.0, 2.0, 3.0, 4.0, 5.0])
     assert np.allclose(interpolated.coordinate_idx, [1.0, 2.0, 3.0, 3.0, 3.0])
+
+    # Test whether concatenation still works after interpolation
+    assert np.allclose(
+        (interpolated + kymoline).time_idx, [1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 3.0, 5.0]
+    )
+    assert np.allclose(
+        (interpolated + kymoline).coordinate_idx, [1.0, 2.0, 3.0, 3.0, 3.0, 1.0, 3.0, 3.0]
+    )
 
 
 def test_refinement_2d():
@@ -25,11 +34,17 @@ def test_refinement_2d():
     data[coordinate_idx + 1 + offset, time_idx] = 1
     image = CalibratedKymographChannel.from_array(data)
 
-    line = refine_lines_centroid([KymoLine(time_idx[::2], coordinate_idx[::2], image=image)], 5)[0]
-    assert np.allclose(line.time_idx, time_idx)
-    assert np.allclose(line.coordinate_idx, coordinate_idx + offset)
-    assert isinstance(line.time_idx, list)
-    assert isinstance(line.coordinate_idx, list)
+    line = KymoLine(time_idx[::2], coordinate_idx[::2], image=image)
+    refined_line = refine_lines_centroid([line], 5)[0]
+    assert np.allclose(refined_line.time_idx, time_idx)
+    assert np.allclose(refined_line.coordinate_idx, coordinate_idx + offset)
+
+    # Test whether concatenation still works after refinement
+    assert np.allclose((refined_line + line).time_idx, np.hstack((time_idx, time_idx[::2])))
+    assert np.allclose(
+        (refined_line + line).coordinate_idx,
+        np.hstack((coordinate_idx + offset, coordinate_idx[::2])),
+    )
 
 
 @pytest.mark.parametrize("loc", [25.3, 25.5, 26.25, 23.6])

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -28,6 +28,8 @@ def test_refinement_2d():
     line = refine_lines_centroid([KymoLine(time_idx[::2], coordinate_idx[::2], image=image)], 5)[0]
     assert np.allclose(line.time_idx, time_idx)
     assert np.allclose(line.coordinate_idx, coordinate_idx + offset)
+    assert isinstance(line.time_idx, list)
+    assert isinstance(line.coordinate_idx, list)
 
 
 @pytest.mark.parametrize("loc", [25.3, 25.5, 26.25, 23.6])

--- a/lumicks/pylake/tests/test_kymotracker.py
+++ b/lumicks/pylake/tests/test_kymotracker.py
@@ -8,6 +8,7 @@ from lumicks.pylake.kymotracker.detail.stitch import distance_line_to_point
 from lumicks.pylake.kymotracker.stitching import stitch_kymo_lines
 from lumicks.pylake.kymotracker.kymotracker import track_greedy, track_lines, filter_lines
 from lumicks.pylake.kymotracker.kymoline import KymoLine, KymoLineGroup
+from lumicks.pylake.kymotracker.detail.trace_line_2d import KymoLineData
 from lumicks.pylake.tests.data.mock_confocal import generate_kymo
 from copy import deepcopy
 from scipy.stats import norm
@@ -281,6 +282,14 @@ def test_kymoline_selection_non_unit_calibration():
 
     assert not KymoLine([4, 5, 6], [7, 7, 7], channel).in_rect(((4, 6*5), (6, 7*5)))
     assert KymoLine([4, 5, 6], [7, 7, 7], channel).in_rect(((4, 6*5), (6, 8*5)))
+
+
+def test_kymoline_from_kymolinedata():
+    channel = CalibratedKymographChannel("test_data", np.array([[]]), 1e9, 5)
+    kl = KymoLine._from_kymolinedata(KymoLineData([4, 5, 6], [7, 7, 7]), channel)
+    assert np.allclose(kl.time_idx, [4, 5, 6])
+    assert np.allclose(kl.coordinate_idx, [7, 7, 7])
+    assert id(kl._image) == id(channel)
 
 
 def test_distance_line_to_point():

--- a/lumicks/pylake/tests/test_kymotracker.py
+++ b/lumicks/pylake/tests/test_kymotracker.py
@@ -264,10 +264,12 @@ def test_kymo_line():
 def test_kymoline_selection():
     channel = CalibratedKymographChannel("test_data", np.array([[]]), 1e9, 1)
 
-    assert not KymoLine([4, 5, 6], [7, 7, 7], channel).in_rect(((4, 6), (6, 7)))
-    assert KymoLine([4, 5, 6], [7, 7, 7], channel).in_rect(((4, 6), (6, 8)))
-    assert not KymoLine([4, 5, 6], [7, 7, 7], channel).in_rect(((3, 6), (4, 8)))
-    assert KymoLine([4, 5, 6], [7, 7, 7], channel).in_rect(((3, 6), (5, 8)))
+    t = np.array([4, 5, 6])
+    y = np.array([7, 7, 7])
+    assert not KymoLine(t, y, channel).in_rect(((4, 6), (6, 7)))
+    assert KymoLine(t, y, channel).in_rect(((4, 6), (6, 8)))
+    assert not KymoLine(t, y, channel).in_rect(((3, 6), (4, 8)))
+    assert KymoLine(t, y, channel).in_rect(((3, 6), (5, 8)))
 
     assert KymoLine([2], [6], channel).in_rect(((2, 5), (3, 8)))
     assert KymoLine([2], [5], channel).in_rect(((2, 5), (3, 8)))
@@ -280,15 +282,17 @@ def test_kymoline_selection():
 def test_kymoline_selection_non_unit_calibration():
     channel = CalibratedKymographChannel("test_data", np.array([[]]), 1e9, 5)
 
-    assert not KymoLine([4, 5, 6], [7, 7, 7], channel).in_rect(((4, 6*5), (6, 7*5)))
-    assert KymoLine([4, 5, 6], [7, 7, 7], channel).in_rect(((4, 6*5), (6, 8*5)))
+    time, pos = np.array([4, 5, 6]), np.array([7, 7, 7])
+    assert not KymoLine(time, pos, channel).in_rect(((4, 6*5), (6, 7*5)))
+    assert KymoLine(time, pos, channel).in_rect(((4, 6*5), (6, 8*5)))
 
 
 def test_kymoline_from_kymolinedata():
     channel = CalibratedKymographChannel("test_data", np.array([[]]), 1e9, 5)
-    kl = KymoLine._from_kymolinedata(KymoLineData([4, 5, 6], [7, 7, 7]), channel)
-    assert np.allclose(kl.time_idx, [4, 5, 6])
-    assert np.allclose(kl.coordinate_idx, [7, 7, 7])
+    time, pos = np.array([4, 5, 6]), np.array([7, 7, 7])
+    kl = KymoLine._from_kymolinedata(KymoLineData(time, pos), channel)
+    assert np.allclose(kl.time_idx, time)
+    assert np.allclose(kl.coordinate_idx, pos)
     assert id(kl._image) == id(channel)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 100
-target-version = ['py36']
+target-version = ['py37']
 exclude = '''
 (
   /(

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import sys
 from setuptools import setup, PEP420PackageFinder
 from setuptools.command.egg_info import manifest_maker
 
-if sys.version_info[:2] < (3, 6):
-    print("Python >= 3.6 is required.")
+if sys.version_info[:2] < (3, 7):
+    print("Python >= 3.7 is required.")
     sys.exit(-1)
 
 
@@ -43,12 +43,12 @@ setup(
         "Topic :: Scientific/Engineering :: Physics",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
     packages=PEP420PackageFinder.find(include=["lumicks.*"]),
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "pytest>=3.5",
         "h5py>=3.0, <4",


### PR DESCRIPTION
This PR changes `KymoLineData` to a dataclass. It also adds some small syntactic sugar for generating a `KymoLine` (user facing) from a `KymoLineData` (backend only).

## Why this PR?
Dataclasses are nice.

Note that this PR requires dropping 3.6 support.