### PR TITLE
force_calibration: check bead diameter > 1e-6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 #### Bug fixes
 
 * Show an error message when user attempts to refine lines before tracking or loading them so the kymotracker widget does not become unresponsive.
+* Force calibration models now throw an error when a bead diameter of less than `10^-2` microns is used (rather than produce `NaN` results).
 
 ## v0.10.0 | 2021-08-20
 

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -69,6 +69,12 @@ class PassiveCalibrationModel:
         rho_sample=None,
         rho_bead=1060.0,
     ):
+        if bead_diameter < 1e-2:
+            raise ValueError(
+                f"Invalid bead diameter specified {bead_diameter}. Bead diameter should be bigger "
+                f"than 10^-2 um"
+            )
+
         if (
             distance_to_surface
             and hydrodynamically_correct

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -285,3 +285,13 @@ def test_repr(reference_calibration_result):
         err_alpha            Diode 'relaxation factor' Std Err                             0.0131415
         chi_squared_per_deg  Chi squared per degree of freedom                             1.06378
         backing              Statistical backing (%)                                      66.4331""")
+
+
+def test_invalid_bead_diameter():
+    with pytest.raises(ValueError, match="Invalid bead diameter specified"):
+        PassiveCalibrationModel(bead_diameter=0)
+
+    with pytest.raises(ValueError, match="Invalid bead diameter specified"):
+        PassiveCalibrationModel(bead_diameter=1e-7)
+
+    PassiveCalibrationModel(bead_diameter=1e-2)


### PR DESCRIPTION
**Why this PR?**
Using bead diameters less or equal to zero produces non-sensical calibrations (NaNs).

The field for bead diameter in Bluelake defaults to zero, so this can be confusing. With this fix it now raises an exception when zero is passed to the calibration routine.