### PR TITLE
Bugfix: WIT color-aligned data is returned but not requested

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,10 @@
 
 * Fixed issue in force calibration where the analytical fit would sometimes fail when the corner frequency is below the lower fitting bound. What would happen is that the analytical fit resulted in a negative term of which the square root was taken to obtain the corner frequency. Now this case is gracefully handled by setting the initial guess halfway between the lowest frequency in the power spectrum and zero.
 
+#### Bug fixes
+
+* Fixed bug where color-aligned data was returned from `TiffFrame.data` although alignment was not requested (e.g., `CorrelatedStack("filename.tiff", align=False)`). This bug was introduced in `v0.10.1`.
+
 #### Deprecations
 
 * `CorrelatedStack.raw` has been deprecated and will be removed in a future release.

--- a/lumicks/pylake/tests/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_correlated_stack.py
@@ -341,6 +341,16 @@ def test_image_reconstruction_rgb(rgb_alignment_image_data, rgb_alignment_image_
     np.testing.assert_allclose(original_data, fr._get_plot_data(), atol=0.05)
 
 
+def test_no_alignment_requested(rgb_alignment_image_data):
+    reference_image, warped_image, description, bit_depth = rgb_alignment_image_data
+    fake_tiff = TiffStack(MockTiffFile(data=[warped_image], times=[["10", "18"]],
+                                       description=json.dumps(description), bit_depth=16),
+                          align_requested=False)
+    stack = CorrelatedStack.from_dataset(fake_tiff)
+    fr = stack._get_frame(0)
+    np.testing.assert_allclose(fr.data, warped_image)
+
+
 def test_image_reconstruction_rgb_multiframe(rgb_alignment_image_data):
     reference_image, warped_image, description, bit_depth = rgb_alignment_image_data
     fake_tiff = TiffStack(MockTiffFile(data=[warped_image]*6,


### PR DESCRIPTION
**Why this PR?**
While prepping figures to add to the `CorrelatedStack` docs, I noticed a bug in which alignment was not requested (`CorrelatedStack(filename, align=False)`) yet the aligned data was still returned. This PR fixes the bug and adds a regression test