### PR TITLE
Wit docs

### DIFF
--- a/docs/tutorial/correlatedstack_aligned.png
+++ b/docs/tutorial/correlatedstack_aligned.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e74a97255a8df98e05a7b14dfe8e5bf1eae6af93347510c1d953fba6aa996ff
+size 183974

--- a/docs/tutorial/correlatedstack_cropped.png
+++ b/docs/tutorial/correlatedstack_cropped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9709b3004d98b632a14f7166cdc5c67077ebbfe6c075b7f7c25fd4da519f96
+size 113053

--- a/docs/tutorial/correlatedstack_raw.png
+++ b/docs/tutorial/correlatedstack_raw.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56409ce52dbd87919ead1901327b67f8384d42d8929a57de0e7b9e6197cb116c
+size 197189

--- a/docs/tutorial/correlatedstack_red.png
+++ b/docs/tutorial/correlatedstack_red.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d93b58138bb69f60f56bf2a6f12b1cd20327afc2c07971f69615701f9e0e89b
+size 90873

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -8,21 +8,40 @@ Correlated stacks
 Bluelake has the ability to export videos from the camera's.
 These videos can be opened and sliced using `CorrelatedStack`::
 
-    stack = lk.CorrelatedStack("example.tiff")  # Loading a stack.
+    stack = lk.CorrelatedStack("cas9_wf.tiff")  # Loading a stack.
     stack_slice = stack[2:10]  # Grab frame 2 to 9
+
+You can quickly plot an individual frame using the `plot()` method::
+
+    stack.plot(frame=0, channel="rgb")
+
+.. image:: correlatedstack_aligned.png
 
 You can also spatially crop to select a smaller region of interest::
 
-    stack_roi = stack.crop_by_pixels(10, 50, 20, 80)  # pixel coordinates as x_max, x_min, y_max, y_min
+    stack_roi = stack.crop_by_pixels(60, 460, 100, 200)  # pixel coordinates as x_max, x_min, y_max, y_min
+    stack_roi.plot()  # note: the default channel is "rgb"
+
+.. image:: correlatedstack_cropped.png
 
 This can be useful, for instance, after applying color alignment to RGB images as the edges
 can become corrupted due to interpolation artifacts.
+
+You can also plot only a single color channel. Note that here we pass some additional formatting arguments, which are
+forwarded to `plt.imshow()`::
+
+    stack_roi.plot(channel="red", cmap="magma", vmin=250, vmax=450)
+
+.. image:: correlatedstack_red.png
 
 Full color RGB images are automatically reconstructed using the alignment matrices
 from Bluelake if available. This functionality can be turned off with the optional
 `align` keyword::
 
-    stack2 = lk.CorrelatedStack("example2.tiff", align=False)
+    stack2 = lk.CorrelatedStack("cas9_wf.tiff", align=False)
+    stack2.plot()
+
+.. image:: correlatedstack_raw.png
 
 You can obtain the image stack data as a `numpy` array using the `get_image()` method::
 
@@ -32,23 +51,31 @@ You can obtain the image stack data as a `numpy` array using the `get_image()` m
 If the `channel` argument is not provided, the default behavior is `"rgb"` for 3-color images. For single-color
 images, this argument is ignored as there is only one channel available.
 
+
+Finally, the aligned image stack can also be exported to TIFF format::
+
+    stack.export_tiff("aligned_stack.tiff")
+    stack[5:20].export_tiff("aligned_short_stack.tiff") # export a slice of the CorrelatedStack
+
+Correlating force with the image stack
+--------------------------------------
+
 Quite often, it is interesting to correlate events on the camera's to `channel` data.
 To quickly explore the correlation between images in a `CorrelatedStack` and channel data
 you can use the following function::
 
     # Making a plot where force is correlated to images in the stack.
+    stack = lk.CorrelatedStack("example.tiff)
     stack.plot_correlated(file.force1x)
 
 .. image:: correlatedstack.png
 
-In some cases, additional processing may be needed, and we desire to have the data
+If the plot is interactive (for example, when `%matplotlib notebook` is used in a Jupyter notebook), you can click
+on the left graph to select a particular force. The corresponding video frame will then automatically appear on the right.
+
+In some cases, additional processing may be needed, and we wish to have the data
 downsampled over the video frames. This can be done using the function `Slice.downsampled_over`
 using timestamps obtained from the `CorrelatedStack`::
 
     # Determine the force trace averaged over frame 2...9.
     file.force1x.downsampled_over(stack[2:10].timestamps)
-
-The aligned image stack can also be exported to tiff format::
-
-    stack.export_tiff("aligned_stack.tiff")
-    stack[5:20].export_tiff("aligned_short_stack.tiff") # export a slice of the CorrelatedStack


### PR DESCRIPTION
**Why this PR?**
It's been bothering me for a while that the tutorial page for `CorrelatedStack` looks pretty barren. Since we got some nice datasets for Cas9 during the WIT acceleration project, here I add some pretty pictures to the docs. [Check them out!](https://lumicks-pylake.readthedocs.io/en/wit_docs/tutorial/correlatedstacks.html)