### PR TITLE
force_calibration: handle corner case fc < lbnd in analytic fit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 * Added `Kymo.calibrate_to_kbp()` for calibrating the position axis of a kymograph from microns to kilobase-pairs. **Note: this calibration is applied to the full kymograph, so one should crop to the bead edges with `Kymo.crop_by_distance()` before calling this method.**
 
+#### Improvements
+
+* Fixed issue in force calibration where the analytical fit would sometimes fail when the corner frequency is below the lower fitting bound. What would happen is that the analytical fit resulted in a negative term of which the square root was taken to obtain the corner frequency. Now this case is gracefully handled by setting the initial guess halfway between the lowest frequency in the power spectrum and zero.
+
 ## v0.10.1 | 2021-10-27
 
 #### New features

--- a/lumicks/pylake/force_calibration/detail/power_models.py
+++ b/lumicks/pylake/force_calibration/detail/power_models.py
@@ -46,7 +46,15 @@ def fit_analytical_lorentzian(ps):
     )
 
     # Having a and b, calculating fc and D is trivial.
-    fc = math.sqrt(a / b)  # corner frequency [Hz]
+    if a > 0:
+        fc = math.sqrt(a / b)  # corner frequency [Hz]
+    else:
+        # When the corner frequency is very low and the power spectrum doesn't reach all the way,
+        # this can fail. As initial guess we then use the half the lowest nonzero frequency observed
+        # in the power spectrum (optimal when assuming uniform prior for our guess). Note that zero
+        # isn't a valid choice, since this leads to nan's and infinities down the road.
+        fc = 0.5 * (ps.frequency[0] if ps.frequency[0] > 0 else ps.frequency[1])
+
     D = (1 / b) * (math.pi ** 2)  # diffusion constant [V^2/s]
 
     # Fitted power spectrum values.

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -128,16 +128,6 @@ def test_bad_calibration_result_arg():
         psc.CalibrationResults(bad_arg=5)
 
 
-def test_bad_data():
-    num_samples = 30000
-    data = np.sin(.1*np.arange(num_samples))
-    model = PassiveCalibrationModel(1, temperature=20, viscosity=0.0001)
-    power_spectrum = psc.PowerSpectrum(data, num_samples)
-
-    with pytest.raises(ValueError):
-        psc.fit_power_spectrum(power_spectrum, model=model)
-
-
 def test_no_data_in_range():
     model = PassiveCalibrationModel(1, temperature=20, viscosity=0.0001)
 


### PR DESCRIPTION
**Why this PR?**
It was noticed that for very low corner frequencies the fit would sometimes fail with a `math domain error`.

What was happening is that in the procedure used to make an initial guess of the corner frequency and diffusion constant, one term (which is monotonically related to the estimate of the corner frequency) becomes negative. Since we take the square root of this term, it fails (since it would have to be complex). 

This is sad, because most of the time, the non-linear fit would've recovered and produced a mostly reasonable estimate. Now this case is gracefully handled by setting the initial guess halfway between the lowest frequency in the power spectrum and zero.

**Notes**
Note that this PR removes the test for `bad_data`. This is because before, we were essentially indirectly testing a case where the value going into the `sqrt` would become negative. I think it's better to remove this test for two reasons.
1. Testing whether the data is OK is not the responsibility of the analytic fit. We may want to consider adding something that tests the fit later, but this is out of scope for this PR.
2. The analytic fit as 'test" for data goodness is not a good idea. It's really just an initial guess mechanism.