### PR TITLE
Simplify force calibration API

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -48,7 +48,8 @@
 * Express kymotracker algorithm parameters `line_width`, `sigma`, `velocity` and `diffusion` in physical units rather than pixels. Prior to this change, the units of the kymotracking algorithm were in pixels. Note that if you want to reproduce your earlier results multiply `line_width` and `sigma` by `kymo.pixelsize_um[0]`, `velocity` by `kymo.pixelsize_um[0] / kymo.line_time_seconds` and `diffusion` by `kymo.pixelsize_um[0] ** 2 / kymo.line_time_seconds`.
 * `Parameters.keys()` is now a member function instead of a property (used to be invoked as `parameter.keys`) to be consistent with dictionary.
 * `Slice.downsampled_like()` now returns both the downsampled `Slice` and a copy of the low frequency reference `Slice` cropped such that both instances have exactly the same timestamps.
-* Optimization settings are now passed to `lk.fit_power_spectrum()` as keyword arguments instead of using the class `lk.CalibrationSettings`.
+* Optimization settings are now passed to `fit_power_spectrum()` as keyword arguments instead of using the class `lk.CalibrationSettings`.
+* Renamed `CalibrationResults.ps_model_fit` and `CalibrationResults.ps_fitted` to `CalibrationResults.ps_model` and `CalibrationResults.ps_data` for clarity.
 
 ## v0.8.2 | 2021-04-30
 

--- a/changelog.md
+++ b/changelog.md
@@ -46,9 +46,7 @@
 * `KymoLineGroup.save()` and `KymoWidgetGreedy.save_lines()` no longer take `dx` and `dt` arguments.
   Instead, the correct time and position calibration is now passed automatically to these functions. See [kymographs](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html) for more information.
 * Express kymotracker algorithm parameters `line_width`, `sigma`, `velocity` and `diffusion` in physical units rather than pixels. Prior to this change, the units of the kymotracking algorithm were in pixels. Note that if you want to reproduce your earlier results multiply `line_width` and `sigma` by `kymo.pixelsize_um[0]`, `velocity` by `kymo.pixelsize_um[0] / kymo.line_time_seconds` and `diffusion` by `kymo.pixelsize_um[0] ** 2 / kymo.line_time_seconds`.
-  * `Parameters.keys()` is now a member function instead of a property (used to be invoked as `parameter.keys`) to be consistent with dictionary.
-
-#### Breaking changes
+* `Parameters.keys()` is now a member function instead of a property (used to be invoked as `parameter.keys`) to be consistent with dictionary.
 * `Slice.downsampled_like()` now returns both the downsampled `Slice` and a copy of the low frequency reference `Slice` cropped such that both instances have exactly the same timestamps.
 
 ## v0.8.2 | 2021-04-30

--- a/changelog.md
+++ b/changelog.md
@@ -48,6 +48,7 @@
 * Express kymotracker algorithm parameters `line_width`, `sigma`, `velocity` and `diffusion` in physical units rather than pixels. Prior to this change, the units of the kymotracking algorithm were in pixels. Note that if you want to reproduce your earlier results multiply `line_width` and `sigma` by `kymo.pixelsize_um[0]`, `velocity` by `kymo.pixelsize_um[0] / kymo.line_time_seconds` and `diffusion` by `kymo.pixelsize_um[0] ** 2 / kymo.line_time_seconds`.
 * `Parameters.keys()` is now a member function instead of a property (used to be invoked as `parameter.keys`) to be consistent with dictionary.
 * `Slice.downsampled_like()` now returns both the downsampled `Slice` and a copy of the low frequency reference `Slice` cropped such that both instances have exactly the same timestamps.
+* Optimization settings are now passed to `lk.fit_power_spectrum()` as keyword arguments instead of using the class `lk.CalibrationSettings`.
 
 ## v0.8.2 | 2021-04-30
 

--- a/changelog.md
+++ b/changelog.md
@@ -50,6 +50,7 @@
 * `Slice.downsampled_like()` now returns both the downsampled `Slice` and a copy of the low frequency reference `Slice` cropped such that both instances have exactly the same timestamps.
 * Optimization settings are now passed to `fit_power_spectrum()` as keyword arguments instead of using the class `lk.CalibrationSettings`.
 * Renamed `CalibrationResults.ps_model_fit` and `CalibrationResults.ps_fitted` to `CalibrationResults.ps_model` and `CalibrationResults.ps_data` for clarity.
+* Drop units from parameter names in `CalibrationResults`.
 
 ## v0.8.2 | 2021-04-30
 

--- a/changelog.md
+++ b/changelog.md
@@ -50,7 +50,8 @@
 * `Slice.downsampled_like()` now returns both the downsampled `Slice` and a copy of the low frequency reference `Slice` cropped such that both instances have exactly the same timestamps.
 * Optimization settings are now passed to `fit_power_spectrum()` as keyword arguments instead of using the class `lk.CalibrationSettings`.
 * Renamed `CalibrationResults.ps_model_fit` and `CalibrationResults.ps_fitted` to `CalibrationResults.ps_model` and `CalibrationResults.ps_data` for clarity.
-* Drop units from parameter names in `CalibrationResults`.
+* Drop units from parameter names in `CalibrationResults`. Note that the unit is still available in the `.unit` attribute of a calibration parameter.
+* Accessing an element from a force calibration performed with Pylake now returns a `CalibrationParameter` instead of a `float`. The calibration value can be accessed as `calibration["kappa"].value`, while the unit can be accessed in the `.unit` property.
 
 ## v0.8.2 | 2021-04-30
 

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -91,7 +91,7 @@ This will produce a table with your fitted calibration parameters.
 
 These parameters can be accessed analogously to the calibrations in Bluelake files::
 
