### PR TITLE
kymo: raise NotImplemented error for slicing post downsampling

### DIFF
--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -53,6 +53,12 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
         self._timestamp_factory = _default_timestamp_factory
         self._cache = {}
 
+    def _has_default_factories(self):
+        return (
+            self._image_factory == _default_image_factory
+            and self._timestamp_factory == _default_timestamp_factory
+        )
+
     @classmethod
     def from_dataset(cls, h5py_dset, file):
         """

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -45,6 +45,12 @@ class Kymo(ConfocalImage):
         super().__init__(name, file, start, stop, json)
         self._line_time_factory = _default_line_time_factory
 
+    def _has_default_factories(self):
+        return (
+            super()._has_default_factories()
+            and self._line_time_factory == _default_line_time_factory
+        )
+
     def __repr__(self):
         name = self.__class__.__name__
         return f"{name}(pixels={self.pixels_per_line})"
@@ -55,6 +61,11 @@ class Kymo(ConfocalImage):
             raise IndexError("Scalar indexing is not supported, only slicing")
         if item.step is not None:
             raise IndexError("Slice steps are not supported")
+        if not self._has_default_factories():
+            raise NotImplementedError(
+                "Slicing is not implemented for processed kymographs. Please slice prior to "
+                "processing the data."
+            )
 
         start = self.start if item.start is None else item.start
         stop = self.stop if item.stop is None else item.stop

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -294,3 +294,20 @@ def test_calibrated_channels():
     assert np.allclose(calibrated_channel.data, image)
     assert np.allclose(calibrated_channel.time_step_ns, kymo.line_time_seconds * int(1e9))
     assert np.allclose(calibrated_channel._pixel_size, kymo.pixelsize_um[0])
+
+
+def test_downsampled_slice():
+    """There was a regression bug that if a Kymo was downsampled and then sliced, it would undo the
+    downsampling. For now, we just flag it as not implemented behaviour."""
+    kymo = generate_kymo(
+        "Mock",
+        image=np.array([[2, 2], [2, 2]], dtype=np.uint8),
+        pixel_size_nm=1,
+        start=100,
+        dt=7,
+        samples_per_pixel=5,
+        line_padding=2,
+    )
+
+    with pytest.raises(NotImplementedError):
+        kymo.downsampled_by(time_factor=2)["1s":"2s"]


### PR DESCRIPTION
## Why this PR?
Currently slicing after downsampling undoes the downsampling. This is undesirable.

In the future, we will implement slicing in a different way, but a good implementation of this will depend on a number of other features being present first (copy constructor, a separate function for getting start times of the lines that is preserved under downsampling). For now, it's best to leave it explicitly `NotImplemented` to prevent users from getting dependent on weird behaviour.

This PR adds a check whether the factories are the defaults prior to slicing as any specialized factories would be ignored currently.