### PR TITLE
calibration: store driving peak parameters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 
 * Fixed issue in force calibration where the analytical fit would sometimes fail when the corner frequency is below the lower fitting bound. What would happen is that the analytical fit resulted in a negative term of which the square root was taken to obtain the corner frequency. Now this case is gracefully handled by setting the initial guess halfway between the lowest frequency in the power spectrum and zero.
 * Fixed bug that would implicitly convert `Kymograph` and `Scan` `timestamps` to floating point values. Converting them to floating point values leads to a loss of precision. For more information see [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#channels) for more information.
+* Fixed issue that led to `DeprecationWarning` in the kymotracker widget.
 
 #### Bug fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * Added function to compute viscosity of water at specific temperature. See: [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html).
 * Added `CorrelatedStack.get_image()` to get the image stack data as an `np.ndarray`.
 * Allow setting custom slider ranges for the algorithm parameters in the kymotracker widget. See: [kymotracker widget](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#using-the-kymotracker-widget).
+* Added parameters describing the inferred driving peak (`driving_amplitude`, `driving_frequency`, `driving_power`) when performing active force calibration to `CalibrationResults`.
 
 #### Improvements
 

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -649,6 +649,22 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
                 measured_drag_coeff / self._drag_correction_factor,
                 "kg/s",
             ),
+            "driving_amplitude": CalibrationParameter(
+                "Driving amplitude",
+                self.driving_amplitude * 1e6,
+                "um",
+            ),
+            "driving_frequency": CalibrationParameter(
+                "Driving frequency",
+                self.driving_frequency,
+                "Hz",
+            ),
+            "driving_power": CalibrationParameter(
+                "Experimentally determined power in the spike observed on the positional power "
+                "spectrum",
+                power_exp,
+                "V^2",
+            ),
             **self._format_passive_result(
                 fc,
                 diffusion_constant_volts,

--- a/lumicks/pylake/force_calibration/tests/test_active_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_active_calibration.py
@@ -11,17 +11,15 @@ from .data.simulate_calibration_data import generate_active_calibration_test_dat
 
 
 @pytest.mark.parametrize(
-    "sample_rate, bead_diameter, stiffness, viscosity, temperature, pos_response_um_volt, "
-    "driving_sinusoid, diode, driving_frequency_guess, power_density",
+    "stiffness, viscosity, temperature, pos_response_um_volt, driving_sinusoid, diode, driving_"
+    "frequency_guess, power_density, response_power",
     [
-        [78125, 1.03, 0.1, 1.002e-3, 20, 0.618, (500, 31.95633), (0.4, 15000), 32, 1.958068e-5],
-        [78125, 1.03, 0.2, 1.012e-3, 20, 1.618, (500, 31.95633), (0.4, 14000), 32, 7.28664e-07],
-        [78125, 1.03, 0.3, 1.002e-3, 50, 1.618, (300, 30.42633), (0.4, 16000), 29, 1.098337e-07],
+        [0.1, 1.002e-3, 20, 0.618, (500, 31.95633), (0.4, 15000), 32, 1.958068e-5, 0.000124879648],
+        [0.2, 1.012e-3, 20, 1.618, (500, 31.95633), (0.4, 14000), 32, 7.28664e-07, 4.64730000e-06],
+        [0.3, 1.002e-3, 50, 1.618, (300, 30.42633), (0.4, 16000), 29, 1.098337e-07, 6.63921666e-07],
     ],
 )
 def test_integration_active_calibration(
-    sample_rate,
-    bead_diameter,
     stiffness,
     viscosity,
     temperature,
@@ -30,9 +28,10 @@ def test_integration_active_calibration(
     diode,
     driving_frequency_guess,
     power_density,
+    response_power,
 ):
     """Functional end to end test for active calibration"""
-
+    sample_rate, bead_diameter = 78125, 1.03
     np.random.seed(0)
     force_voltage_data, driving_data = generate_active_calibration_test_data(
         duration=20,
@@ -90,6 +89,10 @@ def test_integration_active_calibration(
     np.testing.assert_allclose(fit["Sample rate"].value, sample_rate)
     np.testing.assert_allclose(fit["Viscosity"].value, viscosity)
     np.testing.assert_allclose(fit["num_windows"].value, 5)
+
+    np.testing.assert_allclose(fit["driving_amplitude"].value, driving_sinusoid[0] * 1e-3, rtol=1e-5)
+    np.testing.assert_allclose(fit["driving_frequency"].value, driving_sinusoid[1], rtol=1e-5)
+    np.testing.assert_allclose(fit["driving_power"].value, response_power, rtol=1e-6)
 
 
 def test_bias_correction():

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -430,7 +430,6 @@ class KymoWidget:
         self._area_selector = RectangleSelector(
             self._axes,
             self.track_kymo,
-            drawtype="box",
             useblit=True,
             button=[3],
             minspanx=5,


### PR DESCRIPTION
**Why?**
It's nice to have a way to access all the output from the calibration procedure in one and the same data structure. Up to now, you had to keep both the `CalibrationModel` and `FitResult` around, since you needed results from both.

Note: I piggybacked a tiny fix on this for a matplotlib `DeprecationWarning` that showed up in the tests.