### PR TITLE
Add function to define the coordinates of the tether between beads

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## v0.11.1 | t.b.d.
 
+#### New features
+Added `CorrelatedStack.define_tether()` which can be used to define the endpoints of the tether between two beads and return image data rotated such that the tether is horizontal. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html) for more information.
+
 #### Bug fixes
 
 * Fixed issue which resulted in the offset parameter added by `Model.subtract_independent_offset()` not having a unit associated with it.

--- a/docs/tutorial/correlatedstack_aligned.png
+++ b/docs/tutorial/correlatedstack_aligned.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e74a97255a8df98e05a7b14dfe8e5bf1eae6af93347510c1d953fba6aa996ff
-size 183974
+oid sha256:97bec2c5d6e6dae5662ced5eea2d89d67aa0a9e1ce86eb0f85baeaaec44677da
+size 129663

--- a/docs/tutorial/correlatedstack_cropped.png
+++ b/docs/tutorial/correlatedstack_cropped.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c9709b3004d98b632a14f7166cdc5c67077ebbfe6c075b7f7c25fd4da519f96
-size 113053
+oid sha256:552c8372c746da16c3ce359a41ec9a62391120d7fec8c568fd6d8a10db6055df
+size 115294

--- a/docs/tutorial/correlatedstack_raw.png
+++ b/docs/tutorial/correlatedstack_raw.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56409ce52dbd87919ead1901327b67f8384d42d8929a57de0e7b9e6197cb116c
-size 197189
+oid sha256:14c8fac5f414007aec2eaf4e71be4a523162b2f86d8c18f8191d195388cab57c
+size 135729

--- a/docs/tutorial/correlatedstack_red.png
+++ b/docs/tutorial/correlatedstack_red.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d93b58138bb69f60f56bf2a6f12b1cd20327afc2c07971f69615701f9e0e89b
-size 90873
+oid sha256:7c58ffda53ead22ace13697d5c049252b18a31152ac1de6f5654393156d38b59
+size 114096

--- a/docs/tutorial/correlatedstack_tether.png
+++ b/docs/tutorial/correlatedstack_tether.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de12571bb0da765f229044e80f674dced3d0e7b3c4826a45afeb208c2154b2cc
+size 129674

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -17,9 +17,22 @@ You can quickly plot an individual frame using the `plot()` method::
 
 .. image:: correlatedstack_aligned.png
 
+To define the location of the tether between beads, supply the `(x, y)` pixel coordinates of the end points
+to the `define_tether()` method::
+
+    stack = stack.define_tether((126, 193), (341, 200))
+    stack.plot()
+    stack.plot_tether(lw=0.7)
+
+.. image:: correlatedstack_tether.png
+
+Note, after defining a tether location the image is rotated such that the tether is horizontal in the field of view.
+You can also plot the overlay of the tether location using `plot_tether(**kwargs)`, which also accepts keyword
+arguments that are passed to `plt.plot()`.
+
 You can also spatially crop to select a smaller region of interest::
 
-    stack_roi = stack.crop_by_pixels(60, 460, 100, 200)  # pixel coordinates as x_max, x_min, y_max, y_min
+    stack_roi = stack.crop_by_pixels(45, 420, 150, 245)  # pixel coordinates as x_min, x_max, y_min, y_max
     stack_roi.plot()  # note: the default channel is "rgb"
 
 .. image:: correlatedstack_cropped.png
@@ -30,7 +43,7 @@ can become corrupted due to interpolation artifacts.
 You can also plot only a single color channel. Note that here we pass some additional formatting arguments, which are
 forwarded to `plt.imshow()`::
 
-    stack_roi.plot(channel="red", cmap="magma", vmin=250, vmax=450)
+    stack_roi.plot(channel="red", cmap="magma", vmin=550, vmax=800)
 
 .. image:: correlatedstack_red.png
 

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -115,6 +115,20 @@ class CorrelatedStack:
         data = self.src.with_roi(np.array([x_min, x_max, y_min, y_max]))
         return self.from_dataset(data, self.name, self.start_idx, self.stop_idx)
 
