### PR TITLE
Fix CorrelatedStack export bugs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
 
 * Show an error message when user attempts to refine lines before tracking or loading them so the kymotracker widget does not become unresponsive.
 * Force calibration models now throw an error when a bead diameter of less than `10^-2` microns is used (rather than produce `NaN` results).
+* Fixed bug that prevented export of `CorrelatedStack` if the alignment matrices were missing from the metadata.
+* Fixed bug where the exported metadata fields were erroneously exported as `"Applied channel X alignment"` for `CorrelatedStack` where the alignment was not actually applied.
 
 ## v0.10.0 | 2021-08-20
 


### PR DESCRIPTION
**Why this PR?**
This PR addresses two bugs in `CorrelatedStack.export_tiff()`
- previously, attempting to export grayscale images (such as IRM) would throw an exception because the alignment matrices metadata is not there
- exporting changes the alignment matrices metadata keys from `Channel X alignment` to `Applied channel X alignment` to indicate that the data no longer corresponds to the raw data recorded in Bluelake. However, these fields were always changed regardless if the alignment was actually applied to the data or not.

In the process of fixing these, the mock test data was also updated to bring it more in line with what the real files look like.