### PR TITLE
Deprecate `CorrelatedStack.raw`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,9 +14,16 @@
 
 * Fixed issue in force calibration where the analytical fit would sometimes fail when the corner frequency is below the lower fitting bound. What would happen is that the analytical fit resulted in a negative term of which the square root was taken to obtain the corner frequency. Now this case is gracefully handled by setting the initial guess halfway between the lowest frequency in the power spectrum and zero.
 
+#### Deprecations
+
+* `CorrelatedStack.raw` has been deprecated and will be removed in a future release.
+
 #### Breaking changes
 
 * Changed default for `viscosity` in force calibration models. When omitted, `pylake` will use the viscosity of water calculated from the temperature. Note that this results in the default (when no viscosity or temperature is set) changing from `1.002e-3`  to `1.00157e-3`. See: [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html).
+* Units are now included in the headers for exported kymograph traces. The header now reads:</br>
+`# line index;time (pixels);coordinate (pixels);time (seconds);position ({unit});counts (summed over {n} pixels)`</br>
+where `{unit}` is either `um` or `kbp` depending on the calibration of the kymograph.
 
 ## v0.10.1 | 2021-10-27
 
@@ -45,12 +52,6 @@
 #### Deprecations
 
 * `CorrelatedStack.from_data()` has been renamed to `CorrelatedStack.from_dataset()` for consistency with `BaseScan.from_dataset()`.
-
-#### Breaking changes
-
-* Units are now included in the headers for exported kymograph traces. The header now reads:</br>
-`# line index;time (pixels);coordinate (pixels);time (seconds);position ({unit});counts (summed over {n} pixels)`</br>
-where `{unit}` is either `um` or `kbp` depending on the calibration of the kymograph.
 
 ## v0.10.0 | 2021-08-20
 

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -312,6 +312,14 @@ class CorrelatedStack:
         return self.stop_idx - self.start_idx
 
     @property
+    @deprecated(
+        reason=(
+            "Access to raw frame instances will be removed in a future release. "
+            "All operations on these objects should be handled through the `CorrelatedStack` public API."
+        ),
+        action="always",
+        version="0.10.1",
+    )
     def raw(self):
         """Raw frame data."""
         if self.num_frames > 1:

--- a/lumicks/pylake/tests/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_correlated_stack.py
@@ -105,11 +105,11 @@ def test_correlation(shape):
     with pytest.raises(AssertionError):
         cc["40ns":"70ns"].downsampled_over(stack[0:1].timestamps)
 
-    assert (stack[0].raw.start == 10)
-    assert (stack[1].raw.start == 20)
-    assert (stack[1:3][0].raw.start == 20)
-    assert (stack[1:3].raw[0].start == 20)
-    assert (stack[1:3].raw[1].start == 30)
+    assert (stack[0]._get_frame(0).start == 10)
+    assert (stack[1]._get_frame(0).start == 20)
+    assert (stack[1:3]._get_frame(0).start == 20)
+    assert (stack[1:3]._get_frame(0).start == 20)
+    assert (stack[1:3]._get_frame(1).start == 30)
 
     # Regression test downsampled_over losing precision due to reverting to double rather than int64.
     cc = channel.Slice(channel.Continuous(np.arange(10, 80, 2), 1588267266006287100, 1000))
@@ -154,6 +154,14 @@ def test_stack_roi():
     # out of bounds
     with pytest.raises(ValueError):
         stack_5 = stack_0.with_roi([0, 11, 1, 2])
+
+
+def test_deprecate_raw():
+    fake_tiff = TiffStack(MockTiffFile(data=[np.ones((5, 4, 3))], times=[["10", "18"]]), align_requested=False)
+    stack = CorrelatedStack.from_dataset(fake_tiff)
+
+    with pytest.deprecated_call():
+        stack.raw
 
 
 @cleanup


### PR DESCRIPTION
**Why this PR?**

`CorrelatedStack.raw` exposes a list of internal `widefield.TiffFrame` instances. Additionally, the output is dependent on the number of frames in the stack (returns a `list` if `num_frames > 1` or a single `TiffFrame` if `num_frames == 1`). 

 Likely the main use for this property is in constructing a `np.array` of the frame data, which will be implemented as a public method in an upcoming PR. Any other uses for the output of this property in the future should also be implemented as a public method/property directly on `CorrelatedStack` or (for internal use) can still be accessed by `[stack._get_frame(j) for j in range(stack.num_frames)]`.