### PR TITLE
force_calib: remove axial parameter active calibration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * Fixed issue which resulted in the offset parameter added by `Model.subtract_independent_offset()` not having a unit associated with it.
 * Fixed bug which resulted in erroneous standard errors on parameter estimates computed from an `FdFit` with fixed parameters. For such a fitting problem, the covariance matrix was evaluated for the unconstrained problem (without the fixed parameter constraints). As a result, standard errors were always overestimated. Note that uncertainty estimation by profile likelihood was unaffected.
 * Fixed issue which resulted in overly stringent positional tolerance when using the kymotracker widget. This tolerance has now been made proportional to the axis viewport.
+* Removed `axial` parameter from `lk.ActiveCalibrationModel()` as we do not support active force calibration in the axial direction.
 
 ## v0.11.0 | 2021-12-07
 

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -498,7 +498,6 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
         rho_sample=None,
         rho_bead=1060.0,
         fast_sensor=False,
-        axial=False,
     ):
         """
         Active Calibration Model.
@@ -538,8 +537,6 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
             Density of the bead [kg/m**3]. Only used when using hydrodynamically correct model.
         fast_sensor : bool
             Fast sensor? Fast sensors do not have the diode effect included in the model.
-        axial : bool
-            Is this an axial force model?
         """
         super().__init__(
             bead_diameter,
@@ -550,7 +547,7 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
             rho_sample,
             rho_bead,
             fast_sensor,
-            axial,
+            False,
         )
         self.driving_frequency_guess = driving_frequency_guess
         self.sample_rate = sample_rate


### PR DESCRIPTION
**Why this PR?**
We do not support active axial force calibration. The model is not valid here.