### PR TITLE
Import kymolines with Kymo instance

### DIFF
--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -1,4 +1,5 @@
 from lumicks.pylake.kymotracker.detail.msd_estimation import *
+from lumicks.pylake.kymotracker.detail.calibrated_images import CalibratedKymographChannel
 
 
 def export_kymolinegroup_to_csv(filename, kymoline_group, delimiter, sampling_width):
@@ -51,15 +52,17 @@ def export_kymolinegroup_to_csv(filename, kymoline_group, delimiter, sampling_wi
     np.savetxt(filename, data, fmt=fmt, header=delimiter.join(header), delimiter=delimiter)
 
 
-def import_kymolinegroup_from_csv(filename, image, delimiter=";"):
+def import_kymolinegroup_from_csv(filename, kymo, channel, delimiter=";"):
     """Import kymolines from csv
 
     Parameters
     ----------
     filename : str
-        filename to import from
-    image : CalibratedKymographChannel
-        Calibrated 2D kymograph channel that these lines were tracked from
+        filename to import from.
+    kymo : Kymo
+        kymograph instance that these lines were tracked from.
+    channel : str
+        color channel that these lines were tracked from.
     delimiter : str
         A delimiter that delimits the column data.
 
@@ -71,6 +74,8 @@ def import_kymolinegroup_from_csv(filename, image, delimiter=";"):
 
     indices = data[:, 0]
     lines = np.unique(indices)
+
+    image = CalibratedKymographChannel.from_kymo(kymo, channel)
     return KymoLineGroup(
         [KymoLine(data[indices == k, 1], data[indices == k, 2], image) for k in lines]
     )

--- a/lumicks/pylake/kymotracker/tests/test_io.py
+++ b/lumicks/pylake/kymotracker/tests/test_io.py
@@ -2,6 +2,7 @@ from lumicks.pylake.kymotracker.detail.calibrated_images import CalibratedKymogr
 from lumicks.pylake.kymotracker.kymoline import KymoLine, KymoLineGroup, import_kymolinegroup_from_csv
 import numpy as np
 import pytest
+from lumicks.pylake.tests.data.mock_confocal import generate_kymo
 
 
 @pytest.fixture(scope="session")
@@ -44,13 +45,20 @@ def read_txt(testfile, delimiter):
 def test_kymolinegroup_io(tmpdir_factory, kymolinegroup_io_data, dt, dx, delimiter, sampling_width, sampling_outcome):
     test_img, lines = kymolinegroup_io_data
 
-    test_img.time_step_ns = dt
-    test_img._pixel_size = dx
+    kymo = generate_kymo(
+        "test",
+        test_img.data,
+        dx*1000,
+        start=4,
+        dt=dt,
+        samples_per_pixel=5,
+        line_padding=3
+    )
 
     # Test round trip through the API
     testfile = f"{tmpdir_factory.mktemp('pylake')}/test.csv"
     lines.save(testfile, delimiter, sampling_width)
-    read_file = import_kymolinegroup_from_csv(testfile, test_img, delimiter=delimiter)
+    read_file = import_kymolinegroup_from_csv(testfile, kymo, "red", delimiter=delimiter)
 
     # Test raw fields
     data = read_txt(testfile, delimiter)

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -231,8 +231,7 @@ class KymoWidget:
     def _load_from_ui(self):
         try:
             self.lines = import_kymolinegroup_from_csv(
-                self.output_filename,
-                CalibratedKymographChannel.from_kymo(self._kymo, self._channel),
+                self.output_filename, self._kymo, self._channel
             )
             self.update_lines()
             self._set_label(f"Loaded {self.output_filename}")


### PR DESCRIPTION
**Why this PR?**
Currently, in order to import kymolines from a saved .csv you first need to load a `Kymo` instance, manually construct a `CalibratedKymographChannel` from this and the channel name, and finally feed this into the import function. It would be easier to just hand the kymo and channel name directly to the import function and construct the calibrated image internally.

Note, this is an internal function for the time being as the .csv format is likely to change; however in the future when it is made public it cannot rely on the internal `CalibratedKymographChannel` class