### PR TITLE
Make `plot_with_force` sum over entire kymo line.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.9.1 | t.b.d.
+## v0.10.0 | t.b.d.
 
 #### New features
 
@@ -10,6 +10,11 @@
 #### Bug fixes
 
 * Fixed an error in the documentation. In v0.9.0 `PowerSpectrum.power` was changed to represent power in `V^2/Hz` instead of `0.5 V^2/Hz`. However, the docs were not appropriately updated to reflect this change in the model equation that's fitted to the spectrum. This is mitigated now.
+* Fixed bug in `plot_with_force` which caused an exception on Kymographs with a partial last pixel.
+
+#### Breaking changes
+
+* Removed the option to specify a custom `reduce_timestamps` function in `kymo.downsampled_by`. The reason for the removal is that by downsampling repeatedly with different `reduce` functions for the timestamps, the data can end up in an inconsistent state. Additionally, the timestamps of the original object (read directly from the h5 file) are defined as the mean of the pixel timestamps; this definition is now consistent regardless of downsampling state.
 
 ## v0.9.0 | 2021-07-29
 

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -14,7 +14,7 @@ def _default_image_factory(self: "ConfocalImage", color):
     return self._to_spatial(raw_image)
 
 
-def _default_timestamp_factory(self: "ConfocalImage"):
+def _default_timestamp_factory(self: "ConfocalImage", reduce=np.mean):
     # Uses the timestamps from the first non-zero-sized photon channel
     for color in ("red", "green", "blue"):
         channel_data = getattr(self, f"{color}_photon_count").timestamps
@@ -22,7 +22,7 @@ def _default_timestamp_factory(self: "ConfocalImage"):
             break
     else:
         raise RuntimeError("Can't get pixel timestamps if there are no pixels")
-    raw_image = reconstruct_image(channel_data, self.infowave.data, self._shape, reduce=np.mean)
+    raw_image = reconstruct_image(channel_data, self.infowave.data, self._shape, reduce=reduce)
     return self._to_spatial(raw_image)
 
 
@@ -219,9 +219,9 @@ class ConfocalImage(BaseScan):
         return self._image_factory(self, channel)
 
     @cachetools.cachedmethod(lambda self: self._cache)
-    def _timestamps(self, channel):
+    def _timestamps(self, channel, reduce=np.mean):
         assert channel == "timestamps"
-        return self._timestamp_factory(self)
+        return self._timestamp_factory(self, reduce)
 
     def _plot_color(self, color, **kwargs):
         from matplotlib.colors import LinearSegmentedColormap

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -185,18 +185,19 @@ class Kymo(ConfocalImage):
 
         import matplotlib.pyplot as plt
 
-        _, (ax1, ax2) = plt.subplots(2, 1)
+        _, (ax1, ax2) = plt.subplots(2, 1, sharex="all")
 
         # plot kymo
         plt.sca(ax1)
         getattr(self, f"plot_{color_channel}")()
         ax1.set_xlabel(None)
+        xlim_kymo = ax1.get_xlim()  # Stored since plotting the force channel will change the limits
 
         # plot force channel
         plt.sca(ax2)
         force = self._downsample_channel(force_channel[-2], force_channel[-1], reduce=reduce)
         force.plot(**kwargs)
-        ax2.set_xlim(ax1.get_xlim())
+        ax2.set_xlim(xlim_kymo)
 
         set_aspect_ratio(ax1, aspect_ratio)
         set_aspect_ratio(ax2, aspect_ratio)

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -194,9 +194,12 @@ def h5_file(tmpdir_factory, request):
         ds.attrs["Start time (ns)"] = np.int64(20e9)
         ds.attrs["Stop time (ns)"] = np.int64(20e9 + len(infowave) * freq)
         # Force channel that overlaps kymo; step from high to low force
-        force_data = np.hstack((np.ones(35) * 30,
-                                np.ones(35) * 10))
-        force_start = np.int64(ds.attrs["Start time (ns)"] - (freq*5)) # before infowave
+        # We want two lines of the kymo to have a force of 30, the other 10. Force starts 5 samples
+        # before the kymograph. First kymoline is 15 samples long, second is 16 samples long, which
+        # means the third line starts after 31 + 5 = 36 samples
+        force_data = np.hstack((np.ones(37) * 30,
+                                np.ones(33) * 10))
+        force_start = np.int64(ds.attrs["Start time (ns)"] - (freq*5))  # before infowave
         mock_file.make_continuous_channel("Force HF", "Force 2x", force_start, freq, force_data)
         mock_file.make_calibration_data("1", "Force 2x", {calibration_time_field: 0})
         mock_file.make_calibration_data("2", "Force 2x", {calibration_time_field: 1})


### PR DESCRIPTION
**Why this PR?**
`plot_with_force` was not summing over the full line range, but from the center of the first pixel to the center of the last pixel. It also had problems with an incomplete last pixel (always resulting in an exception). This PR changes it so that it is exact and fixes the last pixel issue.

**What to look out for**
To achieve this, I generalized `_timestamps` that allows us to provide a custom reduce function (which will also properly get cached). The only downside of this mini refactor is that it means that we cannot specify a custom downsampler for timestamps in `kymo.downsampled_by()` anymore.

Technically, that makes this a breaking change, though a breakage that I don't expect would affect many people.

The alternative is adding another factory function that is essentially mostly a copy of `_timestamps`, but with the reduce option. We could consider this to avoid the breaking change now (deprecating the reduce option first with the plan of moving to this model once we go to another major release). Personally, I'd rather just break it.