### PR TITLE
Get `CorrelatedStack` data as `np.ndarray`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * Added support for using near-surface corrections for lateral and axial calibration, please read: See [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html#faxen-s-law).
 * Added `Kymo.calibrate_to_kbp()` for calibrating the position axis of a kymograph from microns to kilobase-pairs. **Note: this calibration is applied to the full kymograph, so one should crop to the bead edges with `Kymo.crop_by_distance()` before calling this method.**
 * Added function to compute viscosity of water at specific temperature. See: [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html).
+* Added `CorrelatedStack.get_image()` to get the image stack data as an `np.ndarray`.
 
 #### Improvements
 

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -24,6 +24,14 @@ from Bluelake if available. This functionality can be turned off with the option
 
     stack2 = lk.CorrelatedStack("example2.tiff", align=False)
 
+You can obtain the image stack data as a `numpy` array using the `get_image()` method::
+
+    red_data = stack.get_image(channel="red") # shape = [n_frames, y_pixels, x_pixels]
+    rgb_data = stack.get_image(channel="rgb") # shape = [n_frames, y_pixels, x_pixels, 3 channels]
+
+If the `channel` argument is not provided, the default behavior is `"rgb"` for 3-color images. For single-color
+images, this argument is ignored as there is only one channel available.
+
 Quite often, it is interesting to correlate events on the camera's to `channel` data.
 To quickly explore the correlation between images in a `CorrelatedStack` and channel data
 you can use the following function::

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -115,6 +115,23 @@ class CorrelatedStack:
         data = self.src.with_roi(np.array([x_min, x_max, y_min, y_max]))
         return self.from_dataset(data, self.name, self.start_idx, self.stop_idx)
 
+    def get_image(self, channel="rgb"):
+        """Get image data for the full stack as an `np.ndarray`.
+
+        Parameters
+        ----------
+        channel : {'red', 'green', 'blue', 'rgb'}
+            The color channel of the requested data.
+            For single-color data, this argument is ignored.
+        """
+        if self.src._description.is_rgb:
+            channel_indices = {"red": 0, "green": 1, "blue": 2, "rgb": slice(None)}
+            slc = (slice(None), slice(None), channel_indices[channel])
+        else:
+            slc = (slice(None),)
+
+        return np.stack([frame.data[slc] for frame in self], axis=0).squeeze()
+
     def plot(self, frame=0, channel="rgb", show_title=True, **kwargs):
         """Plot image from image stack
 
@@ -315,7 +332,8 @@ class CorrelatedStack:
     @deprecated(
         reason=(
             "Access to raw frame instances will be removed in a future release. "
-            "All operations on these objects should be handled through the `CorrelatedStack` public API."
+            "All operations on these objects should be handled through the `CorrelatedStack` public API. "
+            "For example, to retrieve the image data as an `np.ndarray` please use `CorrelatedStack.get_image()`."
         ),
         action="always",
         version="0.10.1",

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -199,11 +199,11 @@ class ImageDescription:
             self.json = json.loads(first_page.description)
         except json.decoder.JSONDecodeError:
             self.json = {}
+            self._cmap = {}
 
         # if metadata is missing, set default values
         if len(self.json) == 0:
             self._alignment = Alignment(align_requested, AlignmentStatus.empty, False)
-            self._cmap = {}
             return
 
         # update format if necessary


### PR DESCRIPTION
**Why this PR?**
Sometimes you just want the pure data to work on. This adds a convenience method so that users don't have to fiddle around with the internal source data classes.

[docs are here](https://lumicks-pylake.readthedocs.io/en/wit_get_data/tutorial/correlatedstacks.html)