### PR TITLE
tiff: fix deprecation warning (photometric no longer inferred)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@
   This means that the blurring steps involved in this algorithm become biased (since they do not get contributions from outside the selected areas, while they should).
   In the updated version, all image processing steps that depend on the image use the full image.
 * Fixed a bug in the plotting order of `CalibrationResults.plot()`. Previously, when plotting after performing a force calibration, the model fit was erroneously plotted first (while the legend indicated that the model fit was plotted last). The results of the calibration itself are unchanged.
+* Resolved `DeprecationWarning` with `tifffile >= 2021.7.2`.
 
 #### Breaking changes
 

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -274,6 +274,7 @@ class CorrelatedStack:
                     metadata=None,  # suppress tifffile default ImageDescription tag
                     contiguous=False,  # needed to write tags on each page
                     extratags=parse_tags(frame),
+                    photometric="rgb" if frame.is_rgb else "minisblack",
                 )
 
     @property

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -249,7 +249,11 @@ def save_tiff(image, filename, dtype, clip=False, metadata=ImageMetadata()):
         )
 
     tifffile.imsave(
-        filename, image.astype(dtype), resolution=metadata.resolution, metadata=metadata.metadata
+        filename,
+        image.astype(dtype),
+        resolution=metadata.resolution,
+        metadata=metadata.metadata,
+        photometric="rgb",
     )
 
 


### PR DESCRIPTION
**Why this PR?**
`tifffile` no longer automatically infers what `photometric` type it is dealing with, so now we have to do it.