### PR TITLE
calibration: use viscosity of water as default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,10 +8,15 @@
 * Added support for axial calibration. See See [axial calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html#axial-calibration).
 * Added support for using near-surface corrections for lateral and axial calibration, please read: See [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html#faxen-s-law).
 * Added `Kymo.calibrate_to_kbp()` for calibrating the position axis of a kymograph from microns to kilobase-pairs. **Note: this calibration is applied to the full kymograph, so one should crop to the bead edges with `Kymo.crop_by_distance()` before calling this method.**
+* Added function to compute viscosity of water at specific temperature. See: [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html).
 
 #### Improvements
 
 * Fixed issue in force calibration where the analytical fit would sometimes fail when the corner frequency is below the lower fitting bound. What would happen is that the analytical fit resulted in a negative term of which the square root was taken to obtain the corner frequency. Now this case is gracefully handled by setting the initial guess halfway between the lowest frequency in the power spectrum and zero.
+
+#### Breaking changes
+
+* Changed default for `viscosity` in force calibration models. When omitted, `pylake` will use the viscosity of water calculated from the temperature. Note that this results in the default (when no viscosity or temperature is set) changing from `1.002e-3`  to `1.00157e-3`. See: [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html).
 
 ## v0.10.1 | 2021-10-27
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,6 +31,7 @@ Force calibration
     ActiveCalibrationModel
     force_calibration.power_spectrum.PowerSpectrum
     force_calibration.power_spectrum_calibration.CalibrationResults
+    viscosity_of_water
 
 
 FD Fitting

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,3 +1,15 @@
+@article{huber2009new,
+  title={New international formulation for the viscosity of H 2 O},
+  author={Huber, Marcia L and Perkins, Richard A and Laesecke, Arno and Friend, Daniel G and Sengers, Jan V and Assael, Marc J and Metaxa, Ifigenia N and Vogel, Eckhard and Mare{\v{s}}, R and Miyagawa, Kiyoshi},
+  journal={Journal of Physical and Chemical Reference Data},
+  volume={38},
+  number={2},
+  pages={101--125},
+  year={2009},
+  publisher={American Institute of Physics for the National Institute of Standards and~…}
+}
+
+
 @article{kaur2019dwell,
 title = {Analysis of spliceosome dynamics by maximum likelihood fitting of dwell time distributions},
 author = {Kaur, Harpreet and Jamalidinan, Fatemehsadat and Condon, Samson G. F. and Senes, Alessandro and Hoskins, Aaron A.},

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -99,6 +99,8 @@ You can optionally also provide a viscosity (in Pa/s) and temperature (in degree
     bead_diameter = f.force1x.calibration[1]["Bead diameter (um)"]
     force_model = lk.PassiveCalibrationModel(bead_diameter, viscosity=0.001002, temperature=20)
 
+To find the viscosity of water at a particular temperature, you can use :func:`~lumicks.pylake.viscosity_of_water` :cite:`huber2009new`.
+When omitted, this function will automatically be used to look up the viscosity of water for that particular temperature.
 To fit this model to the data, you can now invoke::
 
     calibration = lk.fit_power_spectrum(power_spectrum, force_model)

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -20,7 +20,11 @@ from .kymotracker.kymotracker import *
 from .nb_widgets.kymotracker_widgets import KymoWidgetGreedy
 from .fdensemble import FdEnsemble
 from .population.mixture import GaussianMixtureModel
-from .force_calibration.calibration_models import PassiveCalibrationModel, ActiveCalibrationModel
+from .force_calibration.calibration_models import (
+    PassiveCalibrationModel,
+    ActiveCalibrationModel,
+    viscosity_of_water,
+)
 from .force_calibration.power_spectrum_calibration import (
     calculate_power_spectrum,
     fit_power_spectrum,


### PR DESCRIPTION
**Why this PR?**
Viscosity is a sensitive calibration parameter. Typically, users do experiments in water.

When no viscosity is specified, we will now use the viscosity of water at that particular temperature as the default.

I decided to go with the simplified model from [1]. The advantage of this model is that it covers a wider range (the Peterman model [2] mentions it should only be used >= 20 C). [3] is the reference Stijn used in his code (but not in his report, where he used [2]).

[[1] Huber, M. L., Perkins, R. A., Laesecke, A., Friend, D. G., Sengers, J. V.,Assael, M. J., & Miyagawa, K. (2009). New international formulation for the viscosity of H2O. Journal of Physical and Chemical Reference Data, 38(2), 101-125.](http://ikee.lib.auth.gr/record/218228/files/Assael3.pdf)
[[2] Peterman, E. J., Gittes, F., & Schmidt, C. F. (2003). Laser-induced heating in optical traps. Biophysical journal, 84(2), 1308-1316.](https://www.sciencedirect.com/science/article/pii/S0006349503749467/pdfft?md5=b928f2468df54a1e79a4bddcc01784f9&pid=1-s2.0-S0006349503749467-main.pdf)
[3] http://ddbonline.ddbst.de/VogelCalculation/VogelCalculationCGI.exe?component=Water&tunit=K&punit=mPa*s&TemperaturesEdit=&calculate=Calculate

See below for the three other models:
![image](https://user-images.githubusercontent.com/19836026/140949629-c6f8197b-d455-4b24-8265-87086e2d840f.png)
