### PR TITLE
force_calibration: tighten test tolerances

### DIFF
--- a/lumicks/pylake/fitting/tests/test_stepping.py
+++ b/lumicks/pylake/fitting/tests/test_stepping.py
@@ -40,7 +40,7 @@ import numpy as np
     (np.array([-1, -1]), np.array([2, -4]), np.array([-2, -2]), np.array([2, 2]), np.array([-0.5, -2.0])),
 ])
 def test_clamp_vector(origin, step, lb, ub, result):
-    assert np.allclose(clamp_step(origin, step, lb, ub)[0], result)
+    np.testing.assert_allclose(clamp_step(origin, step, lb, ub)[0], result)
 
 
 cfg = StepConfig(min_abs_step=1e-4,
@@ -80,7 +80,7 @@ def test_stepper(chi2_function, start_pos, step_sign, target_step_size, target_p
                                  step_config=cfg)
 
     assert step_size == target_step_size
-    assert np.allclose(p_trial, target_p_trial)
+    np.testing.assert_allclose(p_trial, target_p_trial)
 
 
 def test_minimum_step():
@@ -98,4 +98,4 @@ def test_minimum_step():
                                      step_sign=1,
                                      step_config=cfg)
         assert step_size == cfg.min_abs_step
-        assert np.allclose(p_trial, np.array([2.0 + cfg.min_abs_step, 2.0 + cfg.min_abs_step]))
+        np.testing.assert_allclose(p_trial, np.array([2.0 + cfg.min_abs_step, 2.0 + cfg.min_abs_step]))

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -69,7 +69,7 @@ def test_fit_analytic(
     fit = fit_analytical_lorentzian(ps.in_range(1e1, 1e4))
 
     assert np.allclose(fit.fc, corner_frequency)
-    assert np.allclose(fit.D, diffusion_constant)
+    assert np.allclose(fit.D, diffusion_constant, rtol=1e-5, atol=0)
     assert np.allclose(fit.sigma_fc, sigma_fc)
     assert np.allclose(fit.sigma_D, sigma_diffusion)
 

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -68,7 +68,7 @@ def test_fit_analytic(
 
     fit = fit_analytical_lorentzian(ps.in_range(1e1, 1e4))
 
-    np.testing.assert_allclose(fit.fc, corner_frequency)
+    np.testing.assert_allclose(fit.fc, corner_frequency, rtol=1e-5)
     np.testing.assert_allclose(fit.D, diffusion_constant, rtol=1e-5, atol=0)
     np.testing.assert_allclose(fit.sigma_fc, sigma_fc)
     np.testing.assert_allclose(fit.sigma_D, sigma_diffusion)
@@ -79,4 +79,4 @@ def test_fit_analytic_curve():
     ref = [0.0396382, 0.0389208, 0.03691641, 0.03399826, 0.03061068, 0.02713453]
     fit = fit_analytical_lorentzian(ps)
     np.testing.assert_allclose(fit.ps_fit.frequency, np.arange(0, 60, 10))
-    np.testing.assert_allclose(fit.ps_fit.power, ref)
+    np.testing.assert_allclose(fit.ps_fit.power, ref, rtol=1e-5)

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -4,11 +4,11 @@ from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
 
 
 def test_friction_coefficient():
-    assert np.allclose(sphere_friction_coefficient(5, 1), 3 * np.pi * 5 * 1)
+    np.testing.assert_allclose(sphere_friction_coefficient(5, 1), 3 * np.pi * 5 * 1)
 
 
 def test_spectrum(reference_models):
-    assert np.allclose(
+    np.testing.assert_allclose(
         passive_power_spectrum_model(np.arange(10000), 1000, 1e9, 10000, 0.5),
         reference_models.lorentzian_filtered(np.arange(10000), 1000, 1e9, 0.5, 10000),
     )
@@ -25,14 +25,14 @@ def test_spectrum_parameter_scaling(reference_models):
     fc, diff, alpha, diode = 1000, 1e9, 0.5, 10000
     a_scaled = _convert_to_a(alpha) / a_true
 
-    assert np.allclose(
+    np.testing.assert_allclose(
         scaled_psc(f, fc / initials[0], diff / initials[1], diode / initials[2], a_scaled),
         reference_models.lorentzian_filtered(f, fc, diff, alpha, diode),
     )
 
     # Test whether unity values in scaled-world indeed lead to the correct initial parameters
-    assert np.allclose(scaled_psc.scale_params((1.0, 1.0, 1.0, 1.0)), initials)
-    assert np.allclose(
+    np.testing.assert_allclose(scaled_psc.scale_params((1.0, 1.0, 1.0, 1.0)), initials)
+    np.testing.assert_allclose(
         scaled_psc(f, 1.0, 1.0, 1.0, 1.0),
         reference_models.lorentzian_filtered(f, initials[0], initials[1], initials[3], initials[2]),
         rtol=1e-6,
@@ -68,15 +68,15 @@ def test_fit_analytic(
 
     fit = fit_analytical_lorentzian(ps.in_range(1e1, 1e4))
 
-    assert np.allclose(fit.fc, corner_frequency)
-    assert np.allclose(fit.D, diffusion_constant, rtol=1e-5, atol=0)
-    assert np.allclose(fit.sigma_fc, sigma_fc)
-    assert np.allclose(fit.sigma_D, sigma_diffusion)
+    np.testing.assert_allclose(fit.fc, corner_frequency)
+    np.testing.assert_allclose(fit.D, diffusion_constant, rtol=1e-5, atol=0)
+    np.testing.assert_allclose(fit.sigma_fc, sigma_fc)
+    np.testing.assert_allclose(fit.sigma_D, sigma_diffusion)
 
 
 def test_fit_analytic_curve():
     ps = PowerSpectrum([3, 3, 4, 5, 1, 3, 2, 4, 5, 2], 100)
     ref = [0.0396382, 0.0389208, 0.03691641, 0.03399826, 0.03061068, 0.02713453]
     fit = fit_analytical_lorentzian(ps)
-    assert np.allclose(fit.ps_fit.frequency, np.arange(0, 60, 10))
-    assert np.allclose(fit.ps_fit.power, ref)
+    np.testing.assert_allclose(fit.ps_fit.frequency, np.arange(0, 60, 10))
+    np.testing.assert_allclose(fit.ps_fit.power, ref)

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
@@ -28,7 +28,7 @@ def test_power_spectrum_attrs(frequency, num_data, sample_rate):
     assert np.allclose(determined_frequency, frequency)  # Is the frequency at the right position?
 
     # Is all the power at this frequency? (Valid when dealing with multiples of the sample rate)
-    assert np.allclose(power_spectrum.power[np.argmax(power_spectrum.power)], np.sum(power_spectrum.power))
+    assert np.allclose(power_spectrum.power[np.argmax(power_spectrum.power)], np.sum(power_spectrum.power), atol=1e-16)
     assert np.allclose(power_spectrum.total_duration, num_data / sample_rate)
 
 
@@ -50,7 +50,7 @@ def test_power_spectrum_blocking(frequency, num_data, sample_rate, num_blocks, f
     downsampling_factor = len(power_spectrum.frequency) // num_blocks
     blocked = power_spectrum.downsampled_by(downsampling_factor)
     assert np.allclose(blocked.frequency, f_blocked)
-    assert np.allclose(blocked.power, p_blocked)
+    assert np.allclose(blocked.power, p_blocked, atol=1e-16)
     assert np.allclose(blocked.num_samples(), len(f_blocked))
     assert np.allclose(len(power_spectrum.power), num_data // 2 + 1)
     assert np.allclose(blocked.num_points_per_block, np.floor(len(power_spectrum.power) / num_blocks))
@@ -83,7 +83,7 @@ def test_in_range(frequency, num_data, sample_rate, num_blocks, f_min, f_max):
     # Note that this different from the slice behaviour you'd normally expect
     mask = (power_spectrum.frequency > f_min) & (power_spectrum.frequency <= f_max)
     assert np.allclose(power_subset.frequency, power_spectrum.frequency[mask])
-    assert np.allclose(power_subset.power, power_spectrum.power[mask])
+    assert np.allclose(power_subset.power, power_spectrum.power[mask], atol=1e-16)
     assert np.allclose(power_spectrum.total_duration, power_subset.total_duration)
     assert np.allclose(power_spectrum.sample_rate, power_subset.sample_rate)
 
@@ -100,7 +100,7 @@ def test_replace_spectrum():
     replaced = power_spectrum.with_spectrum(np.arange(6))
 
     assert np.allclose(power_spectrum.frequency, replaced.frequency)
-    assert np.allclose(replaced.power, np.arange(6))
+    assert np.allclose(replaced.power, np.arange(6), atol=1e-16)
     assert np.allclose(replaced.num_points_per_block, 1)
     assert np.allclose(replaced.sample_rate, power_spectrum.sample_rate)
     assert np.allclose(replaced.total_duration, power_spectrum.total_duration)

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
@@ -20,16 +20,16 @@ def test_power_spectrum_attrs(frequency, num_data, sample_rate):
 
     df = sample_rate / num_data
     frequency_axis = np.arange(0, 0.5 * sample_rate + 1, df)
-    assert np.allclose(power_spectrum.frequency, frequency_axis)
-    assert np.allclose(power_spectrum.num_samples(), len(frequency_axis))
+    np.testing.assert_allclose(power_spectrum.frequency, frequency_axis)
+    np.testing.assert_allclose(power_spectrum.num_samples(), len(frequency_axis))
 
     # Functional test
     determined_frequency = power_spectrum.frequency[np.argmax(power_spectrum.power)]
-    assert np.allclose(determined_frequency, frequency)  # Is the frequency at the right position?
+    np.testing.assert_allclose(determined_frequency, frequency)  # Is the frequency at the right position?
 
     # Is all the power at this frequency? (Valid when dealing with multiples of the sample rate)
-    assert np.allclose(power_spectrum.power[np.argmax(power_spectrum.power)], np.sum(power_spectrum.power), atol=1e-16)
-    assert np.allclose(power_spectrum.total_duration, num_data / sample_rate)
+    np.testing.assert_allclose(power_spectrum.power[np.argmax(power_spectrum.power)], np.sum(power_spectrum.power), atol=1e-16)
+    np.testing.assert_allclose(power_spectrum.total_duration, num_data / sample_rate)
 
 
 @pytest.mark.parametrize(
@@ -49,15 +49,15 @@ def test_power_spectrum_blocking(frequency, num_data, sample_rate, num_blocks, f
 
     downsampling_factor = len(power_spectrum.frequency) // num_blocks
     blocked = power_spectrum.downsampled_by(downsampling_factor)
-    assert np.allclose(blocked.frequency, f_blocked)
-    assert np.allclose(blocked.power, p_blocked, atol=1e-16)
-    assert np.allclose(blocked.num_samples(), len(f_blocked))
-    assert np.allclose(len(power_spectrum.power), num_data // 2 + 1)
-    assert np.allclose(blocked.num_points_per_block, np.floor(len(power_spectrum.power) / num_blocks))
+    np.testing.assert_allclose(blocked.frequency, f_blocked)
+    np.testing.assert_allclose(blocked.power, p_blocked, atol=1e-16)
+    np.testing.assert_allclose(blocked.num_samples(), len(f_blocked))
+    np.testing.assert_allclose(len(power_spectrum.power), num_data // 2 + 1)
+    np.testing.assert_allclose(blocked.num_points_per_block, np.floor(len(power_spectrum.power) / num_blocks))
 
     # Downsample again and make sure the num_points_per_block is correct
     dual_blocked = blocked.downsampled_by(2)
-    assert np.allclose(dual_blocked.num_points_per_block, blocked.num_points_per_block * 2)
+    np.testing.assert_allclose(dual_blocked.num_points_per_block, blocked.num_points_per_block * 2)
 
 
 @pytest.mark.parametrize(
@@ -82,10 +82,10 @@ def test_in_range(frequency, num_data, sample_rate, num_blocks, f_min, f_max):
 
     # Note that this different from the slice behaviour you'd normally expect
     mask = (power_spectrum.frequency > f_min) & (power_spectrum.frequency <= f_max)
-    assert np.allclose(power_subset.frequency, power_spectrum.frequency[mask])
-    assert np.allclose(power_subset.power, power_spectrum.power[mask], atol=1e-16)
-    assert np.allclose(power_spectrum.total_duration, power_subset.total_duration)
-    assert np.allclose(power_spectrum.sample_rate, power_subset.sample_rate)
+    np.testing.assert_allclose(power_subset.frequency, power_spectrum.frequency[mask])
+    np.testing.assert_allclose(power_subset.power, power_spectrum.power[mask], atol=1e-16)
+    np.testing.assert_allclose(power_spectrum.total_duration, power_subset.total_duration)
+    np.testing.assert_allclose(power_spectrum.sample_rate, power_subset.sample_rate)
 
 
 @cleanup
@@ -99,8 +99,8 @@ def test_replace_spectrum():
     power_spectrum = PowerSpectrum(np.arange(10), 5)
     replaced = power_spectrum.with_spectrum(np.arange(6))
 
-    assert np.allclose(power_spectrum.frequency, replaced.frequency)
-    assert np.allclose(replaced.power, np.arange(6), atol=1e-16)
-    assert np.allclose(replaced.num_points_per_block, 1)
-    assert np.allclose(replaced.sample_rate, power_spectrum.sample_rate)
-    assert np.allclose(replaced.total_duration, power_spectrum.total_duration)
+    np.testing.assert_allclose(power_spectrum.frequency, replaced.frequency)
+    np.testing.assert_allclose(replaced.power, np.arange(6), atol=1e-16)
+    np.testing.assert_allclose(replaced.num_points_per_block, 1)
+    np.testing.assert_allclose(replaced.sample_rate, power_spectrum.sample_rate)
+    np.testing.assert_allclose(replaced.total_duration, power_spectrum.total_duration)

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -55,14 +55,14 @@ def test_calibration_result():
     "corner_frequency,diffusion_constant,alpha,f_diode,num_samples,viscosity,bead_diameter,temperature,err_fc,err_d,"
     "err_f_diode,err_alpha,",
     [
-        [1000, 1e-9, 0.5, 10000, 30000, 1.002e-3, 4.0, 20.0, 29.77266, 0.00000, 1239.06183, 0.05650019],
-        [1500, 1.2e-9, 0.5, 10000, 50000, 1.002e-3, 4.0, 20.0, 47.21810, 0.00000, 1399.04982, 0.05896166],
-        [1500, 1.2e-9, 0.5, 5000, 10000, 1.002e-3, 4.0, 20.0, 84.85429, 0.00000, 827.43118, 0.03077534],
-        [1500, 1.2e-9, 0.5, 5000, 10000, 1.2e-3, 4.0, 20.0, 84.85429, 0.00000, 827.43118, 0.03077534],
-        [1500, 1.2e-9, 0.5, 5000, 10000, 1.002e-3, 8.0, 20.0, 84.85429, 0.00000, 827.43118, 0.03077534],
-        [1500, 1.2e-9, 0.5, 5000, 10000, 1.002e-3, 4.0, 34.0, 84.85429, 0.00000, 827.43118, 0.03077534],
-        [1000, 1e-9, 0.5, 10000, 30000, 1.002e-3, 4.0, 20.0, 29.77266, 0.00000, 1239.06183, 0.05650019],
-        [1000, 1e-9, 0.5, 10000, 30000, 1, 4.0, 20.0, 29.77266, 0.00000, 1239.06183, 0.05650019],
+        [1000, 1e-9, 0.5, 10000, 30000, 1.002e-3, 4.0, 20.0, 29.77266, 2.9846e-11, 1239.06183, 0.05650019],
+        [1500, 1.2e-9, 0.5, 10000, 50000, 1.002e-3, 4.0, 20.0, 47.21810, 4.5890e-11, 1399.04982, 0.05896166],
+        [1500, 1.2e-9, 0.5, 5000, 10000, 1.002e-3, 4.0, 20.0, 84.85429, 1.04547e-10, 827.43118, 0.03077534],
+        [1500, 1.2e-9, 0.5, 5000, 10000, 1.2e-3, 4.0, 20.0, 84.85429, 1.04547e-10, 827.43118, 0.03077534],
+        [1500, 1.2e-9, 0.5, 5000, 10000, 1.002e-3, 8.0, 20.0, 84.85429, 1.04547e-10, 827.43118, 0.03077534],
+        [1500, 1.2e-9, 0.5, 5000, 10000, 1.002e-3, 4.0, 34.0, 84.85429, 1.04547e-10, 827.43118, 0.03077534],
+        [1000, 1e-9, 0.5, 10000, 30000, 1.002e-3, 4.0, 20.0, 29.77266, 2.9846e-11, 1239.06183, 0.05650019],
+        [1000, 1e-9, 0.5, 10000, 30000, 1, 4.0, 20.0, 29.77266, 2.9846e-11, 1239.06183, 0.05650019],
     ],
 )
 def test_good_fit_integration_test(
@@ -86,7 +86,7 @@ def test_good_fit_integration_test(
     ps_calibration = psc.fit_power_spectrum(power_spectrum=power_spectrum, model=model)
 
     assert np.allclose(ps_calibration["fc (Hz)"], corner_frequency, rtol=1e-4)
-    assert np.allclose(ps_calibration["D (V^2/s)"], diffusion_constant, rtol=1e-5)
+    assert np.allclose(ps_calibration["D (V^2/s)"], diffusion_constant, rtol=1e-4, atol=0)
     assert np.allclose(ps_calibration["alpha"], alpha, rtol=1e-4)
     assert np.allclose(ps_calibration["f_diode (Hz)"], f_diode, rtol=1e-4)
 
@@ -102,7 +102,7 @@ def test_good_fit_integration_test(
     assert np.allclose(ps_calibration["chi_squared_per_deg"], 0)  # Noise free
 
     assert np.allclose(ps_calibration["err_fc"], err_fc)
-    assert np.allclose(ps_calibration["err_D"], err_d)
+    assert np.allclose(ps_calibration["err_D"], err_d, rtol=1e-4, atol=0)
     assert np.allclose(ps_calibration["err_f_diode"], err_f_diode)
     assert np.allclose(ps_calibration["err_alpha"], err_alpha)
 
@@ -155,7 +155,7 @@ def reference_calibration_result():
 def test_actual_spectrum(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
 
-    assert np.allclose(ps_calibration["D (V^2/s)"], 0.0018512665210876748, rtol=1e-4)
+    assert np.allclose(ps_calibration["D (V^2/s)"], 0.0018512665210876748, rtol=1e-4, atol=0)
     assert np.allclose(ps_calibration["Rd (um/V)"], 7.253645956145265, rtol=1e-4)
     assert np.allclose(ps_calibration["Rf (pN/V)"], 1243.9711315478219, rtol=1e-4)
     assert np.allclose(ps_calibration["kappa (pN/nm)"], 0.17149598134079505, rtol=1e-4)
@@ -163,7 +163,7 @@ def test_actual_spectrum(reference_calibration_result):
     assert np.allclose(ps_calibration["backing (%)"], 66.4331056392512, rtol=1e-4)
     assert np.allclose(ps_calibration["chi_squared_per_deg"], 1.063783302378645, rtol=1e-4)
     assert np.allclose(ps_calibration["err_fc"], 32.23007993226726, rtol=1e-4)
-    assert np.allclose(ps_calibration["err_D"], 6.43082000774291e-05, rtol=1e-4)
+    assert np.allclose(ps_calibration["err_D"], 6.43082000774291e-05, rtol=1e-4, atol=0)
     assert np.allclose(ps_calibration["err_alpha"], 0.013141463933316694, rtol=1e-4)
     assert np.allclose(ps_calibration["err_f_diode"], 561.6377089699399, rtol=1e-4)
 
@@ -185,7 +185,6 @@ def test_attributes_ps_calibration(reference_calibration_result):
 
 def test_repr(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
-    print(str(ps_calibration))
     assert str(ps_calibration) == dedent("""\
         Name                 Description                                               Value
         -------------------  --------------------------------------------------------  -----------------------

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -99,7 +99,7 @@ def test_good_fit_integration_test(
     np.testing.assert_allclose(ps_calibration["kappa (pN/nm)"], kappa_true, rtol=1e-4)
     np.testing.assert_allclose(ps_calibration["Rd (um/V)"], rd_true, rtol=1e-4)
     np.testing.assert_allclose(ps_calibration["Rf (pN/V)"], rd_true * kappa_true * 1e3, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["chi_squared_per_deg"], 0)  # Noise free
+    np.testing.assert_allclose(ps_calibration["chi_squared_per_deg"], 0, atol=1e-9)  # Noise free
 
     np.testing.assert_allclose(ps_calibration["err_fc"], err_fc)
     np.testing.assert_allclose(ps_calibration["err_D"], err_d, rtol=1e-4, atol=0)

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -85,10 +85,10 @@ def test_good_fit_integration_test(
     power_spectrum = psc.calculate_power_spectrum(data, f_sample, fit_range=(0, 15000), num_points_per_block=20)
     ps_calibration = psc.fit_power_spectrum(power_spectrum=power_spectrum, model=model)
 
-    assert np.allclose(ps_calibration["fc (Hz)"], corner_frequency, rtol=1e-4)
-    assert np.allclose(ps_calibration["D (V^2/s)"], diffusion_constant, rtol=1e-4, atol=0)
-    assert np.allclose(ps_calibration["alpha"], alpha, rtol=1e-4)
-    assert np.allclose(ps_calibration["f_diode (Hz)"], f_diode, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["fc (Hz)"], corner_frequency, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["D (V^2/s)"], diffusion_constant, rtol=1e-4, atol=0)
+    np.testing.assert_allclose(ps_calibration["alpha"], alpha, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["f_diode (Hz)"], f_diode, rtol=1e-4)
 
     gamma = sphere_friction_coefficient(viscosity, bead_diameter * 1e-6)
     kappa_true = 2.0 * np.pi * gamma * corner_frequency * 1e3
@@ -96,15 +96,15 @@ def test_good_fit_integration_test(
         np.sqrt(sp.constants.k * sp.constants.convert_temperature(temperature, "C", "K") / gamma / diffusion_constant)
         * 1e6
     )
-    assert np.allclose(ps_calibration["kappa (pN/nm)"], kappa_true, rtol=1e-4)
-    assert np.allclose(ps_calibration["Rd (um/V)"], rd_true, rtol=1e-4)
-    assert np.allclose(ps_calibration["Rf (pN/V)"], rd_true * kappa_true * 1e3, rtol=1e-4)
-    assert np.allclose(ps_calibration["chi_squared_per_deg"], 0)  # Noise free
+    np.testing.assert_allclose(ps_calibration["kappa (pN/nm)"], kappa_true, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["Rd (um/V)"], rd_true, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["Rf (pN/V)"], rd_true * kappa_true * 1e3, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["chi_squared_per_deg"], 0)  # Noise free
 
-    assert np.allclose(ps_calibration["err_fc"], err_fc)
-    assert np.allclose(ps_calibration["err_D"], err_d, rtol=1e-4, atol=0)
-    assert np.allclose(ps_calibration["err_f_diode"], err_f_diode)
-    assert np.allclose(ps_calibration["err_alpha"], err_alpha)
+    np.testing.assert_allclose(ps_calibration["err_fc"], err_fc)
+    np.testing.assert_allclose(ps_calibration["err_D"], err_d, rtol=1e-4, atol=0)
+    np.testing.assert_allclose(ps_calibration["err_f_diode"], err_f_diode)
+    np.testing.assert_allclose(ps_calibration["err_alpha"], err_alpha)
 
 
 def test_bad_calibration_result_arg():
@@ -155,17 +155,17 @@ def reference_calibration_result():
 def test_actual_spectrum(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
 
-    assert np.allclose(ps_calibration["D (V^2/s)"], 0.0018512665210876748, rtol=1e-4, atol=0)
-    assert np.allclose(ps_calibration["Rd (um/V)"], 7.253645956145265, rtol=1e-4)
-    assert np.allclose(ps_calibration["Rf (pN/V)"], 1243.9711315478219, rtol=1e-4)
-    assert np.allclose(ps_calibration["kappa (pN/nm)"], 0.17149598134079505, rtol=1e-4)
-    assert np.allclose(ps_calibration["alpha"], 0.5006103727942776, rtol=1e-4)
-    assert np.allclose(ps_calibration["backing (%)"], 66.4331056392512, rtol=1e-4)
-    assert np.allclose(ps_calibration["chi_squared_per_deg"], 1.063783302378645, rtol=1e-4)
-    assert np.allclose(ps_calibration["err_fc"], 32.23007993226726, rtol=1e-4)
-    assert np.allclose(ps_calibration["err_D"], 6.43082000774291e-05, rtol=1e-4, atol=0)
-    assert np.allclose(ps_calibration["err_alpha"], 0.013141463933316694, rtol=1e-4)
-    assert np.allclose(ps_calibration["err_f_diode"], 561.6377089699399, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["D (V^2/s)"], 0.0018512665210876748, rtol=1e-4, atol=0)
+    np.testing.assert_allclose(ps_calibration["Rd (um/V)"], 7.253645956145265, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["Rf (pN/V)"], 1243.9711315478219, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["kappa (pN/nm)"], 0.17149598134079505, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["alpha"], 0.5006103727942776, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["backing (%)"], 66.4331056392512, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["chi_squared_per_deg"], 1.063783302378645, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["err_fc"], 32.23007993226726, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["err_D"], 6.43082000774291e-05, rtol=1e-4, atol=0)
+    np.testing.assert_allclose(ps_calibration["err_alpha"], 0.013141463933316694, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["err_f_diode"], 561.6377089699399, rtol=1e-4)
 
 
 @cleanup

--- a/lumicks/pylake/kymotracker/tests/test_calibrated_images.py
+++ b/lumicks/pylake/kymotracker/tests/test_calibrated_images.py
@@ -22,10 +22,10 @@ def test_fields_calibrated_kymograph_channel(test_img):
     )
     assert calibrated_channel.name == "test"
     assert np.all(calibrated_channel.data == test_img)
-    assert np.allclose(calibrated_channel.time_step_ns, 3e9)
-    assert np.allclose(calibrated_channel._pixel_size, 7)
-    assert np.allclose(calibrated_channel.to_position(np.array([1, 2, 3])), [7, 14, 21])
-    assert np.allclose(calibrated_channel.to_seconds(np.array([1, 2, 3])), [3, 6, 9])
+    np.testing.assert_allclose(calibrated_channel.time_step_ns, 3e9)
+    np.testing.assert_allclose(calibrated_channel._pixel_size, 7)
+    np.testing.assert_allclose(calibrated_channel.to_position(np.array([1, 2, 3])), [7, 14, 21])
+    np.testing.assert_allclose(calibrated_channel.to_seconds(np.array([1, 2, 3])), [3, 6, 9])
 
 
 @pytest.mark.parametrize(
@@ -58,7 +58,7 @@ def test_in_rect(test_img, rect, valid_result):
 def test_rect_errors(rect):
     data = np.random.rand(15, 25)
     calibrated_channel = CalibratedKymographChannel("test", data, time_step_ns=1e9, pixel_size=1)
-    assert np.allclose(calibrated_channel.get_rect(((5, 8), (22, 20))), data[8:20, 5:22])
+    np.testing.assert_allclose(calibrated_channel.get_rect(((5, 8), (22, 20))), data[8:20, 5:22])
 
     with pytest.raises(IndexError):
         calibrated_channel.get_rect(rect)

--- a/lumicks/pylake/kymotracker/tests/test_calibrated_images.py
+++ b/lumicks/pylake/kymotracker/tests/test_calibrated_images.py
@@ -39,7 +39,7 @@ def test_in_rect(test_img, rect, valid_result):
     calibrated_channel = CalibratedKymographChannel(
         "test", test_img, time_step_ns=3e9, pixel_size=7
     )
-    np.allclose(calibrated_channel.get_rect(rect), valid_result)
+    np.testing.assert_allclose(calibrated_channel.get_rect(rect), valid_result)
 
 
 @pytest.mark.parametrize(

--- a/lumicks/pylake/kymotracker/tests/test_io.py
+++ b/lumicks/pylake/kymotracker/tests/test_io.py
@@ -57,18 +57,18 @@ def test_kymolinegroup_io(tmpdir_factory, kymolinegroup_io_data, dt, dx, delimit
     assert len(read_file) == len(lines)
 
     for line1, line2 in zip(lines, read_file):
-        assert np.allclose(np.array(line1.coordinate_idx), np.array(line2.coordinate_idx))
-        assert np.allclose(np.array(line1.time_idx), np.array(line2.time_idx))
+        np.testing.assert_allclose(np.array(line1.coordinate_idx), np.array(line2.coordinate_idx))
+        np.testing.assert_allclose(np.array(line1.time_idx), np.array(line2.time_idx))
 
     for line1, time in zip(lines, data["time"]):
-        assert np.allclose(line1.seconds, time)
+        np.testing.assert_allclose(line1.seconds, time)
 
     for line1, coord in zip(lines, data["position"]):
-        assert np.allclose(line1.position, coord)
+        np.testing.assert_allclose(line1.position, coord)
 
     if sampling_width is None:
         assert len([key for key in data.keys() if "counts" in key]) == 0
     else:
         count_field = [key for key in data.keys() if "counts" in key][0]
         for line1, cnt in zip(lines, data[count_field]):
-            assert np.allclose([sampling_outcome] * len(line1.coordinate_idx), cnt)
+            np.testing.assert_allclose([sampling_outcome] * len(line1.coordinate_idx), cnt)

--- a/lumicks/pylake/kymotracker/tests/test_kymoline.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymoline.py
@@ -10,14 +10,14 @@ def test_kymo_line():
     channel = CalibratedKymographChannel("test_data", np.array([[]]), 1e9, 1)
 
     k1 = KymoLine(np.array([1, 2, 3]), np.array([2, 3, 4]), channel)
-    assert np.allclose(k1[1], [2, 3])
-    assert np.allclose(k1[-1], [3, 4])
-    assert np.allclose(k1[0:2], [[1, 2], [2, 3]])
-    assert np.allclose(k1[0:2][:, 1], [2, 3])
+    np.testing.assert_allclose(k1[1], [2, 3])
+    np.testing.assert_allclose(k1[-1], [3, 4])
+    np.testing.assert_allclose(k1[0:2], [[1, 2], [2, 3]])
+    np.testing.assert_allclose(k1[0:2][:, 1], [2, 3])
 
     k2 = KymoLine(np.array([4, 5, 6]), np.array([5, 6, 7]), channel)
-    assert np.allclose((k1 + k2)[:], [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7]])
-    assert np.allclose(k1.extrapolate(True, 3, 2.0), [5, 6])
+    np.testing.assert_allclose((k1 + k2)[:], [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7]])
+    np.testing.assert_allclose(k1.extrapolate(True, 3, 2.0), [5, 6])
 
     # Need at least 2 points for linear extrapolation
     with pytest.raises(AssertionError):
@@ -30,7 +30,7 @@ def test_kymo_line():
     k2 = k1.with_offset(2, 2)
     assert id(k2) != id(k1)
 
-    assert np.allclose(k2.coordinate_idx, [3, 4, 5])
+    np.testing.assert_allclose(k2.coordinate_idx, [3, 4, 5])
     assert k1._image == channel
     assert k2._image == channel
 
@@ -65,8 +65,8 @@ def test_kymoline_from_kymolinedata():
     channel = CalibratedKymographChannel("test_data", np.array([[]]), 1e9, 5)
     time, pos = np.array([4, 5, 6]), np.array([7, 7, 7])
     kl = KymoLine._from_kymolinedata(KymoLineData(time, pos), channel)
-    assert np.allclose(kl.time_idx, time)
-    assert np.allclose(kl.coordinate_idx, pos)
+    np.testing.assert_allclose(kl.time_idx, time)
+    np.testing.assert_allclose(kl.coordinate_idx, pos)
     assert id(kl._image) == id(channel)
 
 
@@ -157,8 +157,8 @@ def test_kymoline_concat():
 
     # Finally do a correct merge
     group._concatenate_lines(k1, k2)
-    assert np.allclose(group[0].seconds, [1, 2, 3, 6, 7, 8])
-    assert np.allclose(group[1].seconds, [3, 4, 5])
+    np.testing.assert_allclose(group[0].seconds, [1, 2, 3, 6, 7, 8])
+    np.testing.assert_allclose(group[1].seconds, [3, 4, 5])
 
 
 @pytest.mark.parametrize(
@@ -183,12 +183,12 @@ def test_msd_api(time_scale, position_scale):
     k = KymoLine(time_scale * time_idx, position_scale * position_idx, image=image)
 
     lags, msd = k.msd()
-    assert np.allclose(lags, time_idx[1:])
-    assert np.allclose(msd, position_idx[1:] ** 2)
+    np.testing.assert_allclose(lags, time_idx[1:])
+    np.testing.assert_allclose(msd, position_idx[1:] ** 2)
 
     lags, msd = k.msd(max_lag=4)
-    assert np.allclose(lags, time_idx[1:5])
-    assert np.allclose(msd, position_idx[1:5] ** 2)
+    np.testing.assert_allclose(lags, time_idx[1:5])
+    np.testing.assert_allclose(msd, position_idx[1:5] ** 2)
 
 
 @pytest.mark.parametrize(
@@ -208,7 +208,7 @@ def test_diffusion_msd(time_idx, coordinate, pixel_size, time_step, max_lag, dif
     image = CalibratedKymographChannel("test", np.array([[]]), time_step, pixel_size)
     k = KymoLine(time_idx, coordinate / pixel_size, image=image)
 
-    assert np.allclose(k.estimate_diffusion_ols(max_lag=max_lag), diffusion_const)
+    np.testing.assert_allclose(k.estimate_diffusion_ols(max_lag=max_lag), diffusion_const)
 
 
 @pytest.mark.parametrize(
@@ -227,5 +227,5 @@ def test_kymoline_msd_plot(max_lag, x_data, y_data):
     plt.figure()
     k = KymoLine(np.arange(1, 6), np.arange(1, 6), image=image)
     k.plot_msd(max_lag=max_lag)
-    assert np.allclose(plt.gca().lines[0].get_xdata(), x_data)
-    assert np.allclose(plt.gca().lines[0].get_ydata(), y_data)
+    np.testing.assert_allclose(plt.gca().lines[0].get_xdata(), x_data)
+    np.testing.assert_allclose(plt.gca().lines[0].get_ydata(), y_data)

--- a/lumicks/pylake/kymotracker/tests/test_msd.py
+++ b/lumicks/pylake/kymotracker/tests/test_msd.py
@@ -49,8 +49,8 @@ def simulate_diffusion_1d(diffusion, steps, dt, observation_noise):
 )
 def test_msd_estimation(time, position, max_lag, lag, msd):
     lag_est, msd_est = calculate_msd(time, position, max_lag)
-    assert np.allclose(lag_est, lag)
-    assert np.allclose(msd_est, msd)
+    np.testing.assert_allclose(lag_est, lag)
+    np.testing.assert_allclose(msd_est, msd)
 
 
 @pytest.mark.parametrize(
@@ -63,7 +63,7 @@ def test_msd_estimation(time, position, max_lag, lag, msd):
 )
 def test_estimate(frame_idx, coordinate, time_step, max_lag, diffusion_const):
     diffusion_est = estimate_diffusion_constant_simple(frame_idx, coordinate, time_step, max_lag)
-    assert np.allclose(diffusion_est, diffusion_const)
+    np.testing.assert_allclose(diffusion_est, diffusion_const)
 
 
 def test_maxlag_asserts():
@@ -110,8 +110,8 @@ def test_localization_eq():
 )
 def test_optimal_points(N, ref_slopes, ref_intercepts):
     test_values = np.hstack((np.arange(-2, 7, 0.5), np.inf))
-    assert np.allclose(ref_slopes, [optimal_points(10 ** x, N)[0] for x in test_values])
-    assert np.allclose(ref_intercepts, [optimal_points(10 ** x, N)[1] for x in test_values])
+    np.testing.assert_allclose(ref_slopes, [optimal_points(10 ** x, N)[0] for x in test_values])
+    np.testing.assert_allclose(ref_intercepts, [optimal_points(10 ** x, N)[1] for x in test_values])
 
 
 @pytest.mark.parametrize(
@@ -128,7 +128,7 @@ def test_optimal_points(N, ref_slopes, ref_intercepts):
 def test_determine_points_from_data(diffusion, num_steps, step, noise, n_optimal):
     with temp_seed(0):
         coordinate = simulate_diffusion_1d(diffusion, num_steps, step, noise)
-        assert np.allclose(
+        np.testing.assert_allclose(
             determine_optimal_points(np.arange(num_steps), coordinate, max_iterations=100),
             n_optimal,
         )

--- a/lumicks/pylake/kymotracker/tests/test_peakfinding.py
+++ b/lumicks/pylake/kymotracker/tests/test_peakfinding.py
@@ -38,12 +38,12 @@ def test_kymopeaks():
     time_points = np.array([0.0, 1.0, 0.5, 1.0])
     peak_amplitudes = np.array([2.0, 3.0, 3.0, 2.0])
     peaks = KymoPeaks(coordinates, time_points, peak_amplitudes)
-    assert np.allclose(peaks.frames[0].coordinates, [3.2, 6.4])
-    assert np.allclose(peaks.frames[1].coordinates, [4.1, 8.2])
-    assert np.allclose(peaks.frames[0].time_points, [0.0, 0.5])
-    assert np.allclose(peaks.frames[1].time_points, [1.0, 1.0])
-    assert np.allclose(peaks.frames[0].peak_amplitudes, [2.0, 3.0])
-    assert np.allclose(peaks.frames[1].peak_amplitudes, [3.0, 2.0])
+    np.testing.assert_allclose(peaks.frames[0].coordinates, [3.2, 6.4])
+    np.testing.assert_allclose(peaks.frames[1].coordinates, [4.1, 8.2])
+    np.testing.assert_allclose(peaks.frames[0].time_points, [0.0, 0.5])
+    np.testing.assert_allclose(peaks.frames[1].time_points, [1.0, 1.0])
+    np.testing.assert_allclose(peaks.frames[0].peak_amplitudes, [2.0, 3.0])
+    np.testing.assert_allclose(peaks.frames[1].peak_amplitudes, [3.0, 2.0])
 
 
 def test_peak_proximity_removal():
@@ -54,8 +54,8 @@ def test_peak_proximity_removal():
     peaks = KymoPeaks(coordinates, time_points, peak_amplitudes)
 
     new_peaks = merge_close_peaks(peaks, 1.0)
-    assert np.allclose(new_peaks.frames[0].coordinates, [4.1, 6.4, 8.2, 12.1])
-    assert np.allclose(new_peaks.frames[1].coordinates, [3.2, 6.4, 8.2, 12.2])
+    np.testing.assert_allclose(new_peaks.frames[0].coordinates, [4.1, 6.4, 8.2, 12.1])
+    np.testing.assert_allclose(new_peaks.frames[1].coordinates, [3.2, 6.4, 8.2, 12.2])
 
     permute = [1, 2, 9, 5, 3, 11, 4, 8, 7, 0, 6, 10]
     coordinates = coordinates[permute]

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -10,14 +10,14 @@ def test_kymoline_interpolation():
     coordinate_idx = np.array([1.0, 3.0, 3.0])
     kymoline = KymoLine(time_idx, coordinate_idx, [])
     interpolated = kymoline.interpolate()
-    assert np.allclose(interpolated.time_idx, [1.0, 2.0, 3.0, 4.0, 5.0])
-    assert np.allclose(interpolated.coordinate_idx, [1.0, 2.0, 3.0, 3.0, 3.0])
+    np.testing.assert_allclose(interpolated.time_idx, [1.0, 2.0, 3.0, 4.0, 5.0])
+    np.testing.assert_allclose(interpolated.coordinate_idx, [1.0, 2.0, 3.0, 3.0, 3.0])
 
     # Test whether concatenation still works after interpolation
-    assert np.allclose(
+    np.testing.assert_allclose(
         (interpolated + kymoline).time_idx, [1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 3.0, 5.0]
     )
-    assert np.allclose(
+    np.testing.assert_allclose(
         (interpolated + kymoline).coordinate_idx, [1.0, 2.0, 3.0, 3.0, 3.0, 1.0, 3.0, 3.0]
     )
 
@@ -36,12 +36,12 @@ def test_refinement_2d():
 
     line = KymoLine(time_idx[::2], coordinate_idx[::2], image=image)
     refined_line = refine_lines_centroid([line], 5)[0]
-    assert np.allclose(refined_line.time_idx, time_idx)
-    assert np.allclose(refined_line.coordinate_idx, coordinate_idx + offset)
+    np.testing.assert_allclose(refined_line.time_idx, time_idx)
+    np.testing.assert_allclose(refined_line.coordinate_idx, coordinate_idx + offset)
 
     # Test whether concatenation still works after refinement
-    assert np.allclose((refined_line + line).time_idx, np.hstack((time_idx, time_idx[::2])))
-    assert np.allclose(
+    np.testing.assert_allclose((refined_line + line).time_idx, np.hstack((time_idx, time_idx[::2])))
+    np.testing.assert_allclose(
         (refined_line + line).coordinate_idx,
         np.hstack((coordinate_idx + offset, coordinate_idx[::2])),
     )
@@ -53,4 +53,4 @@ def test_refinement_line(loc, inv_sigma=0.3):
     image = np.exp(-inv_sigma * xx * xx)
     calibrated_image = CalibratedKymographChannel.from_array(np.expand_dims(image, 1))
     line = refine_lines_centroid([KymoLine([0], [25], image=calibrated_image)], 5)[0]
-    assert np.allclose(line.coordinate_idx, loc, rtol=1e-2)
+    np.testing.assert_allclose(line.coordinate_idx, loc, rtol=1e-2)

--- a/lumicks/pylake/kymotracker/tests/test_tracing.py
+++ b/lumicks/pylake/kymotracker/tests/test_tracing.py
@@ -45,7 +45,7 @@ def test_score_matrix():
             -3.0254695407844476,
         ],
     ]
-    assert np.allclose(matrix, reference)
+    np.testing.assert_allclose(matrix, reference)
 
     # With velocity
     matrix = np.reshape(build_score_matrix(lines, times, positions, kymo_score(vel=1, sigma=.5, diffusion=.125),
@@ -58,7 +58,7 @@ def test_score_matrix():
         [-np.inf, -np.inf, -np.inf, -np.inf, -np.inf, -3.4376941012509463, -1.5278640450004204],
         [-np.inf, -np.inf, -np.inf, -np.inf, -np.inf, -np.inf, -3.0254695407844476],
     ]
-    assert np.allclose(matrix, reference)
+    np.testing.assert_allclose(matrix, reference)
 
 
 def test_line_append():
@@ -72,20 +72,20 @@ def test_line_append():
         return score
 
     assert append_next_point(kymoline, frame, score_fun)
-    assert np.allclose(kymoline.time_idx, [0.0, 1.0])
-    assert np.allclose(kymoline.coordinate_idx, [2.0, 2.0])
+    np.testing.assert_allclose(kymoline.time_idx, [0.0, 1.0])
+    np.testing.assert_allclose(kymoline.coordinate_idx, [2.0, 2.0])
     assert np.array_equal(frame.unassigned, [True, False, True])
 
     # Coordinate 3 is closer, but last score returns -np.inf for score
     assert append_next_point(kymoline, frame, score_fun)
-    assert np.allclose(kymoline.time_idx, [0.0, 1.0, 1.0])
-    assert np.allclose(kymoline.coordinate_idx, [2.0, 2.0, 1.0])
+    np.testing.assert_allclose(kymoline.time_idx, [0.0, 1.0, 1.0])
+    np.testing.assert_allclose(kymoline.coordinate_idx, [2.0, 2.0, 1.0])
     assert np.array_equal(frame.unassigned, [False, False, True])
 
     # Only coordinate 3 is left, but returns -np.inf and should not be considered a candidate ever. Terminate line!
     assert not append_next_point(kymoline, frame, score_fun)  # No more assignable coordinates
-    assert np.allclose(kymoline.time_idx, [0.0, 1.0, 1.0])
-    assert np.allclose(kymoline.coordinate_idx, [2.0, 2.0, 1.0])
+    np.testing.assert_allclose(kymoline.time_idx, [0.0, 1.0, 1.0])
+    np.testing.assert_allclose(kymoline.coordinate_idx, [2.0, 2.0, 1.0])
     assert np.array_equal(frame.unassigned, [False, False, True])
 
 
@@ -105,25 +105,25 @@ def test_extend_line():
     # and our window only goes up one frame
     kymoline = KymoLineData([0.0], [4.0])
     extend_line(kymoline, peaks, 1, score_fun)
-    assert np.allclose(kymoline.coordinate_idx, np.array([4.0, 4.0, 5.0, 6.0]))
+    np.testing.assert_allclose(kymoline.coordinate_idx, np.array([4.0, 4.0, 5.0, 6.0]))
 
     # 4, 5, 6 no longer being available, we should get 1, 2, 3
     kymoline = KymoLineData([0.0], [4.0])
     extend_line(kymoline, peaks, 1, score_fun)
-    assert np.allclose(kymoline.coordinate_idx, np.array([4.0, 1.0, 2.0, 3.0]))
+    np.testing.assert_allclose(kymoline.coordinate_idx, np.array([4.0, 1.0, 2.0, 3.0]))
 
     # With a bigger window, we should get 7.0 too
     peaks.reset_assignment()
     kymoline = KymoLineData([0.0], [4.0])
     extend_line(kymoline, peaks, 2, score_fun)
-    assert np.allclose(kymoline.coordinate_idx, np.array([4.0, 4.0, 5.0, 6.0, 7.0]))
+    np.testing.assert_allclose(kymoline.coordinate_idx, np.array([4.0, 4.0, 5.0, 6.0, 7.0]))
 
     # Starting from t=2, we should only get 6
     # and our window only goes up one frame
     peaks.reset_assignment()
     kymoline = KymoLineData([2.0], [5.0])
     extend_line(kymoline, peaks, 1, score_fun)
-    assert np.allclose(kymoline.coordinate_idx, np.array([5.0, 6.0]))
+    np.testing.assert_allclose(kymoline.coordinate_idx, np.array([5.0, 6.0]))
 
 
 def test_kymotracker_two_integration():
@@ -141,9 +141,9 @@ def test_kymotracker_two_integration():
         window=8,
         sigma_cutoff=2
     )
-    assert np.allclose(lines[0].coordinate_idx, [1.0, 2.0, 3.0])
-    assert np.allclose(lines[1].time_idx, [1.0, 2.0, 3.0, 5.0])
-    assert np.allclose(lines[1].coordinate_idx, [4.0, 5.0, 6.0, 7.0])
+    np.testing.assert_allclose(lines[0].coordinate_idx, [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(lines[1].time_idx, [1.0, 2.0, 3.0, 5.0])
+    np.testing.assert_allclose(lines[1].coordinate_idx, [4.0, 5.0, 6.0, 7.0])
 
     lines = points_to_line_segments(
         peaks,
@@ -151,11 +151,11 @@ def test_kymotracker_two_integration():
         window=1,
         sigma_cutoff=2
     )
-    assert np.allclose(lines[0].coordinate_idx, [1.0, 2.0, 3.0])
-    assert np.allclose(lines[1].time_idx, [1.0, 2.0, 3.0])
-    assert np.allclose(lines[1].coordinate_idx, [4.0, 5.0, 6.0])
-    assert np.allclose(lines[2].time_idx, [5.0])
-    assert np.allclose(lines[2].coordinate_idx, [7.0])
+    np.testing.assert_allclose(lines[0].coordinate_idx, [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(lines[1].time_idx, [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(lines[1].coordinate_idx, [4.0, 5.0, 6.0])
+    np.testing.assert_allclose(lines[2].time_idx, [5.0])
+    np.testing.assert_allclose(lines[2].coordinate_idx, [7.0])
 
 
 def test_sampling():
@@ -171,16 +171,16 @@ def test_sampling():
 
     # Tests the bound handling
     kymoline = KymoLine([0, 1, 2, 3, 4], [0, 1, 2, 3, 4], test_img)
-    assert np.allclose(kymoline.sample_from_image(50), [0, 2, 3, 2, 0])
-    assert np.allclose(kymoline.sample_from_image(2), [0, 2, 3, 2, 0])
-    assert np.allclose(kymoline.sample_from_image(1), [0, 2, 2, 2, 0])
-    assert np.allclose(kymoline.sample_from_image(0), [0, 1, 1, 1, 0])
-    assert np.allclose(KymoLine([0, 1, 2, 3, 4], [4, 4, 4, 4, 4], test_img).sample_from_image(0), [0, 0, 1, 1, 0])
+    np.testing.assert_allclose(kymoline.sample_from_image(50), [0, 2, 3, 2, 0])
+    np.testing.assert_allclose(kymoline.sample_from_image(2), [0, 2, 3, 2, 0])
+    np.testing.assert_allclose(kymoline.sample_from_image(1), [0, 2, 2, 2, 0])
+    np.testing.assert_allclose(kymoline.sample_from_image(0), [0, 1, 1, 1, 0])
+    np.testing.assert_allclose(KymoLine([0, 1, 2, 3, 4], [4, 4, 4, 4, 4], test_img).sample_from_image(0), [0, 0, 1, 1, 0])
 
     kymoline = KymoLine([0.1, 1.1, 2.1, 3.1, 4.1], [0.1, 1.1, 2.1, 3.1, 4.1], test_img)
-    assert np.allclose(kymoline.sample_from_image(50), [0, 2, 3, 2, 0])
-    assert np.allclose(kymoline.sample_from_image(2), [0, 2, 3, 2, 0])
-    assert np.allclose(kymoline.sample_from_image(1), [0, 2, 2, 2, 0])
-    assert np.allclose(kymoline.sample_from_image(0), [0, 1, 1, 1, 0])
-    assert np.allclose(KymoLine([0.1, 1.1, 2.1, 3.1, 4.1], [4.1, 4.1, 4.1, 4.1, 4.1], test_img).sample_from_image(0),
+    np.testing.assert_allclose(kymoline.sample_from_image(50), [0, 2, 3, 2, 0])
+    np.testing.assert_allclose(kymoline.sample_from_image(2), [0, 2, 3, 2, 0])
+    np.testing.assert_allclose(kymoline.sample_from_image(1), [0, 2, 2, 2, 0])
+    np.testing.assert_allclose(kymoline.sample_from_image(0), [0, 1, 1, 1, 0])
+    np.testing.assert_allclose(KymoLine([0.1, 1.1, 2.1, 3.1, 4.1], [4.1, 4.1, 4.1, 4.1, 4.1], test_img).sample_from_image(0),
                        [0, 0, 1, 1, 0])

--- a/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
+++ b/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
@@ -93,7 +93,7 @@ def test_selector_widget(mockevent):
     event = mockevent(selector._axes, 900, 1, rmb, False)
     selector.handle_button_event(event)
     assert selector.current_range == []
-    np.testing.assert_allclose(selector.ranges, [[]])
+    np.testing.assert_allclose(selector.ranges, [])
 
     assert selector.fdcurves == []
 
@@ -171,7 +171,7 @@ def test_distance_selector_widget(mockevent):
     event = mockevent(selector._axes, 7, 1, rmb, False)
     selector.handle_button_event(event)
     assert selector.current_range == []
-    np.testing.assert_allclose(selector.ranges, [[]])
+    np.testing.assert_allclose(selector.ranges, [])
 
     assert selector.fdcurves == []
 

--- a/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
+++ b/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
@@ -32,11 +32,11 @@ def test_selector_widget(mockevent):
     assert selector.current_range == [750]
     selector._add_point(450)
     assert selector.current_range == []
-    assert np.allclose(selector.ranges, [[450, 750]])
+    np.testing.assert_allclose(selector.ranges, [[450, 750]])
     selector._add_point(850)
     selector._add_point(950)
     assert selector.current_range == []
-    assert np.allclose(selector.ranges, [[450, 750], [850, 950]])
+    np.testing.assert_allclose(selector.ranges, [[450, 750], [850, 950]])
 
     assert selector.to_seconds(2500e9) == 0
     selector.update_plot()
@@ -69,9 +69,9 @@ def test_selector_widget(mockevent):
     event = mockevent(selector._axes, 950, 1, lmb, False)
     selector.handle_button_event(event)
     assert selector.current_range == []
-    assert np.allclose(selector.ranges, [start_point + dt, start_point + 2*dt])
+    np.testing.assert_allclose(selector.ranges, [start_point + dt, start_point + 2*dt])
 
-    assert np.allclose(selector.fdcurves[0].f.data, fd_curve[start_point + dt:start_point + 2*dt].f.data)
+    np.testing.assert_allclose(selector.fdcurves[0].f.data, fd_curve[start_point + dt:start_point + 2*dt].f.data)
 
     # Add another segment
     selector.handle_button_event(mockevent(selector._axes, 150, 1, lmb, False))
@@ -81,19 +81,19 @@ def test_selector_widget(mockevent):
     event = mockevent(selector._axes, 1300, 1, rmb, False)
     selector.handle_button_event(event)
     assert selector.current_range == []
-    assert np.allclose(selector.ranges, [[start_point + dt, start_point + 2*dt], [start_point, start_point + 2*dt]])
+    np.testing.assert_allclose(selector.ranges, [[start_point + dt, start_point + 2*dt], [start_point, start_point + 2*dt]])
 
     # Remove a segment (inner segment, smallest segment gets removed first)
     event = mockevent(selector._axes, 900, 1, rmb, False)
     selector.handle_button_event(event)
     assert selector.current_range == []
-    assert np.allclose(selector.ranges, [[start_point, start_point + 2*dt]])
+    np.testing.assert_allclose(selector.ranges, [[start_point, start_point + 2*dt]])
 
     # Remove a segment (inner segment, smallest segment gets removed first)
     event = mockevent(selector._axes, 900, 1, rmb, False)
     selector.handle_button_event(event)
     assert selector.current_range == []
-    assert np.allclose(selector.ranges, [[]])
+    np.testing.assert_allclose(selector.ranges, [[]])
 
     assert selector.fdcurves == []
 
@@ -111,11 +111,11 @@ def test_distance_selector_widget(mockevent):
     assert selector.current_range == [2]
     selector._add_point(4)
     assert selector.current_range == []
-    assert np.allclose(selector.ranges, [[2, 4]])
+    np.testing.assert_allclose(selector.ranges, [[2, 4]])
     selector._add_point(6)
     selector._add_point(9)
     assert selector.current_range == []
-    assert np.allclose(selector.ranges, [[2, 4], [6, 9]])
+    np.testing.assert_allclose(selector.ranges, [[2, 4], [6, 9]])
 
     selector.update_plot()
 
@@ -147,9 +147,9 @@ def test_distance_selector_widget(mockevent):
     event = mockevent(selector._axes, 4, 1, lmb, False)
     selector.handle_button_event(event)
     assert selector.current_range == []
-    assert np.allclose(selector.ranges, [2, 4])
+    np.testing.assert_allclose(selector.ranges, [2, 4])
 
-    assert np.allclose(selector.fdcurves[0].f.data, fd_curve[start_point + 2*dt:start_point + 5*dt].f.data)
+    np.testing.assert_allclose(selector.fdcurves[0].f.data, fd_curve[start_point + 2*dt:start_point + 5*dt].f.data)
 
     # Add another segment
     selector.handle_button_event(mockevent(selector._axes, 6, 1, lmb, False))
@@ -159,19 +159,19 @@ def test_distance_selector_widget(mockevent):
     event = mockevent(selector._axes, 10, 1, rmb, False)
     selector.handle_button_event(event)
     assert selector.current_range == []
-    assert np.allclose(selector.ranges, [[2, 4], [6, 9]])
+    np.testing.assert_allclose(selector.ranges, [[2, 4], [6, 9]])
 
     # Remove a segment (inner segment, smallest segment gets removed first)
     event = mockevent(selector._axes, 3, 1, rmb, False)
     selector.handle_button_event(event)
     assert selector.current_range == []
-    assert np.allclose(selector.ranges, [[6, 9]])
+    np.testing.assert_allclose(selector.ranges, [[6, 9]])
 
     # Remove a segment (inner segment, smallest segment gets removed first)
     event = mockevent(selector._axes, 7, 1, rmb, False)
     selector.handle_button_event(event)
     assert selector.current_range == []
-    assert np.allclose(selector.ranges, [[]])
+    np.testing.assert_allclose(selector.ranges, [[]])
 
     assert selector.fdcurves == []
 

--- a/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
+++ b/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
@@ -69,7 +69,7 @@ def test_selector_widget(mockevent):
     event = mockevent(selector._axes, 950, 1, lmb, False)
     selector.handle_button_event(event)
     assert selector.current_range == []
-    np.testing.assert_allclose(selector.ranges, [start_point + dt, start_point + 2*dt])
+    np.testing.assert_allclose(selector.ranges, [[start_point + dt, start_point + 2*dt]])
 
     np.testing.assert_allclose(selector.fdcurves[0].f.data, fd_curve[start_point + dt:start_point + 2*dt].f.data)
 
@@ -147,7 +147,7 @@ def test_distance_selector_widget(mockevent):
     event = mockevent(selector._axes, 4, 1, lmb, False)
     selector.handle_button_event(event)
     assert selector.current_range == []
-    np.testing.assert_allclose(selector.ranges, [2, 4])
+    np.testing.assert_allclose(selector.ranges, [[2, 4]])
 
     np.testing.assert_allclose(selector.fdcurves[0].f.data, fd_curve[start_point + 2*dt:start_point + 5*dt].f.data)
 

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -45,14 +45,14 @@ def test_track_kymo(kymograph, region_select):
     # Track a line in a particular region. Only a single line exists in this region.
     kymo_widget.algorithm_parameters["pixel_threshold"] = 4
     kymo_widget.track_kymo(*region_select(8, 10, 9, 20))
-    assert np.allclose(kymo_widget.lines[0].time_idx, np.arange(10, 20))
-    assert np.allclose(kymo_widget.lines[0].coordinate_idx, [8] * 10)
+    np.testing.assert_allclose(kymo_widget.lines[0].time_idx, np.arange(10, 20))
+    np.testing.assert_allclose(kymo_widget.lines[0].coordinate_idx, [8] * 10)
     assert len(kymo_widget.lines) == 1
 
     # Verify that if we track the same region, the old one gets deleted and we track the same line again.
     kymo_widget.track_kymo(*region_select(8, 15, 9, 20))
-    assert np.allclose(kymo_widget.lines[0].time_idx, np.arange(15, 20))
-    assert np.allclose(kymo_widget.lines[0].coordinate_idx, [8] * 5)
+    np.testing.assert_allclose(kymo_widget.lines[0].time_idx, np.arange(15, 20))
+    np.testing.assert_allclose(kymo_widget.lines[0].coordinate_idx, [8] * 5)
     assert len(kymo_widget.lines) == 1
 
     # Tracking all lines will result in all lines being found.
@@ -84,8 +84,8 @@ def test_save_load_from_ui(kymograph, tmpdir_factory):
     kymo_widget._load_from_ui()
 
     for l1, l2 in zip(lines, kymo_widget.lines):
-        assert np.allclose(l1.time_idx, l2.time_idx)
-        assert np.allclose(l1.coordinate_idx, l2.coordinate_idx)
+        np.testing.assert_allclose(l1.time_idx, l2.time_idx)
+        np.testing.assert_allclose(l1.coordinate_idx, l2.coordinate_idx)
 
 
 def test_refine_from_widget(kymograph, region_select):
@@ -93,13 +93,13 @@ def test_refine_from_widget(kymograph, region_select):
 
     kymo_widget.algorithm_parameters["pixel_threshold"] = 4
     kymo_widget.track_kymo(*region_select(12, 5, 13, 20))
-    assert np.allclose(kymo_widget.lines[0].time_idx, np.hstack(([5, 6], np.arange(9, 20))))
-    assert np.allclose(kymo_widget.lines[0].coordinate_idx, [12] * 13)
+    np.testing.assert_allclose(kymo_widget.lines[0].time_idx, np.hstack(([5, 6], np.arange(9, 20))))
+    np.testing.assert_allclose(kymo_widget.lines[0].coordinate_idx, [12] * 13)
     assert len(kymo_widget.lines) == 1
 
     kymo_widget.refine()
-    assert np.allclose(kymo_widget.lines[0].time_idx, np.arange(5, 20))
-    assert np.allclose(kymo_widget.lines[0].coordinate_idx, [12] * 15)
+    np.testing.assert_allclose(kymo_widget.lines[0].time_idx, np.arange(5, 20))
+    np.testing.assert_allclose(kymo_widget.lines[0].coordinate_idx, [12] * 15)
     assert len(kymo_widget.lines) == 1
 
 
@@ -133,6 +133,6 @@ def test_stitch(kymograph, mockevent):
     kymo_widget._line_connector.button_release(mockevent(kymo_widget._axes, 6, 3, 3, 0))
 
     # Verify the stitched line
-    assert np.allclose(kymo_widget.lines[0].seconds, [1, 2, 3, 6, 7, 8])
-    assert np.allclose(kymo_widget.lines[0].position, [1, 1, 1, 3, 3, 3])
+    np.testing.assert_allclose(kymo_widget.lines[0].seconds, [1, 2, 3, 6, 7, 8])
+    np.testing.assert_allclose(kymo_widget.lines[0].position, [1, 1, 1, 3, 3, 3])
     assert len(kymo_widget.lines) == 1

--- a/lumicks/pylake/nb_widgets/tests/test_mouse.py
+++ b/lumicks/pylake/nb_widgets/tests/test_mouse.py
@@ -135,4 +135,4 @@ def test_mouse_drag_lim_change(mockevent):
     np.testing.assert_allclose(current_x, 2)
     np.testing.assert_allclose(current_y, 2)
     np.testing.assert_allclose(current_dx, -1)
-    np.testing.assert_allclose(current_dy, 0)
+    np.testing.assert_allclose(current_dy, 0, atol=1e-15)

--- a/lumicks/pylake/nb_widgets/tests/test_mouse.py
+++ b/lumicks/pylake/nb_widgets/tests/test_mouse.py
@@ -37,26 +37,26 @@ def test_mouse_drag(mockevent):
     assert mouse_drag.dragging
 
     mouse_drag.button_down(mockevent(ax, 1, 1, button, 0))
-    assert np.allclose(current_x, 0)
+    np.testing.assert_allclose(current_x, 0)
 
     mouse_drag.handle_motion(mockevent(ax, 2, 2, button, 0))
-    assert np.allclose(current_x, 2)
-    assert np.allclose(current_y, 2)
-    assert np.allclose(current_dx, 1)
-    assert np.allclose(current_dy, 1)
+    np.testing.assert_allclose(current_x, 2)
+    np.testing.assert_allclose(current_y, 2)
+    np.testing.assert_allclose(current_dx, 1)
+    np.testing.assert_allclose(current_dy, 1)
 
     mouse_drag.handle_motion(mockevent(ax, 5, 5, button, 0))
-    assert np.allclose(current_x, 5)
-    assert np.allclose(current_y, 5)
-    assert np.allclose(current_dx, 3)
-    assert np.allclose(current_dy, 3)
+    np.testing.assert_allclose(current_x, 5)
+    np.testing.assert_allclose(current_y, 5)
+    np.testing.assert_allclose(current_dx, 3)
+    np.testing.assert_allclose(current_dy, 3)
 
     mouse_drag.button_release(mockevent(ax, 1, 1, button, 0))
     mouse_drag.handle_motion(mockevent(ax, 15, 15, button, 0))
-    assert np.allclose(current_x, 5)
-    assert np.allclose(current_y, 5)
-    assert np.allclose(current_dx, 3)
-    assert np.allclose(current_dy, 3)
+    np.testing.assert_allclose(current_x, 5)
+    np.testing.assert_allclose(current_y, 5)
+    np.testing.assert_allclose(current_dx, 3)
+    np.testing.assert_allclose(current_dy, 3)
 
 
 def test_set_active():
@@ -126,13 +126,13 @@ def test_mouse_drag_lim_change(mockevent):
     mouse_drag.handle_motion(mockevent(ax, 1, 1, 1, 0))
 
     mouse_drag.handle_motion(mockevent(ax, 2, 2, 1, 0))
-    assert np.allclose(current_x, 2)
-    assert np.allclose(current_y, 2)
-    assert np.allclose(current_dx, 1)
-    assert np.allclose(current_dy, 1)
+    np.testing.assert_allclose(current_x, 2)
+    np.testing.assert_allclose(current_y, 2)
+    np.testing.assert_allclose(current_dx, 1)
+    np.testing.assert_allclose(current_dy, 1)
 
     mouse_drag.handle_motion(mockevent(ax, 2, 2, 1, 0))
-    assert np.allclose(current_x, 2)
-    assert np.allclose(current_y, 2)
-    assert np.allclose(current_dx, -1)
-    assert np.allclose(current_dy, 0)
+    np.testing.assert_allclose(current_x, 2)
+    np.testing.assert_allclose(current_y, 2)
+    np.testing.assert_allclose(current_dx, -1)
+    np.testing.assert_allclose(current_dy, 0)

--- a/lumicks/pylake/population/tests/test_mixture.py
+++ b/lumicks/pylake/population/tests/test_mixture.py
@@ -39,13 +39,13 @@ def test_exit_flag(trace_simple):
     ef = m.exit_flag
     assert ef["converged"] == True
     assert ef["n_iter"] == 2
-    np.testing.assert_allclose(ef["lower_bound"], 0.215335)
+    np.testing.assert_allclose(ef["lower_bound"], 0.215335, rtol=1e-5)
 
 
 def test_pdf(trace_simple):
     data, statepath, params = trace_simple
     m = GaussianMixtureModel(data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100)
-    np.testing.assert_allclose(m.pdf(np.array([10, 11])), [[1.857758, 5e-26], [5e-21, 2.222931]])
+    np.testing.assert_allclose(m.pdf(np.array([10, 11])), [[1.857758, 5e-26], [5e-21, 2.222931]], rtol=1e-5, atol=1e-13)
 
 
 @cleanup

--- a/lumicks/pylake/population/tests/test_mixture.py
+++ b/lumicks/pylake/population/tests/test_mixture.py
@@ -13,23 +13,23 @@ def test_gmm(trace_lownoise):
     weights = weights / weights.sum()
 
     # assert np.all(np.equal(m.label(trace), statepath))
-    assert np.allclose(m.means, params["means"], atol=0.05)
-    assert np.allclose(m.std, params["st_devs"], atol=0.02)
-    assert np.allclose(m.weights, weights)
+    np.testing.assert_allclose(m.means, params["means"], atol=0.05)
+    np.testing.assert_allclose(m.std, params["st_devs"], atol=0.02)
+    np.testing.assert_allclose(m.weights, weights)
 
 def test_gmm_from_slice(trace_simple):
     data, statepath, params = trace_simple
     trace = Slice(Continuous(data, 20000, 12800))
     m = GaussianMixtureModel.from_channel(trace, params["n_states"])
-    assert np.allclose(m.means, params["means"], atol=0.05)
+    np.testing.assert_allclose(m.means, params["means"], atol=0.05)
 
 
 def test_information_criteria(trace_simple):
     data, statepath, params = trace_simple
     m = GaussianMixtureModel(data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100)
 
-    assert np.allclose(m.bic, -20.04115465)
-    assert np.allclose(m.aic, -33.06700559)
+    np.testing.assert_allclose(m.bic, -20.04115465)
+    np.testing.assert_allclose(m.aic, -33.06700559)
 
 
 def test_exit_flag(trace_simple):
@@ -39,13 +39,13 @@ def test_exit_flag(trace_simple):
     ef = m.exit_flag
     assert ef["converged"] == True
     assert ef["n_iter"] == 2
-    assert np.allclose(ef["lower_bound"], 0.215335)
+    np.testing.assert_allclose(ef["lower_bound"], 0.215335)
 
 
 def test_pdf(trace_simple):
     data, statepath, params = trace_simple
     m = GaussianMixtureModel(data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100)
-    assert np.allclose(m.pdf(np.array([10, 11])), [[1.857758, 5e-26], [5e-21, 2.222931]])
+    np.testing.assert_allclose(m.pdf(np.array([10, 11])), [[1.857758, 5e-26], [5e-21, 2.222931]])
 
 
 @cleanup

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -153,20 +153,20 @@ def test_empty_slice():
 
 def test_start_stop():
     s = channel.Slice(channel.TimeSeries([14, 15, 16, 17], [4, 6, 8, 10]))
-    assert np.allclose(s.start, 4)
-    assert np.allclose(s.stop, 10 + 1)
+    np.testing.assert_allclose(s.start, 4)
+    np.testing.assert_allclose(s.stop, 10 + 1)
 
     s = channel.Slice(channel.Continuous([14, 15, 16, 17], 4, 2))
-    assert np.allclose(s.start, 4)
-    assert np.allclose(s.stop, 12)
+    np.testing.assert_allclose(s.start, 4)
+    np.testing.assert_allclose(s.stop, 12)
 
     s = channel.Slice(channel.TimeTags([14, 15, 16, 17]))
-    assert np.allclose(s.start, 14)
-    assert np.allclose(s.stop, 17 + 1)
+    np.testing.assert_allclose(s.start, 14)
+    np.testing.assert_allclose(s.stop, 17 + 1)
 
     s = channel.Slice(channel.TimeTags([14, 15, 16, 17], 4, 30))
-    assert np.allclose(s.start, 4)
-    assert np.allclose(s.stop, 30)
+    np.testing.assert_allclose(s.start, 4)
+    np.testing.assert_allclose(s.stop, 30)
 
 
 def test_timeseries_indexing():
@@ -314,12 +314,12 @@ def test_inspections(h5_file):
 
 def test_channel(h5_file):
     force = channel.Continuous.from_dataset(h5_file["Force HF"]["Force 1x"])
-    assert np.allclose(force.data, [0, 1, 2, 3, 4])
-    assert np.allclose(force.timestamps, [1, 11, 21, 31, 41])
+    np.testing.assert_allclose(force.data, [0, 1, 2, 3, 4])
+    np.testing.assert_allclose(force.timestamps, [1, 11, 21, 31, 41])
 
     downsampled = channel.TimeSeries.from_dataset(h5_file["Force LF"]["Force 1x"])
-    assert np.allclose(downsampled.data, [1.1, 2.1])
-    assert np.allclose(downsampled.timestamps, [1, 2])
+    np.testing.assert_allclose(downsampled.data, [1.1, 2.1])
+    np.testing.assert_allclose(downsampled.timestamps, [1, 2])
 
     if "Photon Time Tags" in h5_file:
         timetags = channel.TimeTags.from_dataset(h5_file["Photon Time Tags"]["Red"])
@@ -373,11 +373,11 @@ def test_continuous_downsampling_to():
     # to 1000 ns step
     s2a = s.downsampled_to(1e6, where='left')
     assert np.all(np.equal(s2a.timestamps, [0, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000]))
-    assert np.allclose(s2a.data, [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5, 21.5])
+    np.testing.assert_allclose(s2a.data, [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5, 21.5])
 
     s2b = s.downsampled_to(1e6, where='center')
     assert np.all(np.equal(s2b.timestamps, (np.arange(0, 10500, 1000) + np.arange(500, 10501, 1000)) / 2))
-    assert np.allclose(s2a.data, [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5, 21.5])
+    np.testing.assert_allclose(s2a.data, [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5, 21.5])
 
     # upsampling
     with pytest.raises(ValueError):
@@ -390,11 +390,11 @@ def test_continuous_downsampling_to():
     # non-integer ratio
     s3a = s.downsampled_to(3e5, where='left', method="ceil")
     assert np.all(np.equal(s3a.timestamps, [0, 3000, 6000]))
-    assert np.allclose(s3a.data, [3.5, 9.5, 15.5])
+    np.testing.assert_allclose(s3a.data, [3.5, 9.5, 15.5])
 
     s3b = s.downsampled_to(3e5, where='center', method="ceil")
     assert np.all(np.equal(s3b.timestamps, [(0+2500)/2, (3000+5500)/2, (6000+8500)/2]))
-    assert np.allclose(s3a.data, [3.5, 9.5, 15.5])
+    np.testing.assert_allclose(s3a.data, [3.5, 9.5, 15.5])
 
 
 def test_continuous_like_downsampling_to():
@@ -407,11 +407,11 @@ def test_continuous_like_downsampling_to():
     # to 1000 ns step
     s2a = s.downsampled_to(1e6, where='left')
     assert np.all(np.equal(s2a.timestamps, [0, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000]))
-    assert np.allclose(s2a.data, [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5, 21.5])
+    np.testing.assert_allclose(s2a.data, [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5, 21.5])
 
     s2b = s.downsampled_to(1e6, where='center')
     assert np.all(np.equal(s2b.timestamps, (np.arange(0, 10500, 1000) + np.arange(500, 10501, 1000)) / 2))
-    assert np.allclose(s2a.data, [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5, 21.5])
+    np.testing.assert_allclose(s2a.data, [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5, 21.5])
 
     # upsampling
     with pytest.raises(ValueError):
@@ -424,10 +424,10 @@ def test_continuous_like_downsampling_to():
     # force non-integer ratio
     s3a = s.downsampled_to(3e5, where='left', method="ceil")
     assert np.all(np.equal(s3a.timestamps, [0, 3000, 6000]))
-    assert np.allclose(s3a.data, [3.5, 9.5, 15.5])
+    np.testing.assert_allclose(s3a.data, [3.5, 9.5, 15.5])
     s3b = s.downsampled_to(3e5, where='center', method="ceil")
     assert np.all(np.equal(s3b.timestamps, [(0+2500)/2, (3000+5500)/2, (6000+8500)/2]))
-    assert np.allclose(s3a.data, [3.5, 9.5, 15.5])
+    np.testing.assert_allclose(s3a.data, [3.5, 9.5, 15.5])
 
 
 def test_variable_downsampling_to():
@@ -447,7 +447,7 @@ def test_variable_downsampling_to():
     # to 2000 ns step
     s2a = s.downsampled_to(5e5, where="left", method="force")
     assert np.all(np.equal(s2a.timestamps, [0, 2000, 4000, 6000, 8000, 10000, 12000]))
-    assert np.allclose(s2a.data, [2.5, 6.5, 10.0, 12.5, 14.5, 16.5, 18.5])
+    np.testing.assert_allclose(s2a.data, [2.5, 6.5, 10.0, 12.5, 14.5, 16.5, 18.5])
     s2b = s.downsampled_to(5e5, where="center", method="force")
 
     # Original samples are 0 500 1000 1500 2000 2500 3000 3500 4000 4500 5000   6000 7000 8000 ...
@@ -462,16 +462,16 @@ def test_variable_downsampling_to():
                         (12000 + 14000 - 1000) / 2,
                     ]
                 ).astype(np.int64)))
-    assert np.allclose(s2b.data, [2.5, 6.5, 10.0, 12.5, 14.5, 16.5, 18.5])
+    np.testing.assert_allclose(s2b.data, [2.5, 6.5, 10.0, 12.5, 14.5, 16.5, 18.5])
 
     # to 3333 ns step
     s3a = s.downsampled_to(3e5, where="left", method="force")
     assert np.all(np.equal(s3a.timestamps, [0, 3333, 6666, 9999]))
-    assert np.allclose(s3a.data, [4.0, 10.0, 14.0, 17.5])
+    np.testing.assert_allclose(s3a.data, [4.0, 10.0, 14.0, 17.5])
     s3b = s.downsampled_to(3e5, where="center", method="force")
 
     assert np.all(np.equal(s3b.timestamps, [3000/2, (3000 + 6500)/2, (7000 + 9000)/2, (10000 + 13000)/2]))
-    assert np.allclose(s3b.data, [4.0, 10.0, 14.0, 17.5])
+    np.testing.assert_allclose(s3b.data, [4.0, 10.0, 14.0, 17.5])
 
     with pytest.raises(ValueError):
         s.downsampled_to(3e8)
@@ -485,8 +485,8 @@ def test_downsampling_consistency():
     # Source frequency was 1e9 / 10 Hz. So we go to .2e8 Hz.
     s1 = s.downsampled_to(.2e8)
     s2 = s.downsampled_by(5)
-    assert np.allclose(s1.data, s2.data)
-    assert np.allclose(s1.timestamps, s2.timestamps)
+    np.testing.assert_allclose(s1.data, s2.data)
+    np.testing.assert_allclose(s1.timestamps, s2.timestamps)
 
     d = np.arange(1, 24)
     s = channel.Slice(channel.Continuous(d, 5, 10))
@@ -495,8 +495,8 @@ def test_downsampling_consistency():
     # Source frequency was 1e9 / 10 Hz. So we go to .2e8 Hz.
     s1 = s.downsampled_to(.2e8)
     s2 = s.downsampled_by(5)
-    assert np.allclose(s1.data, s2.data)
-    assert np.allclose(s1.timestamps, s2.timestamps)
+    np.testing.assert_allclose(s1.data, s2.data)
+    np.testing.assert_allclose(s1.timestamps, s2.timestamps)
 
     # Multiple of 5 should downsample to the same irrespective of the method
     # Source frequency was 1e9 / 7 Hz.
@@ -504,8 +504,8 @@ def test_downsampling_consistency():
     s = channel.Slice(channel.Continuous(d, 0, 7))
     s1 = s.downsampled_to(int(1e9 / 7 / 5))
     s2 = s.downsampled_by(5)
-    assert np.allclose(s1.data, s2.data)
-    assert np.allclose(s1.timestamps, s2.timestamps)
+    np.testing.assert_allclose(s1.data, s2.data)
+    np.testing.assert_allclose(s1.timestamps, s2.timestamps)
 
 
 def test_consistency_downsampled_to():
@@ -515,8 +515,8 @@ def test_consistency_downsampled_to():
     one_step = s.downsampled_to(.1e8)
     two_step = s.downsampled_to(.2e8).downsampled_to(.1e8)
 
-    assert np.allclose(one_step.data, two_step.data)
-    assert np.allclose(one_step.timestamps, two_step.timestamps)
+    np.testing.assert_allclose(one_step.data, two_step.data)
+    np.testing.assert_allclose(one_step.timestamps, two_step.timestamps)
 
 
 def test_downsampled_over_no_data_gap():
@@ -525,8 +525,8 @@ def test_downsampled_over_no_data_gap():
     s = channel.Slice(channel.TimeSeries(d, t))
     ranges = [(t1, t2) for t1, t2 in zip(np.arange(0, 16, 2), np.arange(2, 18, 2))]
     ts = s.downsampled_over(ranges)
-    assert np.allclose(ts.timestamps, [0, 2, 10, 12, 14])
-    assert np.allclose(ts.data, [0.5, 2.5, 4.5, 6.5, 8.5])
+    np.testing.assert_allclose(ts.timestamps, [0, 2, 10, 12, 14])
+    np.testing.assert_allclose(ts.data, [0.5, 2.5, 4.5, 6.5, 8.5])
 
 
 def test_downsampling_over_subset():
@@ -548,8 +548,8 @@ def test_downsampling_like():
 
     ds, ref_out = s.downsampled_like(reference)
     assert np.all(np.equal(ds.timestamps, ref_out.timestamps))
-    assert np.allclose(t_downsampled[1:-1], ds.timestamps)
-    assert np.allclose(y_downsampled[1:-1], ds.data)
+    np.testing.assert_allclose(t_downsampled[1:-1], ds.timestamps)
+    np.testing.assert_allclose(y_downsampled[1:-1], ds.data)
 
     with pytest.raises(NotImplementedError):
         reference.downsampled_like(reference)
@@ -563,8 +563,8 @@ def test_channel_plot():
         data = [obj for obj in mpl.pyplot.gca().get_children() if isinstance(obj, mpl.lines.Line2D)]
         assert len(data) == 1
         line = data[0].get_data()
-        assert np.allclose(line[0], x)
-        assert np.allclose(line[1], y)
+        np.testing.assert_allclose(line[0], x)
+        np.testing.assert_allclose(line[1], y)
 
     d = np.arange(1, 24)
     s = channel.Slice(channel.Continuous(d, int(5e9), int(10e9)))
@@ -593,6 +593,6 @@ def test_regression_lazy_loading(h5_file):
     ],
 )
 def test_with_data(data, new_data):
-    assert np.allclose(data._with_data(new_data).data, new_data)
+    np.testing.assert_allclose(data._with_data(new_data).data, new_data)
     old_timestamps = data.timestamps
-    assert np.allclose(data._with_data(new_data).timestamps, old_timestamps)
+    np.testing.assert_allclose(data._with_data(new_data).timestamps, old_timestamps)

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -534,8 +534,8 @@ def test_downsampling_over_subset():
     s = channel.Slice(channel.Continuous(d, 0, 10))
 
     sd = s.downsampled_over([(20, 40), (40, 60), (60, 80)])
-    np.allclose(sd.data, [(3+4)/2, (4+5)/2, (5+6)/2])
-    np.allclose(sd.timestamps, [(20+30)/2, (40+50)/2, (60+70)/2])
+    np.testing.assert_allclose(sd.data, [(3+4)/2, (4+5)/2, (5+6)/2])
+    np.testing.assert_allclose(sd.timestamps, [(20+30)/2, (40+50)/2, (60+70)/2])
 
 
 def test_downsampling_like():

--- a/lumicks/pylake/tests/test_channels.py
+++ b/lumicks/pylake/tests/test_channels.py
@@ -534,7 +534,8 @@ def test_downsampling_over_subset():
     s = channel.Slice(channel.Continuous(d, 0, 10))
 
     sd = s.downsampled_over([(20, 40), (40, 60), (60, 80)])
-    np.testing.assert_allclose(sd.data, [(3+4)/2, (4+5)/2, (5+6)/2])
+    # Data starts at 1, timestamps start at 0. 20-40 corresponds to data [3, 4], 40-60 to [5,6] etc.
+    np.testing.assert_allclose(sd.data, [(3+4)/2, (5+6)/2, (7+8)/2])
     np.testing.assert_allclose(sd.timestamps, [(20+30)/2, (40+50)/2, (60+70)/2])
 
 

--- a/lumicks/pylake/tests/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_correlated_stack.py
@@ -165,12 +165,12 @@ def test_plot_correlated():
     CorrelatedStack.from_data(fake_tiff)[3:5].plot_correlated(cc)
     imgs = [obj for obj in mpl.pyplot.gca().get_children() if isinstance(obj, mpl.image.AxesImage)]
     assert len(imgs) == 1
-    assert np.allclose(imgs[0].get_array(), np.ones((3, 3)) * 3)
+    np.testing.assert_allclose(imgs[0].get_array(), np.ones((3, 3)) * 3)
 
     CorrelatedStack.from_data(fake_tiff)[3:5].plot_correlated(cc, frame=1)
     imgs = [obj for obj in mpl.pyplot.gca().get_children() if isinstance(obj, mpl.image.AxesImage)]
     assert len(imgs) == 1
-    assert np.allclose(imgs[0].get_array(), np.ones((3, 3)) * 4)
+    np.testing.assert_allclose(imgs[0].get_array(), np.ones((3, 3)) * 4)
 
 
 def test_plot_correlated_smaller_channel():
@@ -197,8 +197,8 @@ def test_plot_correlated_smaller_channel():
         assert len(images) == 1
         return images[0].get_array()
 
-    assert np.allclose(mock_click(mpl.pyplot.gcf(), np.array([0, 40])), np.ones((3, 3)) * 2)
-    assert np.allclose(mock_click(mpl.pyplot.gcf(), np.array([10.1e-9, 40])), np.ones((3, 3)) * 3)
+    np.testing.assert_allclose(mock_click(mpl.pyplot.gcf(), np.array([0, 40])), np.ones((3, 3)) * 2)
+    np.testing.assert_allclose(mock_click(mpl.pyplot.gcf(), np.array([10.1e-9, 40])), np.ones((3, 3)) * 3)
 
 
 def make_alignment_image_data(spots, Tx_red, Ty_red, theta_red, Tx_blue, Ty_blue, theta_blue, bit_depth,
@@ -389,7 +389,7 @@ def test_image_reconstruction_grayscale(gray_alignment_image_data):
 
     assert not fr.is_rgb
     assert np.all(fr.data == fr.raw_data)
-    assert np.allclose(fr.raw_data, fr._get_plot_data())
+    np.testing.assert_allclose(fr.raw_data, fr._get_plot_data())
 
 
 def test_image_reconstruction_rgb(rgb_alignment_image_data, rgb_alignment_image_data_offset,
@@ -410,8 +410,8 @@ def test_image_reconstruction_rgb(rgb_alignment_image_data, rgb_alignment_image_
     assert np.all(diff/max_signal < 0.05)
 
     original_data = (img0 / (2**bit_depth - 1)).astype(float)
-    assert np.allclose(original_data, fr._get_plot_data(), atol=0.05)
-    assert np.allclose(original_data / 0.5, fr._get_plot_data(vmax=0.5), atol=0.10)
+    np.testing.assert_allclose(original_data, fr._get_plot_data(), atol=0.05)
+    np.testing.assert_allclose(original_data / 0.5, fr._get_plot_data(vmax=0.5), atol=0.10)
     max_signal = np.max(np.hstack([img0[:, :, 0], fr._get_plot_data("red")]))
     diff = np.abs(img0[:, :, 0].astype(float)-fr._get_plot_data("red").astype(float))
     assert np.all(diff/max_signal < 0.05)
@@ -438,7 +438,7 @@ def test_image_reconstruction_rgb(rgb_alignment_image_data, rgb_alignment_image_
     fr = stack._get_frame(0)
 
     original_data = (img0 / (2**bit_depth - 1)).astype(float)
-    assert np.allclose(original_data, fr._get_plot_data(), atol=0.05)
+    np.testing.assert_allclose(original_data, fr._get_plot_data(), atol=0.05)
 
 
 def test_image_reconstruction_rgb_multiframe(rgb_alignment_image_data):
@@ -452,7 +452,7 @@ def test_image_reconstruction_rgb_multiframe(rgb_alignment_image_data):
 
     assert fr.is_rgb
     original_data = (img0 / (2**bit_depth - 1)).astype(float)
-    assert np.allclose(original_data, fr._get_plot_data(), atol=0.05)
+    np.testing.assert_allclose(original_data, fr._get_plot_data(), atol=0.05)
 
 
 def test_image_reconstruction_rgb_missing_metadata(rgb_alignment_image_data):

--- a/lumicks/pylake/tests/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_correlated_stack.py
@@ -85,15 +85,15 @@ def test_correlated_stack(shape):
         stack[1:2]._get_frame(1).stop
 
     # Integration test whether slicing from the stack object actually provides you with correct slices
-    assert (np.allclose(stack[2:5].start, 30))
-    assert (np.allclose(stack[2:5].stop, 58))
+    np.testing.assert_allclose(stack[2:5].start, 30)
+    np.testing.assert_allclose(stack[2:5].stop, 58)
 
     # Test iterations
-    assert (np.allclose([x.start for x in stack], [10, 20, 30, 40, 50, 60]))
-    assert (np.allclose([x.start for x in stack[1:]], [20, 30, 40, 50, 60]))
-    assert (np.allclose([x.start for x in stack[:-1]], [10, 20, 30, 40, 50]))
-    assert (np.allclose([x.start for x in stack[2:4]], [30, 40]))
-    assert (np.allclose([x.start for x in stack[2]], [30]))
+    np.testing.assert_allclose([x.start for x in stack], [10, 20, 30, 40, 50, 60])
+    np.testing.assert_allclose([x.start for x in stack[1:]], [20, 30, 40, 50, 60])
+    np.testing.assert_allclose([x.start for x in stack[:-1]], [10, 20, 30, 40, 50])
+    np.testing.assert_allclose([x.start for x in stack[2:4]], [30, 40])
+    np.testing.assert_allclose([x.start for x in stack[2]], [30])
 
 
 @pytest.mark.parametrize("shape", [(3,3), (5,4,3)])
@@ -105,7 +105,7 @@ def test_correlation(shape):
                                        times=[["10", "20"], ["20", "30"], ["30", "40"], ["40", "50"], ["50", "60"], ["60", "70"]]),
                           align=True)
     stack = CorrelatedStack.from_data(fake_tiff)
-    assert (np.allclose(np.hstack([cc[x.start:x.stop].data for x in stack[2:4]]), np.arange(30, 50, 2)))
+    np.testing.assert_allclose(np.hstack([cc[x.start:x.stop].data for x in stack[2:4]]), np.arange(30, 50, 2))
 
     # Test image stack with dead time
     fake_tiff = TiffStack(MockTiffFile(data=[np.ones(shape)]*6,
@@ -113,18 +113,18 @@ def test_correlation(shape):
                           align=True)
     stack = CorrelatedStack.from_data(fake_tiff)
 
-    assert (np.allclose(np.hstack([cc[x.start:x.stop].data for x in stack[2:4]]),
-                        np.hstack([np.arange(30, 38, 2), np.arange(40, 48, 2)])))
+    np.testing.assert_allclose(np.hstack([cc[x.start:x.stop].data for x in stack[2:4]]),
+                        np.hstack([np.arange(30, 38, 2), np.arange(40, 48, 2)]))
 
     # Unit test which tests whether we obtain an appropriately downsampled time series when ask for downsampling of a
     # slice based on a stack.
     ch = cc.downsampled_over(stack[0:3].timestamps)
-    assert(np.allclose(ch.data, [np.mean(np.arange(10, 18, 2)), np.mean(np.arange(20, 28, 2)), np.mean(np.arange(30, 38, 2))]))
-    assert (np.allclose(ch.timestamps, [(10 + 16) / 2, (20 + 26) / 2, (30 + 36) / 2]))
+    np.testing.assert_allclose(ch.data, [np.mean(np.arange(10, 18, 2)), np.mean(np.arange(20, 28, 2)), np.mean(np.arange(30, 38, 2))])
+    np.testing.assert_allclose(ch.timestamps, [(10 + 16) / 2, (20 + 26) / 2, (30 + 36) / 2])
 
     ch = cc.downsampled_over(stack[1:4].timestamps)
-    assert (np.allclose(ch.data, [np.mean(np.arange(20, 28, 2)), np.mean(np.arange(30, 38, 2)), np.mean(np.arange(40, 48, 2))]))
-    assert (np.allclose(ch.timestamps, [(20 + 26) / 2, (30 + 36) / 2, (40 + 46) / 2]))
+    np.testing.assert_allclose(ch.data, [np.mean(np.arange(20, 28, 2)), np.mean(np.arange(30, 38, 2)), np.mean(np.arange(40, 48, 2))])
+    np.testing.assert_allclose(ch.timestamps, [(20 + 26) / 2, (30 + 36) / 2, (40 + 46) / 2])
 
     with pytest.raises(TypeError):
         cc.downsampled_over(stack[1:4])

--- a/lumicks/pylake/tests/test_fdcurve.py
+++ b/lumicks/pylake/tests/test_fdcurve.py
@@ -149,7 +149,7 @@ def test_subtract_too_much_distance():
     """Tests whether we get an exception when we subtract more than the lowest valid distance value"""
     fd1 = make_mock_fd(force=[1, 2, 3], distance=[2.0, 0.0, 4.0], start=0)
 
-    np.allclose(fd1.with_offset(distance_offset=-1.0).d.data, [1.0, 0.0, 3.0])
+    np.testing.assert_allclose(fd1.with_offset(distance_offset=-1.0).d.data, [1.0, 0.0, 3.0])
 
     with pytest.raises(ValueError):
         fd1.with_offset(distance_offset=-2.0)

--- a/lumicks/pylake/tests/test_fdcurve.py
+++ b/lumicks/pylake/tests/test_fdcurve.py
@@ -19,26 +19,26 @@ def make_mock_fd(force, distance, start=0, file=None):
 def test_subtraction():
     fd1 = make_mock_fd(force=[1, 2, 3], distance=[0, 1, 2], start=0)
     fd2 = make_mock_fd(force=[2, 2, 2], distance=[0, 1, 2], start=100)
-    assert np.allclose((fd1 - fd2).f.data, [-1, 0, 1])
-    assert np.allclose((fd2 - fd1).f.data, [1, 0, -1])
+    np.testing.assert_allclose((fd1 - fd2).f.data, [-1, 0, 1])
+    np.testing.assert_allclose((fd2 - fd1).f.data, [1, 0, -1])
 
     fd1 = make_mock_fd(force=[1, 2, 3], distance=[0, 1, 2], start=0)
     fd2 = make_mock_fd(force=[2, 2, 2], distance=[1, 2, 3], start=100)
-    assert np.allclose((fd1 - fd2).f.data, [0, 1])
-    assert np.allclose((fd2 - fd1).f.data, [0, -1])
+    np.testing.assert_allclose((fd1 - fd2).f.data, [0, 1])
+    np.testing.assert_allclose((fd2 - fd1).f.data, [0, -1])
 
     fd1 = make_mock_fd(force=[1, 2, 3], distance=[0, 1, 2], start=0)
     fd2 = make_mock_fd(force=[1, 1, 1], distance=[5, 6, 7], start=100)
-    assert np.allclose((fd1 - fd2).f.data, [])
-    assert np.allclose((fd2 - fd1).f.data, [])
+    np.testing.assert_allclose((fd1 - fd2).f.data, [])
+    np.testing.assert_allclose((fd2 - fd1).f.data, [])
 
 
 def test_slice():
     fd = make_mock_fd(force=[1, 1, 1], distance=[5, 6, 7], start=100)
-    assert np.allclose(fd[101:].d.data, [6, 7])
-    assert np.allclose(fd[:101].d.data, [5])
-    assert np.allclose(fd[101:300].d.data, [6, 7])
-    assert np.allclose(fd[101:102].d.data, [6])
+    np.testing.assert_allclose(fd[101:].d.data, [6, 7])
+    np.testing.assert_allclose(fd[:101].d.data, [5])
+    np.testing.assert_allclose(fd[101:300].d.data, [6, 7])
+    np.testing.assert_allclose(fd[101:102].d.data, [6])
 
     sliced = fd[101:102]
     assert id(fd.f) != id(sliced.f)
@@ -132,8 +132,8 @@ def test_offsets(field, changed_var, other_var):
     assert fd1_sub.d is not fd1.d
     assert fd1_sub.f.data is not fd1.f.data
     assert fd1_sub.d.data is not fd1.d.data
-    assert np.allclose(getattr(fd1_sub, changed_var).data, getattr(fd1, changed_var).data - 1)
-    assert np.allclose(getattr(fd1_sub, other_var).data, getattr(fd1, other_var).data)
+    np.testing.assert_allclose(getattr(fd1_sub, changed_var).data, getattr(fd1, changed_var).data - 1)
+    np.testing.assert_allclose(getattr(fd1_sub, other_var).data, getattr(fd1, other_var).data)
 
 
 def test_distance_offset_tracking_lost():
@@ -142,7 +142,7 @@ def test_distance_offset_tracking_lost():
     this will lead to that data becoming a missing value point. This should not happen for real data though."""
     fd1 = make_mock_fd(force=[1, 2, 3], distance=[2, 0, 4], start=0)
     sub = fd1.with_offset(distance_offset=-1)
-    assert np.allclose(sub.d.data, [1, 0, 3])
+    np.testing.assert_allclose(sub.d.data, [1, 0, 3])
 
 
 def test_subtract_too_much_distance():
@@ -169,8 +169,8 @@ def test_fd_slice(slice_parameters, f, d):
     fd1 = make_mock_fd(force=np.arange(-2, 3, .5), distance=np.arange(-1, 4, .5), start=0)
 
     fdr = fd1._sliced(**slice_parameters)
-    assert np.allclose(fdr.f, f)
-    assert np.allclose(fdr.d, d)
+    np.testing.assert_allclose(fdr.f, f)
+    np.testing.assert_allclose(fdr.d, d)
 
 
 def test_copy_behaviour_with_offset(h5_file):

--- a/lumicks/pylake/tests/test_fdensemble.py
+++ b/lumicks/pylake/tests/test_fdensemble.py
@@ -26,8 +26,8 @@ def test_align_force_simple():
     aligned = align_force_simple({"fd1": fd1, "fd2": fd2, "fd3": fd3}, distance_range=50)
 
     for fd in aligned.values():
-        assert np.allclose(fd.d.data, distance)
-        assert np.allclose(fd.f.data, force)
+        np.testing.assert_allclose(fd.d.data, distance)
+        np.testing.assert_allclose(fd.f.data, force)
 
 
 def test_align_distance_simple():
@@ -41,8 +41,8 @@ def test_align_distance_simple():
     aligned = align_distance_simple({"fd1": fd1, "fd2": fd2, "fd3": fd3}, distance_range=50)
 
     for fd in aligned.values():
-        assert np.allclose(fd.d.data, distance)
-        assert np.allclose(fd.f.data, force)
+        np.testing.assert_allclose(fd.d.data, distance)
+        np.testing.assert_allclose(fd.f.data, force)
 
 
 def test_align_fd_simple():
@@ -56,8 +56,8 @@ def test_align_fd_simple():
     aligned = align_fd_simple({"fd1": fd1, "fd2": fd2, "fd3": fd3}, 50, 50)
 
     for fd in aligned.values():
-        assert np.allclose(fd.f.data, force)
-        assert np.allclose(fd.d.data, distance)
+        np.testing.assert_allclose(fd.f.data, force)
+        np.testing.assert_allclose(fd.d.data, distance)
 
 
 def test_non_constant_rate_fd_alignment_simple():
@@ -78,8 +78,8 @@ def test_non_constant_rate_fd_alignment_simple():
     aligned = align_fd_simple(fds, 1.5, 1.2)
 
     for fd, num_shortened in zip(aligned.values(), shortening):
-        assert np.allclose(fd.f.data, force[:-num_shortened])
-        assert np.allclose(fd.d.data, distance[:-num_shortened])
+        np.testing.assert_allclose(fd.f.data, force[:-num_shortened])
+        np.testing.assert_allclose(fd.d.data, distance[:-num_shortened])
 
 
 def test_back_and_forth_rate_fd_alignment_simple():
@@ -99,8 +99,8 @@ def test_back_and_forth_rate_fd_alignment_simple():
     aligned = align_fd_simple(fds, 1, 1)
 
     for fd, num_shortened in zip(aligned.values(), shortening):
-        assert np.allclose(fd.f.data, force[:-num_shortened])
-        assert np.allclose(fd.d.data, distance[:-num_shortened])
+        np.testing.assert_allclose(fd.f.data, force[:-num_shortened])
+        np.testing.assert_allclose(fd.d.data, distance[:-num_shortened])
 
 
 def test_iteration_fd_ensemble():
@@ -141,8 +141,8 @@ def test_fd_ensemble_accessors():
     }
     fd_ensemble = FdEnsemble(fds)
 
-    assert np.allclose(fd_ensemble.f, np.array([0, 1, 2, 5, 6, 7, 15, 16, 17]))
-    assert np.allclose(fd_ensemble.d, np.array([0, 1, 2, 0, 1, 2, 0, 1, 2]))
+    np.testing.assert_allclose(fd_ensemble.f, np.array([0, 1, 2, 5, 6, 7, 15, 16, 17]))
+    np.testing.assert_allclose(fd_ensemble.d, np.array([0, 1, 2, 0, 1, 2, 0, 1, 2]))
 
     fd_ensemble.align_linear(20, 20)
-    assert np.allclose(fd_ensemble.f, np.array([0, 1, 2, 0, 1, 2, 0, 1, 2]))
+    np.testing.assert_allclose(fd_ensemble.f, np.array([0, 1, 2, 0, 1, 2, 0, 1, 2]))

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -105,7 +105,7 @@ def test_params():
     params2 = Params()
     params2._set_params(['gamma', 'potato', 'beta'], [Parameter(10), Parameter(11), Parameter(12)])
     params.update_params(params2)
-    assert np.allclose(params.values, [2, 12, 10])
+    np.testing.assert_allclose(params.values, [2, 12, 10])
 
     params2 = Params()
     params2._set_params(['spaghetti'], [Parameter(10), Parameter(12)])
@@ -171,13 +171,13 @@ def test_model_calls():
     model = Model("m", model_function)
     y_ref = model._raw_call(t, [2.0, 3.0, 4.0])
 
-    assert np.allclose(model(t, Params(**{"m/a": Parameter(1), "m/b": Parameter(2), "m/c": Parameter(3),
+    np.testing.assert_allclose(model(t, Params(**{"m/a": Parameter(1), "m/b": Parameter(2), "m/c": Parameter(3),
                                           "m/d": Parameter(4)})), y_ref)
 
-    assert np.allclose(model(t, Params(**{"m/d": Parameter(4), "m/c": Parameter(3), "m/b": Parameter(2)})), y_ref)
+    np.testing.assert_allclose(model(t, Params(**{"m/d": Parameter(4), "m/c": Parameter(3), "m/b": Parameter(2)})), y_ref)
 
     with pytest.raises(IndexError):
-        assert np.allclose(model(t, Params(**{"m/a": Parameter(1), "m/b": Parameter(2), "m/d": Parameter(4)})), y_ref)
+        np.testing.assert_allclose(model(t, Params(**{"m/a": Parameter(1), "m/b": Parameter(2), "m/d": Parameter(4)})), y_ref)
 
 
 def test_unique_idx():
@@ -264,7 +264,7 @@ def test_model_fit_object_linking():
     assert set(f.params.keys) == set(all_params)
 
     # Check the parameters included in the model
-    assert np.allclose(f.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
+    np.testing.assert_allclose(f.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
     assert np.all(f.datasets[id(m)]._conditions[0].p_local == [None, None, None, None, 4, None, None, None, None])
     assert fetch_params(f.params, f.datasets[id(m)]._conditions[0]._p_global_indices) == \
            ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e", "M/f", "M/q"]
@@ -275,12 +275,12 @@ def test_model_fit_object_linking():
 
     # Check the parameters included in the model
     f._rebuild()
-    assert np.allclose(f.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
+    np.testing.assert_allclose(f.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
     assert np.all(f.datasets[id(m)]._conditions[0].p_local == [None, None, None, None, 4, None, None, None, None])
     assert fetch_params(f.params, f.datasets[id(m)]._conditions[0]._p_global_indices) == \
            ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e", "M/f", "M/q"]
 
-    assert np.allclose(f.datasets[id(m)]._conditions[1].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
+    np.testing.assert_allclose(f.datasets[id(m)]._conditions[1].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
     assert np.all(f.datasets[id(m)]._conditions[1].p_local == [None, None, None, None, 4, None, None, None, None])
     assert fetch_params(f.params, f.datasets[id(m)]._conditions[1]._p_global_indices) == \
            ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e_new", "M/f", "M/q"]
@@ -296,17 +296,17 @@ def test_model_fit_object_linking():
     all_params = ["M/mu", "M/sig", "M/a", "M/b", "M/d", "M/e", "M/e_new", "M/f", "M/q", "M/r"]
     f[m2]._add_data("test2", [1, 2, 3], [2, 3, 4], {'M/c': 4, 'M/e': 5})
     assert set(f.params.keys) == set(all_params)
-    assert np.allclose(f.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
+    np.testing.assert_allclose(f.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
     assert np.all(f.datasets[id(m)]._conditions[0].p_local == [None, None, None, None, 4, None, None, None, None])
     assert fetch_params(f.params, f.datasets[id(m)]._conditions[0]._p_global_indices) == \
            ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e", "M/f", "M/q"]
 
-    assert np.allclose(f.datasets[id(m)]._conditions[1].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
+    np.testing.assert_allclose(f.datasets[id(m)]._conditions[1].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
     assert np.all(f.datasets[id(m)]._conditions[1].p_local == [None, None, None, None, 4, None, None, None, None])
     assert fetch_params(f.params, f.datasets[id(m)]._conditions[1]._p_global_indices) == \
            ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e_new", "M/f", "M/q"]
 
-    assert np.allclose(f.datasets[id(m2)]._conditions[0].p_external, [0, 1, 2])
+    np.testing.assert_allclose(f.datasets[id(m2)]._conditions[0].p_external, [0, 1, 2])
     assert np.all(f.datasets[id(m2)]._conditions[0].p_local == [None, None, None, 4, 6])
     assert fetch_params(f.params, f.datasets[id(m2)]._conditions[0]._p_global_indices) == \
            ["M/mu", "M/e", "M/q", None, None]
@@ -515,11 +515,11 @@ def test_models():
     assert(inverted_twistable_wlc("itWLC").verify_jacobian(independent, params))
 
     # Check whether the twistable wlc model manipulates the data order
-    assert np.allclose(twistable_wlc("tWLC")._raw_call(independent, params),
+    np.testing.assert_allclose(twistable_wlc("tWLC")._raw_call(independent, params),
                        np.flip(twistable_wlc("tWLC")._raw_call(np.flip(independent), params)))
 
     # Check whether the inverse twistable wlc model manipulates the data order
-    assert np.allclose(inverted_twistable_wlc("itWLC")._raw_call(independent, params),
+    np.testing.assert_allclose(inverted_twistable_wlc("itWLC")._raw_call(independent, params),
                        np.flip(inverted_twistable_wlc("itWLC")._raw_call(np.flip(independent), params)))
 
     # Check whether the inverted models invert correctly
@@ -539,12 +539,12 @@ def test_models():
     m_fwd = marko_siggia_ewlc_force("fwd")
     m_bwd = marko_siggia_ewlc_distance("bwd")
     force = m_fwd._raw_call(d, params)
-    assert np.allclose(m_bwd._raw_call(force, params), d)
+    np.testing.assert_allclose(m_bwd._raw_call(force, params), d)
 
     # Determine whether they actually fulfill the model
     lhs = (force*Lp/kT)
     rhs = 0.25 * (1.0 - (d/Lc) + (force/St))**(-2) - 0.25 + (d/Lc) - (force/St)
-    assert np.allclose(lhs, rhs)
+    np.testing.assert_allclose(lhs, rhs)
 
     # Test inverted simplified model
     d = np.arange(0.15, .377, .05)
@@ -553,7 +553,7 @@ def test_models():
     m_fwd = marko_siggia_simplified("fwd")
     m_bwd = inverted_marko_siggia_simplified("bwd")
     force = m_fwd._raw_call(d, params)
-    assert np.allclose(m_bwd._raw_call(force, params), d)
+    np.testing.assert_allclose(m_bwd._raw_call(force, params), d)
 
     # This model is nonsense about the contour length, so warn the user about this.
     with pytest.warns(RuntimeWarning):
@@ -591,7 +591,7 @@ def test_model_composition():
 
     # Check actual composition
     # (a + b * x) + a - b * x + d * x * x = 2 * a + d * x * x
-    assert np.allclose((m1 + m2)._raw_call(t, np.array([1.0, 2.0, 3.0])), 2.0 + 3.0 * t * t), \
+    np.testing.assert_allclose((m1 + m2)._raw_call(t, np.array([1.0, 2.0, 3.0])), 2.0 + 3.0 * t * t), \
         "Model composition returns invalid function evaluation (parameter order issue?)"
 
     # Check correctness of the Jacobians and derivatives
@@ -627,7 +627,7 @@ def test_model_composition():
     t = np.array([.19, .2, .3])
     p1 = np.array([.1, 4.9e1, 3.8e-1, 2.1e2, 4.11, 1.5])
     p2 = np.array([4.9e1, 3.8e-1, 2.1e2, 4.11, .1, 1.5])
-    assert np.allclose(m1._raw_call(t, p1), m2._raw_call(t, p2))
+    np.testing.assert_allclose(m1._raw_call(t, p1), m2._raw_call(t, p2))
 
     # Check whether incompatible variables are found
     with pytest.raises(AssertionError):
@@ -670,7 +670,7 @@ def test_parameter_inversion():
     fit._add_data("test", x, f_data)
     fit.params["f/a"].value = a_true
     fit.params["f/b"].value = 1.0
-    assert np.allclose(parameter_trace(model, fit.params, 'f/b', x, f_data), b_true)
+    np.testing.assert_allclose(parameter_trace(model, fit.params, 'f/b', x, f_data), b_true)
 
     a_true = 5.0
     b_true = 3.0
@@ -682,7 +682,7 @@ def test_parameter_inversion():
     fit.params["f/a"].value = a_true
     fit.params["f/b"].value = b_true
     fit.params["f/d"].value = 1.0
-    assert np.allclose(parameter_trace(model, fit.params, 'f/d', x, f_plus_g_data), d_true)
+    np.testing.assert_allclose(parameter_trace(model, fit.params, 'f/d', x, f_plus_g_data), d_true)
 
 
 def test_uncertainty_analysis():
@@ -713,20 +713,20 @@ def test_uncertainty_analysis():
     quad_fit._add_data("test", x, y)
     quad_fit.fit()
 
-    assert np.allclose(linear_fit.cov, np.array([[0.08524185, -0.38358832], [-0.38358832, 2.42939269]]))
-    assert np.allclose(quad_fit.cov, np.array([[0.01390294, -0.12512650,  0.16683533],
+    np.testing.assert_allclose(linear_fit.cov, np.array([[0.08524185, -0.38358832], [-0.38358832, 2.42939269]]))
+    np.testing.assert_allclose(quad_fit.cov, np.array([[0.01390294, -0.12512650,  0.16683533],
                                                [-0.1251265,  1.21511735, -1.90192281],
                                                [0.16683533, -1.90192281,  4.53792109]]))
 
-    assert np.allclose(linear_fit.sigma[0], 2.65187717)
-    assert np.allclose(linear_fit.aic, 49.88412577726061)
-    assert np.allclose(linear_fit.aicc, 51.59841149154632)
-    assert np.allclose(linear_fit.bic, 50.4892959632487)
+    np.testing.assert_allclose(linear_fit.sigma[0], 2.65187717)
+    np.testing.assert_allclose(linear_fit.aic, 49.88412577726061)
+    np.testing.assert_allclose(linear_fit.aicc, 51.59841149154632)
+    np.testing.assert_allclose(linear_fit.bic, 50.4892959632487)
 
-    assert np.allclose(quad_fit.sigma[0], 2.70938272)
-    assert np.allclose(quad_fit.aic, 51.31318724618379)
-    assert np.allclose(quad_fit.aicc, 55.31318724618379)
-    assert np.allclose(quad_fit.bic, 52.220942525165924)
+    np.testing.assert_allclose(quad_fit.sigma[0], 2.70938272)
+    np.testing.assert_allclose(quad_fit.aic, 51.31318724618379)
+    np.testing.assert_allclose(quad_fit.aicc, 55.31318724618379)
+    np.testing.assert_allclose(quad_fit.bic, 52.220942525165924)
 
 
 def test_parameter_availability():
@@ -763,10 +763,10 @@ def test_data_loading():
     m = Model("M", lambda x, a: a*x)
     fit = Fit(m)
     fit._add_data("test", [1, np.nan, 3], [2, np.nan, 4])
-    assert np.allclose(fit[m].data["test"].x, [1, 3])
-    assert np.allclose(fit[m].data["test"].y, [2, 4])
-    assert np.allclose(fit[m].data["test"].independent, [1, 3])
-    assert np.allclose(fit[m].data["test"].dependent, [2, 4])
+    np.testing.assert_allclose(fit[m].data["test"].x, [1, 3])
+    np.testing.assert_allclose(fit[m].data["test"].y, [2, 4])
+    np.testing.assert_allclose(fit[m].data["test"].independent, [1, 3])
+    np.testing.assert_allclose(fit[m].data["test"].dependent, [2, 4])
 
     # Name must be unique
     with pytest.raises(KeyError):
@@ -880,7 +880,7 @@ def test_analytic_roots():
     b = np.array([-3.0])
     c = np.array([1.0])
 
-    assert np.allclose(
+    np.testing.assert_allclose(
         np.sort(np.roots(np.hstack((np.array([1.0]), a, b, c)))),
         np.sort(
             np.array(
@@ -903,7 +903,7 @@ def test_analytic_roots():
         db = (solve_cubic_wlc(a, b + dx, c, root) - ref_root) / dx
         dc = (solve_cubic_wlc(a, b, c + dx, root) - ref_root) / dx
 
-        assert np.allclose(np.array(invwlc_root_derivatives(a, b, c, root)), np.array([da, db, dc]), atol=1e-5,
+        np.testing.assert_allclose(np.array(invwlc_root_derivatives(a, b, c, root)), np.array([da, db, dc]), atol=1e-5,
                            rtol=1e-5)
 
     test_root_derivatives(0)
@@ -986,22 +986,22 @@ def test_fd_variable_order():
     m = odijk("M")
     fit = Fit(m)
     fit._add_data("test", [1, 2, 3], [2, 3, 4])
-    assert np.allclose(fit[m].data["test"].x, [1, 2, 3])
-    assert np.allclose(fit[m].data["test"].y, [2, 3, 4])
+    np.testing.assert_allclose(fit[m].data["test"].x, [1, 2, 3])
+    np.testing.assert_allclose(fit[m].data["test"].y, [2, 3, 4])
 
     fit[m]._add_data("test2", [1, 2, 3], [2, 3, 4])
-    assert np.allclose(fit[m].data["test2"].x, [1, 2, 3])
-    assert np.allclose(fit[m].data["test2"].y, [2, 3, 4])
+    np.testing.assert_allclose(fit[m].data["test2"].x, [1, 2, 3])
+    np.testing.assert_allclose(fit[m].data["test2"].y, [2, 3, 4])
 
     m = inverted_odijk("M")
     fit = Fit(m)
     fit._add_data("test", [1, 2, 3], [2, 3, 4])
-    assert np.allclose(fit[m].data["test"].x, [1, 2, 3])
-    assert np.allclose(fit[m].data["test"].y, [2, 3, 4])
+    np.testing.assert_allclose(fit[m].data["test"].x, [1, 2, 3])
+    np.testing.assert_allclose(fit[m].data["test"].y, [2, 3, 4])
 
     fit[m]._add_data("test2", [1, 2, 3], [2, 3, 4])
-    assert np.allclose(fit[m].data["test2"].x, [1, 2, 3])
-    assert np.allclose(fit[m].data["test2"].y, [2, 3, 4])
+    np.testing.assert_allclose(fit[m].data["test2"].x, [1, 2, 3])
+    np.testing.assert_allclose(fit[m].data["test2"].y, [2, 3, 4])
 
     # FdFit always takes f, d and maps it to the correct values
     m = odijk("M")
@@ -1009,24 +1009,24 @@ def test_fd_variable_order():
 
     # Test the FdFit interface
     fit.add_data("test", [1, 2, 3], [2, 3, 4])
-    assert np.allclose(fit[m].data["test"].x, [1, 2, 3])
-    assert np.allclose(fit[m].data["test"].y, [2, 3, 4])
+    np.testing.assert_allclose(fit[m].data["test"].x, [1, 2, 3])
+    np.testing.assert_allclose(fit[m].data["test"].y, [2, 3, 4])
 
     # Test the FdDatasets interface
     fit[m].add_data("test2", [3, 4, 5], [4, 5, 6])
-    assert np.allclose(fit[m].data["test2"].x, [3, 4, 5])
-    assert np.allclose(fit[m].data["test2"].y, [4, 5, 6])
+    np.testing.assert_allclose(fit[m].data["test2"].x, [3, 4, 5])
+    np.testing.assert_allclose(fit[m].data["test2"].y, [4, 5, 6])
 
     m = inverted_odijk("M")
     fit = FdFit(m)
     fit.add_data("test", [1, 2, 3], [2, 3, 4])
-    assert np.allclose(fit[m].data["test"].x, [2, 3, 4])
-    assert np.allclose(fit[m].data["test"].y, [1, 2, 3])
+    np.testing.assert_allclose(fit[m].data["test"].x, [2, 3, 4])
+    np.testing.assert_allclose(fit[m].data["test"].y, [1, 2, 3])
 
     # Test the FdDatasets interface
     fit[m].add_data("test2", [3, 4, 5], [4, 5, 6])
-    assert np.allclose(fit[m].data["test2"].x, [4, 5, 6])
-    assert np.allclose(fit[m].data["test2"].y, [3, 4, 5])
+    np.testing.assert_allclose(fit[m].data["test2"].x, [4, 5, 6])
+    np.testing.assert_allclose(fit[m].data["test2"].y, [3, 4, 5])
 
 
 def test_tex_replacement():
@@ -1109,7 +1109,7 @@ def test_interpolation_inversion():
     m = odijk("Nucleosome").invert(independent_max=120.0, interpolate=True)
     parvec = [5.77336105517341, 7.014180463612673, 1500.0000064812095, 4.11]
     result = np.array([0.17843862, 0.18101283, 0.18364313, 0.18633117, 0.18907864])
-    assert np.allclose(m._raw_call(np.arange(10, 250, 50) / 1000, parvec), result)
+    np.testing.assert_allclose(m._raw_call(np.arange(10, 250, 50) / 1000, parvec), result)
 
 
 def test_no_jac():

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -75,30 +75,30 @@ def test_params():
     assert (params['beta'].value == 0.0)
 
     params['beta'].value = 5.0
-    assert (np.allclose(params.values, [0.0, 5.0, 0.0]))
+    np.testing.assert_allclose(params.values, [0.0, 5.0, 0.0])
 
     params._set_params(['alpha', 'beta', 'gamma', 'delta'], [None]*4)
     assert (params['beta'].value == 5.0)
-    assert (np.allclose(params.values, [0.0, 5.0, 0.0, 0.0]))
+    np.testing.assert_allclose(params.values, [0.0, 5.0, 0.0, 0.0])
 
     params['gamma'].value = 6.0
     params['delta'] = 7.0
     params['gamma'].lower_bound = -4.0
     params['gamma'].upper_bound = 5.0
-    assert (np.allclose(params.values, [0.0, 5.0, 6.0, 7.0]))
-    assert (np.allclose(params.lower_bounds, [-np.inf, -np.inf, -4.0, -np.inf]))
-    assert (np.allclose(params.upper_bounds, [np.inf, np.inf, 5.0, np.inf]))
+    np.testing.assert_allclose(params.values, [0.0, 5.0, 6.0, 7.0])
+    np.testing.assert_allclose(params.lower_bounds, [-np.inf, -np.inf, -4.0, -np.inf])
+    np.testing.assert_allclose(params.upper_bounds, [np.inf, np.inf, 5.0, np.inf])
 
     assert(len(params) == 4.0)
     params._set_params(['alpha', 'beta', 'delta'], [None]*3)
-    assert (np.allclose(params.values, [0.0, 5.0, 7.0]))
+    np.testing.assert_allclose(params.values, [0.0, 5.0, 7.0])
     assert ([p for p in params] == ['alpha', 'beta', 'delta'])
     assert(len(params) == 3.0)
 
     for i, p in params.items():
         p.value = 1.0
 
-    assert (np.allclose(params.values, [1.0, 1.0, 1.0]))
+    np.testing.assert_allclose(params.values, [1.0, 1.0, 1.0])
 
     params = Params()
     params._set_params(['alpha', 'beta', 'gamma'], [Parameter(2), Parameter(3), Parameter(4)])
@@ -157,10 +157,10 @@ def test_condition_struct():
 
     c = Condition(param_trafos, parameter_lookup)
     assert (np.all(c.p_local == [None, None, None, 5, None]))
-    assert (np.allclose(param_vector[c.p_indices], [10, 4, 12, 14]))
+    np.testing.assert_allclose(param_vector[c.p_indices], [10, 4, 12, 14])
     assert (np.all(c.p_external == np.array([0, 1, 2, 4])))
     assert (list(c.transformed) == ['gamma_specific', 'alpha', 'beta_specific', 5, 'zeta'])
-    assert (np.allclose(c.get_local_params(param_vector), [10, 4, 12, 5, 14]))
+    np.testing.assert_allclose(c.get_local_params(param_vector), [10, 4, 12, 5, 14])
 
 
 def test_model_calls():
@@ -527,11 +527,11 @@ def test_models():
 
     d = np.array([3.0, 4.0])
     params = [5.0, 5.0, 5.0]
-    assert (np.allclose(WLC(invWLC(d, *params), *params), d))
+    np.testing.assert_allclose(WLC(invWLC(d, *params), *params), d)
     params = [5.0, 15.0, 1.0, 4.11]
-    assert (np.allclose(FJC(invFJC(independent, *params), *params), independent))
+    np.testing.assert_allclose(FJC(invFJC(independent, *params), *params), independent)
     params = [40.0, 16.0, 750.0, 440.0, -637.0, 17.0, 30.6, 4.11]
-    assert(np.allclose(tWLC(invtWLC(independent, *params), *params), independent))
+    np.testing.assert_allclose(tWLC(invtWLC(independent, *params), *params), independent)
 
     d = np.arange(0.15, 2, .5)
     (Lp, Lc, St, kT) = (38.18281266, 0.37704827, 278.50103452, 4.11)

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -716,7 +716,7 @@ def test_uncertainty_analysis():
     np.testing.assert_allclose(linear_fit.cov, np.array([[0.08524185, -0.38358832], [-0.38358832, 2.42939269]]))
     np.testing.assert_allclose(quad_fit.cov, np.array([[0.01390294, -0.12512650,  0.16683533],
                                                [-0.1251265,  1.21511735, -1.90192281],
-                                               [0.16683533, -1.90192281,  4.53792109]]))
+                                               [0.16683533, -1.90192281,  4.53792109]]), rtol=1e-6)
 
     np.testing.assert_allclose(linear_fit.sigma[0], 2.65187717)
     np.testing.assert_allclose(linear_fit.aic, 49.88412577726061)

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -10,19 +10,19 @@ def test_scans(h5_file):
     if f.format_version == 2:
         scan = f.scans["fast Y slow X"]
         assert scan.pixels_per_line == 4  # Fast axis
-        assert np.allclose(scan.red_image, np.transpose([[2, 0, 0, 0], [2, 0, 0, 0], [0, 0, 1, 0], [0, 0, 1, 0], [1, 1, 1, 0]]))
+        np.testing.assert_allclose(scan.red_image, np.transpose([[2, 0, 0, 0], [2, 0, 0, 0], [0, 0, 1, 0], [0, 0, 1, 0], [1, 1, 1, 0]]))
 
         scan2 = f.scans["fast Y slow X multiframe"]
         reference = np.array([[[2, 0, 0, 0], [2, 0, 0, 0], [0, 0, 1, 0]], [[0, 0, 1, 0], [1, 1, 1, 0], [0, 0, 0, 0]]])
         reference = np.transpose(reference, [0, 2, 1])
-        assert np.allclose(scan2.red_image, reference)
+        np.testing.assert_allclose(scan2.red_image, reference)
 
         scan2 = f.scans["fast Y slow X multiframe"]
         rgb = np.zeros((2, 4, 3, 3))
         rgb[:, :, :, 0] = reference
         rgb[:, :, :, 1] = reference
         rgb[:, :, :, 2] = reference
-        assert np.allclose(scan2.rgb_image, rgb)
+        np.testing.assert_allclose(scan2.rgb_image, rgb)
 
 
 def test_kymos(h5_file):
@@ -30,7 +30,7 @@ def test_kymos(h5_file):
     if f.format_version == 2:
         kymo = f.kymos["Kymo1"]
         assert kymo.pixels_per_line == 5
-        assert np.allclose(kymo.red_image, np.transpose([[2, 0, 0, 0, 2], [0, 0, 0, 0, 0], [1, 0, 0, 0, 1], [0, 1, 1, 1, 0]]))
+        np.testing.assert_allclose(kymo.red_image, np.transpose([[2, 0, 0, 0, 2], [0, 0, 0, 0, 0], [1, 0, 0, 0, 1], [0, 1, 1, 1, 0]]))
 
 
 def test_attributes(h5_file):
@@ -47,21 +47,21 @@ def test_attributes(h5_file):
 def test_channels(h5_file):
     f = pylake.File.from_h5py(h5_file)
 
-    assert np.allclose(f.force1x.data, [0, 1, 2, 3, 4])
-    assert np.allclose(f.force1x.timestamps, [1, 11, 21, 31, 41])
+    np.testing.assert_allclose(f.force1x.data, [0, 1, 2, 3, 4])
+    np.testing.assert_allclose(f.force1x.timestamps, [1, 11, 21, 31, 41])
     assert "x" not in f.force1x.labels
     assert f.force1x.labels["y"] == "Force (pN)"
     assert f.force1x.labels["title"] == "Force HF/Force 1x"
 
-    assert np.allclose(f.downsampled_force1x.data, [1.1, 2.1])
-    assert np.allclose(f.downsampled_force1x.timestamps, [1, 2])
+    np.testing.assert_allclose(f.downsampled_force1x.data, [1.1, 2.1])
+    np.testing.assert_allclose(f.downsampled_force1x.timestamps, [1, 2])
     assert "x" not in f.downsampled_force1x.labels
     assert f.downsampled_force1x.labels["y"] == "Force (pN)"
     assert f.downsampled_force1x.labels["title"] == "Force LF/Force 1x"
 
     vsum_force = np.sqrt(f.downsampled_force1x.data**2 + f.downsampled_force1y.data**2)
-    assert np.allclose(f.downsampled_force1.data, vsum_force)
-    assert np.allclose(f.downsampled_force1.timestamps, [1, 2])
+    np.testing.assert_allclose(f.downsampled_force1.data, vsum_force)
+    np.testing.assert_allclose(f.downsampled_force1.timestamps, [1, 2])
     assert "x" not in f.downsampled_force1.labels
     assert f.downsampled_force1.labels["y"] == "Force (pN)"
     assert f.downsampled_force1.labels["title"] == "Force LF/Force 1"
@@ -319,9 +319,9 @@ def test_h5_export(tmpdir_factory, h5_file, save_h5):
     save_h5(f, new_file, 5, omit_data={"Force LF/Force 1y"})
     omit_lf1y = pylake.File(new_file)
 
-    assert np.allclose(omit_lf1y["Force LF"]["Force 1x"].data, f["Force LF"]["Force 1x"].data)
-    assert np.allclose(omit_lf1y["Force HF"]["Force 1x"].data, f["Force HF"]["Force 1x"].data)
-    assert np.allclose(omit_lf1y["Force HF"]["Force 1y"].data, f["Force HF"]["Force 1y"].data)
+    np.testing.assert_allclose(omit_lf1y["Force LF"]["Force 1x"].data, f["Force LF"]["Force 1x"].data)
+    np.testing.assert_allclose(omit_lf1y["Force HF"]["Force 1x"].data, f["Force HF"]["Force 1x"].data)
+    np.testing.assert_allclose(omit_lf1y["Force HF"]["Force 1y"].data, f["Force HF"]["Force 1y"].data)
     with pytest.raises(KeyError):
         assert np.any(omit_lf1y["Force LF"]["Force 1y"].data)
 
@@ -329,10 +329,10 @@ def test_h5_export(tmpdir_factory, h5_file, save_h5):
     save_h5(f, new_file, 5, omit_data={"*/Force 1y"})
     omit_1y = pylake.File(new_file)
 
-    assert np.allclose(omit_1y["Force LF"]["Force 1x"].data, f["Force LF"]["Force 1x"].data)
-    assert np.allclose(omit_1y["Force HF"]["Force 1x"].data, f["Force HF"]["Force 1x"].data)
+    np.testing.assert_allclose(omit_1y["Force LF"]["Force 1x"].data, f["Force LF"]["Force 1x"].data)
+    np.testing.assert_allclose(omit_1y["Force HF"]["Force 1x"].data, f["Force HF"]["Force 1x"].data)
     with pytest.raises(KeyError):
-        assert np.allclose(omit_1y["Force HF"]["Force 1y"].data, f["Force HF"]["Force 1y"].data)
+        np.testing.assert_allclose(omit_1y["Force HF"]["Force 1y"].data, f["Force HF"]["Force 1y"].data)
     with pytest.raises(KeyError):
         assert np.any(omit_1y["Force LF"]["Force 1y"].data)
 
@@ -340,21 +340,21 @@ def test_h5_export(tmpdir_factory, h5_file, save_h5):
     save_h5(f, new_file, 5, omit_data={"Force HF/*"})
     omit_hf = pylake.File(new_file)
 
-    assert np.allclose(omit_hf["Force LF"]["Force 1x"].data, f["Force LF"]["Force 1x"].data)
-    assert np.allclose(omit_hf["Force LF"]["Force 1y"].data, f["Force LF"]["Force 1y"].data)
+    np.testing.assert_allclose(omit_hf["Force LF"]["Force 1x"].data, f["Force LF"]["Force 1x"].data)
+    np.testing.assert_allclose(omit_hf["Force LF"]["Force 1y"].data, f["Force LF"]["Force 1y"].data)
     with pytest.raises(KeyError):
-        assert np.allclose(omit_hf["Force HF"]["Force 1x"].data, f["Force HF"]["Force 1x"].data)
+        np.testing.assert_allclose(omit_hf["Force HF"]["Force 1x"].data, f["Force HF"]["Force 1x"].data)
     with pytest.raises(KeyError):
-        assert np.allclose(omit_hf["Force HF"]["Force 1y"].data, f["Force HF"]["Force 1y"].data)
+        np.testing.assert_allclose(omit_hf["Force HF"]["Force 1y"].data, f["Force HF"]["Force 1y"].data)
 
     new_file = f"{tmpdir}/omit_two.h5"
     save_h5(f, new_file, 5, omit_data={"Force HF/*", "*/Force 1y"})
     omit_two = pylake.File(new_file)
 
-    assert np.allclose(omit_two["Force LF"]["Force 1x"].data, f["Force LF"]["Force 1x"].data)
+    np.testing.assert_allclose(omit_two["Force LF"]["Force 1x"].data, f["Force LF"]["Force 1x"].data)
     with pytest.raises(KeyError):
-        assert np.allclose(omit_two["Force LF"]["Force 1y"].data, f["Force LF"]["Force 1y"].data)
+        np.testing.assert_allclose(omit_two["Force LF"]["Force 1y"].data, f["Force LF"]["Force 1y"].data)
     with pytest.raises(KeyError):
-        assert np.allclose(omit_two["Force HF"]["Force 1x"].data, f["Force HF"]["Force 1x"].data)
+        np.testing.assert_allclose(omit_two["Force HF"]["Force 1x"].data, f["Force HF"]["Force 1x"].data)
     with pytest.raises(KeyError):
-        assert np.allclose(omit_two["Force HF"]["Force 1y"].data, f["Force HF"]["Force 1y"].data)
+        np.testing.assert_allclose(omit_two["Force HF"]["Force 1y"].data, f["Force HF"]["Force 1y"].data)

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -124,19 +124,19 @@ def test_int_tiff(tmpdir):
 
     tags = grab_tags(str(tmpdir.join("1")))
     assert str(tags['ResolutionUnit']) == "RESUNIT.CENTIMETER"
-    assert np.allclose(tags['ImageDescription']['PixelTime'], 0.001)
+    np.testing.assert_allclose(tags['ImageDescription']['PixelTime'], 0.001)
     assert tags['ImageDescription']['PixelTimeUnit'] == "s"
-    assert np.allclose(tags['ImageDescription']['shape'], [10, 10, 3])
-    assert np.allclose(tags['XResolution'][0], 10000000)
-    assert np.allclose(tags['YResolution'][0], 10000000)
+    np.testing.assert_allclose(tags['ImageDescription']['shape'], [10, 10, 3])
+    np.testing.assert_allclose(tags['XResolution'][0], 10000000)
+    np.testing.assert_allclose(tags['YResolution'][0], 10000000)
 
     tags = grab_tags(str(tmpdir.join("2")))
     assert str(tags['ResolutionUnit']) == "RESUNIT.CENTIMETER"
-    assert np.allclose(tags['ImageDescription']['PixelTime'], 0.005)
+    np.testing.assert_allclose(tags['ImageDescription']['PixelTime'], 0.005)
     assert tags['ImageDescription']['PixelTimeUnit'] == "s"
-    assert np.allclose(tags['ImageDescription']['shape'], [10, 10, 3])
-    assert np.allclose(tags['XResolution'][0], 2000000)
-    assert np.allclose(tags['YResolution'][0], 2000000)
+    np.testing.assert_allclose(tags['ImageDescription']['shape'], [10, 10, 3])
+    np.testing.assert_allclose(tags['XResolution'][0], 2000000)
+    np.testing.assert_allclose(tags['YResolution'][0], 2000000)
 
 
 def test_float_tiff(tmpdir):
@@ -157,17 +157,17 @@ def test_histogram_rows():
     data = np.arange(36).reshape((6,6))
 
     e, h, w = histogram_rows(data, 1, 0.1)
-    assert np.allclose(e, [0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
+    np.testing.assert_allclose(e, [0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
     assert np.all(np.equal(h, [15, 51, 87, 123, 159, 195]))
-    assert np.allclose(w, 0.1)
+    np.testing.assert_allclose(w, 0.1)
 
     e, h, w = histogram_rows(data, 3, 0.1)
-    assert np.allclose(e, [0.0, 0.3])
+    np.testing.assert_allclose(e, [0.0, 0.3])
     assert np.all(np.equal(h, [153, 477]))
-    assert np.allclose(w, 0.3)
+    np.testing.assert_allclose(w, 0.3)
 
     with pytest.warns(UserWarning):
         e, h, w = histogram_rows(data, 5, 0.1)
-        assert np.allclose(e, [0.0, 0.5])
+        np.testing.assert_allclose(e, [0.0, 0.5])
         assert np.all(np.equal(h, [435, 195]))
-        assert np.allclose(w, [0.5, 0.1])
+        np.testing.assert_allclose(w, [0.5, 0.1])

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -33,14 +33,14 @@ def test_kymo_properties(h5_file):
         assert kymo.red_image.shape == (5, 4)
         assert kymo.blue_image.shape == (5, 4)
         assert kymo.green_image.shape == (5, 4)
-        assert np.allclose(kymo.timestamps, reference_timestamps)
+        np.testing.assert_allclose(kymo.timestamps, reference_timestamps)
         assert kymo.fast_axis == "X"
-        assert np.allclose(kymo.pixelsize_um, 10/1000)
-        assert np.allclose(kymo.line_time_seconds, 1.03125)
-        assert np.allclose(kymo.center_point_um["x"], 58.075877109272604)
-        assert np.allclose(kymo.center_point_um["y"], 31.978375270573267)
-        assert np.allclose(kymo.center_point_um["z"], 0)
-        assert np.allclose(kymo.size_um, [0.050])
+        np.testing.assert_allclose(kymo.pixelsize_um, 10/1000)
+        np.testing.assert_allclose(kymo.line_time_seconds, 1.03125)
+        np.testing.assert_allclose(kymo.center_point_um["x"], 58.075877109272604)
+        np.testing.assert_allclose(kymo.center_point_um["y"], 31.978375270573267)
+        np.testing.assert_allclose(kymo.center_point_um["z"], 0)
+        np.testing.assert_allclose(kymo.size_um, [0.050])
 
 
 def test_kymo_slicing(h5_file):
@@ -50,43 +50,43 @@ def test_kymo_slicing(h5_file):
         kymo_reference = np.transpose([[2, 0, 0, 0, 2], [0, 0, 0, 0, 0], [1, 0, 0, 0, 1], [0, 1, 1, 1, 0]])
 
         assert kymo.red_image.shape == (5, 4)
-        assert np.allclose(kymo.red_image.data, kymo_reference)
+        np.testing.assert_allclose(kymo.red_image.data, kymo_reference)
 
         sliced = kymo[:]
         assert sliced.red_image.shape == (5, 4)
-        assert np.allclose(sliced.red_image.data, kymo_reference)
+        np.testing.assert_allclose(sliced.red_image.data, kymo_reference)
 
         sliced = kymo["1s":]
         assert sliced.red_image.shape == (5, 3)
-        assert np.allclose(sliced.red_image.data, kymo_reference[:, 1:])
+        np.testing.assert_allclose(sliced.red_image.data, kymo_reference[:, 1:])
 
         sliced = kymo["0s":]
         assert sliced.red_image.shape == (5, 4)
-        assert np.allclose(sliced.red_image.data, kymo_reference)
+        np.testing.assert_allclose(sliced.red_image.data, kymo_reference)
 
         sliced = kymo["0s":"2s"]
         assert sliced.red_image.shape == (5, 2)
-        assert np.allclose(sliced.red_image.data, kymo_reference[:, :2])
+        np.testing.assert_allclose(sliced.red_image.data, kymo_reference[:, :2])
 
         sliced = kymo["0s":"-1s"]
         assert sliced.red_image.shape == (5, 3)
-        assert np.allclose(sliced.red_image.data, kymo_reference[:, :-1])
+        np.testing.assert_allclose(sliced.red_image.data, kymo_reference[:, :-1])
 
         sliced = kymo["0s":"-2s"]
         assert sliced.red_image.shape == (5, 2)
-        assert np.allclose(sliced.red_image.data, kymo_reference[:, :-2])
+        np.testing.assert_allclose(sliced.red_image.data, kymo_reference[:, :-2])
 
         sliced = kymo["0s":"3s"]
         assert sliced.red_image.shape == (5, 3)
-        assert np.allclose(sliced.red_image.data, kymo_reference[:, :3])
+        np.testing.assert_allclose(sliced.red_image.data, kymo_reference[:, :3])
 
         sliced = kymo["1s":"2s"]
         assert sliced.red_image.shape == (5, 1)
-        assert np.allclose(sliced.red_image.data, kymo_reference[:, 1:2])
+        np.testing.assert_allclose(sliced.red_image.data, kymo_reference[:, 1:2])
 
         sliced = kymo["0s":"10s"]
         assert sliced.red_image.shape == (5, 4)
-        assert np.allclose(sliced.red_image.data, kymo_reference[:, 0:10])
+        np.testing.assert_allclose(sliced.red_image.data, kymo_reference[:, 0:10])
 
         with pytest.raises(IndexError):
             kymo["0s"]
@@ -133,7 +133,7 @@ def test_damaged_kymo(h5_file):
         kymo.start = kymo.red_photon_count.timestamps[0] - 62500000
         with pytest.warns(RuntimeWarning):
             assert kymo.red_image.shape == (5, 3)
-        assert np.allclose(kymo.red_image.data, kymo_reference[:, 1:])
+        np.testing.assert_allclose(kymo.red_image.data, kymo_reference[:, 1:])
 
 
 @cleanup
@@ -146,9 +146,9 @@ def test_plotting(h5_file):
         # The following assertion fails because of unequal line times in the test data. These
         # unequal line times are not typical for BL data. Kymo nowadays assumes equal line times
         # which is why the old version of this test fails.
-        # assert np.allclose(np.sort(plt.xlim()), [-0.5, 3.5], atol=0.05)
-        assert np.allclose(plt.xlim(), [-0.515625, 3.609375])
-        assert np.allclose(np.sort(plt.ylim()), [0, 0.05])
+        # np.testing.assert_allclose(np.sort(plt.xlim()), [-0.5, 3.5], atol=0.05)
+        np.testing.assert_allclose(plt.xlim(), [-0.515625, 3.609375])
+        np.testing.assert_allclose(np.sort(plt.ylim()), [0, 0.05])
 
 
 @cleanup
@@ -158,7 +158,7 @@ def test_plotting_with_force(h5_file):
         kymo = f.kymos["Kymo1"]
 
         ds = kymo._downsample_channel(2, "x", reduce=np.mean)
-        assert np.allclose(ds.data, [30, 30, 10, 10])
+        np.testing.assert_allclose(ds.data, [30, 30, 10, 10])
         assert np.all(np.equal(ds.timestamps, kymo.timestamps[2]))
 
         kymo.plot_with_force(force_channel="2x", color_channel="red")
@@ -166,9 +166,9 @@ def test_plotting_with_force(h5_file):
         # The following assertion fails because of unequal line times in the test data. These
         # unequal line times are not typical for BL data. Kymo nowadays assumes equal line times
         # which is why the old version of this test fails.
-        # assert np.allclose(np.sort(plt.xlim()), [-0.5, 3.5], atol=0.05)
-        assert np.allclose(plt.xlim(), [-0.515625, 3.609375])
-        assert np.allclose(np.sort(plt.ylim()), [10, 30])
+        # np.testing.assert_allclose(np.sort(plt.xlim()), [-0.5, 3.5], atol=0.05)
+        np.testing.assert_allclose(plt.xlim(), [-0.515625, 3.609375])
+        np.testing.assert_allclose(np.sort(plt.ylim()), [10, 30])
 
 
 @cleanup
@@ -184,29 +184,29 @@ def test_plotting_with_histograms(h5_file):
 
         kymo.plot_with_position_histogram(color_channel="red", pixels_per_bin=1)
         w, h = get_rectangle_data()
-        assert np.allclose(h, 0.01)
+        np.testing.assert_allclose(h, 0.01)
         assert np.all(np.equal(w, [3, 1, 1, 1, 3]))
-        assert np.allclose(np.sort(plt.xlim()), [0, 3], atol=0.05)
+        np.testing.assert_allclose(np.sort(plt.xlim()), [0, 3], atol=0.05)
 
         kymo.plot_with_time_histogram(color_channel="red", pixels_per_bin=1)
         w, h = get_rectangle_data()
-        assert np.allclose(w, 1.03, atol=0.002)
+        np.testing.assert_allclose(w, 1.03, atol=0.002)
         assert np.all(np.equal(h, [4, 0, 2, 3]))
-        assert np.allclose(np.sort(plt.ylim()), [0, 4], atol=0.05)
+        np.testing.assert_allclose(np.sort(plt.ylim()), [0, 4], atol=0.05)
 
         with pytest.warns(UserWarning):
             kymo.plot_with_position_histogram(color_channel="red", pixels_per_bin=3)
             w, h = get_rectangle_data()
-            assert np.allclose(h, [0.03, 0.02])
+            np.testing.assert_allclose(h, [0.03, 0.02])
             assert np.all(np.equal(w, [5, 4]))
-            assert np.allclose(np.sort(plt.xlim()), [0, 5], atol=0.05)
+            np.testing.assert_allclose(np.sort(plt.xlim()), [0, 5], atol=0.05)
 
         with pytest.warns(UserWarning):
             kymo.plot_with_time_histogram(color_channel="red", pixels_per_bin=3)
             w, h = get_rectangle_data()
-            assert np.allclose(w, [3.09, 1.03], atol=0.02)
+            np.testing.assert_allclose(w, [3.09, 1.03], atol=0.02)
             assert np.all(np.equal(h, [6, 3]))
-            assert np.allclose(np.sort(plt.ylim()), [0, 6], atol=0.05)
+            np.testing.assert_allclose(np.sort(plt.ylim()), [0, 6], atol=0.05)
 
         with pytest.raises(ValueError):
             kymo.plot_with_position_histogram(color_channel="red", pixels_per_bin=6)
@@ -254,10 +254,10 @@ def test_downsampled_kymo():
     )
 
     assert kymo_ds.name == "Mock"
-    assert np.allclose(kymo_ds.red_image, ds)
-    assert np.allclose(kymo_ds.start, 100)
-    assert np.allclose(kymo_ds.pixelsize_um, 1 / 1000)
-    assert np.allclose(kymo_ds.line_time_seconds, 2 * 7 * (5 * 4 + 2 + 2) / 1e9)
+    np.testing.assert_allclose(kymo_ds.red_image, ds)
+    np.testing.assert_allclose(kymo_ds.start, 100)
+    np.testing.assert_allclose(kymo_ds.pixelsize_um, 1 / 1000)
+    np.testing.assert_allclose(kymo_ds.line_time_seconds, 2 * 7 * (5 * 4 + 2 + 2) / 1e9)
 
     with pytest.raises(
             AttributeError,
@@ -266,7 +266,7 @@ def test_downsampled_kymo():
         kymo_ds.timestamps
 
     # Verify that we can pass a different reduce function
-    assert np.allclose(kymo.downsampled_by(time_factor=2, reduce=np.mean).red_image, ds / 2)
+    np.testing.assert_allclose(kymo.downsampled_by(time_factor=2, reduce=np.mean).red_image, ds / 2)
 
 
 def test_downsampled_kymo_position():
@@ -292,19 +292,19 @@ def test_downsampled_kymo_position():
                       [182.5,  327.5,  472.5,  617.5,  762.5,  907.5, 1052.5]])
 
     assert kymo_ds.name == "Mock"
-    assert np.allclose(kymo_ds.red_image, ds)
-    assert np.allclose(kymo_ds.timestamps, ds_ts)
-    assert np.allclose(kymo_ds.start, 100)
-    assert np.allclose(kymo_ds.pixelsize_um, 2 / 1000)
-    assert np.allclose(kymo_ds.line_time_seconds, kymo.line_time_seconds)
+    np.testing.assert_allclose(kymo_ds.red_image, ds)
+    np.testing.assert_allclose(kymo_ds.timestamps, ds_ts)
+    np.testing.assert_allclose(kymo_ds.start, 100)
+    np.testing.assert_allclose(kymo_ds.pixelsize_um, 2 / 1000)
+    np.testing.assert_allclose(kymo_ds.line_time_seconds, kymo.line_time_seconds)
 
     # We lost one line while downsampling
-    assert np.allclose(kymo_ds.size_um[0], kymo.size_um[0] - kymo.pixelsize_um[0])
+    np.testing.assert_allclose(kymo_ds.size_um[0], kymo.size_um[0] - kymo.pixelsize_um[0])
 
     # Verify that we can pass a different reduce function
     alt_ds = kymo.downsampled_by(position_factor=2, reduce=np.mean, reduce_timestamps=np.sum)
-    assert np.allclose(alt_ds.red_image, ds / 2)
-    assert np.allclose(alt_ds.timestamps, ds_ts * 2)
+    np.testing.assert_allclose(alt_ds.red_image, ds / 2)
+    np.testing.assert_allclose(alt_ds.timestamps, ds_ts * 2)
 
 
 def test_downsampled_kymo_both_axes():
@@ -333,10 +333,10 @@ def test_downsampled_kymo_both_axes():
 
     for kymo_ds in downsampled_kymos:
         assert kymo_ds.name == "Mock"
-        assert np.allclose(kymo_ds.red_image, ds)
-        assert np.allclose(kymo_ds.start, 100)
-        assert np.allclose(kymo_ds.pixelsize_um, 2 / 1000)
-        assert np.allclose(kymo_ds.line_time_seconds, 2 * 5 * (5 * 5 + 2 + 2) / 1e9)
+        np.testing.assert_allclose(kymo_ds.red_image, ds)
+        np.testing.assert_allclose(kymo_ds.start, 100)
+        np.testing.assert_allclose(kymo_ds.pixelsize_um, 2 / 1000)
+        np.testing.assert_allclose(kymo_ds.line_time_seconds, 2 * 5 * (5 * 5 + 2 + 2) / 1e9)
         with pytest.raises(
                 AttributeError,
                 match=re.escape("Per-pixel timestamps are no longer available after downsampling"),
@@ -363,11 +363,11 @@ def test_side_no_side_effects_downsampling():
     timestamps = kymo.timestamps.copy()
     downsampled_kymos = kymo.downsampled_by(time_factor=2, position_factor=2)
 
-    assert np.allclose(kymo.red_image, image)
-    assert np.allclose(kymo.start, 100)
-    assert np.allclose(kymo.pixelsize_um, 1 / 1000)
-    assert np.allclose(kymo.line_time_seconds, 5 * (5 * 5 + 2 + 2) / 1e9)
-    assert np.allclose(kymo.timestamps, timestamps)
+    np.testing.assert_allclose(kymo.red_image, image)
+    np.testing.assert_allclose(kymo.start, 100)
+    np.testing.assert_allclose(kymo.pixelsize_um, 1 / 1000)
+    np.testing.assert_allclose(kymo.line_time_seconds, 5 * (5 * 5 + 2 + 2) / 1e9)
+    np.testing.assert_allclose(kymo.timestamps, timestamps)
 
 
 def test_calibrated_channels():
@@ -392,9 +392,9 @@ def test_calibrated_channels():
     )
 
     calibrated_channel = CalibratedKymographChannel.from_kymo(kymo, "red")
-    assert np.allclose(calibrated_channel.data, image)
-    assert np.allclose(calibrated_channel.time_step_ns, kymo.line_time_seconds * int(1e9))
-    assert np.allclose(calibrated_channel._pixel_size, kymo.pixelsize_um[0])
+    np.testing.assert_allclose(calibrated_channel.data, image)
+    np.testing.assert_allclose(calibrated_channel.time_step_ns, kymo.line_time_seconds * int(1e9))
+    np.testing.assert_allclose(calibrated_channel._pixel_size, kymo.pixelsize_um[0])
 
 
 def test_downsampled_slice():

--- a/lumicks/pylake/tests/test_kymotracker.py
+++ b/lumicks/pylake/tests/test_kymotracker.py
@@ -24,14 +24,17 @@ def test_eigen_2d():
 
         # Test whether eigen values are correct
         i = np.argsort(np_eigen_values)
-        np.testing.assert_allclose(np_eigen_values[i], pl_eigen_values), print(
-            f"Eigen values invalid. Calculated {pl_eigen_values}, expected: {np_eigen_vectors} ")
+        np.testing.assert_allclose(np_eigen_values[i], pl_eigen_values, rtol=1e-6,
+                                   err_msg=f"Eigen values invalid. Calculated {pl_eigen_values}, "
+                                           f"expected: {np_eigen_vectors} ")
 
         # Test whether eigen vectors are correct
         vs = [np.array(eigenvector_2d_symmetric(a, b, d, x)) for x in pl_eigen_values]
 
-        np.testing.assert_allclose(abs(np.dot(vs[0], np_eigen_vectors[:, i[0]])), 1.0), print("First eigen vector invalid")
-        np.testing.assert_allclose(abs(np.dot(vs[1], np_eigen_vectors[:, i[1]])), 1.0), print("Second eigen vector invalid")
+        np.testing.assert_allclose(abs(np.dot(vs[0], np_eigen_vectors[:, i[0]])), 1.0, rtol=1e-6,
+                                   err_msg="First eigen vector invalid")
+        np.testing.assert_allclose(abs(np.dot(vs[1], np_eigen_vectors[:, i[1]])), 1.0, rtol=1e-6,
+                                   err_msg="Second eigen vector invalid")
 
     def np_eigenvalues(a, b, d):
         eig1 = np.empty(a.shape)
@@ -71,7 +74,8 @@ def test_eigen_2d():
     eigenvalues.sort(axis=-1)
     eigenvector_x, eigenvector_y = eigenvector_2d_symmetric(a, b, d, eigenvalues[:, :, 0])
 
-    np.testing.assert_allclose(eigenvalues, np_eigenvalues)
+    # Given that there are some zeroes, we should include an absolute tolerance.
+    np.testing.assert_allclose(eigenvalues, np_eigenvalues, rtol=1e-6, atol=1e-14)
 
     # Eigen vectors have to point in the same direction, but are not necessarily the same sign
     np.testing.assert_allclose(np.abs(np_eigenvector_x*eigenvector_x + np_eigenvector_y*eigenvector_y), np.ones(a.shape))

--- a/lumicks/pylake/tests/test_kymotracker.py
+++ b/lumicks/pylake/tests/test_kymotracker.py
@@ -24,14 +24,14 @@ def test_eigen_2d():
 
         # Test whether eigen values are correct
         i = np.argsort(np_eigen_values)
-        assert np.allclose(np_eigen_values[i], pl_eigen_values), print(
+        np.testing.assert_allclose(np_eigen_values[i], pl_eigen_values), print(
             f"Eigen values invalid. Calculated {pl_eigen_values}, expected: {np_eigen_vectors} ")
 
         # Test whether eigen vectors are correct
         vs = [np.array(eigenvector_2d_symmetric(a, b, d, x)) for x in pl_eigen_values]
 
-        assert np.allclose(abs(np.dot(vs[0], np_eigen_vectors[:, i[0]])), 1.0), print("First eigen vector invalid")
-        assert np.allclose(abs(np.dot(vs[1], np_eigen_vectors[:, i[1]])), 1.0), print("Second eigen vector invalid")
+        np.testing.assert_allclose(abs(np.dot(vs[0], np_eigen_vectors[:, i[0]])), 1.0), print("First eigen vector invalid")
+        np.testing.assert_allclose(abs(np.dot(vs[1], np_eigen_vectors[:, i[1]])), 1.0), print("Second eigen vector invalid")
 
     def np_eigenvalues(a, b, d):
         eig1 = np.empty(a.shape)
@@ -71,10 +71,10 @@ def test_eigen_2d():
     eigenvalues.sort(axis=-1)
     eigenvector_x, eigenvector_y = eigenvector_2d_symmetric(a, b, d, eigenvalues[:, :, 0])
 
-    assert np.allclose(eigenvalues, np_eigenvalues)
+    np.testing.assert_allclose(eigenvalues, np_eigenvalues)
 
     # Eigen vectors have to point in the same direction, but are not necessarily the same sign
-    assert np.allclose(np.abs(np_eigenvector_x*eigenvector_x + np_eigenvector_y*eigenvector_y), np.ones(a.shape))
+    np.testing.assert_allclose(np.abs(np_eigenvector_x*eigenvector_x + np_eigenvector_y*eigenvector_y), np.ones(a.shape))
 
 
 @pytest.mark.parametrize("loc,scale,sig_x,sig_y,transpose", [
@@ -130,7 +130,7 @@ def test_geometry():
     data[2, 2] = 10
     data[3, 3] = 10
     max_derivative, normals, positions, inside = calculate_image_geometry(data, sig_x, sig_y)
-    assert np.allclose(normals[2, 2][1], -normals[2, 2][0])
+    np.testing.assert_allclose(normals[2, 2][1], -normals[2, 2][0])
 
     # Diagonal line y=x, expect normal's coordinates to have same sign
     data = np.zeros((5, 5))
@@ -138,21 +138,21 @@ def test_geometry():
     data[2, 2] = 10
     data[1, 3] = 10
     max_derivative, normals, positions, inside = calculate_image_geometry(data, sig_x, sig_y)
-    assert np.allclose(normals[2, 2][1], normals[2, 2][0])
+    np.testing.assert_allclose(normals[2, 2][1], normals[2, 2][0])
 
 
 def test_candidates():
     candidates = get_candidate_generator()
 
     normal_angle = (-22.4 - 90) * np.pi / 180
-    assert np.allclose(candidates(normal_angle)[0], np.array([1, -1]))
-    assert np.allclose(candidates(normal_angle)[1], np.array([1, 0]))
-    assert np.allclose(candidates(normal_angle)[2], np.array([1, 1]))
+    np.testing.assert_allclose(candidates(normal_angle)[0], np.array([1, -1]))
+    np.testing.assert_allclose(candidates(normal_angle)[1], np.array([1, 0]))
+    np.testing.assert_allclose(candidates(normal_angle)[2], np.array([1, 1]))
 
     normal_angle = (22.4 - 90) * np.pi / 180
-    assert np.allclose(candidates(normal_angle)[0], np.array([1, -1]))
-    assert np.allclose(candidates(normal_angle)[1], np.array([1, 0]))
-    assert np.allclose(candidates(normal_angle)[2], np.array([1, 1]))
+    np.testing.assert_allclose(candidates(normal_angle)[0], np.array([1, -1]))
+    np.testing.assert_allclose(candidates(normal_angle)[1], np.array([1, 0]))
+    np.testing.assert_allclose(candidates(normal_angle)[2], np.array([1, 1]))
 
     normal_angle = (-22.6 - 90) * np.pi / 180
     assert not np.allclose(candidates(normal_angle)[0], np.array([1, -1]))
@@ -176,7 +176,7 @@ def test_candidates():
         direction = np.array([-np.sin(normal_angle), np.cos(normal_angle)])
         direction = np.sign(np.round(direction))
 
-        assert np.allclose(np.sort([np.max(np.abs(direction - option)) for option in options]),
+        np.testing.assert_allclose(np.sort([np.max(np.abs(direction - option)) for option in options]),
                            [0, 1, 1]), f"Failed for normal angle {normal_angle} / direction {direction} => {options}"
 
 
@@ -203,16 +203,16 @@ def test_tracing():
     normals[hx, hx, 1] = 1.0 / np.sqrt(2)
 
     candidates = get_candidate_generator()
-    assert np.allclose(_traverse_line_direction([0, 0], deepcopy(a), positions, normals, -0.5, 1, candidates, 1, True),
+    np.testing.assert_allclose(_traverse_line_direction([0, 0], deepcopy(a), positions, normals, -0.5, 1, candidates, 1, True),
                        np.array([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6]]))
-    assert np.allclose(
+    np.testing.assert_allclose(
         _traverse_line_direction([n - 1, n - 1], deepcopy(a), positions, normals, -0.5, 1, candidates, -1, True),
         np.array([[6, 6], [5, 5], [4, 4], [3, 3], [2, 2], [1, 1], [0, 0]]))
-    assert np.allclose(_traverse_line_direction([hx, 0], deepcopy(a), positions, normals, -0.5, 1, candidates, 1, True),
+    np.testing.assert_allclose(_traverse_line_direction([hx, 0], deepcopy(a), positions, normals, -0.5, 1, candidates, 1, True),
                        np.array([[hx, 0], [hx, 1], [hx, 2], [hx, 3], [4, 4], [5, 5], [6, 6]]))
 
     # Test whether the threshold is enforced
-    assert np.allclose(_traverse_line_direction([0, 0], deepcopy(a), positions, normals, -1.5, 1, candidates, 1, True),
+    np.testing.assert_allclose(_traverse_line_direction([0, 0], deepcopy(a), positions, normals, -1.5, 1, candidates, 1, True),
                        np.array([[0, 0], [1, 1], [2, 2]]))
 
 
@@ -260,18 +260,18 @@ def test_stitching():
 
     stitched = stitch_kymo_lines([segment_1, segment_3, segment_2], radius, 2, 2)
     assert len(stitched) == 2
-    assert np.allclose(stitched[0].coordinate_idx, [0, 1, 2, 3])
-    assert np.allclose(stitched[1].coordinate_idx, [0, 0])
+    np.testing.assert_allclose(stitched[0].coordinate_idx, [0, 1, 2, 3])
+    np.testing.assert_allclose(stitched[1].coordinate_idx, [0, 0])
 
     stitched = stitch_kymo_lines([segment_1b, segment_3, segment_2], radius, 2, 2)
-    assert np.allclose(stitched[0].coordinate_idx, [0, 0, 0, 0])
-    assert np.allclose(stitched[0].time_idx, [0, 1, 2, 3])
-    assert np.allclose(stitched[1].coordinate_idx, [2, 3])
+    np.testing.assert_allclose(stitched[0].coordinate_idx, [0, 0, 0, 0])
+    np.testing.assert_allclose(stitched[0].time_idx, [0, 1, 2, 3])
+    np.testing.assert_allclose(stitched[1].coordinate_idx, [2, 3])
 
     # Check whether only the last two points are used (meaning we extrapolate [0, 0], [1, 1])
     stitched = stitch_kymo_lines([segment_1c, segment_3, segment_2], radius, 2, 2)
-    assert np.allclose(stitched[0].coordinate_idx, [0, 0, 1, 2, 3])
-    assert np.allclose(stitched[0].time_idx, [-1, 0, 1, 2, 3])
+    np.testing.assert_allclose(stitched[0].coordinate_idx, [0, 0, 1, 2, 3])
+    np.testing.assert_allclose(stitched[0].time_idx, [-1, 0, 1, 2, 3])
 
     # When using all three points, we shouldn't stitch
     assert len(stitch_kymo_lines([segment_1c, segment_3, segment_2], radius, 2, 3)) == 3
@@ -314,36 +314,36 @@ def test_kymotracker_integration_tests():
     pixel_size = test_data.pixelsize_um[0]
 
     lines = track_greedy(test_data, "red", 3, 4)
-    assert np.allclose(lines[0].coordinate_idx, [11] * np.ones(10))
-    assert np.allclose(lines[1].coordinate_idx, [21] * np.ones(10))
-    assert np.allclose(lines[0].position, [11 * pixel_size] * np.ones(10))
-    assert np.allclose(lines[1].position, [21 * pixel_size] * np.ones(10))
-    assert np.allclose(lines[0].time_idx, np.arange(10, 20))
-    assert np.allclose(lines[1].time_idx, np.arange(15, 25))
-    assert np.allclose(lines[0].seconds, np.arange(10, 20) * line_time)
-    assert np.allclose(lines[1].seconds, np.arange(15, 25) * line_time)
-    assert np.allclose(lines[0].sample_from_image(1), [50] * np.ones(10))
-    assert np.allclose(lines[1].sample_from_image(1), [40] * np.ones(10))
+    np.testing.assert_allclose(lines[0].coordinate_idx, [11] * np.ones(10))
+    np.testing.assert_allclose(lines[1].coordinate_idx, [21] * np.ones(10))
+    np.testing.assert_allclose(lines[0].position, [11 * pixel_size] * np.ones(10))
+    np.testing.assert_allclose(lines[1].position, [21 * pixel_size] * np.ones(10))
+    np.testing.assert_allclose(lines[0].time_idx, np.arange(10, 20))
+    np.testing.assert_allclose(lines[1].time_idx, np.arange(15, 25))
+    np.testing.assert_allclose(lines[0].seconds, np.arange(10, 20) * line_time)
+    np.testing.assert_allclose(lines[1].seconds, np.arange(15, 25) * line_time)
+    np.testing.assert_allclose(lines[0].sample_from_image(1), [50] * np.ones(10))
+    np.testing.assert_allclose(lines[1].sample_from_image(1), [40] * np.ones(10))
 
     lines = track_lines(test_data, "red", 3, 4)
-    assert np.allclose(lines[0].coordinate_idx, [11] * len(lines[0].coordinate_idx))
-    assert np.allclose(lines[1].coordinate_idx, [21] * len(lines[1].coordinate_idx))
-    assert np.allclose(lines[0].time_idx, np.arange(9, 21))
-    assert np.allclose(lines[1].time_idx, np.arange(14, 26))
-    assert np.allclose(np.sum(lines[0].sample_from_image(1)), 50 * 10 + 6)
-    assert np.allclose(np.sum(lines[1].sample_from_image(1)), 40 * 10 + 6)
+    np.testing.assert_allclose(lines[0].coordinate_idx, [11] * len(lines[0].coordinate_idx))
+    np.testing.assert_allclose(lines[1].coordinate_idx, [21] * len(lines[1].coordinate_idx))
+    np.testing.assert_allclose(lines[0].time_idx, np.arange(9, 21))
+    np.testing.assert_allclose(lines[1].time_idx, np.arange(14, 26))
+    np.testing.assert_allclose(np.sum(lines[0].sample_from_image(1)), 50 * 10 + 6)
+    np.testing.assert_allclose(np.sum(lines[1].sample_from_image(1)), 40 * 10 + 6)
 
     line_time = test_data.line_time_seconds
     pixel_size = test_data.pixelsize_um[0]
     rect = [[0.0 * line_time, 15.0 * pixel_size], [30 * line_time, 30.0 * pixel_size]]
 
     lines = track_greedy(test_data, "red", 3, 4, rect=rect)
-    assert np.allclose(lines[0].coordinate_idx, [21] * np.ones(10))
-    assert np.allclose(lines[0].time_idx, np.arange(15, 25))
+    np.testing.assert_allclose(lines[0].coordinate_idx, [21] * np.ones(10))
+    np.testing.assert_allclose(lines[0].time_idx, np.arange(15, 25))
 
     lines = track_lines(test_data, "red", 3, 4, rect=rect)
-    assert np.allclose(lines[0].coordinate_idx, [21] * len(lines[0].coordinate_idx))
-    assert np.allclose(lines[0].time_idx, np.arange(14, 26))
+    np.testing.assert_allclose(lines[0].coordinate_idx, [21] * len(lines[0].coordinate_idx))
+    np.testing.assert_allclose(lines[0].time_idx, np.arange(14, 26))
 
 
 def test_regression_sample_from_image_clamp():
@@ -368,10 +368,10 @@ def test_kymotracker_integration_tests_subset():
     rect = [[0.0 * line_time, 15.0 * pixel_size], [30 * line_time, 30.0 * pixel_size]]
 
     lines = track_greedy(test_data, "red", 3, 4, rect=rect)
-    assert np.allclose(lines[0].sample_from_image(1), [40] * np.ones(10))
+    np.testing.assert_allclose(lines[0].sample_from_image(1), [40] * np.ones(10))
 
     lines = track_lines(test_data, "red", 3, 4, rect=rect)
-    assert np.allclose(np.sum(lines[0].sample_from_image(1)), 40 * 10 + 6)
+    np.testing.assert_allclose(np.sum(lines[0].sample_from_image(1)), 40 * 10 + 6)
 
 
 def test_kymotracker_test_bias_rect():
@@ -393,7 +393,7 @@ def test_kymotracker_test_bias_rect():
     traces_full = track_greedy(kymo, "red", **tracking_settings)
 
     for t1, t2 in zip(traces_rect, traces_full):
-        assert np.allclose(t1.position, t2.position)
+        np.testing.assert_allclose(t1.position, t2.position)
 
 
 def test_kymotracker_test_bias_rect_lines():
@@ -413,7 +413,7 @@ def test_kymotracker_test_bias_rect_lines():
     traces_full = track_lines(kymo, "red", **tracking_settings)
 
     for t1, t2 in zip(traces_rect, traces_full):
-        assert np.allclose(t1.position, t2.position)
+        np.testing.assert_allclose(t1.position, t2.position)
 
 
 def test_filter_lines():

--- a/lumicks/pylake/tests/test_point_scan.py
+++ b/lumicks/pylake/tests/test_point_scan.py
@@ -17,8 +17,8 @@ def test_point_scans(h5_file):
                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 1, 0, 0, 0, 0, 0,
                                    0, 0, 0, 0, 0, 0, 1, 0, 8, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0,
                                    0, 1, 0, 0, 0, 8, 0])
-        assert np.allclose(ps_red.timestamps, reference_timestamps)
-        assert np.allclose(ps_red.data, reference_data)
+        np.testing.assert_allclose(ps_red.timestamps, reference_timestamps)
+        np.testing.assert_allclose(ps_red.data, reference_data)
 
         with pytest.deprecated_call():
             ps.json
@@ -36,9 +36,9 @@ def test_plotting(h5_file):
         ps = f.point_scans["PointScan1"]
         for plot_func in (ps.plot_red, ps.plot_green, ps.plot_blue):
             plot_func()
-            assert np.allclose(np.sort(plt.xlim()), [0, 0.0625 * 64])
-            assert np.allclose(np.sort(plt.ylim()), [0, 8])
+            np.testing.assert_allclose(np.sort(plt.xlim()), [0, 0.0625 * 64])
+            np.testing.assert_allclose(np.sort(plt.ylim()), [0, 8])
 
         ps.plot_rgb(lw=5)
-        assert np.allclose(np.sort(plt.xlim()), [0, 0.0625 * 64])
-        assert np.allclose(np.sort(plt.ylim()), [0, 8])
+        np.testing.assert_allclose(np.sort(plt.xlim()), [0, 0.0625 * 64])
+        np.testing.assert_allclose(np.sort(plt.ylim()), [0, 8])

--- a/lumicks/pylake/tests/test_scan.py
+++ b/lumicks/pylake/tests/test_scan.py
@@ -18,7 +18,7 @@ def test_scans(h5_file):
                                         [2.243750e+10, 2.262500e+10, 2.284375e+10, 2.309375e+10],
                                         [2.328125e+10, 2.346875e+10, 2.365625e+10, 2.387500e+10]])
 
-        assert np.allclose(scan.timestamps, np.transpose(reference_timestamps))
+        np.testing.assert_allclose(scan.timestamps, np.transpose(reference_timestamps))
         assert scan.num_frames == 1
         with pytest.deprecated_call():
             scan.json
@@ -34,13 +34,13 @@ def test_scans(h5_file):
         assert scan.blue_image.shape == (4, 5)
         assert scan.green_image.shape == (4, 5)
         assert scan.fast_axis == "Y"
-        assert np.allclose(scan.pixelsize_um, [197/1000, 191/1000])
-        assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
-        assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
-        assert np.allclose(scan.center_point_um["z"], 0)
-        assert np.allclose(scan.size_um, [0.197*5, 0.191*4])
+        np.testing.assert_allclose(scan.pixelsize_um, [197/1000, 191/1000])
+        np.testing.assert_allclose(scan.center_point_um["x"], 58.075877109272604)
+        np.testing.assert_allclose(scan.center_point_um["y"], 31.978375270573267)
+        np.testing.assert_allclose(scan.center_point_um["z"], 0)
+        np.testing.assert_allclose(scan.size_um, [0.197*5, 0.191*4])
         with pytest.warns(DeprecationWarning):
-            assert np.allclose(scan.scan_width_um, [[0.197*5 + .5, 0.191*4 + .5]])
+            np.testing.assert_allclose(scan.scan_width_um, [[0.197*5 + .5, 0.191*4 + .5]])
 
         with pytest.raises(NotImplementedError):
             scan["1s":"2s"]
@@ -50,7 +50,7 @@ def test_scans(h5_file):
         reference_timestamps2[0, :, :] = reference_timestamps.T[:, :3]
         reference_timestamps2[1, :, :2] = reference_timestamps.T[:, 3:]
 
-        assert np.allclose(scan.timestamps, reference_timestamps2)
+        np.testing.assert_allclose(scan.timestamps, reference_timestamps2)
         assert scan.num_frames == 2
         with pytest.deprecated_call():
             scan.json
@@ -66,11 +66,11 @@ def test_scans(h5_file):
         assert scan.blue_image.shape == (2, 4, 3)
         assert scan.green_image.shape == (2, 4, 3)
         assert scan.fast_axis == "Y"
-        assert np.allclose(scan.pixelsize_um, [197 / 1000, 191 / 1000])
-        assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
-        assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
-        assert np.allclose(scan.center_point_um["z"], 0)
-        assert np.allclose(scan.size_um, [0.197*3, 0.191*4])
+        np.testing.assert_allclose(scan.pixelsize_um, [197 / 1000, 191 / 1000])
+        np.testing.assert_allclose(scan.center_point_um["x"], 58.075877109272604)
+        np.testing.assert_allclose(scan.center_point_um["y"], 31.978375270573267)
+        np.testing.assert_allclose(scan.center_point_um["z"], 0)
+        np.testing.assert_allclose(scan.size_um, [0.197*3, 0.191*4])
 
         scan = f.scans["fast X slow Z multiframe"]
         reference_timestamps2 = np.zeros((2, 4, 3))
@@ -78,7 +78,7 @@ def test_scans(h5_file):
         reference_timestamps2[1, :, :2] = reference_timestamps.T[:, 3:]
         reference_timestamps2 = reference_timestamps2.transpose([0, 2, 1])
 
-        assert np.allclose(scan.timestamps, reference_timestamps2)
+        np.testing.assert_allclose(scan.timestamps, reference_timestamps2)
         assert scan.num_frames == 2
         with pytest.deprecated_call():
             scan.json
@@ -94,11 +94,11 @@ def test_scans(h5_file):
         assert scan.blue_image.shape == (2, 3, 4)
         assert scan.green_image.shape == (2, 3, 4)
         assert scan.fast_axis == "X"
-        assert np.allclose(scan.pixelsize_um, [191 / 1000, 197 / 1000])
-        assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
-        assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
-        assert np.allclose(scan.center_point_um["z"], 0)
-        assert np.allclose(scan.size_um, [0.191*4, 0.197*3])
+        np.testing.assert_allclose(scan.pixelsize_um, [191 / 1000, 197 / 1000])
+        np.testing.assert_allclose(scan.center_point_um["x"], 58.075877109272604)
+        np.testing.assert_allclose(scan.center_point_um["y"], 31.978375270573267)
+        np.testing.assert_allclose(scan.center_point_um["z"], 0)
+        np.testing.assert_allclose(scan.size_um, [0.191*4, 0.197*3])
 
         scan = f.scans["fast Y slow Z multiframe"]
         reference_timestamps2 = np.zeros((2, 4, 3))
@@ -106,7 +106,7 @@ def test_scans(h5_file):
         reference_timestamps2[1, :, :2] = reference_timestamps.T[:, 3:]
         reference_timestamps2 = reference_timestamps2.transpose([0, 2, 1])
 
-        assert np.allclose(scan.timestamps, reference_timestamps2)
+        np.testing.assert_allclose(scan.timestamps, reference_timestamps2)
         assert scan.num_frames == 2
         with pytest.deprecated_call():
             scan.json
@@ -122,11 +122,11 @@ def test_scans(h5_file):
         assert scan.blue_image.shape == (2, 3, 4)
         assert scan.green_image.shape == (2, 3, 4)
         assert scan.fast_axis == "Y"
-        assert np.allclose(scan.pixelsize_um, [191 / 1000, 197 / 1000])
-        assert np.allclose(scan.center_point_um["x"], 58.075877109272604)
-        assert np.allclose(scan.center_point_um["y"], 31.978375270573267)
-        assert np.allclose(scan.center_point_um["z"], 0)
-        assert np.allclose(scan.size_um, [0.191*4, 0.197*3])
+        np.testing.assert_allclose(scan.pixelsize_um, [191 / 1000, 197 / 1000])
+        np.testing.assert_allclose(scan.center_point_um["x"], 58.075877109272604)
+        np.testing.assert_allclose(scan.center_point_um["y"], 31.978375270573267)
+        np.testing.assert_allclose(scan.center_point_um["z"], 0)
+        np.testing.assert_allclose(scan.size_um, [0.191*4, 0.197*3])
 
 
 def test_damaged_scan(h5_file):
@@ -147,7 +147,7 @@ def test_damaged_scan(h5_file):
         middle = scan.red_photon_count.timestamps[5]
         scan.start = middle - 62400000
         scan.red_image.shape  # should not raise, but change the start appropriately to work around sted bug
-        assert np.allclose(scan.start, middle)
+        np.testing.assert_allclose(scan.start, middle)
 
 
 @cleanup
@@ -156,18 +156,18 @@ def test_plotting(h5_file):
     if f.format_version == 2:
         scan = f.scans["fast Y slow X multiframe"]
         scan.plot_blue()
-        assert np.allclose(np.sort(plt.xlim()), [0, .197 * 3])
-        assert np.allclose(np.sort(plt.ylim()), [0, .191 * 4])
+        np.testing.assert_allclose(np.sort(plt.xlim()), [0, .197 * 3])
+        np.testing.assert_allclose(np.sort(plt.ylim()), [0, .191 * 4])
 
         scan = f.scans["fast X slow Z multiframe"]
         scan.plot_rgb()
-        assert np.allclose(np.sort(plt.xlim()), [0, .191 * 4])
-        assert np.allclose(np.sort(plt.ylim()), [0, .197 * 3])
+        np.testing.assert_allclose(np.sort(plt.xlim()), [0, .191 * 4])
+        np.testing.assert_allclose(np.sort(plt.ylim()), [0, .197 * 3])
 
         scan = f.scans["fast Y slow Z multiframe"]
         scan.plot_rgb()
-        assert np.allclose(np.sort(plt.xlim()), [0, .191 * 4])
-        assert np.allclose(np.sort(plt.ylim()), [0, .197 * 3])
+        np.testing.assert_allclose(np.sort(plt.xlim()), [0, .191 * 4])
+        np.testing.assert_allclose(np.sort(plt.ylim()), [0, .197 * 3])
 
 
 def test_save_tiff(tmpdir_factory, h5_file):

--- a/lumicks/pylake/tests/test_scan.py
+++ b/lumicks/pylake/tests/test_scan.py
@@ -40,7 +40,7 @@ def test_scans(h5_file):
         np.testing.assert_allclose(scan.center_point_um["z"], 0)
         np.testing.assert_allclose(scan.size_um, [0.197*5, 0.191*4])
         with pytest.warns(DeprecationWarning):
-            np.testing.assert_allclose(scan.scan_width_um, [[0.197*5 + .5, 0.191*4 + .5]])
+            np.testing.assert_allclose(scan.scan_width_um, [0.197*5 + .5, 0.191*4 + .5])
 
         with pytest.raises(NotImplementedError):
             scan["1s":"2s"]

--- a/lumicks/pylake/tests/test_utilities.py
+++ b/lumicks/pylake/tests/test_utilities.py
@@ -21,7 +21,7 @@ def test_unique():
 
 def test_colors():
     [mpl.colors.to_rgb(get_color(k)) for k in range(30)]
-    assert np.allclose(lighten_color([0.5, 0, 0], .2), [.7, 0, 0])
+    np.testing.assert_allclose(lighten_color([0.5, 0, 0], .2), [.7, 0, 0])
 
 
 def test_find_contiguous():
@@ -81,5 +81,5 @@ def test_find_contiguous():
     ],
 )
 def test_downsample(data, factor, avg, std):
-    assert np.allclose(avg, downsample(data, factor, reduce=np.mean))
-    assert np.allclose(std, downsample(data, factor, reduce=np.std))
+    np.testing.assert_allclose(avg, downsample(data, factor, reduce=np.mean))
+    np.testing.assert_allclose(std, downsample(data, factor, reduce=np.std))


### PR DESCRIPTION
**Why this PR?**
Diffusion constant and power spectrum tests were ineffective at catching problems, since the default absolute tolerance set by `numpy` was high enough for pretty big relative deviations to slip by (diffusion constants in volts are tiny, in the order of 1e-12). This PR tightens these tolerances to make sure the tests fire when something changes inadvertently.

Note that nothing was broken.