### PR TITLE
force calibration: small private API for carrying over drag coefficient

### DIFF
--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -41,13 +41,14 @@ def viscosity_of_water(temperature):
     array_like
         Viscosity of water [Pa*s]
     """
+    temperature = np.asarray(temperature)
     if not np.all(np.logical_and(temperature >= -20, temperature < 110)):
         raise ValueError("Function for viscosity of water is only valid for -20°C <= T < 110°C")
 
     temp_tilde = np.tile((temperature + 273.15) / 300, (4, 1)).T
     ai = np.array([280.68, 511.45, 61.131, 0.45903])
     bi = np.array([-1.9, -7.7, -19.6, -40.0])
-    return np.sum(ai * temp_tilde ** bi, axis=1) * 1e-6
+    return np.sum(ai * temp_tilde ** bi, axis=1).squeeze() * 1e-6
 
 
 @dataclass

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -539,6 +539,7 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
         self.driving_frequency_guess = driving_frequency_guess
         self.sample_rate = sample_rate
         self.num_windows = num_windows
+        self._measured_drag_fieldname = "gamma_ex"
 
         # Estimate driving input and response
         amplitude_um, self.driving_frequency = estimate_driving_input_parameters(
@@ -642,7 +643,7 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
             self._drag_fieldname: CalibrationParameter(
                 self._drag_description, self.drag_coeff, "kg/s"
             ),
-            "gamma_ex": CalibrationParameter(
+            self._measured_drag_fieldname: CalibrationParameter(
                 "Measured bulk drag coefficient",
                 measured_drag_coeff / self._drag_correction_factor,
                 "kg/s",

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -230,6 +230,8 @@ class PassiveCalibrationModel:
         self.bead_diameter = bead_diameter
         self.drag_coeff = sphere_friction_coefficient(self.viscosity, self.bead_diameter * 1e-6)
         self._filter = NoFilter() if fast_sensor else DiodeModel()
+        self._drag_fieldname = "gamma_0"
+        self._drag_description = "Theoretical bulk drag coefficient"
 
         self.axial = axial
         self.hydrodynamically_correct = hydrodynamically_correct
@@ -291,6 +293,17 @@ class PassiveCalibrationModel:
         to 1).
         """
         return self.drag_coeff * self._drag_correction_factor
