### PR TITLE
widgets: increase tolerance connect lines

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 
 * Fixed issue which resulted in the offset parameter added by `Model.subtract_independent_offset()` not having a unit associated with it.
 * Fixed bug which resulted in erroneous standard errors on parameter estimates computed from an `FdFit` with fixed parameters. For such a fitting problem, the covariance matrix was evaluated for the unconstrained problem (without the fixed parameter constraints). As a result, standard errors were always overestimated. Note that uncertainty estimation by profile likelihood was unaffected.
+* Fixed issue which resulted in overly stringent positional tolerance when using the kymotracker widget. This tolerance has now been made proportional to the axis viewport.
 
 ## v0.11.0 | 2021-12-07
 


### PR DESCRIPTION
**Why this PR?**
Previously, we were determining which line tip was clicked by converting to pixel coordinates. This connection tolerance can be surprisingly finicky in `jupyter notebook` but not `lab`. It seems that internally it renders to a higher resolution image.

This PR changes that handling to handle whether the click was close enough by considering the distance relative to the axes data limits.