### PR TITLE
Interactive plot for `CorrelatedStack` tether definition

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Added `CorrelatedStack.define_tether()` which can be used to define the endpoints of the tether between two beads and return image data rotated such that the tether is horizontal. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html) for more information.
 * Added function to correlate `Scan` frames to channel data. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html#correlating-scans).
+* Added `CorrelatedStack.crop_and_rotate()` for interactive editing of the image stack. Actions include scrolling through image frames with the mouse wheel, and left-clicking to define the tether coordinates. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html#image-stack-editor) for more information.
 
 #### Bug fixes
 
@@ -30,7 +31,7 @@
 * Added `Kymo.calibrate_to_kbp()` for calibrating the position axis of a kymograph from microns to kilobase-pairs. **Note: this calibration is applied to the full kymograph, so one should crop to the bead edges with `Kymo.crop_by_distance()` before calling this method.**
 * Added `CorrelatedStack.get_image()` to get the image stack data as an `np.ndarray`.
 * Allow setting custom slider ranges for the algorithm parameters in the kymotracker widget. Please refer to [kymotracker widget](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#using-the-kymotracker-widget) for more information.
-* Added function `Scan.frame_timestamp_ranges()` to obtain the start and stop timestamp of each frame in a `Scan`. Please refer to [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html) for more information. 
+* Added function `Scan.frame_timestamp_ranges()` to obtain the start and stop timestamp of each frame in a `Scan`. Please refer to [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html) for more information.
 
 #### Bug fixes
 

--- a/docs/tutorial/nbwidgets.rst
+++ b/docs/tutorial/nbwidgets.rst
@@ -115,7 +115,7 @@ It is also possible to select a portion of an F,d curve based on distance::
 
     selector = lk.FdDistanceRangeSelector(fdcurves)
 
-.. image:: fd_dist_widget.png    
+.. image:: fd_dist_widget.png
 
 Again, we can retrieve the selected data just as with `FdRangeSelector`::
 
@@ -135,15 +135,15 @@ Again, we can retrieve the selected data just as with `FdRangeSelector`::
 
 .. image::  fd_dist_widget2.png
 
-The returned F,d curves correspond to the longest contiguous (in time) stretch of data that falls 
+The returned F,d curves correspond to the longest contiguous (in time) stretch of data that falls
 within the distance thresholds. However, noise in the distance measurement can lead to short gaps of the time
 trace falling slightly outside of the thresholds, as illustrated below:
 
 .. image:: fd_dist_widget3a.png
 
-To avoid premature truncation caused by this noise, there is an additional `max_gap` keyword argument 
+To avoid premature truncation caused by this noise, there is an additional `max_gap` keyword argument
 to `FdDistanceRangeSelector` that can be used to adjust the acceptable length of noise gaps. The default values
-is zero, such that all data points are guaranteed to fall within the selected distance range. The effect of this 
+is zero, such that all data points are guaranteed to fall within the selected distance range. The effect of this
 argument is shown below for an F,d curve sliced with the same distance thresholds:
 
 .. image:: fd_dist_widget3.png
@@ -156,3 +156,31 @@ The selector widgets can also be easily accessed from single F,d curve instances
     fdcurve = fdcurves["Fd pull #6"]
     t_selector = fdcurve.range_selector()
     d_selector = fdcurve.distance_range_selector(max_gap=3)
+
+
+Cropping and Rotating Image Stacks
+----------------------------------
+
+You can interactively define the location of a tether for a `CorrelatedStack` by using::
+
+    stack = lk.CorrelatedStack("cas9_wf.tiff")
+    editor = stack.crop_and_rotate()
+    plt.show()
+
+Simply click on the start of the tether
+
+    .. image:: widget_stack_editor_1.png
+
+and then on the end of the tether
+
+    .. image:: widget_stack_editor_2.png
+
+After a tether is defined, the view will update showing the location of the tether and the
+image rotated such that the tether is horizontal. Note that `CorrelatedStack.crop_and_rotate()` accepts
+all of the arguments that can be used for `CorrelatedStack.plot()`.
+
+You can also use the mouse wheel to scroll through the individual frames (if using Jupyter Lab, hold `Shift` while scrolling).
+
+To obtain a copy of the edited `CorrelatedStack` object, use::
+
+    new_stack = editor.image

--- a/docs/tutorial/widget_stack_editor_1.png
+++ b/docs/tutorial/widget_stack_editor_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fbd8ed9ac035ebc9bb8bf256c4287960d614621f7ff467887499fe6f0d3daa3
+size 297528

--- a/docs/tutorial/widget_stack_editor_2.png
+++ b/docs/tutorial/widget_stack_editor_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65848edc559d64a3fa135f0d33612097edc5e78d696c9af76df6bb8e515c2dd9
+size 283856

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -4,6 +4,7 @@ import tifffile
 import warnings
 from deprecated.sphinx import deprecated
 from .detail.widefield import TiffStack
+from .nb_widgets.image_editing import ImageEditorWidget
 
 
 class CorrelatedStack:
@@ -191,6 +192,27 @@ class CorrelatedStack:
         x, y = np.vstack(self.src._tether.ends).T
         tether_kwargs = {"c": "w", "marker": "o", "mfc": "none", "ls": ":", **kwargs}
         plt.plot(x, y, **tether_kwargs)
+
+    def crop_and_rotate(self, frame=0, channel="rgb", show_title=True, **kwargs):
+        """Open a widget to interactively edit the image stack.
+
+        Actions include:
+            * scrolling through frames using the mouse wheel
+            * left-click to define the location of the tether
+
+        Parameters
+        ----------
+        frame : int, optional
+            Index of the frame to plot.
+        channel : 'rgb', 'red', 'green', 'blue', None; optional
+            Channel to plot for RGB images (None defaults to 'rgb')
+            Not used for grayscale images
+        show_title : bool, optional
+            Controls display of auto-generated plot title
+        **kwargs
+            Forwarded to :func:`matplotlib.pyplot.imshow`.
+        """
+        return ImageEditorWidget(self, frame, channel, show_title, **kwargs)
 
     def _get_frame(self, frame=0):
         if frame >= self.num_frames or frame < 0:

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -412,7 +412,7 @@ class TransformMatrix:
         center: np.ndarray
             (x, y) point, center of rotation
         """
-        return cls(cv2.getRotationMatrix2D(center, theta, scale=1.0))
+        return cls(cv2.getRotationMatrix2D(tuple(center), theta, scale=1.0))
 
     @classmethod
     def translation(cls, x, y):

--- a/lumicks/pylake/nb_widgets/image_editing.py
+++ b/lumicks/pylake/nb_widgets/image_editing.py
@@ -1,0 +1,180 @@
+import numpy as np
+from dataclasses import dataclass, field
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+
+
+class ImageStackAxes(Axes):
+    def __init__(
+        self, *args, image, frame=0, channel="rgb", show_title=True, plot_kwargs={}, **kwargs
+    ):
+        """Custom axes to handle mouse events for rotating images about a defined tether.
+
+        Parameters
+        ----------
+        *args
+            positional arguments, forwarded to superclass
+        image : lk.CorrelatedStack
+            image object
+        frame : int
+            initial frame index to plot
+        channel : {'rgb', 'red', 'green', 'blue', None}
+            Channel to plot for RGB images (None defaults to 'rgb')
+            Not used for grayscale images
+        show_title : bool
+            Controls display of auto-generated plot title
+        plot_kwargs : dict
+            plotting keyword arguments, forwarded to `Axes.imshow()`
+        **kwargs
+            keyword arguments, forwarded to superclass
+        """
+        super().__init__(*args, **kwargs)
+        self.current_image = image
+
+        self.channel = channel
+        self.current_frame = frame
+        self.num_frames = self.current_image.num_frames
+        self.make_title = (
+            (lambda: f"{image.name}\n[frame {self.current_frame + 1} / {self.num_frames}]")
+            if show_title
+            else (lambda: "")
+        )
+
+        self.get_figure().canvas.mpl_connect("scroll_event", self.handle_scroll_event)
+
+        self.im = self.imshow(self.get_frame_data(), **plot_kwargs)
+        self.set_title(self.make_title())
+
+    def get_frame_data(self):
+        return self.current_image._get_frame(self.current_frame)._get_plot_data(self.channel)
+
+    def update_image(self):
+        self.im.set_data(self.get_frame_data())
+        self.set_title(self.make_title())
+
+    def handle_scroll_event(self, event):
+        if event.inaxes != self:
+            return
+
+        if event.button == "up":
+            if self.current_frame < self.num_frames - 1:
+                self.current_frame += 1
+        else:
+            if self.current_frame != 0:
+                self.current_frame -= 1
+
+        self.update_image()
+        self.get_figure().canvas.draw()
+
+
+class ImageEditorAxes(ImageStackAxes):
+    def __init__(
+        self, *args, image, frame=0, channel="rgb", show_title=True, plot_kwargs={}, **kwargs
+    ):
+        """Custom axes to handle mouse events for rotating images about a defined tether.
+
+        Parameters
+        ----------
+        *args
+            positional arguments, forwarded to superclass
+        image : lk.CorrelatedStack
+            image object
+        frame : int
+            initial frame index to plot
+        channel : {'rgb', 'red', 'green', 'blue', None}
+            Channel to plot for RGB images (None defaults to 'rgb')
+            Not used for grayscale images
+        show_title : bool
+            Controls display of auto-generated plot title
+        plot_kwargs : dict
+            plotting keyword arguments, forwarded to `Axes.imshow()`
+        **kwargs
+            keyword arguments, forwarded to superclass
+        """
+        super().__init__(
+            *args,
+            image=image,
+            frame=frame,
+            channel=channel,
+            show_title=show_title,
+            plot_kwargs=plot_kwargs,
+            **kwargs,
+        )
+
+        self.current_points = []
+        (self._tether_line,) = self.plot([], [], marker="o", mfc="none", c="w", ls="--", lw="0.5")
+        self.get_figure().canvas.mpl_connect("button_press_event", self.handle_button_event)
+
+    def handle_button_event(self, event):
+        """Function to handle mouse click events."""
+        if event.inaxes != self:
+            return
+
+        # Check if we aren't using a figure widget function like zoom.
+        if event.canvas.widgetlock.locked():
+            return
+
+        if event.button == 1:
+            self.add_point(event.xdata, event.ydata)
+
+    def add_point(self, x, y):
+        """Add a point to the tether coordinates; if both ends are defined, rotate the image."""
+        self.current_points.append(np.array((x, y)))
+
+        if len(self.current_points) == 2:
+            self.current_image = self.current_image.define_tether(*self.current_points)
+            temp_tether = np.vstack(self.current_image[0].src._tether.ends)
+            self.current_points = []
+        else:
+            temp_tether = np.atleast_2d(np.vstack(self.current_points))
+
+        self.update_plot(temp_tether)
+
+    def update_plot(self, tether_coordinates):
+        """Update plot data and re-draw."""
+        current_limits = [self.get_xlim(), self.get_ylim()]
+
+        self.update_image()
+        self._tether_line.set_data(tether_coordinates[:, 0], tether_coordinates[:, 1])
+
+        for lims, setter in zip(current_limits, [self.set_xlim, self.set_ylim]):
+            setter(lims)
+        self.get_figure().canvas.draw()
+
+
+@dataclass
+class ImageEditorProjection:
+    image: object
+    frame: int
+    channel: str
+    show_title: bool
+    plot_kwargs: field(default_factory=dict)
+
+    def _as_mpl_axes(self):
+        return ImageEditorAxes, {
+            "image": self.image,
+            "frame": self.frame,
+            "channel": self.channel,
+            "show_title": self.show_title,
+            "plot_kwargs": self.plot_kwargs,
+        }
+
+
+class ImageEditorWidget:
+    def __init__(self, image, frame=0, channel="rgb", show_title=True, **kwargs):
+        """Wrapper class to handle interactive tether axes.
+
+        Parameters
+        ----------
+        image : lk.CorrelatedStack
+            image object
+        """
+        plt.figure()
+        self._ax = plt.subplot(
+            1, 1, 1, projection=ImageEditorProjection(image, frame, channel, show_title, kwargs)
+        )
+
+    @property
+    def image(self):
+        """Return the edited image object."""
+        return self._ax.current_image

--- a/lumicks/pylake/nb_widgets/tests/test_image_editing.py
+++ b/lumicks/pylake/nb_widgets/tests/test_image_editing.py
@@ -1,0 +1,91 @@
+import pytest
+import numpy as np
+import json
+from matplotlib.testing.decorators import cleanup
+
+from lumicks.pylake.tests.data.mock_widefield import make_alignment_image_data, MockTiffFile
+from lumicks.pylake.detail.widefield import TiffStack
+from lumicks.pylake import CorrelatedStack
+from lumicks.pylake.nb_widgets.image_editing import ImageEditorWidget
+
+import matplotlib.pyplot as plt
+
+
+def make_mock_stack():
+    spot_coordinates = ((25, 25), (50, 50))
+    warp_parameters = {"red_warp_parameters": {"Tx": 0, "Ty": 0, "theta": 0},
+                        "blue_warp_parameters": {"Tx": 0, "Ty": 0, "theta": 0}}
+    _, image, description, bit_depth = make_alignment_image_data(
+                spot_coordinates, version=2, bit_depth=16, camera="wt", **warp_parameters
+            )
+
+    tiff = TiffStack(
+        MockTiffFile(
+            data=[image, image, image],
+            times=[["10", "18"], ["20", "28"], ["30", "38"]],
+            description=json.dumps(description),
+            bit_depth=bit_depth,
+        ),
+        align_requested=True
+    )
+
+    return CorrelatedStack.from_dataset(tiff)
+
+
+def test_editor_scroll(mockevent):
+    # start with widget at beginning of stack
+    stack = make_mock_stack()
+    w = ImageEditorWidget(stack)
+    ax = plt.gca()
+    assert ax.current_frame == 0
+
+    # next frame
+    event = mockevent(ax, 50, 50, "up", False)
+    ax.handle_scroll_event(event)
+    assert ax.current_frame == 1
+
+    # previous frame
+    event = mockevent(ax, 50, 50, "down", False)
+    ax.handle_scroll_event(event)
+    assert ax.current_frame == 0
+
+    # can't go below first frame
+    ax.handle_scroll_event(event)
+    assert ax.current_frame == 0
+
+    # start with widget at end of stack
+    stack = make_mock_stack()
+    w = ImageEditorWidget(stack, frame=2)
+    ax = plt.gca()
+    assert ax.current_frame == 2
+
+    # can't go past last frame
+    event = mockevent(ax, 50, 50, "up", False)
+    ax.handle_scroll_event(event)
+    assert ax.current_frame == 2
+
+
+def test_editor_clicks(mockevent):
+    stack = make_mock_stack()
+    w = ImageEditorWidget(stack)
+    ax = plt.gca()
+
+    # test returned stack is same as currently plotted stack
+    assert id(w.image) == id(ax.current_image)
+    # returned stack is the original stack
+    assert id(w.image) == id(stack)
+    # no points currently defined
+    assert len(ax.current_points) == 0
+
+    # click first tether point
+    event = mockevent(ax, 50, 50, 1, False)
+    ax.handle_button_event(event)
+    assert id(w.image) == id(ax.current_image) # widget synced with axes
+    assert len(ax.current_points) == 1 # one click registered
+
+    # click second tether point
+    event = mockevent(ax, 50, 75, 1, False)
+    ax.handle_button_event(event)
+    assert id(w.image) == id(ax.current_image) # widget synced with axes
+    assert id(w.image) != id(stack) # stack was updated
+    assert len(ax.current_points) == 0 # tether defined, refresh points list

--- a/lumicks/pylake/tests/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_correlated_stack.py
@@ -519,7 +519,7 @@ def test_get_image():
 
 
 def test_define_tether():
-    from pylake.detail.widefield import TransformMatrix
+    from lumicks.pylake.detail.widefield import TransformMatrix
 
     def make_stack(data, description, bit_depth):
         tiff = TiffStack(


### PR DESCRIPTION
**Why this PR?**
Because everybody loves interactive plots!

There are currently two actions possible:
* scrolling with the mouse wheel to scroll through the image frames
* left-clicking to define the end coordinates of the tether

I've tested this in both a normal script and in jupyter notebook and lab. Docs are [here](https://lumicks-pylake.readthedocs.io/en/interactive_tether/tutorial/nbwidgets.html#image-stack-editor)

I've chosen to implement this plot by subclassing `mpl.Axes` which is a different method than we use for all of the other widgets. Personally I find this way much cleaner because all of the visualization and event handling can be abstracted/encapsulated away to the axes instance. If we like this way of doing things, I think it would be straight-forward to refactor some of the other widgets, which I believe would simplify a lot of code. Comments/questions of course welcome.

![tether_demo_final](https://user-images.githubusercontent.com/61475504/146406701-8a139106-3e11-41a1-9a4a-9f15714649b5.gif)

