### PR TITLE
docs: correct error in equation used for force calibration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 * Added option to exclude ranges with potential noise peaks from the calibration routines. Please refer to [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html) for more information.
 
+#### Bug fixes
+
+* Fixed an error in the documentation. In v0.9.0 `PowerSpectrum.power` was changed to represent power in `V^2/Hz` instead of `0.5 V^2/Hz`. However, the docs were not appropriately updated to reflect this change in the model equation that's fitted to the spectrum. This is mitigated now.
+
 ## v0.9.0 | 2021-07-29
 
 `Pylake v0.9` provides several new features. Starting from `pylake v0.9`, the kymotracker will handle units for you. From now on, all you have to worry about is physical quantities rather than pixels. Please see the updated [example on Cas9 binding](https://lumicks-pylake.readthedocs.io/en/latest/examples/cas9_kymotracking/cas9_kymotracking.html) for a demonstration of this. In addition to that, you can now [infer diffusion constants from diffusive kymograph traces](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#studying-diffusion-processes).

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -51,7 +51,7 @@ This model can be found in :class:`~.PassiveCalibrationModel`. It is calibrated 
 
 .. math::
 
-    P(f) = \frac{D}{2 \pi ^ 2 \left(f^2 + f_c ^ 2\right)} g(f, f_{diode}, \alpha)
+    P(f) = \frac{D}{\pi ^ 2 \left(f^2 + f_c ^ 2\right)} g(f, f_{diode}, \alpha)
 
 where :math:`D` corresponds to the diffusion constant, :math:`f` the frequency and :math:`f_c` the fitted cutoff. The second term :math:`g` takes into account the slower response of the position detection system and is given by:
 


### PR DESCRIPTION
**Why?**
Unfortunately, one equation in the documentation didn't get updated appropriately when we made the switch from `0.5 V^2/Hz` to `V^2/Hz`. This PR fixes that.