### PR TITLE
force_feedback: support marker metadata

### DIFF
--- a/lumicks/pylake/marker.py
+++ b/lumicks/pylake/marker.py
@@ -1,8 +1,12 @@
+import json
+
+
 class Marker:
-    def __init__(self, file, marker_data):
+    def __init__(self, file, marker_data, json):
         self.file = file
         self.start = marker_data["Start time (ns)"]
         self.stop = marker_data["Stop time (ns)"]
+        self._json = json
 
     @staticmethod
     def from_dataset(h5py_dset, file):
@@ -16,4 +20,6 @@ class Marker:
         file : lumicks.pylake.File
             The parent file.
         """
-        return Marker(file, h5py_dset.attrs)
+        payload = json.loads(h5py_dset[()])
+        meta_data = json.loads(payload["payload"])["value0"] if "payload" in payload else {}
+        return Marker(file, h5py_dset.attrs, meta_data)

--- a/lumicks/pylake/tests/data/mock_confocal.py
+++ b/lumicks/pylake/tests/data/mock_confocal.py
@@ -1,5 +1,6 @@
 import numpy as np
 import json
+from .mock_json import mock_json
 from lumicks.pylake.detail.image import InfowaveCode
 from lumicks.pylake.channel import Continuous, Slice
 from lumicks.pylake.kymo import Kymo
@@ -21,8 +22,6 @@ def generate_scan_json(axes):
         "pixel size (nm)" : float
             Pixel size along this axis.
     """
-    enc = json.JSONEncoder()
-
     axes_metadata = [
         {
             "axis": int(axis["axis"]),
@@ -35,21 +34,19 @@ def generate_scan_json(axes):
         for axis in axes
     ]
 
-    return enc.encode(
+    return mock_json(
         {
-            "value0": {
+            "cereal_class_version": 1,
+            "fluorescence": True,
+            "force": False,
+            "scan count": 0,
+            "scan volume": {
+                "center point (um)": {"x": 58.075877109272604, "y": 31.978375270573267, "z": 0},
                 "cereal_class_version": 1,
-                "fluorescence": True,
-                "force": False,
-                "scan count": 0,
-                "scan volume": {
-                    "center point (um)": {"x": 58.075877109272604, "y": 31.978375270573267, "z": 0},
-                    "cereal_class_version": 1,
-                    "pixel time (ms)": 0.2,
-                    "scan axes": axes_metadata,
-                },
-            }
-        }
+                "pixel time (ms)": 0.2,
+                "scan axes": axes_metadata,
+            },
+        },
     )
 
 
@@ -160,7 +157,9 @@ def generate_kymo(name, image, pixel_size_nm, start=4, dt=7, samples_per_pixel=5
     return Kymo(name, confocal_file, start, stop, json)
 
 
-def generate_scan(name, scan_data, pixel_sizes_nm, start=4, dt=7, samples_per_pixel=5, line_padding=3):
+def generate_scan(
+    name, scan_data, pixel_sizes_nm, start=4, dt=7, samples_per_pixel=5, line_padding=3
+):
     confocal_file, json, stop = MockConfocalFile.from_image(
         np.swapaxes(scan_data, -1, -2),
         pixel_sizes_nm=pixel_sizes_nm,

--- a/lumicks/pylake/tests/data/mock_json.py
+++ b/lumicks/pylake/tests/data/mock_json.py
@@ -1,0 +1,26 @@
+import json
+
+
+force_feedback_dict = {
+    "settings_at_start": {
+        "enabled_status": 0,
+        "kp": 0.0,
+        "ki": 0.0,
+        "kd": 0.0,
+        "setpoint": 0.0,
+        "lower_output_limit": 0.0,
+        "upper_output_limit": 2.0,
+    },
+    "amplified_input_factor": 10.0,
+    "amplified_input_offset": 0.0,
+    "start_time": {"time_since_epoch": {"count": 1638883620243399988}},
+}
+
+
+def mock_json(data_dict):
+    """Mocks a json as we receive them from BL"""
+    return json.JSONEncoder().encode({"value0": data_dict})
+
+
+def mock_force_feedback_json():
+    return json.JSONEncoder().encode(mock_json(force_feedback_dict))

--- a/lumicks/pylake/tests/test_file.py
+++ b/lumicks/pylake/tests/test_file.py
@@ -3,6 +3,7 @@ from lumicks import pylake
 import pytest
 from textwrap import dedent
 from lumicks.pylake.detail.h5_helper import write_h5
+from .data.mock_json import force_feedback_dict
 
 
 def test_scans(h5_file):
@@ -100,6 +101,17 @@ def test_marker(h5_file):
         assert np.isclose(f.markers["test_marker"].stop, 200)
         assert np.isclose(f.markers["test_marker2"].start, 200)
         assert np.isclose(f.markers["test_marker2"].stop, 300)
+
+
+def test_marker_metadata(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+
+    if f.format_version == 2:
+        assert not f.markers["test_marker"]._json
+        assert not f.markers["test_marker2"]._json
+        assert np.isclose(f.markers["force feedback"].start, 200)
+        assert np.isclose(f.markers["force feedback"].stop, 300)
+        assert f.markers["force feedback"]._json == force_feedback_dict
 
 
 def test_properties(h5_file):
@@ -252,6 +264,7 @@ def test_repr_and_str(h5_file):
               - Size: 1
             
             .markers
+              - force feedback
               - test_marker
               - test_marker2
 


### PR DESCRIPTION
**Why this PR?**
Users need to be able to access specific metadata associated with markers.
Basically it's a `json` attached to a key named `payload` on a marker.

Private API for now since this is for a single user in particular for now.