### PR TITLE
Cropping kymographs.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### New features
 
 * Added option to exclude ranges with potential noise peaks from the calibration routines. Please refer to [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html) for more information.
+* Added `crop_by_distance` to `Kymo` to allow cropping Kymographs by distance. Please refer to [kymographs](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html#kymo-data-and-details).
 * Added `refine_lines_gaussian()` for refining lines detected by the kymotracking algorithm using gaussian localization. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
 
 #### Bug fixes

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -35,6 +35,11 @@ Access the raw image data::
     # Plot manually
     plt.imshow(rgb)
 
+It is possible to crop a kymograph to a specific coordinate range, by using the function :meth:`~lumicks.pylake.Kymo.crop_by_distance`::
+For example, we can crop the region from `2` micron to `7` micron using the following command::
+
+    kymo.crop_by_distance(2, 7)
+
 Kymographs can also be sliced in order to obtain a specific time range.
 For example, one can plot the region of the kymograph between 175 and 180 seconds using::
 


### PR DESCRIPTION
**Why?**
Users often want to exclude the beads from downstream analysis. Therefore it is useful if they can actually crop the kymo easily.

This API introduces Kymograph cropping.

There is also a plan for updating the Cas9 notebook with this functionality, but I will make a separate PR for that.

Note: This PR depends on https://github.com/lumicks/pylake/pull/171