### PR TITLE
scan: add `plot_correlated` for scans

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * Fixed bug which resulted in erroneous standard errors on parameter estimates computed from an `FdFit` with fixed parameters. For such a fitting problem, the covariance matrix was evaluated for the unconstrained problem (without the fixed parameter constraints). As a result, standard errors were always overestimated. Note that uncertainty estimation by profile likelihood was unaffected.
 * Fixed issue which resulted in overly stringent positional tolerance when using the kymotracker widget. This tolerance has now been made proportional to the axis viewport.
 * Removed `axial` parameter from `lk.ActiveCalibrationModel()` as we do not support active force calibration in the axial direction.
+* Improved default scaling behaviour for `CorrelatedStack.plot_correlated()` and `Scan.plot_correlated()`. It now ensures the ratio between the image and temporal plot is according to the aspect ratio of the scan or stack.
 
 ## v0.11.0 | 2021-12-07
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### New features
 
 * Added `CorrelatedStack.define_tether()` which can be used to define the endpoints of the tether between two beads and return image data rotated such that the tether is horizontal. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html) for more information.
+* Added function to correlate `Scan` frames to channel data. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html#correlating-scans).
 
 #### Bug fixes
 

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -99,3 +99,7 @@ We can downsample a scan according to the frames in a scan. We can use :func:`~l
 This returns a list of start and stop timestamps that can be passed directly to :func:`~lumicks.pylake.channel.Slice.downsampled_to`, which will then return a :class:`~lumicks.pylake.channel.Slice` with a datapoint per frame::
 
     downsampled = f.force1x.downsampled_over(frame_timestamp_ranges)
+
+We can also correlate multi-frame confocal scans with a channel :class:`~lumicks.pylake.channel.Slice` using a small interactive plot::
+
+    scan.plot_correlated(f.force1x)

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -197,7 +197,9 @@ class CorrelatedStack:
             raise IndexError("Frame index out of range")
         return self.src.get_frame(self.start_idx + frame)
 
-    def plot_correlated(self, channel_slice, frame=0, reduce=np.mean, channel="rgb"):
+    def plot_correlated(
+        self, channel_slice, frame=0, reduce=np.mean, channel="rgb", figure_scale=0.75
+    ):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling function (e.g. np.mean)
         is evaluated for the time between a start and end time of a frame. Note: In environments which support
         interactive figures (e.g. jupyter notebook with ipywidgets or interactive python) this plot will be interactive.
@@ -215,6 +217,9 @@ class CorrelatedStack:
         channel : 'rgb', 'red', 'green', 'blue', None; optional
             Channel to plot for RGB images (None defaults to 'rgb')
             Not used for grayscale images
+        figure_scale : float
+            Scaling of the figure width and height. Values greater than one increase the size of the
+            figure.
 
 
         Examples
@@ -236,6 +241,7 @@ class CorrelatedStack:
             lambda frame_idx: self._get_frame(frame_idx)._get_plot_data(channel),
             frame,
             reduce,
+            figure_scale=figure_scale,
         )
 
     def export_tiff(self, file_name, roi=None):

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -7,6 +7,13 @@ from .mixin import PhotonCounts
 from .mixin import ExcitationLaserPower
 from .image import reconstruct_image_sum, reconstruct_image, save_tiff, ImageMetadata
 from .utilities import could_sum_overflow
+from matplotlib.colors import LinearSegmentedColormap
+
+linear_colormaps = {
+    "red": LinearSegmentedColormap.from_list("red", colors=[(0, 0, 0), (1, 0, 0)]),
+    "green": LinearSegmentedColormap.from_list("green", colors=[(0, 0, 0), (0, 1, 0)]),
+    "blue": LinearSegmentedColormap.from_list("blue", colors=[(0, 0, 0), (0, 0, 1)]),
+}
 
 
 def _int_mean(a, total_size, axis):
@@ -252,14 +259,6 @@ class ConfocalImage(BaseScan):
         return self._timestamp_factory(self, reduce)
 
     def _plot_color(self, color, **kwargs):
-        from matplotlib.colors import LinearSegmentedColormap
-
-        linear_colormaps = {
-            "red": LinearSegmentedColormap.from_list("red", colors=[(0, 0, 0), (1, 0, 0)]),
-            "green": LinearSegmentedColormap.from_list("green", colors=[(0, 0, 0), (0, 1, 0)]),
-            "blue": LinearSegmentedColormap.from_list("blue", colors=[(0, 0, 0), (0, 0, 1)]),
-        }
-
         image = getattr(self, f"{color}_image")
         return self._plot(image, **{"cmap": linear_colormaps[color], **kwargs})
 

--- a/lumicks/pylake/nb_widgets/correlated_plot.py
+++ b/lumicks/pylake/nb_widgets/correlated_plot.py
@@ -1,0 +1,81 @@
+import numpy as np
+import warnings
+
+
+def plot_correlated(
+    channel_slice, frame_timestamps, get_plot_data, frame=0, reduce=np.mean, colormap="gray"
+):
+    """Downsample channel on a frame by frame basis and plot the results.
+
+    Parameters
+    ----------
+    channel_slice : pylake.channel.Slice
+        Data slice that we with to downsample.
+    frame_timestamps : list of tuple
+        List of tuples with start and stop timestamps of each frame.
+    get_plot_data : callable
+        Function that will return the plotdata for a frame.
+    frame : int
+        Frame to show.
+    reduce : callable
+        The function which is going to reduce multiple samples into one. The default is
+        :func:`numpy.mean`, but :func:`numpy.sum` could also be appropriate for some cases
+        e.g. photon counts.
+    colormap : str or Colormap
+        Colormap used for plotting.
+    """
+    import matplotlib.pyplot as plt
+
+    downsampled = channel_slice.downsampled_over(frame_timestamps, where="left", reduce=reduce)
+
+    if len(downsampled.timestamps) < len(frame_timestamps):
+        warnings.warn("Only subset of time range available for selected channel")
+
+    plot_data = get_plot_data(frame)
+    aspect_ratio = plot_data.shape[0] / np.max([plot_data.shape])
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=plt.figaspect(aspect_ratio / 2))
+    t0 = downsampled.timestamps[0]
+    t, y = (downsampled.timestamps - t0) / 1e9, downsampled.data
+    ax1.step(t, y, where="pre")
+    ax2.tick_params(
+        axis="both", which="both", bottom=False, left=False, labelbottom=False, labelleft=False
+    )
+    image_object = ax2.imshow(plot_data, cmap=colormap)
+    plt.title(f"Frame {frame}")
+
+    # Make sure the y-axis limits stay fixed when we add our little indicator rectangle
+    y1, y2 = ax1.get_ylim()
+    ax1.set_ylim(y1, y2)
+
+    def update_position(start, stop):
+        return ax1.fill_between(
+            (np.array([start, stop]) - t0) / 1e9,
+            y1,
+            y2,
+            alpha=0.7,
+            color="r",
+        )
+
+    poly = update_position(*frame_timestamps[frame])
+
+    ax1.set_xlabel("Time [s]")
+    ax1.set_ylabel(downsampled.labels["y"])
+    ax1.set_title(downsampled.labels["title"])
+    ax1.set_xlim([np.min(t), np.max(t)])
+
+    def select_frame(event):
+        nonlocal poly
+
+        if not event.canvas.widgetlock.locked() and event.inaxes == ax1:
+            time = event.xdata * 1e9 + t0
+            for img_idx, (start, stop) in enumerate(frame_timestamps):
+                if start <= time < stop:
+                    plt.title(f"Frame {img_idx}")
+                    poly.remove()
+                    image_object.set_data(get_plot_data(img_idx))
+                    poly = update_position(*frame_timestamps[img_idx])
+                    fig.canvas.draw()
+                    return
+
+    fig.canvas.mpl_connect("button_press_event", select_frame)

--- a/lumicks/pylake/nb_widgets/correlated_plot.py
+++ b/lumicks/pylake/nb_widgets/correlated_plot.py
@@ -3,7 +3,13 @@ import warnings
 
 
 def plot_correlated(
-    channel_slice, frame_timestamps, get_plot_data, frame=0, reduce=np.mean, colormap="gray"
+    channel_slice,
+    frame_timestamps,
+    get_plot_data,
+    frame=0,
+    reduce=np.mean,
+    colormap="gray",
+    figure_scale=0.75,
 ):
     """Downsample channel on a frame by frame basis and plot the results.
 
@@ -23,6 +29,9 @@ def plot_correlated(
         e.g. photon counts.
     colormap : str or Colormap
         Colormap used for plotting.
+    figure_scale : float
+        Scaling of the figure width and height. Values greater than one increase the size of the
+        figure.
     """
     import matplotlib.pyplot as plt
 
@@ -34,9 +43,15 @@ def plot_correlated(
     plot_data = get_plot_data(frame)
     aspect_ratio = plot_data.shape[0] / np.max([plot_data.shape])
 
-    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=plt.figaspect(aspect_ratio / 2))
+    aspect_ratio = max(0.2, aspect_ratio)
+    fig, (ax1, ax2) = plt.subplots(
+        1,
+        2,
+        figsize=figure_scale * plt.figaspect(aspect_ratio / (aspect_ratio + 1)),
+        gridspec_kw={"width_ratios": [1, 1 / aspect_ratio]},
+    )
     t0 = downsampled.timestamps[0]
-    t, y = (downsampled.timestamps - t0) / 1e9, downsampled.data
+    t, y = downsampled.seconds, downsampled.data
     ax1.step(t, y, where="pre")
     ax2.tick_params(
         axis="both", which="both", bottom=False, left=False, labelbottom=False, labelleft=False
@@ -79,3 +94,4 @@ def plot_correlated(
                     return
 
     fig.canvas.mpl_connect("button_press_event", select_frame)
+    plt.tight_layout()

--- a/lumicks/pylake/nb_widgets/tests/test_correlated_plot.py
+++ b/lumicks/pylake/nb_widgets/tests/test_correlated_plot.py
@@ -1,0 +1,37 @@
+from lumicks.pylake.tests.data.mock_confocal import generate_scan
+from lumicks.pylake.channel import Slice, Continuous
+import pytest
+import numpy as np
+import matplotlib as mpl
+from matplotlib.testing.decorators import cleanup
+
+
+@cleanup
+def test_plot_correlated():
+    start = 1592916040906356300
+    dt = int(1e9)
+    cc = Slice(Continuous(np.arange(0, 1000, 2), start, dt), {"y": "mock", "title": "mock"})
+
+    img = np.array([np.ones((5, 4)) * idx for idx in np.arange(3)])
+    scan = generate_scan(
+        "test",
+        img,
+        [1, 1],
+        start=start,
+        dt=dt,
+        samples_per_pixel=4,
+        line_padding=4,
+    )
+
+    scan.plot_correlated(cc, channel="red")
+    imgs = [obj for obj in mpl.pyplot.gca().get_children() if isinstance(obj, mpl.image.AxesImage)]
+    assert len(imgs) == 1
+    np.testing.assert_allclose(imgs[0].get_array(), np.zeros((5, 4)))
+
+    scan.plot_correlated(cc, channel="red", frame=1)
+    imgs = [obj for obj in mpl.pyplot.gca().get_children() if isinstance(obj, mpl.image.AxesImage)]
+    np.testing.assert_allclose(imgs[0].get_array(), np.ones((5, 4)))
+
+    # When no data overlaps, we need to raise.
+    with pytest.raises(AssertionError, match="No overlap between range and selected channel"):
+        scan.plot_correlated(cc["500s":], channel="red", frame=1)

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -66,7 +66,9 @@ class Scan(ConfocalImage):
                 frame_time = ts_min[1, 0, 0] - ts_min[0, 0, 0]
                 return [(t, t + frame_time) for t in ts_min[:, 0, 0]]
 
-    def plot_correlated(self, channel_slice, frame=0, reduce=np.mean, channel="rgb"):
+    def plot_correlated(
+        self, channel_slice, frame=0, reduce=np.mean, channel="rgb", figure_scale=0.75
+    ):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling
         function (e.g. np.mean) is evaluated for the time between a start and end time of a frame.
         Note: In environments which support interactive figures (e.g. jupyter notebook with
@@ -85,6 +87,9 @@ class Scan(ConfocalImage):
         channel : 'rgb', 'red', 'green', 'blue', None; optional
             Channel to plot for RGB images (None defaults to 'rgb')
             Not used for grayscale images
+        figure_scale : float
+            Scaling of the figure width and height. Values greater than one increase the size of the
+            figure.
 
 
         Examples
@@ -97,7 +102,6 @@ class Scan(ConfocalImage):
             scan = file.scans["my scan"]
             scan.plot_correlated(file.force1x, channel="red")
         """
-        import matplotlib.pyplot as plt
         from lumicks.pylake.nb_widgets.correlated_plot import plot_correlated
         from .detail.confocal import linear_colormaps
 
@@ -119,8 +123,8 @@ class Scan(ConfocalImage):
             frame,
             reduce,
             colormap=linear_colormaps[channel] if channel in channels else None,
+            figure_scale=figure_scale,
         )
-        plt.tight_layout()
 
     @property
     def lines_per_frame(self):


### PR DESCRIPTION
**Why this PR?**
Allow users to also interactively explore the correlation between `Scan` objects and channel data.

**What to look out for?**
I also changed some of the default scaling behaviour. Reason being that the old behaviour opens figures too wide for realistically sized scans. Now I force the relative widths to be `1 : aspect_ratio` of the image, but I'd happily take any suggestions for better alternatives.

I considered piggybacking forwarding of `**kwargs` to this, similarly how we do it for `.plot()`, but decided against it, because I think we need to think about a better API for image adjustments than just forwarding to the very limited options on `imshow`.

Example (this was wider than the notebook):
![scan](https://user-images.githubusercontent.com/19836026/144853995-e673e891-8f5b-4fcc-bd5e-3a116b5fb28d.gif)

Here are some examples of the widget in use now:
![wit_new](https://user-images.githubusercontent.com/19836026/144854115-4cc99139-0cfe-4b6a-82c7-f098c6bde543.gif)
On a cropped TIFF stack (RGB)

![wit_uncropped](https://user-images.githubusercontent.com/19836026/144854120-eb6edf0d-d895-4e3f-b926-87cb45f1d61b.gif)
On an uncropped TIFF stack (RGB)

![scan_new](https://user-images.githubusercontent.com/19836026/144854123-fca261dc-a7e1-4c30-8bee-1f5b99cc1e0f.gif)
On a scan

![image](https://user-images.githubusercontent.com/19836026/144854946-4bf83653-8ef9-4a27-867f-ca26fd4810cf.png)
On a scan (Green only)
