### PR TITLE
file: add support for axial force detection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## v0.10.1 | t.b.d.
 
+#### New features
+
+* Add support for axial force detection (i.e. force detection along the Z axis). The high-frequency data can be accessed with `f.force1z` and `f.force2z` while the downsampled low-frequency channels can be accessed with `f.downsampled_force1z` and `f.downsampled_force2z`. The calibrations can be accessed with `f.force1z.calibration` and `f.force2z.calibration`. The Z component is *not* factored in the calculation of the total force `f.downsampled_force1` and `f.downsampled_force2`.
+
 #### Bug fixes
 
 * Show an error message when user attempts to refine lines before tracking or loading them so the kymotracker widget does not become unresponsive.

--- a/lumicks/pylake/detail/mixin.py
+++ b/lumicks/pylake/detail/mixin.py
@@ -25,12 +25,20 @@ class Force:
         return _try_get_or_empty(self._get_force, 1, "y")
 
     @property
+    def force1z(self) -> Slice:
+        return _try_get_or_empty(self._get_force, 1, "z")
+
+    @property
     def force2x(self) -> Slice:
         return _try_get_or_empty(self._get_force, 2, "x")
 
     @property
     def force2y(self) -> Slice:
         return _try_get_or_empty(self._get_force, 2, "y")
+
+    @property
+    def force2z(self) -> Slice:
+        return _try_get_or_empty(self._get_force, 2, "z")
 
     @property
     def force3x(self) -> Slice:
@@ -41,12 +49,20 @@ class Force:
         return _try_get_or_empty(self._get_force, 3, "y")
 
     @property
+    def force3z(self) -> Slice:
+        return _try_get_or_empty(self._get_force, 3, "z")
+
+    @property
     def force4x(self) -> Slice:
         return _try_get_or_empty(self._get_force, 4, "x")
 
     @property
     def force4y(self) -> Slice:
         return _try_get_or_empty(self._get_force, 4, "y")
+
+    @property
+    def force4z(self) -> Slice:
+        return _try_get_or_empty(self._get_force, 4, "z")
 
 
 class DownsampledFD:
@@ -83,12 +99,20 @@ class DownsampledFD:
         return _try_get_or_empty(self._get_downsampled_force, 1, "y")
 
     @property
+    def downsampled_force1z(self) -> Slice:
+        return _try_get_or_empty(self._get_downsampled_force, 1, "z")
+
+    @property
     def downsampled_force2x(self) -> Slice:
         return _try_get_or_empty(self._get_downsampled_force, 2, "x")
 
     @property
     def downsampled_force2y(self) -> Slice:
         return _try_get_or_empty(self._get_downsampled_force, 2, "y")
+
+    @property
+    def downsampled_force2z(self) -> Slice:
+        return _try_get_or_empty(self._get_downsampled_force, 2, "z")
 
     @property
     def downsampled_force3x(self) -> Slice:
@@ -99,12 +123,20 @@ class DownsampledFD:
         return _try_get_or_empty(self._get_downsampled_force, 3, "y")
 
     @property
+    def downsampled_force3z(self) -> Slice:
+        return _try_get_or_empty(self._get_downsampled_force, 3, "z")
+
+    @property
     def downsampled_force4x(self) -> Slice:
         return _try_get_or_empty(self._get_downsampled_force, 4, "x")
 
     @property
     def downsampled_force4y(self) -> Slice:
         return _try_get_or_empty(self._get_downsampled_force, 4, "y")
+
+    @property
+    def downsampled_force4z(self) -> Slice:
+        return _try_get_or_empty(self._get_downsampled_force, 4, "z")
 
     @property
     def distance1(self) -> Slice:

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -160,12 +160,16 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
                     for field in [
                         "force1x",
                         "force1y",
+                        "force1z",
                         "force2x",
                         "force2y",
+                        "force2z",
                         "force3x",
                         "force3y",
+                        "force3z",
                         "force4x",
                         "force4y",
+                        "force4z",
                     ]
                 )
             )
