### PR TITLE
deps: pin `scikit-learn` to circumvent segfault

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "ipywidgets>=7.0.0",
         "cachetools>=3.1",
         "deprecated>=1.2.8",
-        "scikit-learn>=0.18.0",
+        "scikit-learn>=0.18.0, <1.0",
         "scikit-image>=0.17.2",
     ],
     zip_safe=False,


### PR DESCRIPTION
**Why this PR?**
Latest version of `scikit-learn` is resulting in segmentation faults on CI for `macos-latest`.

The following minimal example segfaults on CI:
```python
from sklearn.mixture import GaussianMixture
import numpy as np
model = GaussianMixture(n_components=2, init_params="kmeans", n_init=1, tol=1e-3, max_iter=100)
data = np.array([[11.20871134], [11.01644412], [11.11502055], [10.8732648]])
model.fit(data)
```

It seems to be segfaulting in `init_bounds` in [k_means_elkan.pyx](https://github.com/scikit-learn/scikit-learn/blob/1.0/sklearn/cluster/_k_means_elkan.pyx).

```python
Fatal Python error: Segmentation fault

Thread 0x000000010e82adc0 (most recent call first):
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sklearn/cluster/_kmeans.py", line 471 in _kmeans_single_elkan
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sklearn/cluster/_kmeans.py", line 1188 in fit
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sklearn/mixture/_base.py", line 143 in _initialize_parameters
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sklearn/mixture/_base.py", line 251 in fit_predict
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sklearn/mixture/_base.py", line 198 in fit
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/lumicks/pylake/population/mixture.py", line 53 in __init__
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/lumicks/pylake/population/tests/test_mixture.py", line 11 in test_gmm
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/python.py", line 183 in pytest_pyfunc_call
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/python.py", line 1641 in runtest
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 162 in pytest_runtest_call
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 255 in <lambda>
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 311 in from_call
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 254 in call_runtest_hook
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 215 in call_and_report
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 126 in runtestprotocol
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 109 in pytest_runtest_protocol
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/main.py", line 348 in pytest_runtestloop
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/main.py", line 323 in _main
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/main.py", line 269 in wrap_session
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/main.py", line 316 in pytest_cmdline_main
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/config/__init__.py", line 162 in main
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/lumicks/pylake/__init__.py", line 47 in pytest
  File "pylake_test.py", line 7 in <module>
3127 Segmentation fault: 11  python pylake_test.py
population/tests/test_mixture.py::test_gmm[2] 
Error: Process completed with exit code 139.
```