### PR TITLE
force_calibration: better validation driving input

### DIFF
--- a/lumicks/pylake/force_calibration/detail/driving_input.py
+++ b/lumicks/pylake/force_calibration/detail/driving_input.py
@@ -94,7 +94,22 @@ def estimate_driving_input_parameters(
     log_magnitudes = np.log(np.abs(windowed_fft[fit_range]))
 
     p = np.polyfit(frequency[fit_range], log_magnitudes, 2)
+
+    if p[0] >= 0:
+        raise RuntimeError(
+            "Did not manage to find driving peak in spectral search range. "
+            "Check whether your initial driving frequency guess is close enough to the driving "
+            "frequency."
+        )
+
     freq = -p[1] / (2.0 * p[0])  # Location of the peak of the quadratic approximation
+
+    if freq < f_drive_guess - f_search or freq > f_drive_guess + f_search:
+        raise RuntimeError(
+            "Peak is outside frequency search range. Check whether your initial driving frequency "
+            "guess is close enough to the driving frequency."
+        )
+
     delta_freq = 2 / sample_rate
     amp = np.exp(p[2] - 0.25 * p[1] ** 2 / p[0] + 0.5 * np.log(-np.pi / p[0])) * delta_freq
 

--- a/lumicks/pylake/force_calibration/tests/test_driving_input.py
+++ b/lumicks/pylake/force_calibration/tests/test_driving_input.py
@@ -11,8 +11,8 @@ import pytest
         [[[0.45, 36.554], [1, 50]], 0.45, 36.554, 36, 5, 2],
         [[[0.5, 36.9], [1, 42.0]], 0.5, 36.9, 36, 5, 2],  # Does window exclude the bigger peak?
         [[[0.5, 36.9], [1, 42.0]], 1.0, 42.0, 36, 10, 2],  # Bigger window includes second peak
-        [[[0.5, 36.9], [1, 41.0]], 1.0, 41.0, 36, 5, 2],  # Does it pick up on the second peak?
-        [[[0.5, 36.9], [-1, 41.0]], 1.0, 41.0, 36, 5, 2],  # Does it pick up on the second peak?
+        [[[0.5, 36.9], [1, 41.0]], 1.0, 41.0, 36, 6, 2],  # Does it pick up on the second peak?
+        [[[0.5, 36.9], [-1, 41.0]], 1.0, 41.0, 36, 6, 2],  # Does it pick up on the second peak?
         [[[0.5, 36.9], [1, 42.0]], 0.617576, 41.999864, 36, 10, 10],  # Fit range has both peaks
         [[[0.5, 2.4], [0, 50]], 0.5, 2.4, 3, 5, 2],  # Does it reject offset correctly?
     ],
@@ -37,3 +37,31 @@ def test_driving_input_estimation(sine_waves, expected_amp, expected_freq, guess
 
     np.testing.assert_allclose(amp, expected_amp, rtol=1e-6)
     np.testing.assert_allclose(freq, expected_freq, rtol=1e-6)
+
+
+def test_frequency_validation():
+    """We want to validate that the driving peak was actually in the search range. If not, that
+    means something may have gone critically wrong. It's better to fail early than to silently
+    calculate a calibration that has a relatively large area because the fitting range
+    did not encompass the peak."""
+    sines = [np.sin(f * 2.0 * np.pi * np.arange(0, 1, 1.0 / 78125)) for f in [32, 70]]
+    driving_data = np.sum(np.vstack(sines), axis=0)
+    with pytest.raises(
+        RuntimeError, match="Did not manage to find driving peak in spectral search range"
+    ):
+        f_drive_guess = 50
+        estimate_driving_input_parameters(
+            78125, driving_data, f_drive_guess, window_factor=10, f_search=5, n_fit=1
+        )
+
+    with pytest.raises(RuntimeError, match="Peak is outside frequency search range"):
+        f_drive_guess = 37.1
+        estimate_driving_input_parameters(
+            78125, driving_data, f_drive_guess, window_factor=10, f_search=5, n_fit=1
+        )
+
+    with pytest.raises(RuntimeError, match="Peak is outside frequency search range"):
+        f_drive_guess = 26.9
+        estimate_driving_input_parameters(
+            78125, driving_data, f_drive_guess, window_factor=10, f_search=5, n_fit=1
+        )


### PR DESCRIPTION
**Why this PR?**
When doing active calibration, we have to find the input magnitude and frequency from the nanostage (or in the future trap) signal.  To obtain this we choose a small region of the Gaussian windowed frequency spectrum and find the largest peak in that region. 

After that, we regress a polynomial to an even smaller range (typically three points) of the log magnitude which provides us with the peak amplitude and frequency.

The best accuracy is obtained if the peak is actually in this region, but this relies on the search range being chosen appropriately in the first step.

This PR adds some validation on whether the peak was indeed in the search range, and whether the found magnitudes correspond to a peak rather than a dip.

If either of these conditions is not met, we throw because our peak estimate may be less accurate than optimal.

Note: I noticed this because I was seeing small biases in my calibrations rather than errors, which underlines the danger of this not being an explicit exception.