### PR TITLE
fdfit: Allow simulating the wlc model without fitting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * Added Mean Square Displacement (MSD) and diffusion constant estimation to `KymoLine`. For more information, please refer to [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html)
 * Added `FdCurve.with_baseline_corrected_x()` to return a baseline corrected version of the FD curve if the corrected data is available. **Note: currently the baseline is only calculated for the x-component of the force channel in Bluelake. Therefore baseline corrected `FdCurve` instances use only the x-component of the force channel, unlike default `FdCurve`s which use the full magnitude of the force channel by default.**
 * Added ability to perform arithmetic on `Slice` (e.g. `(f.force1x - f.force2x) / 2`). For more information see [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#exporting-h5-files) for more information.
+* Allow simulating force model with a custom set of parameters (see tutorial section [Fd Fitting](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/fdfitting.html)).
 * Added a slider to set the algorithm parameter `velocity` to the kymotracker widget.
 
 #### Bug fixes

--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 * `KymoLineGroup.save()` and `KymoWidgetGreedy.save_lines()` no longer take `dx` and `dt` arguments.
   Instead, the correct time and position calibration is now passed automatically to these functions. See [kymographs](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html) for more information.
 * Express kymotracker algorithm parameters `line_width`, `sigma`, `velocity` and `diffusion` in physical units rather than pixels. Prior to this change, the units of the kymotracking algorithm were in pixels. Note that if you want to reproduce your earlier results multiply `line_width` and `sigma` by `kymo.pixelsize_um[0]`, `velocity` by `kymo.pixelsize_um[0] / kymo.line_time_seconds` and `diffusion` by `kymo.pixelsize_um[0] ** 2 / kymo.line_time_seconds`.
+  * `Parameters.keys()` is now a member function instead of a property (used to be invoked as `parameter.keys`) to be consistent with dictionary.
 
 #### Breaking changes
 * `Slice.downsampled_like()` now returns both the downsampled `Slice` and a copy of the low frequency reference `Slice` cropped such that both instances have exactly the same timestamps.

--- a/docs/tutorial/fdfitting.rst
+++ b/docs/tutorial/fdfitting.rst
@@ -53,6 +53,16 @@ We can also obtain the parameters as a list::
 
 As we can see from the model equation, the model is given as distance as a function of force.
 
+Simulating the model
+--------------------
+
+We can simulate the model by passing a dictionary with parameters values::
+
+    dna = lk.odijk("DNA")
+    force = np.arange(0.1, 14, 0.1)
+    dna(force, {"DNA/Lp": 50.0, "DNA/Lc": 16.0, "DNA/St": 1500.0, "kT": 4.11})
+
+Note how the model name is prefixed to the model specific parameters, forming a key-value pair like so: `"name/parameter": value`.
 
 Model composition and inversion
 -------------------------------

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -195,7 +195,7 @@ class Fit:
             parameter_vector[fitted] = params
 
             if show_fit:
-                parameter_names = self.params.keys
+                parameter_names = self.params.keys()
                 for name, value in zip(parameter_names, parameter_vector):
                     self.params[name] = value
                 plt.figure(fig.number)
@@ -242,14 +242,14 @@ class Fit:
         )
         if np.any(out_of_bounds):
             raise ValueError(
-                f"Initial parameters {self.params.keys[fitted][out_of_bounds]} are outside the "
+                f"Initial parameters {self.params.keys()[fitted][out_of_bounds]} are outside the "
                 f"parameter bounds. Please set value, lower_bound and upper_bound for these parameters"
                 f"to consistent values."
             )
 
         parameter_vector = self._fit(parameter_vector, lb, ub, fitted, show_fit=show_fit, **kwargs)
 
-        parameter_names = self.params.keys
+        parameter_names = self.params.keys()
         for name, value in zip(parameter_names, parameter_vector):
             self.params[name] = value
 
@@ -387,7 +387,7 @@ class Fit:
 
         is_close = np.allclose(jacobian, jacobian_fd, **kwargs)
         if not is_close:
