### PR TITLE
Calibrate kymographs to base pairs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.11.0 | t.b.d.
+
+#### New features
+
+* Added `Kymo.calibrate_to_kbp()` for calibrating the position axis of a kymograph from microns to kilobase-pairs. **Note: this calibration is applied to the full kymograph, so one should crop to the bead edges with `Kymo.crop_by_distance()` before calling this method.**
+
 ## v0.10.1 | 2021-10-27
 
 #### New features
@@ -27,6 +33,12 @@
 #### Deprecations
 
 * `CorrelatedStack.from_data()` has been renamed to `CorrelatedStack.from_dataset()` for consistency with `BaseScan.from_dataset()`.
+
+#### Breaking changes
+
+* Units are now included in the headers for exported kymograph traces. The header now reads:</br>
+`# line index;time (pixels);coordinate (pixels);time (seconds);position ({unit});counts (summed over {n} pixels)`</br>
+where `{unit}` is either `um` or `kbp` depending on the calibration of the kymograph.
 
 ## v0.10.0 | 2021-08-20
 

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -54,6 +54,15 @@ There are also several properties available for convenient access to the kymogra
 * `kymo.fast_axis` provides the axis that was scanned (x or y)
 * `kymo.line_time_seconds` provides the time between successive lines
 
+By default, kymographs are constructed with units of microns for the position axis. If, however, the kymograph spans a known length of DNA (for example,
+lambda DNA) we can calibrate the position axis to kilobase pairs::
+
+    kymo.calibrate_to_kbp(14.850)
+
+Now if we plot the image, the y-axis will be labeled in kbp. These units are also carried forward to any downstream operations such as cropping,
+kymotracking algorithms, MSD analysis, etc. *Note: currently this is a static calibration, meaning it is only valid if the traps do not
+change position during the time of the kymograph.*
+
 Downsampling kymograph
 ----------------------
 

--- a/lumicks/pylake/kymotracker/detail/calibrated_images.py
+++ b/lumicks/pylake/kymotracker/detail/calibrated_images.py
@@ -15,13 +15,16 @@ class CalibratedKymographChannel:
         Line time [nanoseconds].
     pixel_size : float
         Pixel calibration.
+    position_unit : tuple
+        Tuple of strings ("position unit raw text", "position unit formatted label")
     """
 
-    def __init__(self, name, data, time_step_ns, pixel_size):
+    def __init__(self, name, data, time_step_ns, pixel_size, position_unit=("", "")):
         self.name = name
         self.data = data
         self.time_step_ns = time_step_ns
         self._pixel_size = pixel_size
+        self._position_unit = position_unit
 
     @classmethod
     def from_array(
@@ -40,11 +43,13 @@ class CalibratedKymographChannel:
 
     @classmethod
     def from_kymo(cls, kymo, channel):
+        position_unit = (kymo._calibration.unit, kymo._calibration.unit_label)
         return cls(
             kymo.name,
             getattr(kymo, f"{channel}_image"),
             kymo.line_time_seconds * int(1e9),
-            kymo.pixelsize_um[0],
+            kymo.pixelsize[0],
+            position_unit,
         )
 
     def _to_pixel_rect(self, rect):
@@ -140,5 +145,5 @@ class CalibratedKymographChannel:
 
         plt.imshow(self.data, **{**default_kwargs, **kwargs})
         plt.xlabel("time (s)")
-        plt.ylabel(r"position ($\mu$m)")
+        plt.ylabel(f"position ({self._position_unit[1]})")
         plt.title(self.name)

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -21,6 +21,9 @@ def export_kymolinegroup_to_csv(filename, kymoline_group, delimiter, sampling_wi
     if not kymoline_group:
         raise RuntimeError("No kymograph traces to export")
 
+    time_units = "seconds"
+    position_units = kymoline_group[0]._image._position_unit[0]
+
     idx = np.hstack([np.full(len(line), idx) for idx, line in enumerate(kymoline_group)])
     coords_idx = np.hstack([line.coordinate_idx for line in kymoline_group])
     times_idx = np.hstack([line.time_idx for line in kymoline_group])
@@ -39,8 +42,8 @@ def export_kymolinegroup_to_csv(filename, kymoline_group, delimiter, sampling_wi
     store_column("time (pixels)", "%.18e", times_idx)
     store_column("coordinate (pixels)", "%.18e", coords_idx)
 
-    store_column("time", "%.18e", seconds)
-    store_column("position", "%.18e", position)
+    store_column(f"time ({time_units})", "%.18e", seconds)
+    store_column(f"position ({position_units})", "%.18e", position)
 
     if sampling_width is not None:
         store_column(
@@ -264,7 +267,7 @@ class KymoLine:
         lag_time, msd = self.msd(max_lag)
         plt.plot(lag_time, msd, **kwargs)
         plt.xlabel("Lag time [s]")
-        plt.ylabel("Mean Squared Displacement [$\\mu m^2$]")
+        plt.ylabel(f"Mean Squared Displacement [{self._image._position_unit[1]}$^2$]")
 
     def estimate_diffusion_ols(self, max_lag=None):
         """Perform an unweighted fit to the MSD estimates to obtain a diffusion constant.

