### PR TITLE
kymotracker: fix position clamping bug in sample_from_image

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,15 @@
 * Added `FdCurve.with_baseline_corrected_x()` to return a baseline corrected version of the FD curve if the corrected data is available. **Note: currently the baseline is only calculated for the x-component of the force channel in Bluelake. Therefore baseline corrected `FdCurve` instances use only the x-component of the force channel, unlike default `FdCurve`s which use the full magnitude of the force channel by default.**
 * Added ability to perform arithmetic on `Slice` (e.g. `(f.force1x - f.force2x) / 2`). For more information see [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#exporting-h5-files) for more information.
 
+#### Bug fixes
+
+* Fixed bug in kymotracker which could result in `sample_from_image` returning erroneous values in some cases.
+  When sampling the image, we sample pixels in a region around the traced line.
+  This sampling procedure is constrained to stay within the image bounds.
+  Previously, we used the incorrect axis to clamp the pixel index along the positional axis.
+  As a consequence, kymographs that are wider (in terms of number of pixels on the positional axis) than they are long (in terms of number of pixels along the time axis) would only have an accurate sampling in the top half of the kymograph.
+  The lower portion of the kymograph would result in zero counts.
+
 #### Breaking changes
 
 * Dropped support for Python 3.6.

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -154,15 +154,9 @@ class KymoLine:
         reduce : callable
             Function evaluated on the sample. (Default: np.sum which produces sum of photon counts).
         """
-        y_size = self._image.data.shape[1]
-
         # Time and coordinates are being cast to an integer since we use them to index into a data array.
         return [
-            reduce(
-                self._image.data[
-                    max(int(c) - num_pixels, 0) : min(int(c) + num_pixels + 1, y_size), int(t)
-                ]
-            )
+            reduce(self._image.data[max(int(c) - num_pixels, 0) : int(c) + num_pixels + 1, int(t)])
             for t, c in zip(self.time_idx, self.coordinate_idx)
         ]
 

--- a/lumicks/pylake/tests/test_kymotracker.py
+++ b/lumicks/pylake/tests/test_kymotracker.py
@@ -346,6 +346,17 @@ def test_kymotracker_integration_tests():
     assert np.allclose(lines[0].time_idx, np.arange(14, 26))
 
 
+def test_regression_sample_from_image_clamp():
+    """This tests for a regression that occurred in sample_from_image. When sampling the image, we
+    sample pixels in a region around the line. This sampling procedure is constrained to stay within
+    the image. Previously, we used the incorrect axis to clamp the coordinate.
+    """
+    # Sampling the bottom row of a three pixel tall image will return [0, 0] instead of [1, 3];
+    # since both coordinates would be clamped to the edge of the image (sampling nothing)."""
+    img = CalibratedKymographChannel("test_data", np.array([[1, 1, 1], [3, 3, 3]]).T, 1e9, 1)
+    assert np.array_equal(KymoLine([0, 1], [2, 2], img).sample_from_image(0), [1, 3])
+
+
 def test_kymotracker_integration_tests_subset():
     """If this test fires, it likely means that either the coordinates are not coordinates w.r.t. the original image,
     or that the reference to the image held by KymoLine is a reference to a subset of the image, while the coordinates


### PR DESCRIPTION
**Why this PR?**
It fixes a pretty serious bug. I think the changelog describes it best:

Fixed bug in kymotracker which could result in `sample_from_image` returning erroneous values in some cases. When sampling the image, we sample pixels in a region around the traced line. This sampling procedure is constrained to stay within the image bounds. Previously, we used the incorrect axis to clamp the pixel index along the positional axis.

As a consequence, kymographs that are wider (in terms of number of pixels on the positional axis) than they are long (in terms of number of pixels along the time axis) would only have an accurate sampling in the top half of the kymograph. The lower portion of the kymograph would result in zero counts.

The fix is simple. You could clamp by the other axis. Now despite that I would like a 1 character fix, we don't actually need the upper bound clamp, since numpy handles this gracefully. The only clamp that is actually needed is the lower bound clamp (since negative indices would imply slicing from the end, which is not what we want).