-            parameter_names = list(self.params.keys)
+            parameter_names = list(self.params.keys())
             if verbose:
                 maxima = np.max(jacobian - jacobian_fd, axis=1)
                 for i, v in enumerate(maxima):

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -135,9 +135,16 @@ class Model:
         params : ``pylake.fitting.Params``
         """
         independent = np.asarray(independent, dtype=np.float64)
+        missing_parameters = set(self.parameter_names) - set(params.keys())
+        if missing_parameters:
+            raise KeyError(
+                f"The following missing parameters must be specified to simulate the "
+                f"model: {missing_parameters}."
+            )
+
         return self._raw_call(
             independent,
-            np.asarray([params[name].value for name in self.parameter_names], dtype=np.float64),
+            np.asarray([float(params[name]) for name in self.parameter_names], dtype=np.float64),
         )
 
     def _raw_call(self, independent, param_vector):

--- a/lumicks/pylake/fitting/parameters.py
+++ b/lumicks/pylake/fitting/parameters.py
@@ -220,7 +220,6 @@ class Params:
 
         self._src = new_params
 
-    @property
     def keys(self):
         return np.asarray([key for key in self._src.keys()])
 

--- a/lumicks/pylake/fitting/parameters.py
+++ b/lumicks/pylake/fitting/parameters.py
@@ -50,6 +50,9 @@ class Parameter:
         self.profile = None
         self.stderr = None
 
+    def __float__(self):
+        return float(self.value)
+
     def __eq__(self, other):
         return (
             all((getattr(self, x) == getattr(other, x) for x in self.__slots__))

--- a/lumicks/pylake/fitting/profile_likelihood.py
+++ b/lumicks/pylake/fitting/profile_likelihood.py
@@ -288,10 +288,10 @@ class ProfileLikelihood1D:
 
         self.profile_info = ProfileInfo(
             minimum_chi2=chi2_function(parameters.values),
-            profiled_parameter_index=list(parameters.keys).index(parameter_name),
+            profiled_parameter_index=list(parameters.keys()).index(parameter_name),
             delta_chi2=chi2.ppf(options["confidence_level"], options["num_dof"]),
             confidence_level=options["confidence_level"],
-            parameter_names=list(parameters.keys),
+            parameter_names=list(parameters.keys()),
         )
 
         fitted = parameters.fitted

--- a/lumicks/pylake/fitting/tests/test_model_sim.py
+++ b/lumicks/pylake/fitting/tests/test_model_sim.py
@@ -1,0 +1,35 @@
+import pytest
+import numpy as np
+from lumicks.pylake.fitting.models import odijk
+from lumicks.pylake.fitting.parameters import Params, Parameter
+
+
+def test_simulation_api():
+    dna = odijk("DNA")
+    force = [0.1, 0.2, 0.3]
+    np.testing.assert_allclose(
+        dna(force, {"DNA/Lp": 50.0, "DNA/Lc": 16.0, "DNA/St": 1500.0, "kT": 4.11}),
+        [8.74792941, 10.8733908, 11.81559925],
+    )
+
+    np.testing.assert_allclose(
+        dna(
+            [0.1, 0.2, 0.3],
+            Params(
+                **{
+                    "DNA/Lp": Parameter(50.0),
+                    "DNA/Lc": Parameter(16.0),
+                    "DNA/St": Parameter(1500.0),
+                    "kT": Parameter(4.11),
+                }
+            ),
+        ),
+        [8.74792941, 10.8733908, 11.81559925],
+    )
+
+
+def test_simulation_api_wrong_par():
+    dna = odijk("DNA")
+
+    with pytest.raises(KeyError):
+        dna([1], {"DNA/Lp": 50.0, "DNA/Lc": 16.0, "DN/St": 1500.0, "kT": 4.11})

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -47,6 +47,7 @@ def test_params():
     assert not Parameter(5.0, 0.0, 1.0, fixed=True) == Parameter(5.0, 0.0, 1.0, fixed=False)
     assert Parameter(5.0, 0.0, 1.0, unit="pN") == Parameter(5.0, 0.0, 1.0, unit="pN")
     assert not Parameter(5.0, 0.0, 1.0, unit="pN") == Parameter(5.0, 0.0, 1.0, unit="potatoes")
+    assert float(Parameter(5.0, 0.0, 1.0, unit="pN")) == 5.0
 
     assert Params(**{"M/a": Parameter(5.0), "M/b": Parameter(5.0)}) == \
         Params(**{"M/a": Parameter(5.0), "M/b": Parameter(5.0)})
@@ -176,7 +177,7 @@ def test_model_calls():
 
     np.testing.assert_allclose(model(t, Params(**{"m/d": Parameter(4), "m/c": Parameter(3), "m/b": Parameter(2)})), y_ref)
 
-    with pytest.raises(IndexError):
+    with pytest.raises(KeyError):
         np.testing.assert_allclose(model(t, Params(**{"m/a": Parameter(1), "m/b": Parameter(2), "m/d": Parameter(4)})), y_ref)
 
 

--- a/lumicks/pylake/tests/test_fdfit.py
+++ b/lumicks/pylake/tests/test_fdfit.py
@@ -240,7 +240,7 @@ def test_datasets_build_status():
 
 def test_model_fit_object_linking():
     def fetch_params(keys, indices):
-        p_list = list(f.params.keys)
+        p_list = list(f.params.keys())
         return [p_list[x] if x is not None else None for x in indices]
 
     def g(data, mu, sig, a, b, c, d, e, f, q):
@@ -261,7 +261,7 @@ def test_model_fit_object_linking():
     # Asking for the parameters should have triggered a build
     f.params
     assert not f.dirty
-    assert set(f.params.keys) == set(all_params)
+    assert set(f.params.keys()) == set(all_params)
 
     # Check the parameters included in the model
     np.testing.assert_allclose(f.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
@@ -291,11 +291,11 @@ def test_model_fit_object_linking():
 
     # Since M/r is set fixed in that model, it should not appear as a parameter
     all_params = ["M/mu", "M/sig", "M/a", "M/b", "M/d", "M/e", "M/e_new", "M/f", "M/q"]
-    assert set(f.params.keys) == set(all_params)
+    assert set(f.params.keys()) == set(all_params)
 
     all_params = ["M/mu", "M/sig", "M/a", "M/b", "M/d", "M/e", "M/e_new", "M/f", "M/q", "M/r"]
     f[m2]._add_data("test2", [1, 2, 3], [2, 3, 4], {'M/c': 4, 'M/e': 5})
-    assert set(f.params.keys) == set(all_params)
+    assert set(f.params.keys()) == set(all_params)
     np.testing.assert_allclose(f.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8])
     assert np.all(f.datasets[id(m)]._conditions[0].p_local == [None, None, None, None, 4, None, None, None, None])
     assert fetch_params(f.params, f.datasets[id(m)]._conditions[0]._p_global_indices) == \


### PR DESCRIPTION
**Why this PR?**
It's a popular feature request to simulate a force-distance model without fitting it first.

With relatively minor modifications, the call operator can be made to take both dictionaries with parameter values and `Parameters`.

**Things to look out for**
Note that this PR changes the `keys` attribute of `Parameters` to a method. I believe having it as a property initially was a mistake, since this is not how the default dictionary behaves.


Before:
```python
import lumicks.pylake as lk
from lumicks.pylake.fitting.parameters import Params, Parameter  # These were not public by default, so users would have to know already what to do
dna = lk.inverted_odijk("DNA")
distances = [.1, .2, .3]
dna(distances, Params(**{"DNA/Lp": Parameter(50.0), "DNA/Lc": Parameter(16.0), "DNA/St": Parameter(1500.0), "kT": Parameter(4.11)}))
```

After:
```python
import lumicks.pylake as lk
dna = lk.inverted_odijk("DNA")
distances = [.1, .2, .3]
dna(distances, {"DNA/Lp": 50.0, "DNA/Lc": 16.0, "DNA/St": 1500.0, "kT": 4.11})
```