### PR TITLE
force calibration: implement exclusion of specific frequency ranges

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.9.1 | t.b.d.
+
+#### New features
+
+* Added option to exclude ranges with potential noise peaks from the calibration routines. Please refer to [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html) for more information.
+
 ## v0.9.0 | 2021-07-29
 
 `Pylake v0.9` provides several new features. Starting from `pylake v0.9`, the kymotracker will handle units for you. From now on, all you have to worry about is physical quantities rather than pixels. Please see the updated [example on Cas9 binding](https://lumicks-pylake.readthedocs.io/en/latest/examples/cas9_kymotracking/cas9_kymotracking.html) for a demonstration of this. In addition to that, you can now [infer diffusion constants from diffusive kymograph traces](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#studying-diffusion-processes).

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -41,9 +41,10 @@ This function returns a power_spectrum which we can plot::
 .. image:: force_calibration_blocked_spectrum.png
 
 Note that the computation of the power spectrum involves some downsampling.
-If you wish to change the amount of downsampling applied or which range to compute the spectrum for, you can specify these as additional arguments::
 
-    lk.calculate_power_spectrum(volts, sample_rate=force_slice.sample_rate, fit_range=(1e2, 23e3), num_points_per_block=2000)
+Additional parameters can be specified to change the amount of downsampling applied (`num_points_per_block`), the range over which to compute the spectrum (`fit_range`) or to exclude specific frequency ranges from the spectrum (`excluded_ranges`)::
+
+    power_spectrum = lk.calculate_power_spectrum(volts, sample_rate=force_slice.sample_rate, fit_range=(1e2, 23e3), num_points_per_block=2000, excluded_ranges=[(700, 800), (14500, 14600)])
 
 To fit the passive calibration data, we will use a model based on a number of publications by the Flyvbjerg group :cite:`berg2004power,tolic2004matlab,hansen2006tweezercalib,berg2006power`.
 This model can be found in :class:`~.PassiveCalibrationModel`. It is calibrated by fitting the following equation to the power spectrum:

--- a/lumicks/pylake/force_calibration/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/power_spectrum.py
@@ -53,6 +53,27 @@ class PowerSpectrum:
 
         return ba
 
+    def _exclude_range(self, excluded_ranges):
+        """Exclude given frequency ranges from the power spectrum.
+
+        This function can be used to exclude noise peaks.
+
+        Parameters
+        ----------
+        excluded_ranges : list of tuple of float
+            List of ranges to exclude specified as a list of (frequency_min, frequency_max)."""
+        if not excluded_ranges:
+            return copy(self)
+
+        ps = copy(self)
+        indices = np.logical_and.reduce(
+            [(ps.frequency < f_min) | (ps.frequency >= f_max) for f_min, f_max in excluded_ranges]
+        )
+
+        ps.frequency = ps.frequency[indices]
+        ps.power = ps.power[indices]
+        return ps
+
     def in_range(self, frequency_min, frequency_max):
         """Returns part of the power spectrum within a given frequency range."""
         ir = copy(self)

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -130,7 +130,9 @@ def guess_f_diode_initial_value(ps, guess_fc, guess_D):
         return 2 * f_nyquist
 
 
-def calculate_power_spectrum(data, sample_rate, fit_range=(1e2, 23e3), num_points_per_block=2000):
+def calculate_power_spectrum(
+    data, sample_rate, fit_range=(1e2, 23e3), num_points_per_block=2000, excluded_ranges=None
+):
     """Compute power spectrum and returns it as a :class:`~.PowerSpectrum`.
 
     Parameters
@@ -139,11 +141,14 @@ def calculate_power_spectrum(data, sample_rate, fit_range=(1e2, 23e3), num_point
         Data used for calibration.
     sample_rate : float
         Sampling rate [Hz]
-    fit_range : tuple (f_min, f_max), optional
-        Tuple of two floats, indicating the frequency range to use for the
-        full model fit [Hz]
+    fit_range : tuple of float, optional
+        Tuple of two floats (f_min, f_max), indicating the frequency range to use for the
+        full model fit. [Hz]
     num_points_per_block : int, optional
         The spectrum is first block averaged by this number of points per block.
+        Default: 2000.
+    excluded_ranges : list of tuple of float, optional
+        List of ranges to exclude specified as a list of (frequency_min, frequency_max).
 
     Returns
     -------
@@ -154,7 +159,7 @@ def calculate_power_spectrum(data, sample_rate, fit_range=(1e2, 23e3), num_point
         raise TypeError('Argument "data" must be a numpy vector')
 
     power_spectrum = PowerSpectrum(data, sample_rate)
-    power_spectrum = power_spectrum.in_range(*fit_range)
+    power_spectrum = power_spectrum.in_range(*fit_range)._exclude_range(excluded_ranges)
     power_spectrum = power_spectrum.downsampled_by(num_points_per_block)
 
     return power_spectrum


### PR DESCRIPTION
**Why this PR?**
For active force calibration it has to be possible to exclude specific regions from the fit. This PR adds that functionality to `PowerSpectrum`.

Typically what happens in an active force calibration procedure is that you'd have a driving input frequency (a spike in the frequency spectrum) that needs to be excluded prior to fitting the thermal part of the spectrum.

In addition, this functionality can be used to reject noise peaks that may happen at various frequencies.