### PR TITLE
Prevent conversion of `timestamps` to floating point during image reconstruction.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 #### Improvements
 
 * Fixed issue in force calibration where the analytical fit would sometimes fail when the corner frequency is below the lower fitting bound. What would happen is that the analytical fit resulted in a negative term of which the square root was taken to obtain the corner frequency. Now this case is gracefully handled by setting the initial guess halfway between the lowest frequency in the power spectrum and zero.
+* Fixed bug that would implicitly convert `Kymograph` and `Scan` `timestamps` to floating point values. Converting them to floating point values leads to a loss of precision. For more information see [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#channels) for more information.
 
 ## v0.10.1 | 2021-10-27
 

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -105,6 +105,14 @@ The channels have a few convenient methods, like `.plot()` which make it easy to
     plt.plot(f1x_timestamps, f1x_data)
 
 The `timestamps` attribute returns absolute values in nanoseconds.
+Note that `timestamps` cannot be converted to floating point without losing precision::
+
+    >>> t = f1x_timestamps[0]
+    >>> roundtrip_t = np.int64(np.float64(t))
+    >>> print(t - roundtrip_t)
+    24
+
+The reason for this is that timestamps exceed the maximum integer value representable by the mantissa.
 The relative time values in seconds can also be accessed directly::
 
     f1x_seconds = file.force1x.seconds

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -18,7 +18,7 @@ def _timestamp_mean(a, axis):
 
 def _default_image_factory(self: "ConfocalImage", color):
     channel_data = getattr(self, f"{color}_photon_count").data
-    raw_image = reconstruct_image_sum(channel_data, self.infowave.data, self._shape)
+    raw_image = reconstruct_image_sum(channel_data.astype(float), self.infowave.data, self._shape)
     return self._to_spatial(raw_image)
 
 

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -14,9 +14,14 @@ def _contiguous_timestamp_mean(a, axis):
     Note: This function should only be used for contiguous timestamps. It is used to avoid
     incurring an integer overflow when computing the mean of a series of timestamps."""
     second_derivative = np.diff(a, n=2, axis=axis)
+
+    # To test whether the timestamps for each pixel are contiguous we look at the second derivative
+    # along the averaged axis. We check all but the last pixel for this precondition. Unfortunately,
+    # this is necessary since Bluelake can end a scan mid-pixel.
     assert np.all(
-        second_derivative == 0
+        second_derivative[:-1] == 0
     ), "This function should only be used for contiguous timestamps"
+
     return (np.take(a, 0, axis=axis) + np.max(a, axis=axis)) // 2  # Lose at most half a nanosecond
 
 

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -161,7 +161,7 @@ def reshape_reconstructed_image(pixels, shape):
     shape : array_like
         The shape of the image ([optional: pixels on slow axis], pixels on fast axis)
     """
-    resized_pixels = np.zeros(round_up(pixels.size, np.prod(shape)))
+    resized_pixels = np.zeros(round_up(pixels.size, np.prod(shape)), dtype=pixels.dtype)
     resized_pixels[: pixels.size] = pixels
     return resized_pixels.reshape(-1, *shape)
 
@@ -217,7 +217,7 @@ def reconstruct_image(data, infowave, shape, reduce=np.sum):
     #   pixel_sizes = np.diff(np.flatnonzero(infowave == InfowaveCode.pixel_boundary))
     # But for now we assume that every pixel consists of the same number of samples
     pixel_size = np.argmax(subset) + 1
-    resized_data = np.zeros(round_up(subset.size, pixel_size))
+    resized_data = np.zeros(round_up(subset.size, pixel_size), dtype=data.dtype)
     resized_data[: subset.size] = data[valid_idx]
     pixels = reduce(resized_data.reshape(-1, pixel_size), axis=1)
     return reshape_reconstructed_image(pixels, shape)

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -380,11 +380,13 @@ class Kymo(ConfocalImage):
             )
 
         def timestamp_factory(_, reduce_timestamps):
-            return block_reduce(
-                self._timestamps("timestamps", reduce_timestamps),
-                (position_factor, 1),
-                func=reduce_timestamps,
-            )[: self.timestamps.shape[0] // position_factor, :]
+            def round_down(n, factor):
+                return (n // factor) * factor
+
+            ts = self._timestamps("timestamps", reduce_timestamps)
+            full_blocks = ts[: round_down(ts.shape[0], position_factor), :]
+            reshaped = full_blocks.reshape(-1, position_factor, ts.shape[1])
+            return reduce_timestamps(reshaped, axis=1)
 
         def line_time_factory(_):
             return self.line_time_seconds * time_factor

--- a/lumicks/pylake/tests/data/mock_confocal.py
+++ b/lumicks/pylake/tests/data/mock_confocal.py
@@ -146,8 +146,8 @@ def generate_kymo(name, image, pixel_size_nm, start=4, dt=7, samples_per_pixel=5
         image,
         pixel_sizes_nm=[pixel_size_nm],
         axes=[0],
-        start=start,
-        dt=dt,
+        start=np.int64(start),
+        dt=np.int64(dt),
         samples_per_pixel=samples_per_pixel,
         line_padding=line_padding,
     )

--- a/lumicks/pylake/tests/test_utilities.py
+++ b/lumicks/pylake/tests/test_utilities.py
@@ -93,7 +93,12 @@ def test_violated_assumption__contiguous_timestamp_mean():
     ds = _contiguous_timestamp_mean(a, axis=1)
     np.testing.assert_equal(ds, [3, 8])
 
-    a = np.array([[1, 2, 3, 4, 5], [4, 7, 8, 10, 12]], dtype=np.int64)  # Variable rate
+    # Test whether ending with a partial pixel doesn't raise
+    a = np.array([[1, 2, 3, 4, 5, 6], [4, 6, 8, 10, 12, 0]], dtype=np.int64)
+    ds = _contiguous_timestamp_mean(a, axis=1)
+    np.testing.assert_equal(ds, [3, 8])
+
+    a = np.array([[1, 2, 3, 4, 5], [4, 7, 8, 10, 12], [2, 3, 4, 5, 6]], dtype=np.int64)  # Variable
     with pytest.raises(
         AssertionError, match="This function should only be used for contiguous timestamps"
     ):
@@ -103,7 +108,7 @@ def test_violated_assumption__contiguous_timestamp_mean():
     _contiguous_timestamp_mean(a, axis=0)
     np.testing.assert_equal(ds, [3, 8])
 
-    a = np.array([[1, 2, 3, 4, 5], [4, 7, 8, 10, 12]], dtype=np.int64).T  # Variable rate
+    a = np.array([[1, 2, 3, 4, 5], [4, 7, 8, 10, 12], [2, 3, 4, 5, 6]], dtype=np.int64).T
     with pytest.raises(
         AssertionError, match="This function should only be used for contiguous timestamps"
     ):


### PR DESCRIPTION
**Why this PR?**
Currently, `reconstruct_image` converts `Scan` and `Kymo` timestamps to a floating point representation. This is undesirable.

After the fix, `reconstruct_image` will provide as output the same type as the input.

To prevent changing two things at once, we enforce the type on image reconstruction to remain `float` (since certain downstream algorithms have issues with fixed precision types).

Note that I have hardened the tests for tests involving `timestamps` as well by providing a more realistic offset. I made these two separate commits, so I would recommend going commit by commit.