-    >>> print(calibration["kappa (pN/nm)"])
+    >>> print(calibration["kappa"])
     >>> print(f.force1x.calibration[1]["kappa (pN/nm)"])
     0.17432391259341345
     0.17431947810792106

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -89,9 +89,9 @@ This will produce a table with your fitted calibration parameters.
 
 .. image:: force_calibration_table.png
 
-These parameters can be accessed analogously to the calibrations in Bluelake files::
+These parameters can be accessed as follows::
 
-    >>> print(calibration["kappa"])
+    >>> print(calibration["kappa"].value)
     >>> print(f.force1x.calibration[1]["kappa (pN/nm)"])
     0.17432391259341345
     0.17431947810792106

--- a/docs/tutorial/force_calibration_table.png
+++ b/docs/tutorial/force_calibration_table.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b10d3fd3d6a247a5908d52de856533e30a4b8d3c07778fd9304623aaf5d5905
-size 34826
+oid sha256:842a2d8611c2e7986eae7d7d970510172940bff4d550b3ca30419d0328c3ec2e
+size 30292

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -24,7 +24,6 @@ from .force_calibration.calibration_models import PassiveCalibrationModel
 from .force_calibration.power_spectrum_calibration import (
     calculate_power_spectrum,
     fit_power_spectrum,
-    CalibrationSettings,
 )
 
 

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -48,7 +48,7 @@ class PassiveCalibrationModel(CalibrationModel):
     bead_diameter : float
         Bead diameter [um].
     viscosity : float, optional
-        Liquid viscosity [Pa*s]. Default: 1.002e-3 Pa*s.
+        Liquid viscosity [Pa*s].
     temperature : float, optional
         Liquid temperature [Celsius].
     """

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -17,7 +17,10 @@ class CalibrationModel:
     def __repr__(self):
         return f"{self.__name__()}({''.join([f'{k}={v}, ' for k, v in vars(self).items()])[:-2]})"
 
-    def calibration_parameters(self, fc, diffusion_constant):
+    def calibration_parameters(self):
+        raise NotImplementedError
+
+    def calibration_results(self, fc, diffusion_constant):
         raise NotImplementedError
 
 
@@ -61,7 +64,14 @@ class PassiveCalibrationModel(CalibrationModel):
     def __call__(self, f, fc, diffusion_constant, f_diode, alpha):
         return passive_power_spectrum_model(f, fc, diffusion_constant, f_diode, alpha)
 
-    def calibration_parameters(self, fc, diffusion_constant):
+    def calibration_parameters(self):
+        return {
+            "Bead diameter (um)": CalibrationParameter("Bead diameter", self.bead_diameter, "um"),
+            "Viscosity (Pa*s)": CalibrationParameter("Liquid viscosity", self.viscosity, "Pa*s"),
+            "Temperature (C)": CalibrationParameter("Liquid temperature", self.temperature, "C"),
+        }
+
+    def calibration_results(self, fc, diffusion_constant):
         """Compute calibration parameters from cutoff frequency and diffusion constant.
 
         Parameters