--- a/lumicks/pylake/kymotracker/tests/test_io.py
+++ b/lumicks/pylake/kymotracker/tests/test_io.py
@@ -68,10 +68,10 @@ def test_kymolinegroup_io(tmpdir_factory, kymolinegroup_io_data, dt, dx, delimit
         np.testing.assert_allclose(np.array(line1.coordinate_idx), np.array(line2.coordinate_idx))
         np.testing.assert_allclose(np.array(line1.time_idx), np.array(line2.time_idx))
 
-    for line1, time in zip(lines, data["time"]):
+    for line1, time in zip(lines, data["time (seconds)"]):
         np.testing.assert_allclose(line1.seconds, time)
 
-    for line1, coord in zip(lines, data["position"]):
+    for line1, coord in zip(lines, data["position ()"]):
         np.testing.assert_allclose(line1.position, coord)
 
     if sampling_width is None:

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -178,3 +178,19 @@ def test_refine_line_width_units(kymograph, region_select):
     true_coordinate[2] = 12
     true_coordinate[3] = 12
     np.testing.assert_allclose(kymo_widget.lines[0].coordinate_idx, true_coordinate)
+
+
+@cleanup
+def test_widget_with_calibration(kymograph):
+    widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
+    np.testing.assert_allclose(widget.algorithm_parameters["line_width"],
+                               kymograph.pixelsize[0] * 4)
+    np.testing.assert_allclose(widget.algorithm_parameters["line_width"], 1.6)
+    assert widget._axes.get_ylabel() == r"position ($\mu$m)"
+
+    kymo_bp = kymograph.calibrate_to_kbp(10.000)
+    widget = KymoWidgetGreedy(kymo_bp, "red", 1, use_widgets=False)
+    np.testing.assert_allclose(widget.algorithm_parameters["line_width"],
+                               kymo_bp.pixelsize[0] * 4)
+    np.testing.assert_allclose(widget.algorithm_parameters["line_width"], 2.0)
+    assert widget._axes.get_ylabel() == "position (kbp)"


### PR DESCRIPTION
**Why this PR?**

Often it is more interesting to know the position of binding events in base pairs along the DNA tether rather than in microns.

**Things to note:**
- calibration is forwarded to all downstream analyses (plotting, kymotracking, MSD analysis)
- length in microns is still available (since this information is in the original h5 file and some attributes such as `pixelsize_um` are public). I think this is reasonable since you might want to know some information in um and other info in bp
- I chose to use a small dataclass to store the calibration information. This allows access to the current unit, formatted labels for plotting, and we can extend with other functionality in the future as needed without introducing tons of attributes to `Kymo`. Additionally in the future we will need to support variable calibration (depending on the position of the beads for instance) and it is nice to have this functionality abstracted away from the main class

docs are [here](https://lumicks-pylake.readthedocs.io/en/calib_bp/tutorial/kymographs.html#kymo-data-and-details)