### PR TITLE
Invalid timestamps after slicing `Kymo`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 
 #### Bug fixes
 
+* Fixed bug in `Kymo` which resulted in erroneous timestamps and line times after slicing the Kymograph by time (e.g. `Kymo["1s":"5s"]`). The reason for this was imprecision in the timestamp reconstruction that occurred when slicing the data. This in turn led to an erroneous reconstruction of the timestamps. **As a result, any downstream analysis that relies on the time axis of a Kymograph post-slicing cannot be trusted (MSD analysis, plotting, tracking, attributes such as `.line_time_seconds`, etc.) in pylake v0.8.2 and v0.9.0.** Only those two versions are affected. Note that regular image reconstruction was not affected. Timestamps of unsliced kymographs constructed directly from the `.h5` files are also not affected.
 * Fixed an error in the documentation. In v0.9.0 `PowerSpectrum.power` was changed to represent power in `V^2/Hz` instead of `0.5 V^2/Hz`. However, the docs were not appropriately updated to reflect this change in the model equation that's fitted to the spectrum. This is mitigated now.
 * Fixed bug in `plot_with_force` which caused an exception on Kymographs with a partial last pixel.
 

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -114,8 +114,11 @@ def line_timestamps_image(time_stamps, infowave, pixels_per_line):
     pixels_per_line : int
         The number of pixels on the fast axis of the scan.
     """
-    min_stamps = reconstruct_image(time_stamps, infowave, shape=(pixels_per_line,), reduce=np.min)
-    return min_stamps.astype(np.int64)[:, 0]
+    infowave, valid_idx = discard_zeros(infowave)
+    time_stamps = time_stamps[valid_idx]
+    pixel_start_idx = np.flatnonzero(infowave == InfowaveCode.pixel_boundary)
+    pixel_start_idx = np.concatenate(([0], pixel_start_idx + 1))
+    return time_stamps[pixel_start_idx[0:-1:pixels_per_line]]
 
 
 def seek_timestamp_next_line(infowave):

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -40,11 +40,15 @@ def test_timestamps_image(num_lines, pixels_per_line, pad_size):
     pad = np.zeros(pad_size, dtype=np.int32)
     infowave = np.hstack([np.hstack([pad, line_info_wave, pad]) for _ in np.arange(num_lines)])
     start_indices = np.hstack([np.hstack([pad, line_selector, pad]) for _ in np.arange(num_lines)])
-    time = np.arange(len(infowave), dtype=np.int64) + 100
+
+    # Generate list of timestamp data.
+    # It is important to use timestamps that are large enough such that floating point
+    # round-off errors will occur if the data is converted to floating point representation.
+    time = np.arange(len(infowave), dtype=np.int64) * int(700e9) + 1623965975045144000
 
     line_stamps = line_timestamps_image(time, infowave, pixels_per_line)
     assert line_stamps.shape == (sum(start_indices), )
-    assert np.all(np.allclose(line_stamps, time[start_indices == 1]))
+    np.testing.assert_equal(line_stamps, time[start_indices == 1])
 
 
 def test_reconstruct():


### PR DESCRIPTION
**Why this PR?**
It fixes a critical bug in Kymograph slicing that would lead to erroneous timestamp reconstruction.

**What went wrong?**
Kymographs are encoded with the so-called infowave. It's a list containing a mapping which indicates which sample to include, where the pixel ends are etc. Reconstruction is hardcoded to use a constant number of samples per pixel. There is no way to tell where a line ends in the kymograph (other than knowing the number of pixels in the kymograph metadata).

When slicing a kymograph, we need to round the slicing to the next kymograph line to make sure reconstruction does not fail.

In PR https://github.com/lumicks/pylake/pull/124 we changed the code that handles the slicing to use the same reconstruction algorithm to obtain the timestamps. Unfortunately, this led to the following critical bug:

- The reconstruction algorithm allocates a new array to return the timestamps in. This array has a different type than the timestamps (`np.float` as opposed to `np.int64`). As a consequence, we have now incurred a small roundoff error in our timestamps (since timestamps are defined w.r.t. epoch, they are generally quite large).
- What happens next is that the timestamp returned is slightly beyond the first DAQ sample of line we intended to start at.
- Slicing from this timestamp results in an infowave that has fewer samples in the first pixel, violating our assumption of a constant number of samples per pixel.
- As a consequence, the timestamp reconstruction fails.
- As a consequence of this, the `line_time_seconds` property, which is used in plotting, kymotracking, MSD analysis is incorrect (and off by a potentially large margin!).

The errors you get in the line time are substantial and unpredictable. In the table below you can see the line time before and after slicing (both values should be the same).
```
0.1043328 vs 0.0977664
0.042393600000000004 vs 0.036479744
0.24999680000000002  vs 0.196992
0.24999680000000002  vs 0.19893760000000002
0.020070400000000002 vs 0.0120576
0.020070400000000002  vs 0.020070400000000002  (cas9 example we use for manual testing, and probably part of the reason we didn't pick up on it earlier)
```

**Who is affected?**
Everyone who sliced a Kymograph and subsequently did analysis on it since Pylake v0.8.2.

**Next steps**
While this PR fixes the most acute problem and introduces a test for it. It does not fix the precision issue at the core (yet).

This requires some additional investigation and introduces additional design questions, since `np.mean` which we use for kymograph downsampling is at risk of overflow at high sample rates (when using fixed precision).

The branch `dtype_experimental` has a fix that actually propagates the `dtypes`, but we should discuss the implications of this first.