+    def define_tether(self, point1, point2):
+        """Returns a copy of the stack rotated such that the tether defined by `point_1` and
+        `point_2` is horizontal.
+
+        Parameters
+        ----------
+        point_1 : (float, float)
+            (x, y) coordinates of the tether start point
+        point_2 : (float, float)
+            (x, y) coordinates of the tether end point
+        """
+        data = self.src.with_tether((point1, point2))
+        return self.from_dataset(data, self.name, self.start_idx, self.stop_idx)
+
     def get_image(self, channel="rgb"):
         """Get image data for the full stack as an `np.ndarray`.
 
@@ -161,6 +175,23 @@ class CorrelatedStack:
             else:
                 # display with 1-based index for frames and total frames
                 plt.title(f"{self.name} [frame {frame+1}/{self.num_frames}]")
+
+    def plot_tether(self, **kwargs):
+        """Plot a line at the tether position.
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to :fun:`matplotlib.pyplot.plot`.
+        """
+        import matplotlib.pyplot as plt
+
+        if not self.src._tether:
+            raise ValueError("A tether is not defined yet for this image stack.")
+
+        x, y = np.vstack(self.src._tether.ends).T
+        tether_kwargs = {"c": "w", "marker": "o", "mfc": "none", "ls": ":", **kwargs}
+        plt.plot(x, y, **tether_kwargs)
 
     def _get_frame(self, frame=0):
         if frame >= self.num_frames or frame < 0:

--- a/lumicks/pylake/detail/tests/test_widefield.py
+++ b/lumicks/pylake/detail/tests/test_widefield.py
@@ -132,3 +132,30 @@ def test_transform_multiplication_identity():
     np.testing.assert_equal(mat_a.matrix, (mat_b * mat_a).matrix)
     np.testing.assert_equal(mat_a.matrix, (mat_c * mat_a).matrix)
     np.testing.assert_equal(mat_a.matrix, (mat_d * mat_a).matrix)
+
+
+def test_tether():
+    origin = (0, 0)
+    point_1 = np.array((1.46446609, 1.46446609))
+    point_2 = np.array((8.53553391, 8.53553391))
+
+    # empty tether
+    tether = widefield.Tether((0, 0), None)
+    assert tether._ends is None
+    np.testing.assert_allclose(tether.rot_matrix.matrix, widefield.TransformMatrix().matrix)
+    with pytest.raises(TypeError, match="did not return an iterable$"):
+        tether.ends
+
+    # test coordinates of tether after rotation
+    tether = widefield.Tether(origin, (point_1, point_2))
+    np.testing.assert_allclose(tether.ends[0], (0, 5), atol=1e-8)
+    np.testing.assert_allclose(tether.ends[1], (10, 5))
+
+    # test offsets
+    tether = widefield.Tether((1, 2), (point_1 - (1, 2), point_2 - (1, 2)))
+    np.testing.assert_allclose(tether.ends, [(-1, 3), (9, 3)])
+
+    # test re-define offsets
+    tether = widefield.Tether((0, 0), (point_1, point_2))
+    tether = tether.with_new_offsets((1, 2))
+    np.testing.assert_allclose(tether.ends, [(-1, 3), (9, 3)])

--- a/lumicks/pylake/detail/tests/test_widefield.py
+++ b/lumicks/pylake/detail/tests/test_widefield.py
@@ -85,6 +85,16 @@ def test_rotate_image():
     assert np.max(np.abs(rotation_wrong_origin.warp_image(original_image), target_image)) > 0.02
 
 
+@pytest.mark.parametrize("x, y", [(0, 0), (1, 1), (-3, 4), (2, -6)])
+def test_transform_translation(x, y):
+    points = ((1, 2), (3, 4), (6, 5), (-5, -5))
+    translation = widefield.TransformMatrix.translation(x, y)
+
+    expected_points = np.vstack(points) + (x, y)
+    new_points = translation.warp_coordinates(points)
+    np.testing.assert_allclose(np.vstack(new_points), expected_points)
+
+
 @pytest.mark.parametrize(
     "theta1, theta2, center",
     [(5, 10, (8, 6)), (-5, 10, (8, 6)), (0, 0, (0, 0)), (0, 10, (6, 8)), (5, 0, (6, 8))],

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -358,6 +358,21 @@ class TransformMatrix:
         """
         return cls(cv2.getRotationMatrix2D(center, theta, scale=1.0))
 
+    @classmethod
+    def translation(cls, x, y):
+        """Construct matrix for translation by `x` and `y`.
+
+        Parameters
+        ----------
+        x: float
+            translation in x direction
+        y: float
+            translation in y direction
+        """
+        matrix = np.eye(3)
+        matrix[:2, -1] = (x, y)
+        return cls(matrix[:2])
+
     def warp_image(self, data):
         """Apply affine transformation to image data.
 


### PR DESCRIPTION
**Why this PR?**
This adds functionality to define the location of the tether between beads, which will be needed in order to construct WIT kymographs in the future.

Additionally, when the tether coordinates are set, the returned image data is rotated such that the tether is horizontal. Rotation is combined with the color channel alignment if applicable, such that only one linear interpolation is needed to get to the final image