@@ -176,39 +180,43 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
                     for field in [
                         "downsampled_force1x",
                         "downsampled_force1y",
+                        "downsampled_force1z",
                         "downsampled_force2x",
                         "downsampled_force2y",
+                        "downsampled_force2z",
                         "downsampled_force3x",
                         "downsampled_force3y",
+                        "downsampled_force3z",
                         "downsampled_force4x",
                         "downsampled_force4y",
+                        "downsampled_force4z",
                     ]
                 )
             )
         )
 
-    def _get_force(self, n, xy):
+    def _get_force(self, n, xyz):
         """Return a Slice of force measurements, including calibration
         Note: direct access to HDF dataset does not include calibration data"""
-        force_group = self.h5["Force HF"][f"Force {n}{xy}"]
-        calibration_data = ForceCalibration.from_dataset(self.h5, n, xy)
+        force_group = self.h5["Force HF"][f"Force {n}{xyz}"]
+        calibration_data = ForceCalibration.from_dataset(self.h5, n, xyz)
 
         return Continuous.from_dataset(force_group, "Force (pN)", calibration_data)
 
-    def _get_downsampled_force(self, n, xy):
+    def _get_downsampled_force(self, n, xyz):
         """Return a Slice of low frequency force measurements, including calibration if applicable
         Note: direct access to HDF dataset does not include calibration data"""
         group = self.h5["Force LF"]
 
         def make(channel):
-            if xy:
-                calibration_data = ForceCalibration.from_dataset(self.h5, n, xy)
+            if xyz:
+                calibration_data = ForceCalibration.from_dataset(self.h5, n, xyz)
                 return TimeSeries.from_dataset(group[channel], "Force (pN)", calibration_data)
             else:
                 return TimeSeries.from_dataset(group[channel], "Force (pN)")
 
-        if xy:  # An x or y component of the downsampled force is easy
-            return make(f"Force {n}{xy}")
+        if xyz:  # An x, y or z component of the downsampled force is easy
+            return make(f"Force {n}{xyz}")
 
         # Sum force channels can have inconsistent names
         if f"Force {n}" in group:
@@ -216,7 +224,7 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
         elif f"Trap {n}" in group:
             return make(f"Trap {n}")
 
-        # If it's completely missing, we can reconstruct it from the x and y components
+        # If it's completely missing, we can reconstruct it from the x and y components, z is not included
         fx = make(f"Force {n}x")
         fy = make(f"Force {n}y")
         return Slice(
@@ -224,12 +232,12 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
             labels={"title": f"Force LF/Force {n}", "y": "Force (pN)"},
         )
 
-    def _get_corrected_force(self, n, xy):
+    def _get_corrected_force(self, n, xyz):
         """Return a Slice of force measurements, including calibration, with baseline
         correction applied. Only the x-component has correction available.
         Note: direct access to HDF dataset does not include calibration data"""
-        force_group = self.h5["Force HF"][f"Corrected Force {n}{xy}"]
-        calibration_data = ForceCalibration.from_dataset(self.h5, n, xy)
+        force_group = self.h5["Force HF"][f"Corrected Force {n}{xyz}"]
+        calibration_data = ForceCalibration.from_dataset(self.h5, n, xyz)
 
         return Continuous.from_dataset(force_group, "Force (pN)", calibration_data)
 

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -148,9 +148,11 @@ def h5_file(tmpdir_factory, request):
 
     mock_file.make_continuous_channel("Force HF", "Force 1x", 1, 10, np.arange(5.0))
     mock_file.make_continuous_channel("Force HF", "Force 1y", 1, 10, np.arange(5.0, 10.0))
+    mock_file.make_continuous_channel("Force HF", "Force 1z", 1, 10, np.arange(10.0, 15.0))
 
     mock_file.make_timeseries_channel("Force LF", "Force 1x", [(1, 1.1), (2, 2.1)])
     mock_file.make_timeseries_channel("Force LF", "Force 1y", [(1, 1.2), (2, 2.2)])
