### PR TITLE
Support `None` value parameters in calibration results repr

### DIFF
--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -84,7 +84,9 @@ class CalibrationResults:
                 [
                     key,
                     f"{param.description}{f' ({param.unit})' if param.unit else ''}",
-                    param.value if isinstance(param.value, str) else f"{param.value:.6g}",
+                    param.value
+                    if isinstance(param.value, str)
+                    else ("" if param.value is None else f"{param.value:.6g}"),
                 ]
                 for key, param in entries.items()
             ]


### PR DESCRIPTION
Why this PR?

Currently a calibration parameter with value `None` throws a `TypeError` when a `CalibrationResults` object is printed. Now it will just be printed as a blank string