### PR TITLE
force_calibration: validate calibration params

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
 * Units are now included in the headers for exported kymograph traces. The header now reads:</br>
 `# line index;time (pixels);coordinate (pixels);time (seconds);position ({unit});counts (summed over {n} pixels)`</br>
 where `{unit}` is either `um` or `kbp` depending on the calibration of the kymograph.
+* Added more input validation for force calibration. We now force bead and sample density to be more than 100 kg/m^3 when specified. Temperature should stay between 5 and 90 degrees Celsius and viscosity should be bigger than 0.0003 (viscosity of water at 90 degrees Celsius).
 
 ## v0.10.1 | 2021-10-27
 

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -226,6 +226,12 @@ class PassiveCalibrationModel:
         if distance_to_surface and distance_to_surface < bead_diameter / 2.0:
             raise ValueError("Distance from bead center to surface is smaller than the bead radius")
 
+        if viscosity and viscosity <= 0.0003:
+            raise ValueError("Viscosity must be higher than 0.0003 Pa*s")
+
+        if not 5.0 < temperature < 90.0:
+            raise ValueError("Temperature must be between 5 and 90 Celsius")
+
         self.viscosity = viscosity if viscosity is not None else viscosity_of_water(temperature)
         self.temperature = temperature
         self.bead_diameter = bead_diameter
@@ -259,6 +265,12 @@ class PassiveCalibrationModel:
                     "larger than 1.5 times the bead radius. For distances closer to the surface, "
                     "turn off the hydrodynamically correct model."
                 )
+
+            if rho_sample and rho_sample < 100.0:
+                raise ValueError("Density of the sample cannot be below 100 kg/m^3")
+
+            if rho_bead < 100.0:
+                raise ValueError("Density of the bead cannot be below 100 kg/m^3")
 
             self._passive_power_spectrum_model = partial(
                 passive_power_spectrum_model_hydro,


### PR DESCRIPTION
Added more input validation for force calibration. We now force bead and sample density to be more than 100 kg/m^3 when specified. Temperature should stay between 5 and 90 degrees Celsius and viscosity should be bigger than 0.0003 (viscosity of water at 90 degrees Celsius).

***Why this PR?**
Reason we wish to validate some more input parameters is because certain invalid parameters produce garbage results (`viscosity = 0`, `bead_density = 0` etc). Also, by pinning them to at least ballpark values we reduce the chances of user error (for example passing Kelvins instead of Celsius, or passing viscosity or density in an incorrect unit).