### PR TITLE
force_calibration: fix plotting order model and data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
   Selecting which region to track used to pass that region specifically to the tracking algorithm.
   This means that the blurring steps involved in this algorithm become biased (since they do not get contributions from outside the selected areas, while they should).
   In the updated version, all image processing steps that depend on the image use the full image.
+* Fixed a bug in the plotting order of `CalibrationResults.plot()`. Previously, when plotting after performing a force calibration, the model fit was erroneously plotted first (while the legend indicated that the model fit was plotted last). The results of the calibration itself are unchanged.
 
 #### Breaking changes
 

--- a/lumicks/pylake/force_calibration/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/power_spectrum.py
@@ -74,9 +74,15 @@ class PowerSpectrum:
 
         return ps
 
-    def plot(self):
-        """Plot power spectrum"""
-        plt.plot(self.frequency, self.power)
+    def plot(self, **kwargs):
+        """Plot power spectrum
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to :func:`matplotlib.pyplot.plot`.
+        """
+        plt.plot(self.frequency, self.power, **kwargs)
         plt.xlabel("Frequency [Hz]")
         plt.ylabel(f"Power [${self.unit}^2/Hz$]")
         plt.xscale("log")

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -87,9 +87,9 @@ class CalibrationResults:
 
     def plot(self):
         """Plot the fitted spectrum"""
-        self.ps_model_fit.plot()
-        self.ps_fitted.plot()
-        plt.legend(["Data", "Model"])
+        self.ps_fitted.plot(label="Data")
+        self.ps_model_fit.plot(label="Model")
+        plt.legend()
 
     def _print_data(self, tablefmt="text"):
         table = [


### PR DESCRIPTION
**Why this PR?**
This PR fixes a bug in the plotting order of `CalibrationResults.plot()`. Previously, when plotting after performing a force calibration, the model fit was erroneously plotted first (while the legend indicated that the model fit was plotted last). The results of the calibration itself are unchanged.

![image](https://user-images.githubusercontent.com/19836026/117979983-c719e880-b333-11eb-95da-f22cd750c759.png)
*Figure 1: Cool. The model looks more non-ideal than the data ?!?*