### PR TITLE
docs: fix error in kymotracker tutorial

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * Fixed issue in force calibration where the analytical fit would sometimes fail when the corner frequency is below the lower fitting bound. What would happen is that the analytical fit resulted in a negative term of which the square root was taken to obtain the corner frequency. Now this case is gracefully handled by setting the initial guess halfway between the lowest frequency in the power spectrum and zero.
 * Fixed bug that would implicitly convert `Kymograph` and `Scan` `timestamps` to floating point values. Converting them to floating point values leads to a loss of precision. For more information see [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#channels) for more information.
 * Fixed issue that led to `DeprecationWarning` in the kymotracker widget.
+* Fixed error in kymotracking documentation. The tutorial previously indicated the incorrect number of samples for `sample_from_image`.
 
 #### Bug fixes
 

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -210,7 +210,7 @@ Extracting summed intensities
 
 Sometimes, it can be desirable to extract pixel intensities in a region around our kymograph trace. We can quite easily
 extract these using the method :func:`~lumicks.pylake.kymotracker.kymoline.KymoLine.sample_from_image`. For instance,
-if we want to sum the pixels in a 9 pixel area around the longest kymograph trace, we can invoke::
+if we want to sum the pixels in a 11 pixel area around the longest kymograph trace, we can invoke::
 
     plt.figure()
     longest_trace_idx = np.argmax([len(trace) for trace in traces])


### PR DESCRIPTION
The kymotracker tutorial previously indicated the incorrect number of samples for `sample_from_image`.