### PR TITLE
release: preparing for v0.8.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.8.2 | t.b.d.
+## v0.8.2 | 2021-04-30
 
 #### New features
 
@@ -14,7 +14,7 @@
 * Fixed bug in kymotracker which could result in a line being extended one pixel too far in either direction. Reason for the bug was that a blurring step in the peak-finding routine was being applied on both axes, while it should have only been applied to one axis. Note that while this bug affects peak detection (finding one too many), it should not affect peak localization as that is performed in a separate step.
 * Fixed bug in kymotracker slicing which could result in one line too many or too few being included. The bug was caused by using the timestamp corresponding to one sample beyond the last pixel of the line as "start of the next line" without accounting for the dead time that may be there.
 
-#### Breaking changes
+#### Deprecations
 
 * `Scan.scan_width_um` and `Kymo.scan_width_um` have been deprecated. Use `Scan.size_um` and `Kymo.size_um` to get the scan sizes. When performing a scan, Bluelake determines an appropriate scan width based on the desired pixel size and the scan width entered in the UI. The property `scan_width_um` returned the scan size entered by the user, rather than the actual scan size achieved. To obtain the achieved scan size, use `Scan.size_um` and `Kymo.size_um`.
 

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -1,3 +1,9 @@
+.. warning::
+    This is alpha functionality.
+    While usable, this has not yet been tested in a large number of different scenarios.
+    The API is still be subject to change *without any prior deprecation notice*! If you use this
+    functionality keep a close eye on the changelog for any changes that may affect your analysis.
+
 Force calibration
 =================
 

--- a/lumicks/pylake/__about__.py
+++ b/lumicks/pylake/__about__.py
@@ -1,5 +1,5 @@
 __title__ = "lumicks.pylake"
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 __summary__ = "Bluelake data analysis tools"
 __url__ = "https://github.com/lumicks/pylake"
 


### PR DESCRIPTION
#### Why this PR?
We want to do a release to get some of the bugfixes and new features out there.

Note that this PR puts a notice at the top of the force calibration page that this API may still be subject to change (as this depends on how well the current API integrates with BL).