### PR TITLE
Rename `CorrelatedStack.from_data()`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,10 @@
 * Make sure that `f_diode` stays below the Nyquist frequency during fitting.
 * Implemented a bias correction for the thermal calibration. Note that this typically leads to a small correction unless you use a very low number of points per block.
 
+#### Deprecations
+
+* `CorrelatedStack.from_data()` has been renamed to `CorrelatedStack.from_dataset()` for consistency with `BaseScan.from_dataset()`.
+
 ## v0.10.0 | 2021-08-20
 
 Important notice: This release contains an important fix that could lead to timestamp corruption when slicing kymographs. If you are still on version `0.8.2` or `0.9.0` we highly recommend updating or not using the kymograph slicing functionality (e.g. using the syntax `kymo["0s":"5s"]`). Please refer to the `Bug fixes` section for more information.

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -3,6 +3,7 @@ import os
 import json
 import tifffile
 import warnings
+from deprecated.sphinx import deprecated
 from .detail.widefield import TiffStack
 
 
@@ -49,14 +50,14 @@ class CorrelatedStack:
                 raise IndexError("Slice steps are not supported")
 
             start, stop, _ = item.indices(self.num_frames)
-            return CorrelatedStack.from_data(
+            return CorrelatedStack.from_dataset(
                 self.src, self.name, self.start_idx + start, self.start_idx + stop
             )
         else:
             item = self.start_idx + item if item >= 0 else self.stop_idx + item
             if item >= self.stop_idx or item < self.start_idx:
                 raise IndexError("Index out of bounds")
-            return CorrelatedStack.from_data(self.src, self.name, item, item + 1)
+            return CorrelatedStack.from_dataset(self.src, self.name, item, item + 1)
 
     def __iter__(self):
         idx = 0
@@ -65,7 +66,16 @@ class CorrelatedStack:
             idx += 1
 
     @classmethod
+    @deprecated(
+        reason=("Renamed to `from_dataset()` for consistency with `Kymo` and `Scan`."),
+        action="always",
+        version="0.10.1",
+    )
     def from_data(cls, data, name=None, start_idx=0, stop_idx=None):
+        return cls.from_dataset(data, name, start_idx, stop_idx)
+
+    @classmethod
+    def from_dataset(cls, data, name=None, start_idx=0, stop_idx=None):
         """Construct CorrelatedStack from image stack object
 
         Parameters


### PR DESCRIPTION
**Why this PR?**

Relevant `CorrelatedStack` methods should be named similarly to those for confocal image classes (and vice versa). To that end, this PR adds `CorrelatedStack.from_dataset()` for consistency with `BaseScan.from_dataset()` and deprecates the previous `CorrelatedStack.from_data()`

*Note: this is meant for internal usage, but by naming convention is already a public method, therefore requires deprecation*