### PR TITLE
Force calibration: Active calibration scaffold model

### DIFF
--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -1,5 +1,9 @@
-import math
+import numpy as np
 import scipy
+from .detail.driving_input import (
+    estimate_driving_input_parameters,
+    driving_power_peak,
+)
 from .detail.power_models import passive_power_spectrum_model, sphere_friction_coefficient
 from .power_spectrum_calibration import CalibrationParameter
 
@@ -11,8 +15,8 @@ class CalibrationModel:
     def __name__(self):
         raise NotImplementedError
 
-    def __call__(self):
-        raise NotImplementedError
+    def __call__(self, f, fc, diffusion_constant, f_diode, alpha):
+        return passive_power_spectrum_model(f, fc, diffusion_constant, f_diode, alpha)
 
     def __repr__(self):
         return f"{self.__name__()}({''.join([f'{k}={v}, ' for k, v in vars(self).items()])[:-2]})"
@@ -20,7 +24,7 @@ class CalibrationModel:
     def calibration_parameters(self):
         raise NotImplementedError
 
-    def calibration_results(self, fc, diffusion_constant):
+    def calibration_results(self, fc, diffusion_constant_volts, f_diode, alpha):
         raise NotImplementedError
 
 
@@ -61,9 +65,6 @@ class PassiveCalibrationModel(CalibrationModel):
         self.viscosity = viscosity
         self.temperature = temperature
 
-    def __call__(self, f, fc, diffusion_constant, f_diode, alpha):
-        return passive_power_spectrum_model(f, fc, diffusion_constant, f_diode, alpha)
-
     def calibration_parameters(self):
         return {
             "Bead diameter": CalibrationParameter("Bead diameter", self.bead_diameter, "um"),
@@ -71,31 +72,197 @@ class PassiveCalibrationModel(CalibrationModel):
             "Temperature": CalibrationParameter("Liquid temperature", self.temperature, "C"),
         }
 
