### PR TITLE
black: don't let black affect the testing environment

### DIFF
--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -22,10 +22,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .
-        pip install black==20.8b1
     - name: Pytest
       run: |
         cd .github/workflows
         python pylake_test.py
     - name: Black
-      run: black --check --diff --color .
+      run: |
+        pip install black==20.8b1
+        black --check --diff --color .


### PR DESCRIPTION
**Why this PR?**
Black's dependencies should be installed after running pytest, so that its dependencies don't affect the tests. Otherwise this could mask missing dependencies.

Note that I did test this on a commit which had this problem, and indeed now the test that should have failed fails.