@@ -85,9 +95,6 @@ class PassiveCalibrationModel(CalibrationModel):
         Rf = Rd * kappa * 1e3
 
         return {
-            "Bead diameter (um)": CalibrationParameter("Bead diameter", self.bead_diameter, "um"),
-            "Viscosity (Pa*s)": CalibrationParameter("Liquid viscosity", self.viscosity, "Pa*s"),
-            "Temperature (C)": CalibrationParameter("Liquid temperature", self.temperature, "C"),
             "Rd (um/V)": CalibrationParameter("Distance response", Rd, "um/V"),
             "kappa (pN/nm)": CalibrationParameter("Trap stiffness", kappa, "pN/nm"),
             "Rf (pN/V)": CalibrationParameter("Force response", Rf, "pN/V"),

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -66,9 +66,9 @@ class PassiveCalibrationModel(CalibrationModel):
 
     def calibration_parameters(self):
         return {
-            "Bead diameter (um)": CalibrationParameter("Bead diameter", self.bead_diameter, "um"),
-            "Viscosity (Pa*s)": CalibrationParameter("Liquid viscosity", self.viscosity, "Pa*s"),
-            "Temperature (C)": CalibrationParameter("Liquid temperature", self.temperature, "C"),
+            "Bead diameter": CalibrationParameter("Bead diameter", self.bead_diameter, "um"),
+            "Viscosity": CalibrationParameter("Liquid viscosity", self.viscosity, "Pa*s"),
+            "Temperature": CalibrationParameter("Liquid temperature", self.temperature, "C"),
         }
 
     def calibration_results(self, fc, diffusion_constant):
@@ -95,7 +95,7 @@ class PassiveCalibrationModel(CalibrationModel):
         Rf = Rd * kappa * 1e3
 
         return {
-            "Rd (um/V)": CalibrationParameter("Distance response", Rd, "um/V"),
-            "kappa (pN/nm)": CalibrationParameter("Trap stiffness", kappa, "pN/nm"),
-            "Rf (pN/V)": CalibrationParameter("Force response", Rf, "pN/V"),
+            "Rd": CalibrationParameter("Distance response", Rd, "um/V"),
+            "kappa": CalibrationParameter("Trap stiffness", kappa, "pN/nm"),
+            "Rf": CalibrationParameter("Force response", Rf, "pN/V"),
         }

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -286,7 +286,6 @@ def fit_power_spectrum(
         },
         params={
             **model.calibration_parameters(),
-            "Model": CalibrationParameter("Calibration model", model.__name__(), ""),
             "Max iterations": CalibrationParameter(
                 "Maximum number of function evaluations", max_function_evals, ""
             ),

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -70,8 +70,7 @@ class CalibrationResults:
                 raise RuntimeError(f"Calibration did not provide calibration parameter {key}")
 
     def __getitem__(self, item):
-        # Provides the same access pattern as ForceCalibration
-        return self.params[item].value if item in self.params else self.results[item].value
+        return self.params[item] if item in self.params else self.results[item]
 
     def plot(self):
         """Plot the fitted spectrum"""

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -77,7 +77,7 @@ class CalibrationResults:
         self.results = results
 
         # A few parameters have to be present for this calibration to be used.
-        mandatory_params = ["kappa (pN/nm)", "Rd (um/V)", "Rf (pN/V)"]
+        mandatory_params = ["kappa (pN/nm)", "Rf (pN/V)"]
         for key in mandatory_params:
             if key not in results:
                 raise RuntimeError(f"Calibration did not provide calibration parameter {key}")

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -141,10 +141,9 @@ def calculate_power_spectrum(data, sample_rate, fit_range=(1e2, 23e3), num_point
         Sampling rate [Hz]
     fit_range : tuple (f_min, f_max), optional
         Tuple of two floats, indicating the frequency range to use for the
-        full model fit. Default: (1e2, 23e3) [Hz]
+        full model fit [Hz]
     num_points_per_block : int, optional
         The spectrum is first block averaged by this number of points per block.
-        Default: 2000.
 
     Returns
     -------
@@ -175,11 +174,11 @@ def fit_power_spectrum(
     analytical_fit_range : tuple (f_min, f_max), optional
         Tuple of two floats, indicating the frequency range to use for the
         analytical simple Lorentzian fit, used to obtain initial parameter
-        guesses. Default: (1e1, 1e4) [Hz]
+        guesses [Hz]
     ftol : float
-        Termination tolerance for the model fit. Default: 1e-7
+        Termination tolerance for the model fit.
     max_function_evals : int
-        Maximum number of function evaluations during the fit. Default: 10000
+        Maximum number of function evaluations during the fit.
 
     Returns
     -------

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -64,7 +64,7 @@ class CalibrationResults:
         self.results = results
 
         # A few parameters have to be present for this calibration to be used.
-        mandatory_params = ["kappa (pN/nm)", "Rf (pN/V)"]
+        mandatory_params = ["kappa", "Rf"]
         for key in mandatory_params:
             if key not in results:
                 raise RuntimeError(f"Calibration did not provide calibration parameter {key}")
@@ -84,7 +84,7 @@ class CalibrationResults:
             return [
                 [
                     key,
-                    f"{param.description} ({param.unit})",
+                    f"{param.description}{f' ({param.unit})' if param.unit else ''}",
                     param.value if isinstance(param.value, str) else f"{param.value:.6g}",
                 ]
                 for key, param in entries.items()
@@ -268,35 +268,33 @@ def fit_power_spectrum(
             **model.calibration_results(
                 fc=solution_params[0], diffusion_constant=solution_params[1]
             ),
-            "fc (Hz)": CalibrationParameter("Corner frequency", solution_params[0], "Hz"),
-            "D (V^2/s)": CalibrationParameter("Diffusion constant", solution_params[1], "V^2/s"),
-            "f_diode (Hz)": CalibrationParameter(
+            "fc": CalibrationParameter("Corner frequency", solution_params[0], "Hz"),
+            "D": CalibrationParameter("Diffusion constant", solution_params[1], "V^2/s"),
+            "f_diode": CalibrationParameter(
                 "Diode low-pass filtering roll-off frequency", solution_params[2], "Hz"
             ),
-            "alpha": CalibrationParameter("Diode 'relaxation factor'", solution_params[3], "-"),
+            "alpha": CalibrationParameter("Diode 'relaxation factor'", solution_params[3], ""),
             "err_fc": CalibrationParameter("Corner frequency Std Err", perr[0], "Hz"),
             "err_D": CalibrationParameter("Diffusion constant Std Err", perr[1], "V^2/s"),
             "err_f_diode": CalibrationParameter(
                 "Diode low-pass filtering roll-off frequency Std Err", perr[2], "Hz"
             ),
-            "err_alpha": CalibrationParameter("Diode 'relaxation factor' Std Err", perr[3], "-"),
+            "err_alpha": CalibrationParameter("Diode 'relaxation factor' Std Err", perr[3], ""),
             "chi_squared_per_deg": CalibrationParameter(
-                "Chi squared per degree of freedom", chi_squared_per_deg, "-"
+                "Chi squared per degree of freedom", chi_squared_per_deg, ""
             ),
-            "backing (%)": CalibrationParameter("Statistical backing", backing, "%"),
+            "backing": CalibrationParameter("Statistical backing", backing, "%"),
         },
         params={
             **model.calibration_parameters(),
-            "Model": CalibrationParameter("Calibration model", model.__name__(), "-"),
+            "Model": CalibrationParameter("Calibration model", model.__name__(), ""),
             "Max iterations": CalibrationParameter(
-                "Maximum number of function evaluations", max_function_evals, "-"
+                "Maximum number of function evaluations", max_function_evals, ""
             ),
-            "Fit tolerance": CalibrationParameter("Fitting tolerance", ftol, "-"),
+            "Fit tolerance": CalibrationParameter("Fitting tolerance", ftol, ""),
             "Points per block": CalibrationParameter(
-                "Number of points per block", power_spectrum.num_points_per_block, "-"
+                "Number of points per block", power_spectrum.num_points_per_block, ""
             ),
-            "Sample rate (Hz)": CalibrationParameter(
-                "Sample rate", power_spectrum.sample_rate, "Hz"
-            ),
+            "Sample rate": CalibrationParameter("Sample rate", power_spectrum.sample_rate, "Hz"),
         },
     )

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -40,12 +40,26 @@ CalibrationParameter = namedtuple("CalibrationParameter", ["description", "value
 
 
 class CalibrationResults:
-    """Power spectrum calibration results."""
+    """Power spectrum calibration results.
 
-    def __init__(self, model, ps_model_fit, ps_fitted, params, results):
+    Attributes
+    ----------
+    model : `lumicks.pylake.force_calibration.CalibrationModel`
+        Model used for calibration.
+    ps_model : `lumicks.pylake.PowerSpectrum`
+        Power spectrum of the fitted model.
+    ps_data : `lumicks.pylake.PowerSpectrum`
+        Power spectrum of the data that the model was fitted to.
+    params : dict
+        Dictionary of input parameters.
+    results : dict
+        Dictionary of calibration results.
+    """
+
+    def __init__(self, model, ps_model, ps_data, params, results):
         self.model = model
-        self.ps_model_fit = ps_model_fit
-        self.ps_fitted = ps_fitted
+        self.ps_model = ps_model
+        self.ps_data = ps_data
         self.params = params
         self.results = results
 
@@ -61,8 +75,8 @@ class CalibrationResults:
 
     def plot(self):
         """Plot the fitted spectrum"""
-        self.ps_fitted.plot(label="Data")
-        self.ps_model_fit.plot(label="Model")
+        self.ps_data.plot(label="Data")
+        self.ps_model.plot(label="Model")
         plt.legend()
 
     def _print_data(self, tablefmt="text"):
@@ -242,14 +256,14 @@ def fit_power_spectrum(
     backing = (1 - scipy.special.gammainc(chi_squared / 2, n_degrees_of_freedom / 2)) * 100
 
     # Fitted power spectrum values.
-    ps_model_fit = power_spectrum.with_spectrum(
+    ps_model = power_spectrum.with_spectrum(
         model(power_spectrum.frequency, *solution_params), power_spectrum.num_points_per_block
     )
 
     return CalibrationResults(
         model=model,
-        ps_fitted=power_spectrum,
-        ps_model_fit=ps_model_fit,
+        ps_data=power_spectrum,
+        ps_model=ps_model,
         results={
             **model.calibration_results(
                 fc=solution_params[0], diffusion_constant=solution_params[1]

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -155,17 +155,36 @@ def reference_calibration_result():
 def test_actual_spectrum(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
 
-    np.testing.assert_allclose(ps_calibration["D (V^2/s)"], 0.0018512665210876748, rtol=1e-4, atol=0)
-    np.testing.assert_allclose(ps_calibration["Rd (um/V)"], 7.253645956145265, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["Rf (pN/V)"], 1243.9711315478219, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["kappa (pN/nm)"], 0.17149598134079505, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["alpha"], 0.5006103727942776, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["backing (%)"], 66.4331056392512, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["chi_squared_per_deg"], 1.063783302378645, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["err_fc"], 32.23007993226726, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["err_D"], 6.43082000774291e-05, rtol=1e-4, atol=0)
-    np.testing.assert_allclose(ps_calibration["err_alpha"], 0.013141463933316694, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["err_f_diode"], 561.6377089699399, rtol=1e-4)
+    results = {
+        "D (V^2/s)": {"desired": 0.0018512665210876748, "rtol": 1e-4, "atol": 0},
+        "Rd (um/V)": {"desired": 7.253645956145265, "rtol": 1e-4},
+        "Rf (pN/V)": {"desired": 1243.9711315478219, "rtol": 1e-4},
+        "kappa (pN/nm)": {"desired": 0.17149598134079505, "rtol": 1e-4},
+        "alpha": {"desired": 0.5006103727942776, "rtol": 1e-4},
+        "backing (%)": {"desired": 66.4331056392512, "rtol": 1e-4},
+        "chi_squared_per_deg": {"desired": 1.063783302378645, "rtol": 1e-4},
+        "err_fc": {"desired": 32.23007993226726, "rtol": 1e-4},
+        "err_D": {"desired": 6.43082000774291e-05, "rtol": 1e-4, "atol": 0},
+        "err_alpha": {"desired": 0.013141463933316694, "rtol": 1e-4},
+        "err_f_diode": {"desired": 561.6377089699399, "rtol": 1e-4},
+    }
+
+    for name, expected_result in results.items():
+        np.testing.assert_allclose(ps_calibration[name], **expected_result)
+        np.testing.assert_allclose(ps_calibration.results[name].value, **expected_result)
+
+    params = {
+        "Viscosity (Pa*s)": {"desired": 0.001002},
+        "Temperature (C)": {"desired": 20},
+        "Max iterations": {"desired": 10000},
+        "Fit tolerance": {"desired": 1e-07},
+        "Points per block": {"desired": 100},
+        "Sample rate (Hz)": {"desired": 78125}
+    }
+
+    for name, expected_result in params.items():
+        np.testing.assert_allclose(ps_calibration[name], **expected_result)
+        np.testing.assert_allclose(ps_calibration.params[name].value, **expected_result)
 
     # Test whether the model contains the number of points per block that were used to fit it
     np.testing.assert_allclose(ps_calibration.ps_model_fit.num_points_per_block, 100)
@@ -184,7 +203,11 @@ def test_attributes_ps_calibration(reference_calibration_result):
     assert id(ps_calibration.ps_fitted) == id(reference_spectrum)
 
     with pytest.raises(RuntimeError):
-        psc.CalibrationResults(model=None, ps_model_fit=None, ps_fitted=None, params={"test": 5})
+        psc.CalibrationResults(model=None,
+                               ps_model_fit=None,
+                               ps_fitted=None,
+                               params={"test": 5},
+                               results={"test2": 5})
 
 
 def test_repr(reference_calibration_result):
@@ -195,6 +218,11 @@ def test_repr(reference_calibration_result):
         Bead diameter (um)   Bead diameter (um)                                        4.4
         Viscosity (Pa*s)     Liquid viscosity (Pa*s)                                   0.001002
         Temperature (C)      Liquid temperature (C)                                    20
+        Model                Calibration model (-)                                     PassiveCalibrationModel
+        Max iterations       Maximum number of function evaluations (-)                10000
+        Fit tolerance        Fitting tolerance (-)                                     1e-07
+        Points per block     Number of points per block (-)                            100
+        Sample rate (Hz)     Sample rate (Hz)                                          78125
         Rd (um/V)            Distance response (um/V)                                  7.25365
         kappa (pN/nm)        Trap stiffness (pN/nm)                                    0.171496
         Rf (pN/V)            Force response (pN/V)                                     1243.97
@@ -207,9 +235,4 @@ def test_repr(reference_calibration_result):
         err_f_diode          Diode low-pass filtering roll-off frequency Std Err (Hz)  561.638
         err_alpha            Diode 'relaxation factor' Std Err (-)                     0.0131415
         chi_squared_per_deg  Chi squared per degree of freedom (-)                     1.06378
-        backing (%)          Statistical backing (%)                                   66.4331
-        Max iterations       Maximum number of function evaluations (-)                10000
-        Model                Calibration model (-)                                     PassiveCalibrationModel
-        Fit tolerance        Fitting tolerance (-)                                     1e-07
-        Points per block     Number of points per block (-)                            100
-        Sample rate (Hz)     Sample rate (Hz)                                          78125""")
+        backing (%)          Statistical backing (%)                                   66.4331""")

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -76,10 +76,10 @@ def test_good_fit_integration_test(
     power_spectrum = psc.calculate_power_spectrum(data, f_sample, fit_range=(0, 15000), num_points_per_block=20)
     ps_calibration = psc.fit_power_spectrum(power_spectrum=power_spectrum, model=model)
 
-    np.testing.assert_allclose(ps_calibration["fc (Hz)"], corner_frequency, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["D (V^2/s)"], diffusion_constant, rtol=1e-4, atol=0)
+    np.testing.assert_allclose(ps_calibration["fc"], corner_frequency, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["D"], diffusion_constant, rtol=1e-4, atol=0)
     np.testing.assert_allclose(ps_calibration["alpha"], alpha, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["f_diode (Hz)"], f_diode, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["f_diode"], f_diode, rtol=1e-4)
 
     gamma = sphere_friction_coefficient(viscosity, bead_diameter * 1e-6)
     kappa_true = 2.0 * np.pi * gamma * corner_frequency * 1e3
@@ -87,9 +87,9 @@ def test_good_fit_integration_test(
         np.sqrt(sp.constants.k * sp.constants.convert_temperature(temperature, "C", "K") / gamma / diffusion_constant)
         * 1e6
     )
-    np.testing.assert_allclose(ps_calibration["kappa (pN/nm)"], kappa_true, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["Rd (um/V)"], rd_true, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["Rf (pN/V)"], rd_true * kappa_true * 1e3, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["kappa"], kappa_true, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["Rd"], rd_true, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["Rf"], rd_true * kappa_true * 1e3, rtol=1e-4)
     np.testing.assert_allclose(ps_calibration["chi_squared_per_deg"], 0, atol=1e-9)  # Noise free
 
     np.testing.assert_allclose(ps_calibration["err_fc"], err_fc)
@@ -128,8 +128,8 @@ def test_fit_settings(reference_models):
     calib = psc.fit_power_spectrum(
         power_spectrum=power_spectrum, model=model, ftol=10, max_function_evals=1
     )
-    np.testing.assert_allclose(calib["fc (Hz)"], corner_frequency, rtol=1e-3)
-    np.testing.assert_allclose(calib["D (V^2/s)"], diffusion_volt, rtol=1e-3)
+    np.testing.assert_allclose(calib["fc"], corner_frequency, rtol=1e-3)
+    np.testing.assert_allclose(calib["D"], diffusion_volt, rtol=1e-3)
 
     # If we corrupt the power spectrum, then the parameters should be quite different
     bad_power_spectrum = deepcopy(power_spectrum)
@@ -138,10 +138,10 @@ def test_fit_settings(reference_models):
         power_spectrum=bad_power_spectrum, model=model, ftol=10, max_function_evals=1
     )
     assert (
-        np.abs(bad_calibration["fc (Hz)"] - calib["fc (Hz)"]) > 1e-4
+        np.abs(bad_calibration["fc"] - calib["fc"]) > 1e-4
     ), "Fit did not get worse from including bad data."
     assert (
-        np.abs(bad_calibration["D (V^2/s)"] - calib["D (V^2/s)"]) > 1e-4
+        np.abs(bad_calibration["D"] - calib["D"]) > 1e-4
     ), "Fit did not get worse from including bad data."
 
     # If we exclude that region now, the fit should be OK again.
@@ -152,8 +152,8 @@ def test_fit_settings(reference_models):
         ftol=10,
         max_function_evals=1,
     )
-    np.testing.assert_allclose(ranged_calibration["fc (Hz)"], corner_frequency, rtol=1e-3)
-    np.testing.assert_allclose(ranged_calibration["D (V^2/s)"], diffusion_volt, rtol=1e-3)
+    np.testing.assert_allclose(ranged_calibration["fc"], corner_frequency, rtol=1e-3)
+    np.testing.assert_allclose(ranged_calibration["D"], diffusion_volt, rtol=1e-3)
 
 
 def test_bad_calibration_result_arg():
@@ -205,12 +205,12 @@ def test_actual_spectrum(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
 
     results = {
-        "D (V^2/s)": {"desired": 0.0018512665210876748, "rtol": 1e-4, "atol": 0},
-        "Rd (um/V)": {"desired": 7.253645956145265, "rtol": 1e-4},
-        "Rf (pN/V)": {"desired": 1243.9711315478219, "rtol": 1e-4},
-        "kappa (pN/nm)": {"desired": 0.17149598134079505, "rtol": 1e-4},
+        "D": {"desired": 0.0018512665210876748, "rtol": 1e-4, "atol": 0},
+        "Rd": {"desired": 7.253645956145265, "rtol": 1e-4},
+        "Rf": {"desired": 1243.9711315478219, "rtol": 1e-4},
+        "kappa": {"desired": 0.17149598134079505, "rtol": 1e-4},
         "alpha": {"desired": 0.5006103727942776, "rtol": 1e-4},
-        "backing (%)": {"desired": 66.4331056392512, "rtol": 1e-4},
+        "backing": {"desired": 66.4331056392512, "rtol": 1e-4},
         "chi_squared_per_deg": {"desired": 1.063783302378645, "rtol": 1e-4},
         "err_fc": {"desired": 32.23007993226726, "rtol": 1e-4},
         "err_D": {"desired": 6.43082000774291e-05, "rtol": 1e-4, "atol": 0},
@@ -223,12 +223,12 @@ def test_actual_spectrum(reference_calibration_result):
         np.testing.assert_allclose(ps_calibration.results[name].value, **expected_result)
 
     params = {
-        "Viscosity (Pa*s)": {"desired": 0.001002},
-        "Temperature (C)": {"desired": 20},
+        "Viscosity": {"desired": 0.001002},
+        "Temperature": {"desired": 20},
         "Max iterations": {"desired": 10000},
         "Fit tolerance": {"desired": 1e-07},
         "Points per block": {"desired": 100},
-        "Sample rate (Hz)": {"desired": 78125}
+        "Sample rate": {"desired": 78125}
     }
 
     for name, expected_result in params.items():
@@ -264,24 +264,24 @@ def test_repr(reference_calibration_result):
     assert str(ps_calibration) == dedent("""\
         Name                 Description                                               Value
         -------------------  --------------------------------------------------------  -----------------------
-        Bead diameter (um)   Bead diameter (um)                                        4.4
-        Viscosity (Pa*s)     Liquid viscosity (Pa*s)                                   0.001002
-        Temperature (C)      Liquid temperature (C)                                    20
-        Model                Calibration model (-)                                     PassiveCalibrationModel
-        Max iterations       Maximum number of function evaluations (-)                10000
-        Fit tolerance        Fitting tolerance (-)                                     1e-07
-        Points per block     Number of points per block (-)                            100
-        Sample rate (Hz)     Sample rate (Hz)                                          78125
-        Rd (um/V)            Distance response (um/V)                                  7.25365
-        kappa (pN/nm)        Trap stiffness (pN/nm)                                    0.171496
-        Rf (pN/V)            Force response (pN/V)                                     1243.97
-        fc (Hz)              Corner frequency (Hz)                                     656.875
-        D (V^2/s)            Diffusion constant (V^2/s)                                0.00185127
-        f_diode (Hz)         Diode low-pass filtering roll-off frequency (Hz)          7936.4
-        alpha                Diode 'relaxation factor' (-)                             0.50061
+        Bead diameter        Bead diameter (um)                                        4.4
+        Viscosity            Liquid viscosity (Pa*s)                                   0.001002
+        Temperature          Liquid temperature (C)                                    20
+        Model                Calibration model                                         PassiveCalibrationModel
+        Max iterations       Maximum number of function evaluations                    10000
+        Fit tolerance        Fitting tolerance                                         1e-07
+        Points per block     Number of points per block                                100
+        Sample rate          Sample rate (Hz)                                          78125
+        Rd                   Distance response (um/V)                                  7.25365
+        kappa                Trap stiffness (pN/nm)                                    0.171496
+        Rf                   Force response (pN/V)                                     1243.97
+        fc                   Corner frequency (Hz)                                     656.875
+        D                    Diffusion constant (V^2/s)                                0.00185127
+        f_diode              Diode low-pass filtering roll-off frequency (Hz)          7936.4
+        alpha                Diode 'relaxation factor'                                 0.50061
         err_fc               Corner frequency Std Err (Hz)                             32.2301
         err_D                Diffusion constant Std Err (V^2/s)                        6.43082e-05
         err_f_diode          Diode low-pass filtering roll-off frequency Std Err (Hz)  561.638
-        err_alpha            Diode 'relaxation factor' Std Err (-)                     0.0131415
-        chi_squared_per_deg  Chi squared per degree of freedom (-)                     1.06378
-        backing (%)          Statistical backing (%)                                   66.4331""")
+        err_alpha            Diode 'relaxation factor' Std Err                         0.0131415
+        chi_squared_per_deg  Chi squared per degree of freedom                         1.06378
+        backing              Statistical backing (%)                                   66.4331""")

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -262,26 +262,25 @@ def test_attributes_ps_calibration(reference_calibration_result):
 def test_repr(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
     assert str(ps_calibration) == dedent("""\
-        Name                 Description                                               Value
-        -------------------  --------------------------------------------------------  -----------------------
-        Bead diameter        Bead diameter (um)                                        4.4
-        Viscosity            Liquid viscosity (Pa*s)                                   0.001002
-        Temperature          Liquid temperature (C)                                    20
-        Model                Calibration model                                         PassiveCalibrationModel
+        Name                 Description                                                         Value
+        -------------------  --------------------------------------------------------  ---------------
+        Bead diameter        Bead diameter (um)                                            4.4
+        Viscosity            Liquid viscosity (Pa*s)                                       0.001002
+        Temperature          Liquid temperature (C)                                       20
         Max iterations       Maximum number of function evaluations                    10000
-        Fit tolerance        Fitting tolerance                                         1e-07
-        Points per block     Number of points per block                                100
+        Fit tolerance        Fitting tolerance                                             1e-07
+        Points per block     Number of points per block                                  100
         Sample rate          Sample rate (Hz)                                          78125
-        Rd                   Distance response (um/V)                                  7.25365
-        kappa                Trap stiffness (pN/nm)                                    0.171496
-        Rf                   Force response (pN/V)                                     1243.97
-        fc                   Corner frequency (Hz)                                     656.875
-        D                    Diffusion constant (V^2/s)                                0.00185127
-        f_diode              Diode low-pass filtering roll-off frequency (Hz)          7936.4
-        alpha                Diode 'relaxation factor'                                 0.50061
-        err_fc               Corner frequency Std Err (Hz)                             32.2301
-        err_D                Diffusion constant Std Err (V^2/s)                        6.43082e-05
-        err_f_diode          Diode low-pass filtering roll-off frequency Std Err (Hz)  561.638
-        err_alpha            Diode 'relaxation factor' Std Err                         0.0131415
-        chi_squared_per_deg  Chi squared per degree of freedom                         1.06378
-        backing              Statistical backing (%)                                   66.4331""")
+        Rd                   Distance response (um/V)                                      7.25365
+        kappa                Trap stiffness (pN/nm)                                        0.171496
+        Rf                   Force response (pN/V)                                      1243.97
+        fc                   Corner frequency (Hz)                                       656.875
+        D                    Diffusion constant (V^2/s)                                    0.00185127
+        f_diode              Diode low-pass filtering roll-off frequency (Hz)           7936.4
+        alpha                Diode 'relaxation factor'                                     0.50061
+        err_fc               Corner frequency Std Err (Hz)                                32.2301
+        err_D                Diffusion constant Std Err (V^2/s)                            6.43082e-05
+        err_f_diode          Diode low-pass filtering roll-off frequency Std Err (Hz)    561.638
+        err_alpha            Diode 'relaxation factor' Std Err                             0.0131415
+        chi_squared_per_deg  Chi squared per degree of freedom                             1.06378
+        backing              Statistical backing (%)                                      66.4331""")

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -236,8 +236,8 @@ def test_actual_spectrum(reference_calibration_result):
         np.testing.assert_allclose(ps_calibration.params[name].value, **expected_result)
 
     # Test whether the model contains the number of points per block that were used to fit it
-    np.testing.assert_allclose(ps_calibration.ps_model_fit.num_points_per_block, 100)
-    np.testing.assert_allclose(ps_calibration.ps_fitted.num_points_per_block, 100)
+    np.testing.assert_allclose(ps_calibration.ps_model.num_points_per_block, 100)
+    np.testing.assert_allclose(ps_calibration.ps_data.num_points_per_block, 100)
 
 
 @cleanup
@@ -249,12 +249,12 @@ def test_result_plot(reference_calibration_result):
 def test_attributes_ps_calibration(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
     assert id(ps_calibration.model) == id(model)
-    assert id(ps_calibration.ps_fitted) == id(reference_spectrum)
+    assert id(ps_calibration.ps_data) == id(reference_spectrum)
 
     with pytest.raises(RuntimeError):
         psc.CalibrationResults(model=None,
-                               ps_model_fit=None,
-                               ps_fitted=None,
+                               ps_model=None,
+                               ps_data=None,
                                params={"test": 5},
                                results={"test2": 5})
 

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -76,10 +76,10 @@ def test_good_fit_integration_test(
     power_spectrum = psc.calculate_power_spectrum(data, f_sample, fit_range=(0, 15000), num_points_per_block=20)
     ps_calibration = psc.fit_power_spectrum(power_spectrum=power_spectrum, model=model)
 
-    np.testing.assert_allclose(ps_calibration["fc"], corner_frequency, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["D"], diffusion_constant, rtol=1e-4, atol=0)
-    np.testing.assert_allclose(ps_calibration["alpha"], alpha, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["f_diode"], f_diode, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["fc"].value, corner_frequency, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["D"].value, diffusion_constant, rtol=1e-4, atol=0)
+    np.testing.assert_allclose(ps_calibration["alpha"].value, alpha, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["f_diode"].value, f_diode, rtol=1e-4)
 
     gamma = sphere_friction_coefficient(viscosity, bead_diameter * 1e-6)
     kappa_true = 2.0 * np.pi * gamma * corner_frequency * 1e3
@@ -87,15 +87,15 @@ def test_good_fit_integration_test(
         np.sqrt(sp.constants.k * sp.constants.convert_temperature(temperature, "C", "K") / gamma / diffusion_constant)
         * 1e6
     )
-    np.testing.assert_allclose(ps_calibration["kappa"], kappa_true, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["Rd"], rd_true, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["Rf"], rd_true * kappa_true * 1e3, rtol=1e-4)
-    np.testing.assert_allclose(ps_calibration["chi_squared_per_deg"], 0, atol=1e-9)  # Noise free
+    np.testing.assert_allclose(ps_calibration["kappa"].value, kappa_true, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["Rd"].value, rd_true, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["Rf"].value, rd_true * kappa_true * 1e3, rtol=1e-4)
+    np.testing.assert_allclose(ps_calibration["chi_squared_per_deg"].value, 0, atol=1e-9)  # Noise free
 
-    np.testing.assert_allclose(ps_calibration["err_fc"], err_fc)
-    np.testing.assert_allclose(ps_calibration["err_D"], err_d, rtol=1e-4, atol=0)
-    np.testing.assert_allclose(ps_calibration["err_f_diode"], err_f_diode)
-    np.testing.assert_allclose(ps_calibration["err_alpha"], err_alpha, rtol=1e-6)
+    np.testing.assert_allclose(ps_calibration["err_fc"].value, err_fc)
+    np.testing.assert_allclose(ps_calibration["err_D"].value, err_d, rtol=1e-4, atol=0)
+    np.testing.assert_allclose(ps_calibration["err_f_diode"].value, err_f_diode)
+    np.testing.assert_allclose(ps_calibration["err_alpha"].value, err_alpha, rtol=1e-6)
 
 
 def test_fit_settings(reference_models):
@@ -128,8 +128,8 @@ def test_fit_settings(reference_models):
     calib = psc.fit_power_spectrum(
         power_spectrum=power_spectrum, model=model, ftol=10, max_function_evals=1
     )
-    np.testing.assert_allclose(calib["fc"], corner_frequency, rtol=1e-3)
-    np.testing.assert_allclose(calib["D"], diffusion_volt, rtol=1e-3)
+    np.testing.assert_allclose(calib["fc"].value, corner_frequency, rtol=1e-3)
+    np.testing.assert_allclose(calib["D"].value, diffusion_volt, rtol=1e-3)
 
     # If we corrupt the power spectrum, then the parameters should be quite different
     bad_power_spectrum = deepcopy(power_spectrum)
@@ -138,10 +138,10 @@ def test_fit_settings(reference_models):
         power_spectrum=bad_power_spectrum, model=model, ftol=10, max_function_evals=1
     )
     assert (
-        np.abs(bad_calibration["fc"] - calib["fc"]) > 1e-4
+        np.abs(bad_calibration["fc"].value - calib["fc"].value) > 1e-4
     ), "Fit did not get worse from including bad data."
     assert (
-        np.abs(bad_calibration["D"] - calib["D"]) > 1e-4
+        np.abs(bad_calibration["D"].value - calib["D"].value) > 1e-4
     ), "Fit did not get worse from including bad data."
 
     # If we exclude that region now, the fit should be OK again.
@@ -152,8 +152,8 @@ def test_fit_settings(reference_models):
         ftol=10,
         max_function_evals=1,
     )
-    np.testing.assert_allclose(ranged_calibration["fc"], corner_frequency, rtol=1e-3)
-    np.testing.assert_allclose(ranged_calibration["D"], diffusion_volt, rtol=1e-3)
+    np.testing.assert_allclose(ranged_calibration["fc"].value, corner_frequency, rtol=1e-3)
+    np.testing.assert_allclose(ranged_calibration["D"].value, diffusion_volt, rtol=1e-3)
 
 
 def test_bad_calibration_result_arg():
@@ -219,7 +219,7 @@ def test_actual_spectrum(reference_calibration_result):
     }
 
     for name, expected_result in results.items():
-        np.testing.assert_allclose(ps_calibration[name], **expected_result)
+        np.testing.assert_allclose(ps_calibration[name].value, **expected_result)
         np.testing.assert_allclose(ps_calibration.results[name].value, **expected_result)
 
     params = {
@@ -232,7 +232,7 @@ def test_actual_spectrum(reference_calibration_result):
     }
 
     for name, expected_result in params.items():
-        np.testing.assert_allclose(ps_calibration[name], **expected_result)
+        np.testing.assert_allclose(ps_calibration[name].value, **expected_result)
         np.testing.assert_allclose(ps_calibration.params[name].value, **expected_result)
 
     # Test whether the model contains the number of points per block that were used to fit it


### PR DESCRIPTION
**Why?**
To make integration with Bluelake easier and have a clearer separation between inputs and outputs of the calibration routine.