-    def calibration_results(self, fc, diffusion_constant):
+    def calibration_results(self, fc, diffusion_constant_volts, f_diode, alpha):
+        """Compute calibration parameters from cutoff frequency and diffusion constant.
+
+        Note: f_diode and alpha are not used for passive calibration and are there to maintain
+        the same call signature for active and passive calibration.
+
+        Parameters
+        ----------
+        fc : float
+            Corner frequency, in Hz.
+        diffusion_constant_volts : float
+            Diffusion constant, in V^2/s
+        f_diode : float
+            Diode frequency.
+        alpha : float
+            Fraction of PSD signal that is instantaneous
+        """
+        # diameter [um] -> [m]
+        gamma_0 = sphere_friction_coefficient(self.viscosity, self.bead_diameter * 1e-6)
+        temperature_k = scipy.constants.convert_temperature(self.temperature, "C", "K")
+
+        # Distance response (Rd) needs to be output in um/V (m -> um or 1e6)
+        distance_response = (
+            np.sqrt(scipy.constants.k * temperature_k / gamma_0 / diffusion_constant_volts) * 1e6
+        )
+
+        # Stiffness is output in pN/nm (N/m -> pN/nm or 1e12 / 1e9 = 1e3)
+        kappa = 2 * np.pi * gamma_0 * fc * 1e3
+
+        # Force response (Rf) is output in pN/V. Rd [um/V], stiffness [pN/nm]: um -> nm = 1e3
+        force_response = distance_response * kappa * 1e3
+
+        return {
+            "Rd": CalibrationParameter("Distance response", distance_response, "um/V"),
+            "kappa": CalibrationParameter("Trap stiffness", kappa, "pN/nm"),
+            "Rf": CalibrationParameter("Force response", force_response, "pN/V"),
+        }
+
+
+class ActiveCalibrationModel(CalibrationModel):
+    """Model to fit data acquired during active calibration.
+
+    The power spectrum calibration algorithm implemented here is based on [1]_, [2]_, [3]_, [4]_,
+    [5]_, [6]_.
+
+    References
+    ----------
+    .. [1] Berg-Sørensen, K. & Flyvbjerg, H. Power spectrum analysis for optical tweezers. Rev. Sci.
+           Instrum. 75, 594 (2004).
+    .. [2] Tolić-Nørrelykke, I. M., Berg-Sørensen, K. & Flyvbjerg, H. MatLab program for precision
+           calibration of optical tweezers. Comput. Phys. Commun. 159, 225–240 (2004).
+    .. [3] Hansen, P. M., Tolic-Nørrelykke, I. M., Flyvbjerg, H. & Berg-Sørensen, K.
+           tweezercalib 2.1: Faster version of MatLab package for precise calibration of optical
+           tweezers. Comput. Phys. Commun. 175, 572–573 (2006).
+    .. [4] Berg-Sørensen, K., Peterman, E. J. G., Weber, T., Schmidt, C. F. & Flyvbjerg, H. Power
+           spectrum analysis for optical tweezers. II: Laser wavelength dependence of parasitic
+           filtering, and how to achieve high bandwidth. Rev. Sci. Instrum. 77, 063106 (2006).
+    .. [5] Tolić-Nørrelykke, S. F, and Flyvbjerg, H, "Power spectrum analysis with least-squares
+           fitting: amplitude bias and its elimination, with application to optical tweezers and
+           atomic force microscope cantilevers." Review of Scientific Instruments 81.7 (2010)
+    .. [6] Tolić-Nørrelykke S. F, Schäffer E, Howard J, Pavone F. S, Jülicher F and Flyvbjerg, H.
+           Calibration of optical tweezers with positional detection in the back focal plane,
+           Review of scientific instruments 77, 103101 (2006).
+
+    Attributes
+    ----------
+    sample_rate : float
+        Sample rate at which the signals we acquired.
+    bead_diameter : float
+        Bead diameter [um].
+    driving_frequency : float
+        Estimated driving frequency [Hz].
+    driving_amplitude : float
+        Estimated driving amplitude [m].
+    viscosity : float, optional
+        Liquid viscosity [Pa*s].
+    temperature : float, optional
+        Liquid temperature [Celsius].
+    num_windows : int, optional
+        Number of windows to average for the uncalibrated force. Using a larger number of
+        windows potentially increases the bleed, but may be useful when the SNR is low.
+    """
+
+    def __name__(self):
+        return "ActiveCalibrationModel"
+
+    def __init__(
+        self,
+        driving_data,
+        force_voltage_data,
+        sample_rate,
+        bead_diameter,
+        driving_frequency_guess,
+        viscosity=1.002e-3,
+        temperature=20,
+        num_windows=5,
+    ):
+        """
+        Active Calibration Model.
+
+        This model fits data acquired in the presence of nanostage or mirror oscillation.
+
+        Parameters
+        ----------
+        driving_data : array_like
+            Array of driving data.
+        force_voltage_data : array_like
+            Uncalibrated force data in volts.
+        sample_rate : float
+            Sample rate at which the signals we acquired.
+        bead_diameter : float
+            Bead diameter [um].
+        driving_frequency_guess : float
+            Guess of the driving frequency.
+        viscosity : float, optional
+            Liquid viscosity [Pa*s].
+        temperature : float, optional
+            Liquid temperature [Celsius].
+        num_windows : int, optional
+            Number of windows to average for the uncalibrated force. Using a larger number of
+            windows potentially increases the bleed, but may be useful when the SNR is low.
+        """
+        super().__init__(bead_diameter)
+        self.driving_frequency_guess = driving_frequency_guess
+        self.sample_rate = sample_rate
+        self.viscosity = viscosity
+        self.temperature = temperature
+        self.num_windows = num_windows
+
+        # Estimate driving input and response
+        amplitude_um, self.driving_frequency = estimate_driving_input_parameters(
+            sample_rate, driving_data, driving_frequency_guess
+        )
+        self.driving_amplitude = amplitude_um * 1e-6
+
+        # The power density is the density (V^2/Hz) at the driving input. Multiplying this with
+        # the frequency bin width gives the absolute power.
+        self._response_power_density, self._frequency_bin_width = driving_power_peak(
+            force_voltage_data, sample_rate, self.driving_frequency, num_windows
+        )
+
+    def calibration_parameters(self):
+        return {
+            "Bead diameter": CalibrationParameter("Bead diameter", self.bead_diameter, "um"),
+            "Driving frequency (guess)": CalibrationParameter(
+                "Driving frequency (guess)", self.driving_frequency_guess, "Hz"
+            ),
+            "Sample rate": CalibrationParameter("Sample rate", self.sample_rate, "Hz"),
+            "Temperature": CalibrationParameter("Liquid temperature", self.temperature, "C"),
+            "Viscosity": CalibrationParameter("Liquid viscosity", self.viscosity, "Pa*s"),
+            "num_windows": CalibrationParameter("Number of averaged windows", self.num_windows, ""),
+        }
+
+    def _theoretical_driving_power(self, f_corner):
+        """Compute the power expected for a given driving input.
+
+        When driving the stage or trap, we expect to see a delta spike in the power density
+        spectrum. This function returns the expected power contribution of the bead motion to the
+        power spectrum. It corresponds to the driven power spectrum minus the thermal power spectrum
+        integrated over the frequency bin corresponding to the driving input."""
+        return self.driving_amplitude ** 2 / (2 * (1 + (f_corner / self.driving_frequency) ** 2))
+
+    def calibration_results(self, fc, diffusion_constant_volts, f_diode, alpha):
         """Compute calibration parameters from cutoff frequency and diffusion constant.
 
         Parameters
         ----------
         fc : float
             Corner frequency, in Hz.
-        diffusion_constant : float
-            Diffusion constant, in (a.u.)^2/s
+        diffusion_constant_volts : float
+            Diffusion constant, in V^2/s
+        f_diode : float
+            Diode frequency.
+        alpha : float
+            Fraction of PSD signal that is instantaneous
         """
