### PR TITLE
kymotracker: algorithm parameter units

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * Added Mean Square Displacement (MSD) and diffusion constant estimation to `KymoLine`. For more information, please refer to [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html)
 * Added `FdCurve.with_baseline_corrected_x()` to return a baseline corrected version of the FD curve if the corrected data is available. **Note: currently the baseline is only calculated for the x-component of the force channel in Bluelake. Therefore baseline corrected `FdCurve` instances use only the x-component of the force channel, unlike default `FdCurve`s which use the full magnitude of the force channel by default.**
 * Added ability to perform arithmetic on `Slice` (e.g. `(f.force1x - f.force2x) / 2`). For more information see [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#exporting-h5-files) for more information.
+* Added a slider to set the algorithm parameter `velocity` to the kymotracker widget.
 
 #### Bug fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,7 @@
   See the [Cas9 kymotracking example](https://lumicks-pylake.readthedocs.io/en/latest/examples/cas9_kymotracking/cas9_kymotracking.html) or the [kymotracking tutorial](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
 * `KymoLineGroup.save()` and `KymoWidgetGreedy.save_lines()` no longer take `dx` and `dt` arguments.
   Instead, the correct time and position calibration is now passed automatically to these functions. See [kymographs](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html) for more information.
+* Express kymotracker algorithm parameters `line_width`, `sigma`, `velocity` and `diffusion` in physical units rather than pixels. Prior to this change, the units of the kymotracking algorithm were in pixels. Note that if you want to reproduce your earlier results multiply `line_width` and `sigma` by `kymo.pixelsize_um[0]`, `velocity` by `kymo.pixelsize_um[0] / kymo.line_time_seconds` and `diffusion` by `kymo.pixelsize_um[0] ** 2 / kymo.line_time_seconds`.
 
 #### Breaking changes
 * `Slice.downsampled_like()` now returns both the downsampled `Slice` and a copy of the low frequency reference `Slice` cropped such that both instances have exactly the same timestamps.

--- a/docs/examples/cas9_kymotracking/cas9_kymotracking.rst
+++ b/docs/examples/cas9_kymotracking/cas9_kymotracking.rst
@@ -114,7 +114,7 @@ In this mode you can click the end of one kymoline with the right mouse button a
 Note that in this data for example, there are some regions where fluorescence starts building up on the surface of the
 bead. This binding should be omitted from the analysis::
 
-    kymowidget = lk.KymoWidgetGreedy(kymo_ds, "green", axis_aspect_ratio=2, min_length=4, pixel_threshold=3, window=6, sigma=1.4, vmax=8)
+    kymowidget = lk.KymoWidgetGreedy(kymo_ds, "green", axis_aspect_ratio=2, min_length=4, pixel_threshold=3, window=6, sigma=0.14, vmax=8)
 
 .. image:: kymowidget.png
 

--- a/docs/examples/cas9_kymotracking/kymowidget.png
+++ b/docs/examples/cas9_kymotracking/kymowidget.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc57d47da867bfbe607960bb3077b1e23b292cb5a429df4ae450406117d466c8
-size 157049
+oid sha256:d25f492a9f00288fdd857eb39542e70cc90819d9b02b56353d9edae58f305e23
+size 114811

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -46,7 +46,7 @@ use the region from 7 to 22 micrometer. Let's have a look at what that looks lik
     >>> kymo.plot_green(aspect="auto", vmax=5)
     >>> plt.ylim([22, 7])
 
-If we zoom in a bit, we can see that our traces in this image are about 3 pixels wide, so let's set this as our
+If we zoom in a bit, we can see that our traces in this image are about 0.3 microns wide, so let's set this as our
 `line_width`. Note that we invoked `plt.colorbar()` to add a little color legend here.
 
 .. image:: kymo_zoom.png
@@ -58,12 +58,12 @@ Considering that we only want to run the kymotracker on part of the image, we al
 In this case, we track particles between 0 and 350 seconds, and 7 and 22 micron.
 Running the algorithm is easy using the function :func:`~lumicks.pylake.track_greedy`::
 
-    traces = lk.track_greedy(kymo, "green", line_width=3, pixel_threshold=3, window=6, rect=[[0, 7], [350, 22]])
+    traces = lk.track_greedy(kymo, "green", line_width=0.3, pixel_threshold=3, window=6, rect=[[0, 7], [350, 22]])
 
 The result of tracking is a list of kymograph traces::
 
     >>> print(len(traces))  # the number of traces found in the kymo
-    7411
+    7417
 
 Sometimes, we can have very short spurious traces. To remove these from the list of detected traces we can use
 :func:`~lumicks.pylake.filter_lines`. To omit all traces with fewer than 4 detected points, we
@@ -122,7 +122,7 @@ by invoking the following command::
 
 You can optionally also pass algorithm parameters when opening the widget::
 
-    KymoWidgetGreedy(kymo, "green", axis_aspect_ratio=2, min_length=4, pixel_threshold=3, window=6, sigma=1.4)
+    KymoWidgetGreedy(kymo, "green", axis_aspect_ratio=2, min_length=4, pixel_threshold=3, window=6, sigma=0.14)
 
 Traced lines are accessible through the `.lines` property::
 
@@ -138,7 +138,7 @@ The second algorithm present is an algorithm that works purely on signal derivat
 the image, and then performing sub-pixel accurate line detection. It can be a bit more robust to low signal levels,
 but is generally less temporally and spatially accurate due to the blurring involved::
 
-    traces = lk.track_lines(kymo, "green", line_width=3, max_lines=50)
+    traces = lk.track_lines(kymo, "green", line_width=0.3, max_lines=50)
 
 The interface is mostly the same, aside from an extra required parameter named `max_lines` which indicates the maximum
 number of lines we want to detect.

--- a/lumicks/pylake/kymotracker/tests/test_algorithm_scaling.py
+++ b/lumicks/pylake/kymotracker/tests/test_algorithm_scaling.py
@@ -1,0 +1,47 @@
+import pytest
+import numpy as np
+from lumicks.pylake.kymotracker.kymotracker import track_greedy
+from lumicks.pylake.tests.data.mock_confocal import generate_kymo
+
+
+def generate_gaussian_line(vel, dt, dx, sigma=0.3, area=10, samples_per_pixel=10):
+    """Generate a Gaussian test line with a certain velocity"""
+    time = np.arange(0, 2, dt)
+    time_mesh, coord_mesh = np.meshgrid(time, np.arange(0, 4, dx))
+    img_data = (area * np.exp(-(((vel * time_mesh - coord_mesh + 1) / sigma) ** 2))).astype(int)
+    ns_per_sample = int(1e9 * dt / len(time) / samples_per_pixel)
+    return generate_kymo(
+        "chan",
+        img_data,
+        dt=ns_per_sample,
+        samples_per_pixel=samples_per_pixel,
+        line_padding=0,
+        pixel_size_nm=1e3 * dx,
+    )
+
+
+@pytest.mark.parametrize(
+    "vel, dt, dx",
+    [
+        [1.0, 0.1, 0.2],
+        [0.5, 0.1, 0.2],
+    ],
+)
+def test_kymotracker_positional_scaling(vel, dt, dx):
+    """Integration test to make sure position and velocity parameters are correctly scaled"""
+    kymo = generate_gaussian_line(vel=vel, dt=dt, dx=dx)
+    traces = track_greedy(kymo, "red", pixel_threshold=3, line_width=1, sigma=0.01, vel=vel)
+    ref_seconds = np.arange(0.0, 2.0, dt)
+    ref_positions = 1 + vel * ref_seconds
+    np.testing.assert_allclose(traces[0].seconds, ref_seconds)
+    np.testing.assert_allclose(traces[0].position, ref_positions, rtol=1e-2)
+
+    # Check whether a wrong velocity also fails to track the line
+    traces = track_greedy(kymo, "red", pixel_threshold=3, line_width=1, sigma=0.01, vel=2 * vel)
+    np.testing.assert_equal(len(traces[0].seconds), 1)
+    np.testing.assert_equal(len(traces[0].position), 1)
+
+    # When sigma is large, we expect the line to be strung together despite the velocity being zero
+    traces = track_greedy(kymo, "red", pixel_threshold=3, line_width=1, sigma=0.5 * vel * dx, vel=0)
+    np.testing.assert_allclose(traces[0].seconds, ref_seconds)
+    np.testing.assert_allclose(traces[0].position, ref_positions, rtol=1e-2)

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -566,6 +566,16 @@ class KymoWidgetGreedy(KymoWidget):
             step_size=0.001 * position_scale,
             slider_type=ipywidgets.FloatSlider,
         )
+        vel_calibration = position_scale / calibrated_kymo_channel.line_time_seconds
+        vel_slider = self._add_slider(
+            "Velocity",
+            "vel",
+            "How fast does the particle move?",
+            minimum=-5.0 * vel_calibration,
+            maximum=5.0 * vel_calibration,
+            step_size=0.001 * vel_calibration,
+            slider_type=ipywidgets.FloatSlider,
+        )
         return ipywidgets.VBox(
-            [thresh_slider, line_width_slider, window_slider, sigma_slider]
+            [thresh_slider, line_width_slider, window_slider, sigma_slider, vel_slider]
         )

--- a/lumicks/pylake/nb_widgets/tests/conftest.py
+++ b/lumicks/pylake/nb_widgets/tests/conftest.py
@@ -43,13 +43,17 @@ def kymograph():
     data[8, 10:25] = 8
     data[12, 5:7] = 10
     data[12, 9:20] = 10
+    data[15, 5:7] = 2
+    data[15, 9:20] = 2
 
+    pixel_size_um = 0.4
+    line_time_seconds = 5
     return generate_kymo(
         "test",
         data,
-        pixel_size_nm=1000,
+        pixel_size_nm=1000 * pixel_size_um,
         start=int(4e9),
-        dt=int(1e9 / 100),
+        dt=int(1e9 / 100) * line_time_seconds,
         samples_per_pixel=3,
         line_padding=20,
     )

--- a/lumicks/pylake/tests/test_kymotracker.py
+++ b/lumicks/pylake/tests/test_kymotracker.py
@@ -317,7 +317,7 @@ def test_kymotracker_integration_tests():
     line_time = test_data.line_time_seconds
     pixel_size = test_data.pixelsize_um[0]
 
-    lines = track_greedy(test_data, "red", 3, 4)
+    lines = track_greedy(test_data, "red", 3 * pixel_size, 4)
     np.testing.assert_allclose(lines[0].coordinate_idx, [11] * np.ones(10))
     np.testing.assert_allclose(lines[1].coordinate_idx, [21] * np.ones(10))
     np.testing.assert_allclose(lines[0].position, [11 * pixel_size] * np.ones(10))
@@ -329,7 +329,7 @@ def test_kymotracker_integration_tests():
     np.testing.assert_allclose(lines[0].sample_from_image(1), [50] * np.ones(10))
     np.testing.assert_allclose(lines[1].sample_from_image(1), [40] * np.ones(10))
 
-    lines = track_lines(test_data, "red", 3, 4)
+    lines = track_lines(test_data, "red", 3 * pixel_size, 4)
     np.testing.assert_allclose(lines[0].coordinate_idx, [11] * len(lines[0].coordinate_idx))
     np.testing.assert_allclose(lines[1].coordinate_idx, [21] * len(lines[1].coordinate_idx))
     np.testing.assert_allclose(lines[0].time_idx, np.arange(9, 21))
@@ -341,11 +341,11 @@ def test_kymotracker_integration_tests():
     pixel_size = test_data.pixelsize_um[0]
     rect = [[0.0 * line_time, 15.0 * pixel_size], [30 * line_time, 30.0 * pixel_size]]
 
-    lines = track_greedy(test_data, "red", 3, 4, rect=rect)
+    lines = track_greedy(test_data, "red", 3 * pixel_size, 4, rect=rect)
     np.testing.assert_allclose(lines[0].coordinate_idx, [21] * np.ones(10))
     np.testing.assert_allclose(lines[0].time_idx, np.arange(15, 25))
 
-    lines = track_lines(test_data, "red", 3, 4, rect=rect)
+    lines = track_lines(test_data, "red", 3 * pixel_size, 4, rect=rect)
     np.testing.assert_allclose(lines[0].coordinate_idx, [21] * len(lines[0].coordinate_idx))
     np.testing.assert_allclose(lines[0].time_idx, np.arange(14, 26))
 
@@ -371,10 +371,10 @@ def test_kymotracker_integration_tests_subset():
     pixel_size = test_data.pixelsize_um[0]
     rect = [[0.0 * line_time, 15.0 * pixel_size], [30 * line_time, 30.0 * pixel_size]]
 
-    lines = track_greedy(test_data, "red", 3, 4, rect=rect)
+    lines = track_greedy(test_data, "red", 3 * pixel_size, 4, rect=rect)
     np.testing.assert_allclose(lines[0].sample_from_image(1), [40] * np.ones(10))
 
-    lines = track_lines(test_data, "red", 3, 4, rect=rect)
+    lines = track_lines(test_data, "red", 3 * pixel_size, 4, rect=rect)
     np.testing.assert_allclose(np.sum(lines[0].sample_from_image(1)), 40 * 10 + 6)
 
 
@@ -392,7 +392,10 @@ def test_kymotracker_test_bias_rect():
 
     # We grab a subset of the image right beyond the bright pixel. If there's a bias induced
     # by the rectangle crop, we'll see it!
-    tracking_settings = {"line_width": 3, "pixel_threshold": 4, "sigma": 5, "window": 9}
+    tracking_settings = {"line_width": 3,
+                         "pixel_threshold": 4,
+                         "sigma": 5,
+                         "window": 9}
     traces_rect = track_greedy(kymo, "red", **tracking_settings, rect=[[0, 2], [1000, 12]])
     traces_full = track_greedy(kymo, "red", **tracking_settings)
 


### PR DESCRIPTION
**Why this PR?**
We recently switched over Kymographs in a way that they can hold calibrations.

In addition, the algorithms now return traces in real units. However, the algorithm parameters were not using these physical units (and still had to be specified in pixels). This PR mitigates this.

I would argue that this should be part of the `v0.9` release to minimize the number of breaking changes in versions after this.

**Notes**
- Note that a separate ticket exists to actually put these units on the sliders. It is out of scope for this PR.
- Plan is to squash this into a single commit when merging.

Docs for your reading pleasure: https://lumicks-pylake.readthedocs.io/en/kymo_units/
Changes are in the Cas9 example and the kymotracking tutorial.