+
+    def _set_drag(
+        self,
+        drag,
+        new_name="gamma_ex_lateral",
+        new_description="Bulk drag coefficient from lateral calibration",
+    ):
+        """Set the bulk drag parameter used for this calibration."""
+        self.drag_coeff = drag
+        self._drag_fieldname = new_name
+        self._drag_description = new_description
 
     def calibration_parameters(self):
         hydrodynamic_parameters = (
@@ -381,8 +394,8 @@ class PassiveCalibrationModel:
             "Rd": CalibrationParameter("Distance response", distance_response, "um/V"),
             "kappa": CalibrationParameter("Trap stiffness", kappa, "pN/nm"),
             "Rf": CalibrationParameter("Force response", force_response, "pN/V"),
-            "gamma_0": CalibrationParameter(
-                "Theoretical drag coefficient", self.drag_coeff, "kg/s"
+            self._drag_fieldname: CalibrationParameter(
+                self._drag_description, self.drag_coeff, "kg/s"
             ),
             **self._format_passive_result(
                 fc,
@@ -626,8 +639,8 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
             "Rd": CalibrationParameter("Distance response", distance_response * 1e6, "um/V"),
             "kappa": CalibrationParameter("Trap stiffness", kappa * 1e3, "pN/nm"),
             "Rf": CalibrationParameter("Force response", force_response * 1e12, "pN/V"),
-            "gamma_0": CalibrationParameter(
-                "Theoretical bulk drag coefficient", self.drag_coeff, "kg/s"
+            self._drag_fieldname: CalibrationParameter(
+                self._drag_description, self.drag_coeff, "kg/s"
             ),
             "gamma_ex": CalibrationParameter(
                 "Measured bulk drag coefficient",

--- a/lumicks/pylake/force_calibration/tests/test_active_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_active_calibration.py
@@ -198,4 +198,6 @@ def test_faxen_correction_active():
     np.testing.assert_allclose(fit.results["gamma_0"].value, 1.0678273429551705e-08)
     # The drag is now much different, since we're not using Faxen's law to back-correct the drag
     # to its actual bulk value.
-    np.testing.assert_allclose(fit.results["gamma_ex"].value, 1.571688034506783e-08)
+    np.testing.assert_allclose(
+        fit.results[model._measured_drag_fieldname].value, 1.571688034506783e-08
+    )

--- a/lumicks/pylake/force_calibration/tests/test_axial.py
+++ b/lumicks/pylake/force_calibration/tests/test_axial.py
@@ -92,10 +92,14 @@ def test_axial_calibration(reference_models, hydro):
     )
 
     # Transfer the result to axial calibration
-    axial_model.drag_coeff = lateral_fit["gamma_ex"].value
+    axial_model._set_drag(lateral_fit["gamma_ex"].value)
 
     volts_axial, stage = height_simulation(brenner_axial)
     ps_axial = calculate_power_spectrum(volts_axial, sample_rate=78125)
     axial_fit = fit_power_spectrum(ps_axial, axial_model)
-    np.testing.assert_allclose(axial_fit["gamma_0"].value, gamma_ref, rtol=5e-2)
+    np.testing.assert_allclose(axial_fit["gamma_ex_lateral"].value, gamma_ref, rtol=5e-2)
     np.testing.assert_allclose(axial_fit["kappa"].value, sim_params["stiffness"], rtol=5e-2)
+    assert (
+        axial_fit["gamma_ex_lateral"].description
+        == "Bulk drag coefficient from lateral calibration"
+    )

--- a/lumicks/pylake/force_calibration/tests/test_axial.py
+++ b/lumicks/pylake/force_calibration/tests/test_axial.py
@@ -80,7 +80,9 @@ def test_axial_calibration(reference_models, hydro):
     )
     ps_lateral = calculate_power_spectrum(volts_lateral, sample_rate=78125)
     lateral_fit = fit_power_spectrum(ps_lateral, lateral_model)
-    np.testing.assert_allclose(lateral_fit["gamma_ex"].value, gamma_ref, rtol=5e-2)
+    np.testing.assert_allclose(
+        lateral_fit[lateral_model._measured_drag_fieldname].value, gamma_ref, rtol=5e-2
+    )
 
     # Axial calibration
     axial_model = PassiveCalibrationModel(
@@ -92,7 +94,7 @@ def test_axial_calibration(reference_models, hydro):
     )
 
     # Transfer the result to axial calibration
-    axial_model._set_drag(lateral_fit["gamma_ex"].value)
+    axial_model._set_drag(lateral_fit[lateral_model._measured_drag_fieldname].value)
 
     volts_axial, stage = height_simulation(brenner_axial)
     ps_axial = calculate_power_spectrum(volts_axial, sample_rate=78125)

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -323,18 +323,22 @@ def test_viscosity_calculation_invalid_range(temperatures):
 def test_viscosity_calculation():
     temperatures = np.arange(20, 100, 10)
 
-    np.testing.assert_allclose(
-        viscosity_of_water(temperatures),
-        np.array(
-            [
-                0.0010015672646030015,
-                0.0007972062022678064,
-                0.0006527334742093661,
-                0.0005465265005450516,
-                0.00046603929414699226,
-                0.000403545426497709,
-                0.000354046106187348,
-                0.0003141732579601075,
-            ]
-        ),
+    ref = np.array(
+        [
+            0.0010015672646030015,
+            0.0007972062022678064,
+            0.0006527334742093661,
+            0.0005465265005450516,
+            0.00046603929414699226,
+            0.000403545426497709,
+            0.000354046106187348,
+            0.0003141732579601075,
+        ]
     )
+
+    np.testing.assert_allclose(viscosity_of_water(temperatures), ref)
+    np.testing.assert_allclose(viscosity_of_water(list(temperatures)), ref)
+    assert viscosity_of_water(temperatures).shape == ref.shape
+
+    np.testing.assert_allclose(viscosity_of_water(20), 0.0010015672646030015)
+    assert viscosity_of_water(20).shape == ()

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -243,7 +243,7 @@ def test_repr(reference_calibration_result):
         Rd                   Distance response (um/V)                                  7.25366
         kappa                Trap stiffness (pN/nm)                                    0.171495
         Rf                   Force response (pN/V)                                     1243.97
-        gamma_0              Theoretical drag coefficient (kg/s)                       4.1552e-08
+        gamma_0              Theoretical bulk drag coefficient (kg/s)                  4.1552e-08
         fc                   Corner frequency (Hz)                                     656.872
         D                    Diffusion constant (V^2/s)                                0.00185126
         err_fc               Corner frequency Std Err (Hz)                             32.2284


### PR DESCRIPTION
**Why this PR?**
- Add a small private API for using drag from lateral experiment, and make sure the field name changes so it can be seen in the results.
- The name of the field where the experimental drag can be found is stored as an attribute so we don't have to hardcode the fieldname in both Pylake and Bluelake.
- Fixes a bug in `viscosity_of_water`. This function should return a 0D array for a 0D input.