### PR TITLE
kymotracker: fix bug in `track_lines`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,10 @@
   This means that the algorithm is unable to sample the image outside of the passed region.
   Therefore, this can lead to a bias when the line to be tracked is near the edge of the selected region.
   In the updated version, all image processing steps that depend on the image use the full image.
+* Fixed bug which could lead to bias when tracking lines using `track_lines()` with the rectangle tool.
+  Selecting which region to track used to pass that region specifically to the tracking algorithm.
+  This means that the blurring steps involved in this algorithm become biased (since they do not get contributions from outside the selected areas, while they should).
+  In the updated version, all image processing steps that depend on the image use the full image.
 
 #### Breaking changes
 

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -170,8 +170,8 @@ def track_lines(
         Factor which determines how the angle between normals needs to be weighted relative to
         distance. High values push for straighter lines. Weighting occurs according to
         distance + angle_weight * angle difference
-    rect : tuple of two pixel coordinates
-        Only perform tracking over a subset of the image. Pixel coordinates should be given as:
+    rect : tuple of two coordinates
+        Only perform tracking over a subset of the image. Coordinates should be given as:
         ((min_time, min_coord), (max_time, max_coord)).
 
     References
@@ -181,19 +181,18 @@ def track_lines(
     """
     kymograph_channel = CalibratedKymographChannel.from_kymo(kymograph, channel)
     lines = detect_lines(
-        kymograph_channel.get_rect(rect) if rect else kymograph_channel.data,
+        kymograph_channel.data,
         line_width,
         max_lines=max_lines,
         start_threshold=start_threshold,
         continuation_threshold=continuation_threshold,
         angle_weight=angle_weight,
         force_dir=1,
+        roi=kymograph_channel._to_pixel_rect(rect) if rect else None,
     )
 
-    lines = [KymoLine(line.time_idx, line.coordinate_idx, kymograph_channel) for line in lines]
-
     return KymoLineGroup(
-        [line.with_offset(rect[0][0], rect[0][1]) for line in lines] if rect else lines
+        [KymoLine(line.time_idx, line.coordinate_idx, kymograph_channel) for line in lines]
     )
 
 

--- a/lumicks/pylake/tests/test_kymotracker.py
+++ b/lumicks/pylake/tests/test_kymotracker.py
@@ -376,7 +376,9 @@ def test_kymotracker_integration_tests_subset():
 
 def test_kymotracker_test_bias_rect():
     """Computing the kymograph of a subset of the image should not affect the results of the
-    tracking."""
+    tracking. If this test fires, it means that kymotracking on a subset of the image does not
+    produce the same result as on the full thing for `track_greedy()`.
+    """
 
     # Generate a checkerboard pattern with a single line that we wish to track. The line is on the
     # 12th pixel.
@@ -389,6 +391,26 @@ def test_kymotracker_test_bias_rect():
     tracking_settings = {"line_width": 3, "pixel_threshold": 4, "sigma": 5, "window": 9}
     traces_rect = track_greedy(kymo, "red", **tracking_settings, rect=[[0, 2], [1000, 12]])
     traces_full = track_greedy(kymo, "red", **tracking_settings)
+
+    for t1, t2 in zip(traces_rect, traces_full):
+        assert np.allclose(t1.position, t2.position)
+
+
+def test_kymotracker_test_bias_rect_lines():
+    """Computing the kymograph of a subset of the image should not affect the results of the
+    tracking. If this test fires, it means that kymotracking on a subset of the image does not
+    produce the same result as on the full thing for `track_lines()`.
+    """
+
+    img_data = np.array([np.array([1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 6, 0, 1, 0]),
+                         np.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 6, 1, 0, 1])])
+    img_data = np.tile(img_data.T, (1, 7))
+
+    kymo = generate_kymo("chan", img_data, dt=int(0.01e9), pixel_size_nm=1e3)
+
+    tracking_settings = {"line_width": 1.5, "max_lines": 0}
+    traces_rect = track_lines(kymo, "red", **tracking_settings, rect=[[0, 2], [22, 12]])
+    traces_full = track_lines(kymo, "red", **tracking_settings)
 
     for t1, t2 in zip(traces_rect, traces_full):
         assert np.allclose(t1.position, t2.position)


### PR DESCRIPTION
This PR fixes a bug which could lead to bias when tracking lines using track_greedy with the rectangle tool.

Selecting which region to track used to pass that region specifically to the tracking algorithm. This algorithm does a lot of filtering, which means that all these results become biased if the distance between the edge of the ROI and the line becomes too small.

See also https://github.com/lumicks/pylake/pull/146 which fixes a similar issue for the other Kymotracking algorithm.

While the problem is similar, the fixes are different for the two algorithms (hence two PRs).