### PR TITLE
Bugfix rectangle-based tracking `track_greedy`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,11 @@
   Previously, we used the incorrect axis to clamp the pixel index along the positional axis.
   As a consequence, kymographs that are wider (in terms of number of pixels on the positional axis) than they are long (in terms of number of pixels along the time axis) would only have an accurate sampling in the top half of the kymograph.
   The lower portion of the kymograph would result in zero counts.
+* Fixed bug which could lead to bias when tracking lines using `track_greedy()` with the rectangle tool.
+  Selecting which region to track used to pass that region specifically to the tracking algorithm.
+  This means that the algorithm is unable to sample the image outside of the passed region.
+  Therefore, this can lead to a bias when the line to be tracked is near the edge of the selected region.
+  In the updated version, all image processing steps that depend on the image use the full image.
 
 #### Breaking changes
 

--- a/lumicks/pylake/kymotracker/detail/calibrated_images.py
+++ b/lumicks/pylake/kymotracker/detail/calibrated_images.py
@@ -47,6 +47,13 @@ class CalibratedKymographChannel:
             kymo.pixelsize_um[0],
         )
 
+    def _to_pixel_rect(self, rect):
+        (t0, p0), (t1, p1) = rect
+        return [
+            [self.from_seconds(t0), self.from_position(p0)],
+            [self.from_seconds(t1), self.from_position(p1)],
+        ]
+
     def get_rect(self, rect):
         """Grab a subset of the image in the coordinates of the image
 
@@ -56,9 +63,7 @@ class CalibratedKymographChannel:
             Rectangle specified in time and positional units according to
             ((min_time, min_position), (max_time, max_position))
         """
-        ((t0, p0), (t1, p1)) = rect
-        t0_pixels, t1_pixels = self.from_seconds(t0), self.from_seconds(t1)
-        p0_pixels, p1_pixels = self.from_position(p0), self.from_position(p1)
+        (t0_pixels, p0_pixels), (t1_pixels, p1_pixels) = self._to_pixel_rect(rect)
 
         if np.any(np.array([t0_pixels, t1_pixels, p0_pixels, p1_pixels]) < 0):
             raise IndexError(
@@ -68,18 +73,18 @@ class CalibratedKymographChannel:
 
         if p0_pixels > self.data.shape[0]:
             raise IndexError(
-                f"Specified minimum position {p0} beyond the valid position range {self.to_position(self.data.shape[0])}"
+                f"Specified minimum position beyond the valid position range {self.to_position(self.data.shape[0])}"
             )
 
         if t0_pixels > self.data.shape[1]:
             raise IndexError(
-                f"Specified minimum time {t0} beyond the time range {self.to_seconds(self.data.shape[1])}"
+                f"Specified minimum time beyond the time range {self.to_seconds(self.data.shape[1])}"
             )
 
-        if t0 >= t1:
+        if t0_pixels >= t1_pixels:
             raise IndexError("Please specify rectangle from minimum time to maximum time")
 
-        if p0 >= p1:
+        if p0_pixels >= p1_pixels:
             raise IndexError("Please specify rectangle from minimum position to maximum position")
 
         return self.data[p0_pixels:p1_pixels, t0_pixels:t1_pixels]


### PR DESCRIPTION
This PR fixes a bug which could lead to bias when tracking lines using `track_greedy` with the rectangle tool.

Basically, in the widget, a user can select a rectangle in which to track lines. Selecting which region to track used to pass that region specifically to the tracking algorithm. This means that the algorithm is unable to sample the image outside of the passed region. Therefore, this can lead to a bias when the line to be tracked is near the edge of the selected region. In the updated version, all image processing steps that depend on the image use the full image.

One could argue that we could be more restrictive and apply the image processing on only a small portion of the image, but given that this is only a very small part of the run-time of the algorithm, the added complexity this would induce doesn't make much sense.

Note that `track_lines` is affected by the same bug, but was left out of scope for this PR to keep it a manageable size.

Broken (red lines indicate the region "selected" to be passed to the tracker):
![image](https://user-images.githubusercontent.com/19836026/117303013-883fea80-ae7c-11eb-8a52-1f324ca257b5.png)
You can see how there's a slight bias in estimated y-position.

Fixed (red lines indicate the region "selected" to be passed to the tracker):
![image](https://user-images.githubusercontent.com/19836026/117303075-9a218d80-ae7c-11eb-910e-042c2bdebd35.png)
