### PR TITLE
Prevent conversion of timestamps to floating point during image reconstruction.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 #### Improvements
 
 * Fixed issue in force calibration where the analytical fit would sometimes fail when the corner frequency is below the lower fitting bound. What would happen is that the analytical fit resulted in a negative term of which the square root was taken to obtain the corner frequency. Now this case is gracefully handled by setting the initial guess halfway between the lowest frequency in the power spectrum and zero.
+* Fixed bug that would implicitly convert `Kymograph` and `Scan` `timestamps` to floating point values. Converting them to floating point values leads to a loss of precision. For more information see [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#channels) for more information.
 
 #### Bug fixes
 

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -104,7 +104,15 @@ The channels have a few convenient methods, like `.plot()` which make it easy to
     f1x_timestamps = file.force1x.timestamps
     plt.plot(f1x_timestamps, f1x_data)
 
-The `timestamps` attribute returns absolute values in nanoseconds.
+The `timestamps` attribute returns the measurement time in nanoseconds since epoch (January 1st 1970, midnight UTC/GMT).
+Note that since these values are typically very large, they cannot be converted to floating point without losing precision::
+
+    >>> t = f1x_timestamps[0]
+    >>> roundtrip_t = np.int64(np.float64(t))
+    >>> print(t - roundtrip_t)
+    24
+
+The reason for this is that timestamps exceed the maximum integer value representable by the mantissa.
 The relative time values in seconds can also be accessed directly::
 
     f1x_seconds = file.force1x.seconds

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -37,7 +37,7 @@ def timestamp_mean(a, axis=None):
 
 def _default_image_factory(self: "ConfocalImage", color):
     channel_data = getattr(self, f"{color}_photon_count").data
-    raw_image = reconstruct_image_sum(channel_data, self.infowave.data, self._shape)
+    raw_image = reconstruct_image_sum(channel_data.astype(float), self.infowave.data, self._shape)
     return self._to_spatial(raw_image)
 
 

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -151,6 +151,11 @@ def round_up(size, n):
     return int(math.ceil(size / n)) * n
 
 
+def round_down(size, n):
+    """Round down `size` to the nearest multiple of `n`"""
+    return (size // n) * n
+
+
 def reshape_reconstructed_image(pixels, shape):
     """Reshape reconstructed image data from 1D array into appropriate shape for plotting
 
@@ -161,7 +166,7 @@ def reshape_reconstructed_image(pixels, shape):
     shape : array_like
         The shape of the image ([optional: pixels on slow axis], pixels on fast axis)
     """
-    resized_pixels = np.zeros(round_up(pixels.size, np.prod(shape)))
+    resized_pixels = np.zeros(round_up(pixels.size, np.prod(shape)), dtype=pixels.dtype)
     resized_pixels[: pixels.size] = pixels
     return resized_pixels.reshape(-1, *shape)
 
@@ -217,8 +222,7 @@ def reconstruct_image(data, infowave, shape, reduce=np.sum):
     #   pixel_sizes = np.diff(np.flatnonzero(infowave == InfowaveCode.pixel_boundary))
     # But for now we assume that every pixel consists of the same number of samples
     pixel_size = np.argmax(subset) + 1
-    resized_data = np.zeros(round_up(subset.size, pixel_size))
-    resized_data[: subset.size] = data[valid_idx]
+    resized_data = data[valid_idx][: round_down(subset.size, pixel_size)]
     pixels = reduce(resized_data.reshape(-1, pixel_size), axis=1)
     return reshape_reconstructed_image(pixels, shape)
 

--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -69,3 +69,27 @@ def downsample(data, factor, reduce):
 
     data = data[: round_down(data.size, factor)]
     return reduce(data.reshape(-1, factor), axis=1)
+
+
+def will_mul_overflow(a, b):
+    """Will `a * b` overflow?
+
+    We know that `a * b > int_max` iff `a > int_max // b`. The expression `a * b > int_max` can
+    overflow but the `a > int_max // b` cannot. Hence the latter can be used for testing whether
+    the former will overflow without actually incurring an overflow. The result is an array if
+    the inputs are arrays.
+    """
+    int_max = np.iinfo(np.result_type(a, b)).max
+    return np.logical_and(b > 0, a > int_max // b)
+
+
+def could_sum_overflow(a, axis=None):
+    """Could the sum of `a` overflow?
+
+    For safety, this estimate is conservative. A `True` result indicates that the result could
+    overflow, but it may not. This is because it assumes that the largest number in the array
+    could appear at every index.
+
+    A `False` result is definitive. The sum will definitely not overflow.
+    """
+    return np.any(will_mul_overflow(np.max(a, axis), a.size if axis is None else a.shape[axis]))

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -9,6 +9,7 @@ from .detail.image import (
     line_timestamps_image,
     seek_timestamp_next_line,
     histogram_rows,
+    round_down,
 )
 from .detail.timeindex import to_timestamp
 
@@ -380,11 +381,10 @@ class Kymo(ConfocalImage):
             )
 
         def timestamp_factory(_, reduce_timestamps):
-            return block_reduce(
-                self._timestamps("timestamps", reduce_timestamps),
-                (position_factor, 1),
-                func=reduce_timestamps,
-            )[: self.timestamps.shape[0] // position_factor, :]
+            ts = self._timestamps("timestamps", reduce_timestamps)
+            full_blocks = ts[: round_down(ts.shape[0], position_factor), :]
+            reshaped = full_blocks.reshape(-1, position_factor, ts.shape[1])
+            return reduce_timestamps(reshaped, axis=1)
 
         def line_time_factory(_):
             return self.line_time_seconds * time_factor

--- a/lumicks/pylake/tests/data/mock_confocal.py
+++ b/lumicks/pylake/tests/data/mock_confocal.py
@@ -146,8 +146,8 @@ def generate_kymo(name, image, pixel_size_nm, start=4, dt=7, samples_per_pixel=5
         image,
         pixel_sizes_nm=[pixel_size_nm],
         axes=[0],
-        start=start,
-        dt=dt,
+        start=np.int64(start),
+        dt=np.int64(dt),
         samples_per_pixel=samples_per_pixel,
         line_padding=line_padding,
     )

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -175,3 +175,21 @@ def test_histogram_rows():
         np.testing.assert_allclose(e, [0.0, 0.5])
         assert np.all(np.equal(h, [435, 195]))
         np.testing.assert_allclose(w, [0.5, 0.1])
+
+
+def test_partial_pixel_image_reconstruction():
+    """This function tests whether a partial pixel at the end is fully dropped. This is important,
+    since in the timestamp reconstruction, we subtract the minimum value prior to averaging (to
+    allow taking averages of larger chunks). Without this functionality, the lowest timestamp to be
+    reconstructed can be smaller than the first timestamp. This means that the value subtracted
+    from the timestamps prior to summing is smaller. This means that the timestamps more quickly
+    get into the range where they are at risk of overflow (and therefore have to be summed in
+    smaller blocks). This in turn can lead to unnecessarily long reconstruction times."""
+    def size_test(x, axis):
+        assert len(x) == 4, "The last pixel should have been dropped since it was partial"
+        return np.array([1, 1, 1, 1])
+
+    iw = np.tile([1, 1, 1, 1, 2], (5,))
+    iw[-1] = 0
+    ts = np.arange(iw.size)
+    reconstruct_image(ts, iw, (5, 1), reduce=size_test)

--- a/lumicks/pylake/tests/test_kymo.py
+++ b/lumicks/pylake/tests/test_kymo.py
@@ -367,7 +367,7 @@ def test_downsampled_kymo_position():
 
     assert kymo_ds.name == "Mock"
     np.testing.assert_allclose(kymo_ds.red_image, ds)
-    np.testing.assert_allclose(kymo_ds.timestamps, ds_ts)
+    np.testing.assert_allclose(kymo_ds.timestamps, ds_ts.astype(np.int64))
     np.testing.assert_allclose(kymo_ds.start, 100)
     np.testing.assert_allclose(kymo_ds.pixelsize_um, 2 / 1000)
     np.testing.assert_allclose(kymo_ds.line_time_seconds, kymo.line_time_seconds)
@@ -506,6 +506,7 @@ def test_kymo_crop():
                                                     [0.0, 12.0, 12.0, 12.0,  0.0,  6.0,  0.0]])
     np.testing.assert_allclose(cropped.timestamps, [[170, 315, 460, 605, 750, 895, 1040],
                                                     [195, 340, 485, 630, 775, 920, 1065]])
+    assert cropped.timestamps.dtype == np.int64
     np.testing.assert_allclose(cropped.pixelsize_um, kymo.pixelsize_um)
     np.testing.assert_allclose(cropped.line_time_seconds, kymo.line_time_seconds)
     np.testing.assert_allclose(cropped.pixels_per_line, 2)
@@ -730,6 +731,64 @@ def test_slice_timestamps():
     np.testing.assert_allclose(sliced.timestamps, ref_ts[:, :6])
 
 
+def test_roundoff_errors_kymo():
+    """Test slicing with realistically sized timestamps (this tests against floating point errors
+    induced in kymograph reconstruction)"""
+    image = np.array(
+        [
+            [0, 12, 0, 12, 0, 6, 0],
+            [0, 0, 0, 0, 0, 6, 0],
+            [12, 0, 0, 0, 12, 6, 0],
+            [12, 0, 0, 0, 12, 6, 0],
+        ],
+        dtype=np.uint8
+    )
+
+    test_parameters = {
+        "start": 1623965975045144000,
+        "dt": int(1e9),
+        "samples_per_pixel": 10,
+        "line_padding": 2,
+    }
+
+    kymo = generate_kymo(
+        "Mock",
+        image,
+        pixel_size_nm=4,
+        **test_parameters,
+    )
+
+    pixel_time = test_parameters["dt"] * test_parameters["samples_per_pixel"]
+    padding_time = test_parameters["dt"] * test_parameters["line_padding"]
+
+    first_pixel_start = test_parameters["start"] + padding_time
+    pixel_area_time = image.shape[0] * pixel_time
+    line_time = pixel_area_time + 2 * padding_time
+    # Note that the - dt comes from the mean over the pixel being not inclusive of the end.
+    first_pixel_center = (2 * first_pixel_start + pixel_time - test_parameters["dt"]) // 2
+    timestamp_line = first_pixel_center + np.arange(image.shape[0], dtype=np.int64) * pixel_time
+
+    ref_timestamps = np.tile(timestamp_line, (image.shape[1], 1)).T
+    ref_timestamps += np.arange(image.shape[1], dtype=np.int64) * line_time
+
+    np.testing.assert_equal(kymo.timestamps, ref_timestamps)
+
+
+def test_regression_unequal_timestamp_spacing():
+    """This particular set of initial timestamp and sampler per pixel led to unequal timestamp
+    spacing in an actual dataset."""
+    kymo = generate_kymo(
+        "Mock",
+        np.array([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]]),
+        pixel_size_nm=100,
+        start=1536582124217030400,
+        dt=int(1e9 / 78125),
+        samples_per_pixel=47,
+        line_padding=0
+    )
+    assert len(np.unique(np.diff(kymo.timestamps))) == 1
+
+
 def test_calibrate_to_kbp():
 
     image = np.array(
@@ -807,3 +866,27 @@ def test_calibrate_to_kbp():
     # but will change total length
     np.testing.assert_allclose(kymo_bp._calibration.from_um(kymo_bp.size_um[0] * 5/6),
                                cropped_kymo_bp._calibration.from_um(cropped_kymo_bp.size_um[0]))
+
+
+def test_partial_pixel_kymo():
+    """This function tests whether a partial pixel at the end is fully dropped. This is important,
+    since in the timestamp reconstruction, we subtract the minimum value from a row prior to
+    averaging (to allow taking averages of larger chunks). Without this functionality, the lowest
+    pixel to be reconstructed can be smaller than the first timestamp, which means the subtraction
+    of the minimum is rendered less effective (leading to unnecessarily long reconstruction
+    times)."""
+    kymo = generate_kymo(
+        "Mock",
+        np.ones((5, 5)),
+        pixel_size_nm=100,
+        start=1536582124217030400,
+        dt=int(1e9 / 78125),
+        samples_per_pixel=47,
+        line_padding=0
+    )
+
+    kymo.infowave.data[-60:] = 0  # Remove the last pixel entirely, and a partial pixel before that
+    np.testing.assert_equal(kymo.timestamps[-1, -1], 0)
+    np.testing.assert_equal(kymo.timestamps[-2, -1], 0)
+    np.testing.assert_equal(kymo.red_image[-1, -1], 0)
+    np.testing.assert_equal(kymo.red_image[-2, -1], 0)

--- a/lumicks/pylake/tests/test_utilities.py
+++ b/lumicks/pylake/tests/test_utilities.py
@@ -1,12 +1,15 @@
 from lumicks.pylake.detail.utilities import *
+from lumicks.pylake.detail.confocal import timestamp_mean
+from lumicks.pylake.detail.utilities import will_mul_overflow, could_sum_overflow
+from numpy.testing import assert_array_equal
 import pytest
 import matplotlib as mpl
 import numpy as np
 
 
 def test_first():
-    assert(first((1, 2, 3), condition=lambda x: x % 2 == 0) == 2)
-    assert(first(range(3, 100)) == 3)
+    assert first((1, 2, 3), condition=lambda x: x % 2 == 0) == 2
+    assert first(range(3, 100)) == 3
 
     with pytest.raises(StopIteration):
         first((1, 2, 3), condition=lambda x: x % 5 == 0)
@@ -15,13 +18,13 @@ def test_first():
 
 
 def test_unique():
-    uiq = unique(['str', 'str', 'hmm', 'potato', 'hmm', 'str'])
-    assert(uiq == ['str', 'hmm', 'potato'])
+    uiq = unique(["str", "str", "hmm", "potato", "hmm", "str"])
+    assert uiq == ["str", "hmm", "potato"]
 
 
 def test_colors():
     [mpl.colors.to_rgb(get_color(k)) for k in range(30)]
-    np.testing.assert_allclose(lighten_color([0.5, 0, 0], .2), [.7, 0, 0])
+    np.testing.assert_allclose(lighten_color([0.5, 0, 0], 0.2), [0.7, 0, 0])
 
 
 def test_find_contiguous():
@@ -36,7 +39,7 @@ def test_find_contiguous():
     assert np.all(np.equal(ranges, [[1, 10]]))
     assert np.all(np.equal(lengths, [9]))
     check_blocks_are_true(mask, ranges)
-    
+
     mask = data < 10
     ranges, lengths = find_contiguous(mask)
     assert np.all(np.equal(ranges, [[0, 11]]))
@@ -51,8 +54,7 @@ def test_find_contiguous():
 
     mask = data < 4
     ranges, lengths = find_contiguous(mask)
-    assert np.all(np.equal(ranges, [[0, 4],
-                                    [7, 11]]))
+    assert np.all(np.equal(ranges, [[0, 4], [7, 11]]))
     assert np.all(np.equal(lengths, [4, 4]))
     check_blocks_are_true(mask, ranges)
 
@@ -83,3 +85,70 @@ def test_find_contiguous():
 def test_downsample(data, factor, avg, std):
     np.testing.assert_allclose(avg, downsample(data, factor, reduce=np.mean))
     np.testing.assert_allclose(std, downsample(data, factor, reduce=np.std))
+
+
+def test_will_mul_overflow():
+    assert not will_mul_overflow(2, np.int64(2 ** 62 - 1))
+    assert will_mul_overflow(2, np.int64(2 ** 62))
+    assert will_mul_overflow(2, np.int64(2 ** 63 - 1))
+
+    assert not will_mul_overflow(np.array(2), np.array(2 ** 62 - 1, dtype=np.int64))
+    assert will_mul_overflow(np.array(2), np.array(2 ** 62, dtype=np.int64))
+    assert will_mul_overflow(np.array(2), np.array(2 ** 63 - 1, dtype=np.int64))
+
+
+def test_could_sum_overflow():
+    assert not could_sum_overflow(np.array([1, 2 ** 62 - 1]))
+    assert could_sum_overflow(np.array([1, 2 ** 62]))
+    assert could_sum_overflow(np.array([1, 2 ** 63 - 1]))
+
+    assert not could_sum_overflow(np.array([1, 1, 2 ** 61]))
+    assert could_sum_overflow(np.array([1, 1, 2 ** 62]))
+    assert could_sum_overflow(np.array([1, 1, 2 ** 63 - 1]))
+
+    assert not could_sum_overflow(np.array([[1, 1], [1, 1]]), axis=0)
+    assert not could_sum_overflow(np.array([[1, 1], [1, 1]]), axis=1)
+    assert not could_sum_overflow(np.array([[1, 2 ** 62 - 1], [1, 2 ** 62 - 1]]), axis=0)
+    assert not could_sum_overflow(np.array([[1, 2 ** 62 - 1], [1, 2 ** 62 - 1]]), axis=1)
+    assert could_sum_overflow(np.array([[1, 2 ** 62], [1, 2 ** 62]]), axis=0)
+    assert could_sum_overflow(np.array([[1, 2 ** 62], [1, 2 ** 62]]), axis=1)
+
+
+def assert_1d(a):
+    assert timestamp_mean(np.array(a)) == sum(a) // len(a)
+
+
+def test_timestamp_mean():
+    n = 2 ** 62
+    assert_1d([2, 4])
+    assert_1d([n - 1, n - 3])
+    assert_1d([0, 0, n - 1, n - 1])
+    assert_1d([0, n - 1, 0, 0, 0, 0])
+    assert_1d([n, n])
+
+    assert_array_equal(timestamp_mean(np.array([[2, 4], [2, 4]]), axis=0), [2, 4])
+    assert_array_equal(timestamp_mean(np.array([[2, 4], [2, 4]]), axis=1), [3, 3])
+    assert_array_equal(timestamp_mean(np.array([[n - 1, n - 3]] * 2), axis=0), [n - 1, n - 3])
+    assert_array_equal(timestamp_mean(np.array([[n - 1, n - 3]] * 2), axis=1), [n - 2, n - 2])
+
+    assert_array_equal(
+        timestamp_mean(np.array([[n - 1, n - 3, n - 5]] * 2), axis=0), [n - 1, n - 3, n - 5]
+    )
+    assert_array_equal(
+        timestamp_mean(np.array([[n - 1, n - 3, n - 5, n - 7]] * 2), axis=1), [n - 4, n - 4]
+    )
+
+
+def test_timestamp_mean_2d():
+    """Test 2D behaviour of timestamp_mean."""
+    n = 2 ** 62 // 4
+    t_range = np.arange(0, n * 8, n, dtype=np.int64)
+    ts = np.tile(t_range, (6, 1))
+
+    # Note that small round-off errors still occur since we average blocks. Note that these errors
+    # are far smaller than with FP, and will only occur for cases that are otherwise extremely rare.
+    np.testing.assert_equal(timestamp_mean(ts, 0) - t_range, [0, -4, -2, 0, -4, -2, 0, -4])
+    np.testing.assert_equal(timestamp_mean(ts.T, 1) - t_range, [0, -4, -2, 0, -4, -2, 0, -4])
+
+    np.testing.assert_equal(timestamp_mean(ts, 1), np.tile(n * 7 // 2, (6,)))
+    np.testing.assert_equal(timestamp_mean(ts.T, 0), np.tile(n * 7 // 2, (6,)))


### PR DESCRIPTION
**Why this PR?**
Currently, `reconstruct_image` converts `Scan` and `Kymo` `timestamps` to a floating point representation. This is undesirable. In addition, any incomplete pixel will now be dropped from reconstruction.

After the fix, `reconstruct_image` will provide as output the same type as the input.

To prevent changing two things at once, we enforce the type on image reconstruction to remain float (since certain downstream algorithms have issues with fixed precision types).

Note that I have hardened the tests for tests involving timestamps as well by providing a more realistic offset. I made these two separate commits, so I would recommend going commit by commit.

Note: Because I force pushed to the branch, I couldn't reopen the old PR :(