### PR TITLE
fdfit: fix standard errors in the presence of fixed parameters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,11 +3,13 @@
 ## v0.11.1 | t.b.d.
 
 #### New features
-Added `CorrelatedStack.define_tether()` which can be used to define the endpoints of the tether between two beads and return image data rotated such that the tether is horizontal. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html) for more information.
+
+* Added `CorrelatedStack.define_tether()` which can be used to define the endpoints of the tether between two beads and return image data rotated such that the tether is horizontal. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html) for more information.
 
 #### Bug fixes
 
 * Fixed issue which resulted in the offset parameter added by `Model.subtract_independent_offset()` not having a unit associated with it.
+* Fixed bug which resulted in erroneous standard errors on parameter estimates computed from an `FdFit` with fixed parameters. For such a fitting problem, the covariance matrix was evaluated for the unconstrained problem (without the fixed parameter constraints). As a result, standard errors were always overestimated. Note that uncertainty estimation by profile likelihood was unaffected.
 
 ## v0.11.0 | 2021-12-07
 

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -254,8 +254,11 @@ class Fit:
             self.params[name] = value
 
         if self.has_jacobian:
-            for name, value in zip(parameter_names, np.diag(self.cov)):
+            for name, value in zip(parameter_names[fitted], np.diag(self.cov)):
                 self.params[name].stderr = np.sqrt(value)
+
+            for name in parameter_names[np.logical_not(fitted)]:
+                self.params[name].stderr = None
 
         return self
 
@@ -623,12 +626,12 @@ class Fit:
         """
         # Note that this approximation is only valid if the noise on each data set is the same.
         if self.has_jacobian:
-            J = self._calculate_jacobian()
+            J = self._calculate_jacobian()[:, self.params.fitted]
             J = J / np.transpose(np.tile(self.sigma, (J.shape[1], 1)))
             return np.linalg.pinv(np.transpose(J).dot(J))
         else:
             raise NotImplementedError(
-                "In order to calculate a covariance matrix, a model Jacobian has to be specified"
+                "In order to calculate a covariance matrix, a model Jacobian has to be specified "
                 "for the model."
             )
 


### PR DESCRIPTION
**Why this PR?**
Currently, Pylake evaluates the covariance matrix for the unconstrained fitting problem (not taking into account possible fixed parameters). This leads to overly pessimistic standard errors (too big).

This PR fixes that issue.