-        # diameter [um] -> [m]
-        gamma_0 = sphere_friction_coefficient(self.viscosity, self.bead_diameter * 1e-6)
-        temperature_k = scipy.constants.convert_temperature(self.temperature, "C", "K")
+        reference_peak = self(self.driving_frequency, fc, diffusion_constant_volts, f_diode, alpha)
 
-        # Rd needs to be output in um/V (m -> um or 1e6)
-        Rd = math.sqrt(scipy.constants.k * temperature_k / gamma_0 / diffusion_constant) * 1e6
+        power_exp = (self._response_power_density - reference_peak) * self._frequency_bin_width
+        distance_response = np.sqrt(self._theoretical_driving_power(fc) / power_exp)  # m/V
 
-        # Kappa is output in pN/nm (N/m -> pN/nm or 1e12 / 1e9 = 1e3)
-        kappa = 2 * math.pi * gamma_0 * fc * 1e3
+        temperature_kelvin = scipy.constants.convert_temperature(self.temperature, "C", "K")
+        k_temperature = scipy.constants.k * temperature_kelvin
+        gamma_0 = k_temperature / (distance_response ** 2 * diffusion_constant_volts)  # kg/s^2
+        kappa = 2.0 * np.pi * fc * gamma_0  # N/m
 
-        # Rf is output in pN/V. Rd [um/V], kappa [pN/nm]: um -> nm = 1e3
-        Rf = Rd * kappa * 1e3
+        force_response = distance_response * kappa  # N/V
 
         return {
-            "Rd": CalibrationParameter("Distance response", Rd, "um/V"),
-            "kappa": CalibrationParameter("Trap stiffness", kappa, "pN/nm"),
-            "Rf": CalibrationParameter("Force response", Rf, "pN/V"),
+            "Rd": CalibrationParameter("Distance response", distance_response * 1e6, "um/V"),
+            "kappa": CalibrationParameter("Trap stiffness", kappa * 1e3, "pN/nm"),
+            "Rf": CalibrationParameter("Force response", force_response * 1e12, "pN/V"),
+            "gamma_0": CalibrationParameter("Drag coefficient", gamma_0, "kg/s**2"),
         }

