### PR TITLE
force_calibration: store points per block with fit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
   In the updated version, all image processing steps that depend on the image use the full image.
 * Fixed a bug in the plotting order of `CalibrationResults.plot()`. Previously, when plotting after performing a force calibration, the model fit was erroneously plotted first (while the legend indicated that the model fit was plotted last). The results of the calibration itself are unchanged.
 * Resolved `DeprecationWarning` with `tifffile >= 2021.7.2`.
+* Fixed a bug in `CalibrationResults.ps_model_fit` which resulted in its attribute `num_points_per_block` to be `1` rather than the number of points per block the model was fitted to. Note that this does not affect the calibration results as the calibration procedure internally used the correct number of points per block.
 
 #### Breaking changes
 

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -257,7 +257,9 @@ def fit_power_spectrum(power_spectrum, model, settings=CalibrationSettings()):
     backing = (1 - scipy.special.gammainc(chi_squared / 2, n_degrees_of_freedom / 2)) * 100
 
     # Fitted power spectrum values.
-    ps_model_fit = power_spectrum.with_spectrum(model(power_spectrum.frequency, *solution_params))
+    ps_model_fit = power_spectrum.with_spectrum(
+        model(power_spectrum.frequency, *solution_params), power_spectrum.num_points_per_block
+    )
 
     return CalibrationResults(
         model=model,

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -167,6 +167,10 @@ def test_actual_spectrum(reference_calibration_result):
     np.testing.assert_allclose(ps_calibration["err_alpha"], 0.013141463933316694, rtol=1e-4)
     np.testing.assert_allclose(ps_calibration["err_f_diode"], 561.6377089699399, rtol=1e-4)
 
+    # Test whether the model contains the number of points per block that were used to fit it
+    np.testing.assert_allclose(ps_calibration.ps_model_fit.num_points_per_block, 100)
+    np.testing.assert_allclose(ps_calibration.ps_fitted.num_points_per_block, 100)
+
 
 @cleanup
 def test_result_plot(reference_calibration_result):


### PR DESCRIPTION
**Why this PR?**
Currently, the returned model fit contains a `num_points_per_block` of `1`. Instead, it would make a lot more sense to store the number of points per block that were used in the fitting procedure.

This PR mitigates that by storing the number of points per block used for fitting in the `num_points_per_block` attribute of the fitted power spectrum.