### PR TITLE
Force calibration: Simulate calibration spectra

### DIFF
--- a/lumicks/pylake/force_calibration/tests/data/simulate_calibration_data.py
+++ b/lumicks/pylake/force_calibration/tests/data/simulate_calibration_data.py
@@ -1,0 +1,109 @@
+import numpy as np
+from functools import partial
+import scipy.constants
+from lumicks.pylake.force_calibration.detail.power_models import (
+    sphere_friction_coefficient,
+    passive_power_spectrum_model,
+)
+
+
+def power_model_to_time_series(sample_rate, num_points, power_spectral_density):
+    """Generates channel data with a desired power spectral density.
+
+    Function generates random uncorrelated noise and then multiplies it spectrally such that it
+    would have a specific target spectral density. Returns time trace of a specified duration.
+
+    Parameters
+    ----------
+    sample_rate : int
+        Sample rate
+    num_points : float
+        Number of points in the desired trace.
+    power_spectral_density : callable
+        Function that takes frequencies and produces power spectral density in V^2/Hz at those
+        points.
+    """
+    freq = np.fft.rfftfreq(num_points, 1 / sample_rate)
+    noise = np.sqrt(sample_rate / 2) * np.random.randn(num_points)  # Flat spectrum at 1.0 V^2/Hz
+    return np.fft.irfft(np.fft.rfft(noise) * np.sqrt(power_spectral_density(freq)))
+
+
+def response_peak_ideal(corner_frequency, driving_amplitude, driving_frequency):
+    """Spectral peak corresponding to the driving input (no hydrodynamic corrections).
+
+    Eq. 13 in [1].
+
+    [1] Tolić-Nørrelykke, S. F., Schäffer, E., Howard, J., Pavone, F. S., Jülicher, F., &
+    Flyvbjerg, H. (2006). Calibration of optical tweezers with positional detection in the back
+    focal plane. Review of scientific instruments, 77(10), 103101.
+    """
+    return driving_amplitude ** 2 / (2 * (1 + (corner_frequency / driving_frequency) ** 2))
+
+
+def generate_test_realisation_ideal(
+    duration,
+    sample_rate,
+    bead_diameter,
+    stiffness,
+    viscosity,
+    temperature,
+    pos_response_um_volt,
+    driving_sinusoid,
+    diode,
+):
+    """Generate test data to test active calibration.
+
+    Note: This generation does not get the phase information right (but this is not used for
+    spectral calibration).
+
+    Parameters
+    ----------
+    duration : float
+        Time [s]
+    sample_rate : int
+        Sampling rate [Hz]
+    bead_diameter : float
+        Bead diameter [micron]
+    stiffness : float
+        Spring constant of the trap [pN/nm]
+    viscosity : float
+        Viscosity [Pa*s]
+    temperature : float
+        Temperature [C]
+    pos_response_um_volt : float
+        Response [um/V], also denoted in papers as Rd
+    driving_sinusoid : tuple of floats
+        Parameters for the driving input.
+        Amplitude [nm] and frequency of active [Hz] calibration stage movement
+    diode : tuple of floats
+        Diode parameters:
+        Alpha of the diode response that is instantaneous, ranges from 0 to 1 [-]
+        Corner frequency of the filtering effect of the PSD [Hz]
+    """
+    pos_response_m_volt = pos_response_um_volt / 1e6
+    gamma_0 = sphere_friction_coefficient(viscosity, bead_diameter * 1e-6)  # Ns/m
+    diffusion_physical = scipy.constants.k * (temperature + 273.15) / gamma_0  # m^2/s
+    diffusion_volt = diffusion_physical / pos_response_m_volt / pos_response_m_volt  # V^2/s
+    stiffness_si = stiffness * 1e-3  # N/m
+    fc = stiffness_si / (2.0 * np.pi * gamma_0)  # Hz
+
+    power_spectrum_model = partial(
+        passive_power_spectrum_model, fc=fc, D=diffusion_volt, alpha=diode[0], f_diode=diode[1]
+    )
+
+    driving_amplitude, driving_frequency = driving_sinusoid
+    p_response_m_squared = response_peak_ideal(fc, driving_amplitude * 1e-9, driving_frequency)
+    p_response_volts = np.sqrt(p_response_m_squared) / pos_response_m_volt
+
+    num_points = 2 * (sample_rate * duration // 2)  # Has to be multiple of two for FFT
+    time = np.arange(num_points) / sample_rate
+    driving_sine = np.sin(2.0 * np.pi * driving_frequency * time)
+    nano_stage = driving_amplitude * 1e-9 * driving_sine
+
+    # Center to peak amplitude is given by sqrt(2) * RMS Voltage
+    psd_component = np.sqrt(2) * p_response_volts * driving_sine
+
+    return (
+        power_model_to_time_series(sample_rate, num_points, power_spectrum_model) + psd_component,
+        nano_stage * 1e6,
+    )

--- a/lumicks/pylake/force_calibration/tests/data/simulate_ideal.py
+++ b/lumicks/pylake/force_calibration/tests/data/simulate_ideal.py
@@ -1,0 +1,194 @@
+import numpy as np
+import scipy.constants, scipy.signal
+
+
+def calculate_active_term(time, driving_sinusoid, stiffness, gamma):
+    """Simulate stage and bead position from simulation parameters.
+
+    There's a term in the Langevin equation that can be used to take into account stage movement.
+    Because the equations are linear, this term can be evaluated independently from the thermal
+    part and added. See [1].
+
+    The driving response is given by (Eq. 7 in [1]):
+
+        x_response(t) = x_drive(t - t_lag) / sqrt(1 + (fc / fdrive)**2)
+
+    With:
+
+        fc = stiffness / (2.0 pi gamma)
+        t_lag = (arctan(f_drive / fc) - pi/2) / (2 pi f_drive)
+
+    [1] Tolić-Nørrelykke, S. F., Schäffer, E., Howard, J., Pavone, F. S., Jülicher, F., &
+    Flyvbjerg, H. (2006). Calibration of optical tweezers with positional detection in the back
+    focal plane. Review of scientific instruments, 77(10), 103101.
+
+    Parameters
+    ----------
+    time : array_like
+        Time axis [s]
+    driving_sinusoid : tuple of float
+        Amplitude [nm] and frequency [Hz] of active calibration stage movement
+    stiffness : float
+        Stiffness of the trap [N/m]
+    gamma : float
+        Friction coefficient [Ns/m]
+
+    Returns
+    -------
+    stage_position : array_like
+        Stage position in [m]
+    bead_position_contribution : array_like
+        Contribution to the bead position in [m]
+    """
+    amp_stage, f_stage = driving_sinusoid
+    omega_stage = 2.0 * np.pi * f_stage
+    stage_position = amp_stage * np.sin(omega_stage * time) * 1e-9
+
+    fc = stiffness / (2.0 * np.pi * gamma)
+    t_lag = (np.arctan(f_stage / fc) - np.pi / 2) / omega_stage
+    amp_bead_position = amp_stage / np.sqrt(1.0 + (fc / f_stage) ** 2)
+    bead_position_contribution = amp_bead_position * np.sin(omega_stage * (time - t_lag)) * 1e-9
+
+    return stage_position, bead_position_contribution
+
+
+def apply_diode_filter(positions, diode_alpha, diode_frequency, time_step):
+    """Applies the simple diode filter model to the data.
+
+    Parameters
+    ----------
+    positions : array_like
+        List of bead positions [m]
+    diode_alpha : float
+        Fraction of the diode response that is instantaneous [-]
+    diode_frequency : float
+        Corner frequency of the filtering effect of the PSD [Hz]
+    time_step : float
+        Time step of the simulation [s]
+    """
+    assert 0 <= diode_alpha <= 1, (
+        "Invalid diode fraction (alpha) provided. " "Should be between 0 and 1"
+    )
+    filter_coeff = np.exp(-2.0 * np.pi * time_step * diode_frequency)
+    filtered = scipy.signal.lfilter([(1 - filter_coeff)], [1, -filter_coeff], positions)
+    return positions * diode_alpha + filtered * (1.0 - diode_alpha)
+
+
+def simulate_calibration_data(
+    duration,
+    sample_rate,
+    bead_diameter,
+    stiffness,
+    viscosity,
+    temperature,
+    pos_response_um_volt,
+    anti_aliasing,
+    oversampling=8,
+    driving_sinusoid=None,
+    diode=None,
+):
+    """Simulate Brownian motion in optical trap
+
+    This function simulates the Langevin equation that arises from a bead in an optical trap while
+    the stage is oscillating. Rather than using a basic Euler scheme, we use the more exact
+    simulation method from [1] which does not suffer from discretization error. Equation (72)
+    from [1] reads:
+
+        x[n+1] = c * x[n] + dx
+
+    with:
+
+        c = exp(-stiffness * dt / gamma)
+        dx = sqrt( (1 - c^2) * diffusion * gamma / stiffness ) * normal(0, 1)
+
+    For performance, we recast this simulation as a digital filter applied to a list of values drawn
+    from a normal distribution rather than simulate it with a for loop.
+
+    [1] Nørrelykke, S. F., & Flyvbjerg, H. (2011). Harmonic oscillator in heat bath: Exact
+    simulation of time-lapse-recorded data and exact analytical benchmark statistics. Physical
+    Review E, 83(4), 041103.
+
+    Parameters
+    ----------
+    duration : float
+        Time [s]
+    sample_rate : int
+        Sampling rate [Hz]
+    bead_diameter : float
+        Bead diameter [micron]
+    stiffness : float
+        Spring constant of the trap [pN/nm]
+    viscosity : float
+        Viscosity [Pa*s]
+    temperature : float
+        Temperature [C]
+    pos_response_um_volt : float
+        Response [um/V], also denoted in papers as Rd
+    anti_aliasing : bool
+        Should we anti-alias the data?
+    oversampling : int
+        Oversampling factor. Relatively high oversampling ratios are required to reject aliasing
+        effectively.
+    driving_sinusoid : tuple of float or None
+        Parameters for the driving input.
+        Amplitude [nm] and frequency of active [Hz] calibration stage movement
+    diode : tuple of float or None
+        Diode parameters:
+        Alpha of the diode response that is instantaneous, ranges from 0 to 1 [-]
+        Corner frequency of the filtering effect of the PSD [Hz]
+
+    Returns
+    -------
+    time : np.ndarray
+        Time in nanoseconds.
+    volt : np.ndarray
+        Position in volts.
+    stage_pos : np.ndarray
+        Stage position in microns.
+    """
+    boltzmann_const = scipy.constants.k
+    gamma = 3.0 * np.pi * viscosity * bead_diameter * 1e-6  # friction coefficient [Ns/m]
+    diffusion_const = (boltzmann_const * (temperature + 273.15)) / gamma  # diffusion [m^2/s]
+    dt = 1 / sample_rate
+    stiffness_si = stiffness * 1e-3  # Trap stiffness [N/m]
+
+    # For stability, dt *must* be less than gamma / stiffness.
+    dt_limit = gamma / stiffness_si
+    if oversampling < int(np.ceil(dt / dt_limit)):
+        raise RuntimeError("Oversampling ratio needs to be higher for stable simulation")
+
+    oversampled_dt = dt / oversampling
+    kappa_div_gamma_dt = (stiffness_si / gamma) * oversampled_dt
+    c = np.exp(-kappa_div_gamma_dt)
+
+    time = np.arange(0, duration, oversampled_dt)
+    rand_scale = np.sqrt((gamma / stiffness_si) * diffusion_const * (1.0 - c * c))
+    input_signal = rand_scale * np.random.standard_normal(time.shape)
+
+    # Equation (72) from the paper can be rewritten as a digital filter with:
+    #   b[0] = 1, a[0] = 1 and a[1] = -c.
+    # One can see that from: a[0]*x[n] = b[0]*u[n] - a[1]*x[n-1].
+    positions = scipy.signal.lfilter([1.0], [1.0, -c], input_signal)
+
+    if diode:
+        positions = apply_diode_filter(positions, *diode, oversampled_dt)
+
+    # Decimate the signal
+    positions = (
+        scipy.signal.decimate(positions, oversampling, ftype="fir")
+        if anti_aliasing
+        else positions[::oversampling]
+    )
+    time = time[::oversampling]
+
+    if driving_sinusoid:
+        # Because the SD equations are linear, this term can be evaluated independently.
+        stage_m, dx_active_m = calculate_active_term(time, driving_sinusoid, stiffness_si, gamma)
+        positions += dx_active_m
+    else:
+        stage_m = np.zeros(time.shape)
+
+    # Convert from meters to voltage
+    positions_volt = positions * 1e6 / pos_response_um_volt
+
+    return positions_volt, stage_m * 1e6

--- a/lumicks/pylake/force_calibration/tests/test_simulations.py
+++ b/lumicks/pylake/force_calibration/tests/test_simulations.py
@@ -1,0 +1,51 @@
+import pytest
+import numpy as np
+from lumicks.pylake.force_calibration.power_spectrum_calibration import calculate_power_spectrum
+from .data.simulate_calibration_data import generate_test_realisation_ideal
+from .data.simulate_ideal import simulate_calibration_data
+
+
+@pytest.mark.slow
+def test_simulation():
+    """Compares two methods to simulate the power spectrum."""
+
+    params = {
+        "duration": 10,
+        "sample_rate": 78125,
+        "bead_diameter": 1.01,
+        "stiffness": 0.4,
+        "viscosity": 1.002e-3,
+        "temperature": 20,
+        "pos_response_um_volt": 0.618,
+        "driving_sinusoid": (500, 31.95633),
+        "diode": (0.4, 10000),
+    }
+
+    sim1_position, sim1_nanostage = simulate_calibration_data(
+        **params, anti_aliasing=True, oversampling=16
+    )
+    sim2_position, sim2_nanostage = generate_test_realisation_ideal(**params)
+
+    def power(data):
+        return calculate_power_spectrum(data, params["sample_rate"], fit_range=(1, 2e4)).power
+
+    # Check whether the spectra are close. Note that these tolerances are pretty loose, but the
+    # errors quickly get very big.
+    np.testing.assert_allclose(power(sim2_position) / power(sim1_position), 1, atol=2e-1)
+    np.testing.assert_allclose(power(sim2_nanostage) / power(sim1_nanostage), 1, atol=2e-1)
+
+
+def test_stability_throw():
+    """Test whether simulation function throws when simulation would be unstabble"""
+    with pytest.raises(RuntimeError):
+        simulate_calibration_data(
+            duration=1,
+            sample_rate=78125,
+            stiffness=1,
+            bead_diameter=1,
+            viscosity=1e-3,
+            temperature=20,
+            pos_response_um_volt=1,
+            anti_aliasing=False,
+            oversampling=1,
+        )


### PR DESCRIPTION
**Why this PR?**
We need to be able to simulate test spectra to test the force calibration procedures.

**What's in here?**
There's two methods here. One is to simulate active calibration spectra via actual simulation of the Langevin equation. This is quite slow and requires oversampling to reduce aliasing. This only does idealized spectrum (since I do not have a model for the hydrodynamics at this point).

The other method is a method that can simulate any desired power spectral density (which will be useful for when we start simulating hydrodynamically correct spectra) and add a driving oscillation to it. Since the Langevin equation is linear, these can be treated separately. One caveat of this method is that it does not produce the correct phase on the driving input, but for a purely power spectrum based method this should not be a problem.

Finally, there's a test comparing the two. I tagged it as `runslow` since even despite the optimizations (`lfilter`) it is quite slow due to the large amount of oversampling required. Nevertheless, it's a good check for the other method.