### PR TITLE
calibration: add contains operator to `CalibrationResults`

### DIFF
--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -76,6 +76,9 @@ class CalibrationResults:
             if key not in results:
                 raise RuntimeError(f"Calibration did not provide calibration parameter {key}")
 
+    def __contains__(self, key):
+        return key in self.params or key in self.results
+
     def __getitem__(self, item):
         return self.params[item] if item in self.params else self.results[item]
 

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -226,6 +226,22 @@ def test_attributes_ps_calibration(reference_calibration_result):
                                results={"test2": 5})
 
 
+def test_calibration_results_params():
+    result = psc.CalibrationResults(
+        model=None,
+        ps_model=None,
+        ps_data=None,
+        params={"test": psc.CalibrationParameter("par", "val", 5)},
+        results={
+            "Rf": psc.CalibrationParameter("Rf", "val", 5),
+            "kappa": psc.CalibrationParameter("kappa", "val", 5),
+        },
+    )
+    assert "test" in result
+    assert "Rf" in result
+    assert "nope" not in result
+
+
 def test_repr(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
     assert str(ps_calibration) == dedent("""\


### PR DESCRIPTION
**Why this PR?**
Just a small dunder method because it's driving me crazy that I can't just do:
```python
"gamma_ex" in result
```
To quickly check whether it's there.