### PR TITLE
kymo: fix `plot_with_force` for kymos with an incomplete last line

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@
 * Fixed a bug in the plotting order of `CalibrationResults.plot()`. Previously, when plotting after performing a force calibration, the model fit was erroneously plotted first (while the legend indicated that the model fit was plotted last). The results of the calibration itself are unchanged.
 * Resolved `DeprecationWarning` with `tifffile >= 2021.7.2`.
 * Fixed a bug in `CalibrationResults.ps_model_fit` which resulted in its attribute `num_points_per_block` to be `1` rather than the number of points per block the model was fitted to. Note that this does not affect the calibration results as the calibration procedure internally used the correct number of points per block.
+* Fixed a bug in `Kymo.plot_with_force()` which resulted in the plotting function throwing an error for Kymographs with an incomplete final line.
 
 #### Breaking changes
 

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -149,6 +149,11 @@ class Kymo(ConfocalImage):
         # downsample exactly over the scanline time range
         min_times = self.timestamps[0, :].astype(np.int64)
         max_times = self.timestamps[-1, :].astype(np.int64)
+
+        # If the last line is incomplete, drop it!
+        if max_times[-1] == 0:
+            min_times, max_times = min_times[:-1], max_times[:-1]
+
         time_ranges = [(mini, maxi) for mini, maxi in zip(min_times, max_times)]
         return force.downsampled_over(time_ranges, reduce=reduce, where="center")
 
@@ -157,10 +162,12 @@ class Kymo(ConfocalImage):
     ):
         """Plot kymo with force channel downsampled over scan lines
 
+        Note that high frequency channel data must be available for this function to work.
+
         Parameters
         ----------
         force_channel: str
-            name of force channel to downsample and plot
+            name of force channel to downsample and plot (e.g. '1x')
         color_channel: str
             color channel of kymo to plot ('red', 'green', 'blue', 'rgb')
         aspect_ratio: float


### PR DESCRIPTION
**Why this PR?**
`plot_with_force` always fails for kymographs with an incomplete last line.

The reason for this is that the last few timestamps on the last line have zero as their timestamp. This meant it was trying to downsample a range from X to 0, which made the downsampler think that there was no overlap between the kymograph and the force channel (as it checks the last timestamp of the ranges to downsample to against the first one of the channel to downsample).

I've also added a regression test for it.

There's one other issue I have with this function, which is that there's no way to have it use the LF force and that the string input for the channel is ambiguous (passing `downsampled_force1x` for channel is accepted, but it's not what would be used as a source). From the docstring it was not clear what the function expects (name of the force channel is ambiguous).