### PR TITLE
force_calibration: ensure zero parameter values are rejected

### DIFF
--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -223,10 +223,10 @@ class PassiveCalibrationModel:
                 f"than 10^-2 um"
             )
 
-        if distance_to_surface and distance_to_surface < bead_diameter / 2.0:
+        if distance_to_surface is not None and distance_to_surface < bead_diameter / 2.0:
             raise ValueError("Distance from bead center to surface is smaller than the bead radius")
 
-        if viscosity and viscosity <= 0.0003:
+        if viscosity is not None and viscosity <= 0.0003:
             raise ValueError("Viscosity must be higher than 0.0003 Pa*s")
 
         if not 5.0 < temperature < 90.0:
@@ -259,14 +259,17 @@ class PassiveCalibrationModel:
             # Here the drag coefficient in the model represents the bulk drag coefficient.
             self._drag_correction_factor = 1
             # This model is only valid up to l/R < 1.5 [6] so throw in case that is violated.
-            if distance_to_surface and distance_to_surface / (self.bead_diameter / 2) < 1.5:
+            if (
+                distance_to_surface is not None
+                and distance_to_surface / (self.bead_diameter / 2) < 1.5
+            ):
                 raise ValueError(
                     "The hydrodynamically correct model is only valid for distances to the surface "
                     "larger than 1.5 times the bead radius. For distances closer to the surface, "
                     "turn off the hydrodynamically correct model."
                 )
 
-            if rho_sample and rho_sample < 100.0:
+            if rho_sample is not None and rho_sample < 100.0:
                 raise ValueError("Density of the sample cannot be below 100 kg/m^3")
 
             if rho_bead < 100.0:

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -368,6 +368,12 @@ def test_invalid_densities():
     ):
         PassiveCalibrationModel(4.1, hydrodynamically_correct=True, rho_sample=99.9)
 
+    # Make sure 0 also fires (since it's falsy)
+    with pytest.raises(
+            ValueError, match=re.escape("Density of the sample cannot be below 100 kg/m^3")
+    ):
+        PassiveCalibrationModel(4.1, hydrodynamically_correct=True, rho_sample=0)
+
     with pytest.raises(
             ValueError, match=re.escape("Density of the bead cannot be below 100 kg/m^3")
     ):
@@ -387,6 +393,11 @@ def test_invalid_viscosity():
     ):
         PassiveCalibrationModel(4.1, viscosity=0.0003)
 
+    with pytest.raises(
+            ValueError, match=re.escape("Viscosity must be higher than 0.0003 Pa*s")
+    ):
+        PassiveCalibrationModel(4.1, viscosity=0)
+
     PassiveCalibrationModel(4.1, viscosity=0.00031)
 
 
@@ -403,3 +414,12 @@ def test_invalid_temperature():
 
     PassiveCalibrationModel(4.1, temperature=89.9)
     PassiveCalibrationModel(4.1, temperature=5.1)
+
+
+def test_invalid_distance_to_surface():
+    # Check that zero does not work specifically (since it is falsy).
+    with pytest.raises(
+        ValueError,
+        match="Distance from bead center to surface is smaller than the bead radius",
+    ):
+        PassiveCalibrationModel(4.11, distance_to_surface=0, hydrodynamically_correct=False)


### PR DESCRIPTION
**Why this PR?**
This fixes a bug which allowed calibrations with a parameter set to zero to go through.
This fix ensures that they lead to an exception.