### PR TITLE
`Scan`: added `frame_timestamp_ranges()`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 * Added `CorrelatedStack.get_image()` to get the image stack data as an `np.ndarray`.
 * Allow setting custom slider ranges for the algorithm parameters in the kymotracker widget. See: [kymotracker widget](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#using-the-kymotracker-widget).
 * Added parameters describing the inferred driving peak (`driving_amplitude`, `driving_frequency`, `driving_power`) when performing active force calibration to `CalibrationResults`.
+* Added function (`Scan.frame_timestamp_ranges()`) to obtain start and stop timestamp of each frame in a `Scan`. See: [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html). 
 
 #### Improvements
 

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -87,3 +87,15 @@ at a frame rate of 40 frames per second, we can do this::
 
 For other video formats such as `.mp4` or `.avi`, ffmpeg must be installed. See
 :ref:`installation instructions <ffmpeg_installation>` for more information on this.
+
+
+Correlating scans
+-----------------
+
+We can downsample a scan according to the frames in a scan. We can use :func:`~lumicks.pylake.scan.Scan.frame_timestamp_ranges()` for this::
+
+    frame_timestamp_ranges = scan.frame_timestamp_ranges()
+
+This returns a list of start and stop timestamps that can be passed directly to :func:`~lumicks.pylake.channel.Slice.downsampled_to`, which will then return a :class:`~lumicks.pylake.channel.Slice` with a datapoint per frame::
+
+    downsampled = f.force1x.downsampled_over(frame_timestamp_ranges)

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -46,6 +46,26 @@ class Scan(ConfocalImage):
             )
         return self._num_frames
 
+    def frame_timestamp_ranges(self, exclude=True):
+        """Get start and stop timestamp of each frame in the scan.
+
+        Parameters
+        ----------
+        exclude : bool
+            Exclude dead time at the end of each frame.
+        """
+        ts_min = self._timestamps("timestamps", reduce=np.min)
+        ts_max = self._timestamps("timestamps", reduce=np.max)
+        if ts_min.ndim == 2:
+            return [(np.min(ts_min), np.max(ts_max))]
+        else:
+            if exclude:
+                maximum_timestamp = [np.max(ts) for ts in ts_max]
+                return [(t1, t2) for t1, t2 in zip(ts_min[:, 0, 0], maximum_timestamp)]
+            else:
+                frame_time = ts_min[1, 0, 0] - ts_min[0, 0, 0]
+                return [(t, t + frame_time) for t in ts_min[:, 0, 0]]
+
     @property
     def lines_per_frame(self):
         return self._num_pixels[self._scan_order[1]]


### PR DESCRIPTION
**Why this PR?**
This PR adds a function to obtain the start and stop timestamp of individual `Scan` frames. This was a user request.

Note that the name `frame_timestamp_ranges` is a bit verbose, but `timestamps` is already taken for the per pixel timestamps. `time_ranges` doesn't communicate that we are talking about `timestamps` here and `frame_timestamps` doesn't imply well enough that the returned quantity is a range. Please feel free to suggest a better name. Especially since the plan is to add an alias on `CorrelatedStack` with the same name (so that the API for getting these downsampled series is the same on both sides).

Another PR will build on top of this to provide users with a small widget to quickly correlate these. This second PR will expose the same widget as we already have for `CorrelatedStack`.

Docs build here: https://lumicks-pylake.readthedocs.io/en/ds_scan/
Note that it is still a little spartan to warrant a whole section, but in the next PR the widget will be there too.

![image](https://user-images.githubusercontent.com/19836026/144603726-6b68915e-d32c-453b-948a-754c14a41b5c.png)
