### PR TITLE
Spatial cropping for CorrelatedStack

### DIFF
--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -11,6 +11,13 @@ These videos can be opened and sliced using `CorrelatedStack`::
     stack = lk.CorrelatedStack("example.tiff")  # Loading a stack.
     stack_slice = stack[2:10]  # Grab frame 2 to 9
 
+You can also spatially crop to select a smaller region of interest::
+
+    stack_roi = stack.crop_by_pixels(10, 50, 20, 80)  # pixel coordinates as x_max, x_min, y_max, y_min
+
+This can be useful, for instance, after applying color alignment to RGB images as the edges
+can become corrupted due to interpolation artifacts.
+
 Full color RGB images are automatically reconstructed using the alignment matrices
 from Bluelake if available. This functionality can be turned off with the optional
 `align` keyword::
@@ -37,9 +44,3 @@ The aligned image stack can also be exported to tiff format::
 
     stack.export_tiff("aligned_stack.tiff")
     stack[5:20].export_tiff("aligned_short_stack.tiff") # export a slice of the CorrelatedStack
-
-Generally, the edges of an aligned image can become corrupted due interopolation artefacts. 
-In this case, we can export a cropped region of interest by supplying the `roi` kwarg in the form
-`[min_x_pixel, max_x_pixel, min_y_pixel, max_y_pixel]`::
-
-    stack.export_tiff("aligned_cropped_stack.tiff", roi=[20, 280, 20, 180])

--- a/lumicks/pylake/tests/data/mock_widefield.py
+++ b/lumicks/pylake/tests/data/mock_widefield.py
@@ -19,7 +19,9 @@ class MockTiffPage:
         self.tags = {"DateTime": MockTag(f"{start_time}:{end_time}"),
                      "ImageDescription": MockTag(description),
                      "BitsPerSample": MockTag(bit_depth),
-                     "SamplesPerPixel": MockTag(1 if (data.ndim==2) else data.shape[2])}
+                     "SamplesPerPixel": MockTag(1 if (data.ndim==2) else data.shape[2]),
+                     "ImageWidth": MockTag(data.shape[1]),
+                     "ImageLength": MockTag(data.shape[0])}
 
     def asarray(self):
         return self._data.copy()


### PR DESCRIPTION
**Why this PR?**
Often you want to work with a smaller portion of the image (region of interest: ROI)

**Notes**
- first 2 commits are with all of the logic incorporated into `TiffStack` `TiffFrame` and `ImageDescription`. 3rd commit refactors to a dataclass to encapsulate everything. Personally I think it's cleaner this way, but could be reverted back to original form if preferred.
- Currently implemented using pixel coordinates (we may add spatial calibration at a later point). Definitely feel free to suggest a better name than `crop_by_pixels()` or a nicer way of handling units here
- cropping is done on-demand at data request; class still holds the reference to the full TIFF file