### PR TITLE
Force calibration: Drag correction

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,9 @@
 
 #### New features
 
-* Added support for active force calibration. For more information, please read: See [force calibration](https://lumicks-pylake.readthedocs.io/en/active_calibration_docs/tutorial/force_calibration.html#active-calibration).
+* Added support for active force calibration. For more information, please read: See [active force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html#active-calibration).
+* Added support for axial calibration. See See [axial calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html#axial-calibration).
+* Added support for using near-surface corrections for lateral and axial calibration, please read: See [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html#faxen-s-law).
 * Added `Kymo.calibrate_to_kbp()` for calibrating the position axis of a kymograph from microns to kilobase-pairs. **Note: this calibration is applied to the full kymograph, so one should crop to the bead edges with `Kymo.crop_by_distance()` before calling this method.**
 
 #### Improvements

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -65,6 +65,17 @@ publisher = {Biophysical Society}
   publisher={Elsevier}
 }
 
+@article{schaffer2007surface,
+  title={Surface forces and drag coefficients of microspheres near a plane surface measured with optical tweezers},
+  author={Sch{\"a}ffer, Erik and N{\o}rrelykke, Simon F and Howard, Jonathon},
+  journal={Langmuir},
+  volume={23},
+  number={7},
+  pages={3654--3665},
+  year={2007},
+  publisher={ACS Publications}
+}
+
 @article{tolic2006calibration,
   title={Calibration of optical tweezers with positional detection in the back focal plane},
   author={Toli{\'c}-N{\o}rrelykke, Simon F and Sch{\"a}ffer, Erik and Howard, Jonathon and Pavone, Francesco S and J{\"u}licher, Frank and Flyvbjerg, Henrik},

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -188,6 +188,53 @@ Note that when `rho_sample` and `rho_bead` are omitted, values for water and pol
 
 Additionally, when the parameter `distance_to_surface` is omitted, a simpler model is used which assumes the experiment was performed deep in bulk (neglecting the increased drag induced by the nearby surface).
 
+Faxen's law
+-----------
+
+The hydrodynamically correct model presented in the previous section works well when the bead center is at least 1.5 times the radius above the surface.
+
+When going closer, the drag effect becomes stronger than the frequency dependent effects and better models to approximate the local drag exist.
+
+For lateral calibration, the following approximation is typically used :cite:`schaffer2007surface`:
+
+.. math::
+
+    \gamma_\mathrm{faxen}(R/l) = \frac{\gamma_0}{
+        1 - \frac{9R}{16l} + \frac{1R^3}{8l^3} - \frac{45R^4}{256l^4} - \frac{1R^5}{16l^5}
+    }
+
+We can use this model by setting `hydrodynamically_correct` to `False`, while still providing a distance to the surface::
+
+    force_model = lk.PassiveCalibrationModel(bead_diameter, hydrodynamically_correct=False, distance_to_surface=1e-6)
+
+Note that `pylake` always returns the bulk drag coefficient :math:`\gamma_0`.
+
+Axial Calibration
+-----------------
+
+For calibration in the axial direction, no hydrodynamically correct theory exists.
+In this case, one should use a Lorentzian with a specific correction term :cite:`schaffer2007surface`:
+
+.. math::
+
+    \gamma_\mathrm{axial}(R/l) = \frac{\gamma_0}{
+        1.0
+        - \frac{9R}{8l}
+        + \frac{1R^3}{2l^3}
+        - \frac{57R^4}{100l^4}
+        + \frac{1R^5}{5l^5}
+        + \frac{7R^{11}}{200l^{11}}
+        - \frac{1R^{12}}{25l^{12}}
+    }
+
+This model deviates less than 0.1% from Brenner's exact formula for :math:`l/R >= 1.1` and less than 0.3% over the entire range of :math:`l` :cite:`schaffer2007surface`:.
+
+This model can be used in Pylake by specifying `axial=True`::
+
+    force_model = lk.PassiveCalibrationModel(bead_diameter, distance_to_surface=1e-6, axial=True)
+
+Note that no hydrodynamically correct model is available for axial calibration.
+
 Fast Sensors
 ------------
 

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -593,10 +593,12 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
             "kappa": CalibrationParameter("Trap stiffness", kappa * 1e3, "pN/nm"),
             "Rf": CalibrationParameter("Force response", force_response * 1e12, "pN/V"),
             "gamma_0": CalibrationParameter(
-                "Theoretical drag coefficient", self.drag_coeff, "kg/s"
+                "Theoretical bulk drag coefficient", self.drag_coeff, "kg/s"
             ),
             "gamma_ex": CalibrationParameter(
-                "Measured drag coefficient", measured_drag_coeff, "kg/s"
+                "Measured bulk drag coefficient",
+                measured_drag_coeff / self._drag_correction_factor,
+                "kg/s",
             ),
             **self._format_passive_result(
                 fc,

--- a/lumicks/pylake/force_calibration/detail/drag_models.py
+++ b/lumicks/pylake/force_calibration/detail/drag_models.py
@@ -1,0 +1,57 @@
+import numpy as np
+
+
+def faxen_factor(distance_to_surface_m, radius_m):
+    """Faxen factor for lateral drag coefficient.
+
+    This factor provides a correction to the drag force for a nearby wall.
+
+    [6] Schäffer, E., Nørrelykke, S. F., & Howard, J. "Surface forces and drag coefficients of
+    microspheres near a plane surface measured with optical tweezers." Langmuir, 23(7), 3654-3665
+    (2007).
+
+    Parameters
+    ----------
+    distance_to_surface_m : float
+        Distance from the center of the bead to the surface [m]
+    radius_m : float
+        Radius of the bead [m]
+    """
+    height_ratio = radius_m / distance_to_surface_m
+    denominator = (
+        1
+        - 9 / 16 * height_ratio
+        + 1 / 8 * height_ratio ** 3
+        - 45 / 256 * height_ratio ** 4
+        - 1 / 16 * height_ratio ** 5
+    )
+    return 1.0 / denominator
+
+
+def brenner_axial(distance_to_surface_m, radius_m):
+    """Brenner factor for lateral drag coefficient.
+
+    This factor provides a correction to the drag force for a nearby wall.
+
+    [6] Schäffer, E., Nørrelykke, S. F., & Howard, J. "Surface forces and drag coefficients of
+    microspheres near a plane surface measured with optical tweezers." Langmuir, 23(7), 3654-3665
+    (2007).
+
+    Parameters
+    ----------
+    distance_to_surface_m : float
+        Distance from the center of the bead to the surface [m]
+    radius_m : float
+        Radius of the bead [m]
+    """
+    height_ratio = radius_m / distance_to_surface_m
+    denominator = (
+        1.0
+        - (9 / 8) * height_ratio
+        + 0.5 * height_ratio ** 3
+        - (57 / 100) * height_ratio ** 4
+        + (1 / 5) * height_ratio ** 5
+        + (7 / 200) * height_ratio ** 11
+        - (1 / 25) * height_ratio ** 12
+    )
+    return 1.0 / denominator

--- a/lumicks/pylake/force_calibration/detail/drag_models.py
+++ b/lumicks/pylake/force_calibration/detail/drag_models.py
@@ -1,6 +1,3 @@
-import numpy as np
-
-
 def faxen_factor(distance_to_surface_m, radius_m):
     """Faxen factor for lateral drag coefficient.
 

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -23,6 +23,9 @@ References
        least-squares fitting: amplitude bias and its elimination, with application
        to optical tweezers and atomic force microscope cantilevers." Review of
        Scientific Instruments 81.7 (2010).
+.. [6] Schäffer, E., Nørrelykke, S. F., & Howard, J. "Surface forces and drag
+       coefficients of microspheres near a plane surface measured with optical
+       tweezers." Langmuir, 23(7), 3654-3665 (2007).
 """
 
 import numpy as np

--- a/lumicks/pylake/force_calibration/tests/test_axial.py
+++ b/lumicks/pylake/force_calibration/tests/test_axial.py
@@ -1,0 +1,101 @@
+from lumicks.pylake.force_calibration.calibration_models import (
+    ActiveCalibrationModel,
+    PassiveCalibrationModel,
+)
+from lumicks.pylake.force_calibration.tests.data.simulate_calibration_data import (
+    generate_active_calibration_test_data,
+)
+from lumicks.pylake.force_calibration.power_spectrum_calibration import (
+    calculate_power_spectrum,
+    fit_power_spectrum,
+)
+from lumicks.pylake.force_calibration.detail.drag_models import faxen_factor, brenner_axial
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("hydro", [False, True])
+def test_axial_calibration(reference_models, hydro):
+    """We currently have no way to perform active axial calibration.
+
+    However, we can make the passive calibration slightly more accurate by transferring the active
+    calibration result from the lateral calibration over to it.
+
+    This test performs an integration test which tests whether carrying over the drag coefficient
+    from a lateral calibration to an axial one produces the correct results. To test this, we
+    deliberately mis-specify our viscosity in the models (since active calibration is more
+    robust against mis-specification of viscosity and bead radius).
+
+    Approaching the surface leads to an increase in the drag coefficient:
+
+        gamma(h) = gamma_bulk * correction_factor(h)
+
+    For lateral this factor is given by a different function than axial. The experimental drag
+    coefficient returned by the calibration procedure (gamma_ex) is the back-corrected bulk drag
+    coefficient gamma_bulk. This can be directly transferred to the axial direction which then
+    applies the correct forward correction factor for axial. This test verifies that this behaviour
+    stays preserved (as we rely on it)."""
+    np.random.seed(17256246)
+    viscosity = 0.0011
+    shared_pars = {"bead_diameter": 0.5, "temperature": 20}
+    sim_params = {
+        "sample_rate": 78125,
+        "duration": 10,
+        "stiffness": 0.05,
+        "pos_response_um_volt": 0.6,
+        "driving_sinusoid": (500, 31.9563),
+        "diode": (1.0, 10000),
+        **shared_pars,
+    }
+    # For reference, these parameters lead to a true bulk gamma of:
+    gamma_ref = 5.183627878423158e-09
+
+    # Distance to the surface
+    dist = 1.5 * shared_pars["bead_diameter"] / 2
+
+    def height_simulation(height_factor):
+        """We hack in height dependence using the viscosity. Since the calibration procedure covers
+        the same bead, we can do this (gamma_bulk is linearly proportional to the viscosity and
+        bead size).
+
+        height_factor : callable
+            Provides the height dependent drag model.
+        """
+        return generate_active_calibration_test_data(
+            **sim_params,
+            viscosity=viscosity
+            * height_factor(dist * 1e-6, shared_pars["bead_diameter"] * 1e-6 / 2),
+        )
+
+    volts_lateral, stage = height_simulation(faxen_factor)
+    lateral_model = ActiveCalibrationModel(
+        stage,
+        volts_lateral,
+        **shared_pars,
+        sample_rate=sim_params["sample_rate"],
+        viscosity=viscosity * 2,  # We mis-specify viscosity since we measure experimental drag
+        driving_frequency_guess=32,
+        hydrodynamically_correct=hydro,
+        distance_to_surface=dist,
+    )
+    ps_lateral = calculate_power_spectrum(volts_lateral, sample_rate=78125)
+    lateral_fit = fit_power_spectrum(ps_lateral, lateral_model)
+    np.testing.assert_allclose(lateral_fit["gamma_ex"].value, gamma_ref, rtol=5e-2)
+
+    # Axial calibration
+    axial_model = PassiveCalibrationModel(
+        **shared_pars,
+        viscosity=viscosity * 2,  # We deliberately mis-specify the viscosity to test the transfer
+        hydrodynamically_correct=False,
+        distance_to_surface=dist,
+        axial=True,
+    )
+
+    # Transfer the result to axial calibration
+    axial_model.drag_coeff = lateral_fit["gamma_ex"].value
+
+    volts_axial, stage = height_simulation(brenner_axial)
+    ps_axial = calculate_power_spectrum(volts_axial, sample_rate=78125)
+    axial_fit = fit_power_spectrum(ps_axial, axial_model)
+    np.testing.assert_allclose(axial_fit["gamma_0"].value, gamma_ref, rtol=5e-2)
+    np.testing.assert_allclose(axial_fit["kappa"].value, sim_params["stiffness"], rtol=5e-2)


### PR DESCRIPTION
**Why this PR?**
Both for distances very close to the surface as well as axial force, the hydrodynamic model is less than suitable.
In these cases it is recommended to just use a simple Lorentzian, but take the distance to the nearest surface into account through the drag coefficient.

The effective drag coefficient at a particular distance from the surface is given by:
`gamma(l) = gamma_bulk * height_factor(l)`

This PR adds this option.

**More info**
When the hydrodynamic flag is set to off, but a height is specified, it will apply a correct correction on the drag force.
Note that the correction is different for axial and lateral force! For this an extra flag was added to the calibration models named `axial`.

Note that in the future, we will rely on carrying over drag coefficients from lateral to axial calibrations. The way I set up the models in this PR, this is all handled by the calibration models themselves. When doing any sort of calibration, the model will always return "bulk" values. Then the models only responsibility is to forward correct (and they don't need to know where the bulk value came from). This decouples the from and target model.

Implicitly, it would amount to the same as calculating a local drag coefficient for lateral, uncorrecting it with Faxen's law and then correcting the result with Brenner's law. While we explicitly test the lateral -> axial behaviour in a test, we do not document this yet, since a good API for this procedure is still t.b.d.

I have also added a test to specifically test the transfer of drag coefficients from lateral to axial calibration.

**Recommended reading (if you are interested)**: 
Schäffer, E., Nørrelykke, S. F., & Howard, J. (2007). Surface forces and drag coefficients of microspheres near a plane surface measured with optical tweezers. Langmuir, 23(7), 3654-3665.
https://publications.mpi-cbg.de/Sch%C3%A4ffer_2007_894.pdf