### PR TITLE
Update to newer version of `black`

### DIFF
--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -28,5 +28,5 @@ jobs:
         python pylake_test.py
     - name: Black
       run: |
-        pip install black==20.8b1
+        pip install black==21.10b0
         black --check --diff --color .

--- a/docs/_ext/nbexport.py
+++ b/docs/_ext/nbexport.py
@@ -204,7 +204,7 @@ class NBTranslator(nodes.NodeVisitor):
 
 
 def export_notebooks(app, document, docname):
-    """"Export the recently resolved document to a Jupyter notebook"""
+    """Export the recently resolved document to a Jupyter notebook"""
     if not hasattr(app.env, "nbfiles"):
         return
     if docname not in app.env.nbfiles:

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -193,7 +193,7 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
 
     @property
     def center_point_um(self):
-        """Returns a dictionary of the x/y/z center coordinates of the scan (w.r.t. brightfield field of view) """
+        """Returns a dictionary of the x/y/z center coordinates of the scan (w.r.t. brightfield field of view)"""
         return self._json["scan volume"]["center point (um)"]
 
 
@@ -210,7 +210,7 @@ class ConfocalImage(BaseScan):
         return np.argsort([x["axis"] for x in self._json["scan volume"]["scan axes"]])
 
     def _to_spatial(self, data):
-        """Implements any necessary post-processing actions after image reconstruction from infowave """
+        """Implements any necessary post-processing actions after image reconstruction from infowave"""
         raise NotImplementedError
 
     @cachetools.cachedmethod(lambda self: self._cache)


### PR DESCRIPTION
**Why this PR?**
The version of black we use used `typed-ast`. Typed-ast currently has an open issue on 3.9.8 which is causing black to break; see here: https://github.com/python/typed_ast/issues/169

The latest version of black doesn't rely on the library with the issue anymore and just works. Note that the latest version of black made a few touchups to some docstrings. I have committed these in a separate commit as `black`.

Note that after this gets merged, you will have to update your local install of `black` to `21.10b0`.