### PR TITLE
force_calibration: document and release active calibration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 #### New features
 
+* Added support for active force calibration. For more information, please read: See [force calibration](https://lumicks-pylake.readthedocs.io/en/active_calibration_docs/tutorial/force_calibration.html#active-calibration).
 * Added `Kymo.calibrate_to_kbp()` for calibrating the position axis of a kymograph from microns to kilobase-pairs. **Note: this calibration is applied to the full kymograph, so one should crop to the bead edges with `Kymo.crop_by_distance()` before calling this method.**
 
 #### Improvements

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,6 +28,7 @@ Force calibration
     calculate_power_spectrum
     fit_power_spectrum
     PassiveCalibrationModel
+    ActiveCalibrationModel
     force_calibration.power_spectrum.PowerSpectrum
     force_calibration.power_spectrum_calibration.CalibrationResults
 

--- a/docs/tutorial/driving_input.png
+++ b/docs/tutorial/driving_input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90fcd8f7c11b7277a6647ee4ae125d70d63a53c25d1c68f640ae080072cfe05c
+size 25827

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -20,7 +20,7 @@ from .kymotracker.kymotracker import *
 from .nb_widgets.kymotracker_widgets import KymoWidgetGreedy
 from .fdensemble import FdEnsemble
 from .population.mixture import GaussianMixtureModel
-from .force_calibration.calibration_models import PassiveCalibrationModel
+from .force_calibration.calibration_models import PassiveCalibrationModel, ActiveCalibrationModel
 from .force_calibration.power_spectrum_calibration import (
     calculate_power_spectrum,
     fit_power_spectrum,


### PR DESCRIPTION
**Why this PR?**
This PR documents active calibration and makes it part of the public API.

Docs build here:
https://lumicks-pylake.readthedocs.io/en/active_calibration_docs/tutorial/force_calibration.html#active-calibration