--- a/lumicks/pylake/force_calibration/detail/driving_input.py
+++ b/lumicks/pylake/force_calibration/detail/driving_input.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy.signal
+from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
 
 
 def estimate_driving_input_parameters(
@@ -98,3 +99,16 @@ def estimate_driving_input_parameters(
     amp = np.exp(p[2] - 0.25 * p[1] ** 2 / p[0] + 0.5 * np.log(-np.pi / p[0])) * delta_freq
 
     return amp, freq
+
+
+def driving_power_peak(psd_data, sample_rate, driving_frequency, num_windows, freq_window=50.0):
+    """This function finds the amplitude and frequency bin size of the driving input."""
+    power_spectrum = PowerSpectrum(
+        psd_data, sample_rate, window_seconds=num_windows / driving_frequency
+    )
+
+    power_spectrum = power_spectrum.in_range(
+        max(1.0, driving_frequency - freq_window), driving_frequency + freq_window
+    )
+
+    return max(power_spectrum.power), power_spectrum.frequency[1] - power_spectrum.frequency[0]

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -269,7 +269,10 @@ def fit_power_spectrum(
         ps_model=ps_model,
         results={
             **model.calibration_results(
-                fc=solution_params[0], diffusion_constant=solution_params[1]
+                fc=solution_params[0],
+                diffusion_constant_volts=solution_params[1],
+                f_diode=solution_params[2],
+                alpha=solution_params[3],
             ),
             "fc": CalibrationParameter("Corner frequency", solution_params[0], "Hz"),
             "D": CalibrationParameter("Diffusion constant", solution_params[1], "V^2/s"),

--- a/lumicks/pylake/force_calibration/tests/data/simulate_calibration_data.py
+++ b/lumicks/pylake/force_calibration/tests/data/simulate_calibration_data.py
@@ -40,7 +40,7 @@ def response_peak_ideal(corner_frequency, driving_amplitude, driving_frequency):
     return driving_amplitude ** 2 / (2 * (1 + (corner_frequency / driving_frequency) ** 2))
 
 
-def generate_test_realisation_ideal(
+def generate_active_calibration_test_data(
     duration,
     sample_rate,
     bead_diameter,

--- a/lumicks/pylake/force_calibration/tests/test_active_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_active_calibration.py
@@ -6,7 +6,7 @@ from lumicks.pylake.force_calibration.power_spectrum_calibration import (
     fit_power_spectrum,
 )
 from lumicks.pylake.force_calibration.calibration_models import ActiveCalibrationModel
-from .data.simulate_calibration_data import generate_test_realisation_ideal
+from .data.simulate_calibration_data import generate_active_calibration_test_data
 
 
 @pytest.mark.parametrize(
@@ -33,7 +33,7 @@ def test_integration_active_calibration(
     """Functional end to end test for active calibration"""
 
     np.random.seed(0)
-    force_voltage_data, driving_data = generate_test_realisation_ideal(
+    force_voltage_data, driving_data = generate_active_calibration_test_data(
         duration=20,
         sample_rate=sample_rate,
         bead_diameter=bead_diameter,

--- a/lumicks/pylake/force_calibration/tests/test_active_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_active_calibration.py
@@ -1,0 +1,86 @@
+import numpy as np
+import scipy.constants
+import pytest
+from lumicks.pylake.force_calibration.power_spectrum_calibration import (
+    calculate_power_spectrum,
+    fit_power_spectrum,
+)
+from lumicks.pylake.force_calibration.calibration_models import ActiveCalibrationModel
+from .data.simulate_calibration_data import generate_test_realisation_ideal
+
+
+@pytest.mark.parametrize(
+    "sample_rate, bead_diameter, stiffness, viscosity, temperature, pos_response_um_volt, "
+    "driving_sinusoid, diode, driving_frequency_guess, power_density",
+    [
+        [78125, 1.03, 0.1, 1.002e-3, 20, 0.618, (500, 31.95633), (0.4, 15000), 32, 1.958068e-5],
+        [78125, 1.03, 0.2, 1.002e-3, 20, 1.618, (500, 31.95633), (0.4, 14000), 32, 7.143526e-07],
+        [78125, 1.03, 0.3, 1.002e-3, 50, 1.618, (300, 30.42633), (0.4, 16000), 29, 1.098337e-07],
+    ],
+)
+def test_integration_active_calibration(
+    sample_rate,
+    bead_diameter,
+    stiffness,
+    viscosity,
+    temperature,
+    pos_response_um_volt,
+    driving_sinusoid,
+    diode,
+    driving_frequency_guess,
+    power_density
+):
+    """Functional end to end test for active calibration"""
+
+    np.random.seed(0)
+    force_voltage_data, driving_data = generate_test_realisation_ideal(
+        duration=20,
+        sample_rate=sample_rate,
+        bead_diameter=bead_diameter,
+        stiffness=stiffness,
+        viscosity=viscosity,
+        temperature=temperature,
+        pos_response_um_volt=pos_response_um_volt,
+        driving_sinusoid=driving_sinusoid,
+        diode=diode,
+    )
+
+    model = ActiveCalibrationModel(
+        driving_data,
+        force_voltage_data,
+        sample_rate,
+        bead_diameter,
+        driving_frequency_guess,
+        viscosity,
+        temperature,
+    )
+
+    # Validate estimation of the driving input
+    np.testing.assert_allclose(model.driving_amplitude, driving_sinusoid[0] * 1e-9, rtol=1e-5)
+    np.testing.assert_allclose(model.driving_frequency, driving_sinusoid[1], rtol=1e-5)
+
+    np.testing.assert_allclose(model._response_power_density, power_density, rtol=1e-5)
+    num_points_per_window = int(np.round(sample_rate * model.num_windows / model.driving_frequency))
+    freq_axis = np.fft.rfftfreq(num_points_per_window, 1.0 / sample_rate)
+    np.testing.assert_allclose(model._frequency_bin_width, freq_axis[1] - freq_axis[0])
+
+    power_spectrum = calculate_power_spectrum(force_voltage_data, sample_rate)
+    fit = fit_power_spectrum(power_spectrum, model)
+
+    np.testing.assert_allclose(fit["kappa"].value, stiffness, rtol=5e-2)
+    np.testing.assert_allclose(fit["alpha"].value, diode[0], rtol=5e-2)
+    np.testing.assert_allclose(fit["f_diode"].value, diode[1], rtol=5e-2)
+    np.testing.assert_allclose(fit["Rd"].value, pos_response_um_volt, rtol=5e-2)
+
+    response_calc = fit["Rd"].value * fit["kappa"].value * 1e3
+    np.testing.assert_allclose(fit["Rf"].value, response_calc, rtol=1e-9)
+
+    kt = scipy.constants.k * scipy.constants.convert_temperature(temperature, "C", "K")
+    drag_coeff_calc = kt / (fit["D"].value * fit["Rd"].value ** 2)
+    np.testing.assert_allclose(fit["gamma_0"].value, drag_coeff_calc * 1e12, rtol=1e-9)
+
+    np.testing.assert_allclose(fit["Bead diameter"].value, bead_diameter)
+    np.testing.assert_allclose(fit["Driving frequency (guess)"].value, driving_frequency_guess)
+    np.testing.assert_allclose(fit["Sample rate"].value, sample_rate)
+    np.testing.assert_allclose(fit["Viscosity"].value, viscosity)
+    np.testing.assert_allclose(fit["num_windows"].value, 5)

--- a/lumicks/pylake/force_calibration/tests/test_simulations.py
+++ b/lumicks/pylake/force_calibration/tests/test_simulations.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 from lumicks.pylake.force_calibration.power_spectrum_calibration import calculate_power_spectrum
-from .data.simulate_calibration_data import generate_test_realisation_ideal
+from .data.simulate_calibration_data import generate_active_calibration_test_data
 from .data.simulate_ideal import simulate_calibration_data
 
 
@@ -24,7 +24,7 @@ def test_simulation():
     sim1_position, sim1_nanostage = simulate_calibration_data(
         **params, anti_aliasing=True, oversampling=16
     )
-    sim2_position, sim2_nanostage = generate_test_realisation_ideal(**params)
+    sim2_position, sim2_nanostage = generate_active_calibration_test_data(**params)
 
     def power(data):
         return calculate_power_spectrum(data, params["sample_rate"], fit_range=(1, 2e4)).power


### PR DESCRIPTION
**Why this PR?**
Because we want to have active calibration functionality in Pylake.

**What's in this PR?**
This PR contains the basic scaffold for active calibration for an ideal spectrum.

The suggested API looks something like this:

```python
    model = ActiveCalibrationModel(
        driving_data,
        force_voltage_data,
        sample_rate,
        bead_diameter,
        driving_frequency_guess,
        viscosity,
        temperature,
    )

    power_spectrum = calculate_power_spectrum(force_voltage_data, sample_rate)
    fit = fit_power_spectrum(power_spectrum, model)

    fit.plot()
    fit
```

**Out of scope, but good to keep in mind when considering architecture**
Documentation is out of scope, since this functionality is not yet public (we deliberately do not import it yet).

This PR does not cover:
- Hydrodynamic correction.
- Bias correction.
- Fixing specific parameters in the thermal calibration.

Which all affect passive and active calibration and will be part of future PRs in this vein.