+    mock_file.make_timeseries_channel("Force LF", "Force 1z", [(1, 1.3), (2, 2.3)])
 
     if mock_class == MockDataFile_v2:
         mock_file.make_timetags_channel(
@@ -166,6 +168,10 @@ def h5_file(tmpdir_factory, request):
         mock_file.make_calibration_data("2", "Force 1y", {calibration_time_field: 1})
         mock_file.make_calibration_data("3", "Force 1y", {calibration_time_field: 10})
         mock_file.make_calibration_data("4", "Force 1y", {calibration_time_field: 100})
+        mock_file.make_calibration_data("1", "Force 1z", {calibration_time_field: 0})
+        mock_file.make_calibration_data("2", "Force 1z", {calibration_time_field: 1})
+        mock_file.make_calibration_data("3", "Force 1z", {calibration_time_field: 10})
+        mock_file.make_calibration_data("4", "Force 1z", {calibration_time_field: 100})
 
         mock_file.make_marker("test_marker", {'Start time (ns)': 100, 'Stop time (ns)': 200})
         mock_file.make_marker("test_marker2", {'Start time (ns)': 200, 'Stop time (ns)': 300})

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -122,7 +122,7 @@ def test_properties(h5_file):
 def test_groups(h5_file):
     f = pylake.File.from_h5py(h5_file)
     if f.format_version == 1:
-        assert str(f["Force HF"]) == "{'Force 1x', 'Force 1y'}"
+        assert str(f["Force HF"]) == "{'Force 1x', 'Force 1y', 'Force 1z'}"
 
         for x in range(0, 2):
             t = [name for name in f]
@@ -130,7 +130,7 @@ def test_groups(h5_file):
 
         for x in range(0, 2):
             t = [name for name in f["Force HF"]]
-            assert set(t) == set(["Force 1x", "Force 1y"])
+            assert set(t) == set(["Force 1x", "Force 1y", "Force 1z"])
 
 
 def test_redirect_list(h5_file):
@@ -173,6 +173,9 @@ def test_repr_and_str(h5_file):
               Force 1y:
               - Data type: float64
               - Size: 5
+              Force 1z:
+              - Data type: float64
+              - Size: 5
             Force LF:
               Force 1x:
               - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
@@ -180,12 +183,17 @@ def test_repr_and_str(h5_file):
               Force 1y:
               - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
               - Size: 2
+              Force 1z:
+              - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
+              - Size: 2
             
             .force1x
             .force1y
+            .force1z
 
             .downsampled_force1x
             .downsampled_force1y
+            .downsampled_force1z
         """)
     if f.format_version == 2:
         assert str(f) == dedent("""\
@@ -204,6 +212,9 @@ def test_repr_and_str(h5_file):
               Force 1y:
               - Data type: float64
               - Size: 5
+              Force 1z:
+              - Data type: float64
+              - Size: 5
               Force 2x:
               - Data type: float64
               - Size: 70
@@ -212,6 +223,9 @@ def test_repr_and_str(h5_file):
               - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
               - Size: 2
               Force 1y:
+              - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
+              - Size: 2
+              Force 1z:
               - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
               - Size: 2
             Info wave:
@@ -254,12 +268,16 @@ def test_repr_and_str(h5_file):
               .calibration
             .force1y
               .calibration
+            .force1z
+              .calibration
             .force2x
               .calibration
 
             .downsampled_force1x
               .calibration
             .downsampled_force1y
+              .calibration
+            .downsampled_force1z
               .calibration
         """)
 


### PR DESCRIPTION
Add support for axial force detection (i.e. force detection along the Z-axis). The high-frequency data can be accessed with `f.force1z` and `f.force2z` while the downsampled low-frequency channels can be accessed with `f.downsampled_force1z` and `f.downsampled_force2z`. The calibrations can be accessed with `f.force1z.calibration` and `f.force2z.calibration`. The Z component is *not* factored in the calculation of the total force `f.force1` and `f.force2` as specifically requested by BD.