### PR TITLE
kymo: bugfix for plot_with_force for incomplete last line

### DIFF
--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -151,7 +151,7 @@ class Kymo(ConfocalImage):
         max_times = self.timestamps[-1, :].astype(np.int64)
 
         # If the last line is incomplete, drop it!
-        if max_times[-1] == 0:
+        if force.start >= max_times[-1]:
             min_times, max_times = min_times[:-1], max_times[:-1]
 
         time_ranges = [(mini, maxi) for mini, maxi in zip(min_times, max_times)]

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -186,6 +186,9 @@ def test_regression_plot_with_force(h5_file):
         kymo._timestamp_factory = lambda self: incomplete_last_line_timestamps
         kymo.plot_with_force(force_channel="2x", color_channel="red")
 
+        incomplete_last_line_timestamps[-1, -1] = 100
+        kymo._timestamp_factory = lambda self: incomplete_last_line_timestamps
+        kymo.plot_with_force(force_channel="2x", color_channel="red")
 
 @cleanup
 def test_plotting_with_histograms(h5_file):


### PR DESCRIPTION
**Why this PR?**
The last fix was not sufficient. It worked if the last pixel was really blank, but not if the last pixel was still partially available.

What we should have checked is whether the `maxtime` is indeed after the start of the force trace. 
