### PR TITLE
kymotracker: allow changing slider ranges in the Kymotracker widget

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * Added `Kymo.calibrate_to_kbp()` for calibrating the position axis of a kymograph from microns to kilobase-pairs. **Note: this calibration is applied to the full kymograph, so one should crop to the bead edges with `Kymo.crop_by_distance()` before calling this method.**
 * Added function to compute viscosity of water at specific temperature. See: [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html).
 * Added `CorrelatedStack.get_image()` to get the image stack data as an `np.ndarray`.
+* Allow setting custom slider ranges for the algorithm parameters in the kymotracker widget. See: [kymotracker widget](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#using-the-kymotracker-widget).
 
 #### Improvements
 

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -179,6 +179,12 @@ You can optionally also pass algorithm parameters when opening the widget::
 
     KymoWidgetGreedy(kymo, "green", axis_aspect_ratio=2, min_length=4, pixel_threshold=3, window=6, sigma=0.14)
 
+You can also change the range of each of the algorithm parameter sliders.
+To do this, simply pass a dictionary where the key indicates the algorithm parameter and the value contains its desired range in the form `(minimum bound, maximum bound)`.
+For example::
+
+    KymoWidgetGreedy(kymo, "green", axis_aspect_ratio=2, slider_ranges={"window": (0, 8)})
+
 Traced lines are accessible through the `.lines` property::
 
     >>> lines = kymowidget.lines

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -20,6 +20,7 @@ class KymoWidget:
         output_filename,
         algorithm,
         algorithm_parameters,
+        min_length_range,
         **kwargs,
     ):
         """Create a widget for performing kymotracking.
@@ -43,6 +44,8 @@ class KymoWidget:
             Kymotracking algorithm used
         algorithm_parameters : dict
             Parameters for the kymotracking algorithm.
+        minimum_length_range : tuple of int
+            Range of the minimum length parameter. Should be of the form (lower bound, upper bound).
         **kwargs
             Extra arguments forwarded to imshow.
         """
@@ -61,6 +64,7 @@ class KymoWidget:
         self.lines = KymoLineGroup([])
         self.plotted_lines = []
         self.min_length = min_length
+        self._min_length_range = min_length_range
         self._kymo = kymo
         self._channel = channel
         self._label = None
@@ -323,8 +327,8 @@ class KymoWidget:
                 description="Min length",
                 value=self.min_length,
                 disabled=False,
-                min=1,
-                max=10,
+                min=self._min_length_range[0],
+                max=self._min_length_range[1],
                 tooltip="Minimum number of frames a spot has to be detected in to be considered",
             ),
         )
@@ -503,7 +507,8 @@ class KymoWidgetGreedy(KymoWidget):
         slider_ranges : dict of list, optional
             Dictionary with custom ranges for selected parameter sliders. Ranges should be in the
             following format: (lower bound, upper bound).
-            Valid options are: "window", "pixel_threshold", "line_width", "sigma" and "vel".
+            Valid options are: "window", "pixel_threshold", "line_width", "sigma", "min_length" and
+            "vel".
         """
         algorithm = track_greedy
         calibrated_kymo_channel = CalibratedKymographChannel.from_kymo(kymo, channel)
@@ -530,6 +535,7 @@ class KymoWidgetGreedy(KymoWidget):
             "line_width": (0.0, 15.0 * position_scale),
             "sigma": (1.0 * position_scale, 5.0 * position_scale),
             "vel": (-5.0 * vel_calibration, 5.0 * vel_calibration),
+            "min_length": (1, 10),
         }
         for key, slider_range in slider_ranges.items():
             if key not in self._slider_ranges:
@@ -560,6 +566,7 @@ class KymoWidgetGreedy(KymoWidget):
             output_filename,
             algorithm,
             algorithm_parameters,
+            min_length_range=self._slider_ranges["min_length"],
             **kwargs,
         )
 

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -225,3 +225,8 @@ def test_valid_override(kymograph):
         kymograph, "red", 1, use_widgets=False, slider_ranges={"pixel_threshold": (5, 10)}
     )
     assert kw._slider_ranges["pixel_threshold"] == (5, 10)
+
+    kw = KymoWidgetGreedy(
+        kymograph, "red", 1, use_widgets=False, slider_ranges={"min_length": (5, 10)}
+    )
+    assert kw._min_length_range == (5, 10)


### PR DESCRIPTION
**Why this PR?**
It's been requested to allow changing the ranges of the sliders in the kymotracker widget.

The modification in this PR allows you to override the slider ranges when opening the widget.

![rangetest](https://user-images.githubusercontent.com/19836026/141799977-0d823352-de04-4695-ac63-33f63a02fb02.gif)

Docs build here: https://lumicks-pylake.readthedocs.io/en/kymo_slider_ranges/tutorial/kymotracking.html#using-the-kymotracker-widget