### PR TITLE
force_calibration: add bias correction

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 
 * Switch to trust region reflective algorithm for fitting thermal calibration spectrum. This results in fewer optimization failures.
 * Make sure that `f_diode` stays below the Nyquist frequency during fitting.
+* Implemented a bias correction for the thermal calibration. Note that this typically leads to a small correction unless you use a very low number of points per block.
 
 ## v0.10.0 | 2021-08-20
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -43,6 +43,17 @@ publisher = {Biophysical Society}
   publisher={American Institute of Physics}
 }
 
+@article{norrelykke2010power,
+  title={Power spectrum analysis with least-squares fitting: amplitude bias and its elimination, with application to optical tweezers and atomic force microscope cantilevers},
+  author={Nørrelykke, Simon F and Flyvbjerg, Henrik},
+  journal={Review of Scientific Instruments},
+  volume={81},
+  number={7},
+  pages={075103},
+  year={2010},
+  publisher={American Institute of Physics}
+}
+
 @article{tolic2004matlab,
   title={MatLab program for precision calibration of optical tweezers},
   author={Tolić-Nørrelykke, Iva Marija and Berg-Sørensen, Kirstine and Flyvbjerg, Henrik},

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -119,6 +119,10 @@ We can plot the calibration by calling::
 
 .. image:: force_calibration_fit.png
 
+Note that by default, a bias correction is applied to the fitted results :cite:`norrelykke2010power`.
+This bias correction is applied to the diffusion constant and amounts to a correction of :math:`\frac{N}{N+1}`, where :math:`N` refers to the number of points used for a particular spectral data point.
+It can optionally be disabled by passing `bias_correction=False` to :func:`~lumicks.pylake.fit_power_spectrum`.
+
 Hydrodynamically correct model
 ------------------------------
 

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -139,6 +139,12 @@ class PassiveCalibrationModel:
     .. [4] Berg-Sørensen, K., Peterman, E. J. G., Weber, T., Schmidt, C. F. & Flyvbjerg, H. Power
            spectrum analysis for optical tweezers. II: Laser wavelength dependence of parasitic
            filtering, and how to achieve high bandwidth. Rev. Sci. Instrum. 77, 063106 (2006).
+    .. [5] Tolić-Nørrelykke, S. F, and Flyvbjerg, H, "Power spectrum analysis with least-squares
+           fitting: amplitude bias and its elimination, with application to optical tweezers and
+           atomic force microscope cantilevers." Review of Scientific Instruments 81.7 (2010)
+    .. [6] Tolić-Nørrelykke S. F, Schäffer E, Howard J, Pavone F. S, Jülicher F and Flyvbjerg, H.
+           Calibration of optical tweezers with positional detection in the back focal plane,
+           Review of scientific instruments 77, 103101 (2006).
 
     Attributes
     ----------

--- a/lumicks/pylake/force_calibration/tests/test_active_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_active_calibration.py
@@ -79,7 +79,9 @@ def test_integration_active_calibration(
     kt = scipy.constants.k * scipy.constants.convert_temperature(temperature, "C", "K")
     drag_coeff_calc = kt / (fit["D"].value * fit["Rd"].value ** 2)
     np.testing.assert_allclose(
-        fit["gamma_0"].value, sphere_friction_coefficient(viscosity, bead_diameter*1e-6), rtol=1e-9
+        fit["gamma_0"].value,
+        sphere_friction_coefficient(viscosity, bead_diameter * 1e-6),
+        rtol=1e-9,
     )
     np.testing.assert_allclose(fit["gamma_ex"].value, drag_coeff_calc * 1e12, rtol=1e-9)
 
@@ -88,3 +90,52 @@ def test_integration_active_calibration(
     np.testing.assert_allclose(fit["Sample rate"].value, sample_rate)
     np.testing.assert_allclose(fit["Viscosity"].value, viscosity)
     np.testing.assert_allclose(fit["num_windows"].value, 5)
+
+
+def test_bias_correction():
+    """Functional end to end test for active calibration"""
+
+    np.random.seed(0)
+    force_voltage_data, driving_data = generate_active_calibration_test_data(
+        duration=20,
+        sample_rate=78125,
+        bead_diameter=1.03,
+        stiffness=0.2,
+        viscosity=1.002e-3,
+        temperature=20,
+        pos_response_um_volt=0.618,
+        driving_sinusoid=(500, 31.95633),
+        diode=(0.4, 13000),
+    )
+
+    model = ActiveCalibrationModel(driving_data, force_voltage_data, 78125, 1.03, 32, 1.002e-3, 20)
+
+    # Low blocking deliberately leads to higher bias (so it's easier to measure)
+    block_size = 3
+    power_spectrum_low = calculate_power_spectrum(
+        force_voltage_data, 78125, num_points_per_block=block_size
+    )
+
+    fit_biased = fit_power_spectrum(power_spectrum_low, model, bias_correction=False)
+    fit_debiased = fit_power_spectrum(power_spectrum_low, model, bias_correction=True)
+
+    bias_corr = block_size / (block_size + 1)
+    np.testing.assert_allclose(fit_debiased["D"].value, fit_biased["D"].value * bias_corr)
+    np.testing.assert_allclose(fit_debiased["err_D"].value, fit_biased["err_D"].value * bias_corr)
+
+    # Biased vs debiased estimates (in comments are the reference values for N_pts_per_block = 150
+    # Note how the estimates are better on the right.
+    comparisons = {
+        "fc": [3310.651532245893, 3310.651532245893],  # Ref: 3277.6576037747836
+        "D": [1.472922058628551, 1.1046915439714131],  # Ref: 1.0896306365192108
+        "kappa": [0.15317517466591019, 0.2043759281959786],  # Ref: 0.20106518840690035
+        "Rd": [0.6108705452113169, 0.6106577513480039],  # Ref: 0.6168083172053238
+        "Rf": [93.57020246100325, 124.8037447418174],  # Ref: 124.0186805098316
+    }
+
+    for key, values in comparisons.items():
+        for fit, value in zip([fit_biased, fit_debiased], values):
+            np.testing.assert_allclose(fit[key].value, value)
+
+    assert fit_biased.params["Bias correction"].value is False
+    assert fit_debiased.params["Bias correction"].value is True

--- a/lumicks/pylake/force_calibration/tests/test_alternate_diode_models.py
+++ b/lumicks/pylake/force_calibration/tests/test_alternate_diode_models.py
@@ -29,7 +29,7 @@ def test_fit_fixed_pars(reference_models):
     """Test model without diode effect"""
     models, power_spectrum = model_and_data(reference_models, diode_alpha=1.0, fast_sensor=True)
     for model in models:
-        fit = fit_power_spectrum(power_spectrum, model=model)
+        fit = fit_power_spectrum(power_spectrum, model=model, bias_correction=False)
         np.testing.assert_allclose(fit.results["fc"].value, 4000, 1e-6)
         np.testing.assert_allclose(fit.results["D"].value, 1.14632, 1e-6)
         assert "f_diode" not in fit.results
@@ -50,7 +50,7 @@ def test_fixed_diode(reference_models):
     models, power_spectrum = model_and_data(reference_models, diode_alpha=0.4, fast_sensor=True)
     for model in models:
         model._filter = FixedDiodeModel(14000)
-        fit = fit_power_spectrum(power_spectrum, model=model)
+        fit = fit_power_spectrum(power_spectrum, model=model, bias_correction=False)
 
         np.testing.assert_allclose(fit.results["fc"].value, 4000, 1e-6)
         np.testing.assert_allclose(fit.results["D"].value, 1.14632, 1e-6)
@@ -62,6 +62,6 @@ def test_fixed_diode(reference_models):
 
         # Fix diode to the wrong frequency. We should not get a great fit that way.
         model._filter = FixedDiodeModel(13000)
-        fit = fit_power_spectrum(power_spectrum, model=model)
+        fit = fit_power_spectrum(power_spectrum, model=model, bias_correction=False)
         assert abs(fit.results["fc"].value - 4000) > 1.0
         assert abs(fit.results["D"].value - 1.14632) > 1e-2

--- a/lumicks/pylake/force_calibration/tests/test_hydro.py
+++ b/lumicks/pylake/force_calibration/tests/test_hydro.py
@@ -262,7 +262,7 @@ def test_integration_active_calibration_hydrodynamics(integration_test_parameter
         driving_frequency_guess=33,
     )
     power_spectrum = calculate_power_spectrum(volts, simulation_pars["sample_rate"])
-    fit = fit_power_spectrum(power_spectrum, model)
+    fit = fit_power_spectrum(power_spectrum, model, bias_correction=False)
 
     np.testing.assert_allclose(fit.params["Sample density"].value, 997.0)
     np.testing.assert_allclose(fit.params["Bead density"].value, 1040.0)
@@ -301,7 +301,7 @@ def test_integration_passive_calibration_hydrodynamics(integration_test_paramete
     volts, _ = generate_active_calibration_test_data(10, **simulation_pars, **shared_pars)
     model = PassiveCalibrationModel(**shared_pars)
     power_spectrum = calculate_power_spectrum(volts, simulation_pars["sample_rate"])
-    fit = fit_power_spectrum(power_spectrum, model)
+    fit = fit_power_spectrum(power_spectrum, model, bias_correction=False)
 
     np.testing.assert_allclose(fit.params["Sample density"].value, 997.0)
     np.testing.assert_allclose(fit.params["Bead density"].value, 1040.0)
@@ -344,7 +344,7 @@ def test_integration_active_calibration_hydrodynamics_bulk(integration_test_para
         driving_frequency_guess=33,
     )
     power_spectrum = calculate_power_spectrum(volts, simulation_pars["sample_rate"])
-    fit = fit_power_spectrum(power_spectrum, model)
+    fit = fit_power_spectrum(power_spectrum, model, bias_correction=False)
 
     np.testing.assert_allclose(fit.params["Sample density"].value, 997.0)
     np.testing.assert_allclose(fit.params["Bead density"].value, 1040.0)

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -74,7 +74,7 @@ def test_good_fit_integration_test(
     data, f_sample = reference_models.lorentzian_td(corner_frequency, diffusion_constant, alpha, f_diode, num_samples)
     model = PassiveCalibrationModel(bead_diameter, temperature=temperature, viscosity=viscosity)
     power_spectrum = psc.calculate_power_spectrum(data, f_sample, fit_range=(0, 15000), num_points_per_block=20)
-    ps_calibration = psc.fit_power_spectrum(power_spectrum=power_spectrum, model=model)
+    ps_calibration = psc.fit_power_spectrum(power_spectrum=power_spectrum, model=model, bias_correction=False)
 
     np.testing.assert_allclose(ps_calibration["fc"].value, corner_frequency, rtol=1e-4)
     np.testing.assert_allclose(ps_calibration["D"].value, diffusion_constant, rtol=1e-4, atol=0)
@@ -163,7 +163,9 @@ def reference_calibration_result():
     reference_spectrum = psc.calculate_power_spectrum(reference_spectrum, sample_rate=78125,
                                                       num_points_per_block=100,
                                                       fit_range=(100.0, 23000.0))
-    ps_calibration = psc.fit_power_spectrum(power_spectrum=reference_spectrum, model=model)
+    ps_calibration = psc.fit_power_spectrum(power_spectrum=reference_spectrum,
+                                            model=model,
+                                            bias_correction=False)
 
     return ps_calibration, model, reference_spectrum
 
@@ -244,6 +246,7 @@ def test_repr(reference_calibration_result):
         Fit tolerance        Fitting tolerance                                             1e-07
         Points per block     Number of points per block                                  100
         Sample rate          Sample rate (Hz)                                          78125
+        Bias correction      Perform bias correction thermal fit                           0
         Rd                   Distance response (um/V)                                      7.25366
         kappa                Trap stiffness (pN/nm)                                        0.171495
         Rf                   Force response (pN/V)                                      1243.97


### PR DESCRIPTION
**Why this PR?**
The way we fit power spectral densities is inherently biased.
In most cases, the bias will be very low (since we use relatively high blocking counts), but it is still good to just fix it.

Paper with all the details here: https://arxiv.org/pdf/0906.1708.pdf
Note if you decide to dive into this, we are using method 2.

I added a few sentences to the docs about it too.

![image](https://user-images.githubusercontent.com/19836026/136448976-22e8e476-eb91-4b50-a311-00228e09c59d.png)
_Estimates for different blocksizes. Left without bias correction, Right is with bias correction._