### PR TITLE
Replace `CorrelatedStack.timestamps` with `frame_timestamp_ranges` (via deprecation)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,10 @@
 * Removed `axial` parameter from `lk.ActiveCalibrationModel()` as we do not support active force calibration in the axial direction.
 * Improved default scaling behaviour for `CorrelatedStack.plot_correlated()` and `Scan.plot_correlated()`. It now ensures the ratio between the image and temporal plot is according to the aspect ratio of the scan or stack.
 
+#### Deprecations
+
+* Deprecated `CorrelatedStack.timestamps` and replaced with `CorrelatedStack.frame_timestamp_ranges`. The reason for this change is that per-pixel timestamps are not defined for camera based images; therefore, this previous use was not in line with the use of the `timestamps` property of confocal image classes. This change also brings consistency with `Scan.frame_timestamp_ranges`.
+
 ## v0.11.0 | 2021-12-07
 
 #### New force calibration features

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -91,4 +91,4 @@ downsampled over the video frames. This can be done using the function `Slice.do
 using timestamps obtained from the `CorrelatedStack`::
 
     # Determine the force trace averaged over frame 2...9.
-    file.force1x.downsampled_over(stack[2:10].timestamps)
+    file.force1x.downsampled_over(stack[2:10].frame_timestamp_ranges)

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -174,7 +174,7 @@ class Slice:
 
             file = pylake.File("example.h5")
             stack = pylake.CorrelatedStack("example.tiff")
-            file.force1x.downsampled_over(stack.timestamps)
+            file.force1x.downsampled_over(stack.frame_timestamp_ranges)
         """
         if not isinstance(range_list, list):
             raise TypeError("Did not pass timestamps to range_list.")

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -34,7 +34,7 @@ class CorrelatedStack:
         stack.plot_correlated(file.force1x)
 
         # Determine the force trace averaged over frame 2...9.
-        file.force1x.downsampled_over(stack[2:10].timestamps)
+        file.force1x.downsampled_over(stack[2:10].frame_timestamp_ranges)
     """
 
     def __init__(self, image_name, align=True):
@@ -256,7 +256,7 @@ class CorrelatedStack:
         """
         from lumicks.pylake.nb_widgets.correlated_plot import plot_correlated
 
-        frame_timestamps = self.timestamps
+        frame_timestamps = self.frame_timestamp_ranges
         plot_correlated(
             channel_slice,
             frame_timestamps,
@@ -367,7 +367,19 @@ class CorrelatedStack:
         return self._get_frame(self.num_frames - 1).stop
 
     @property
+    @deprecated(
+        reason=(
+            "For camera based images only the integration start/stop timestamps are defined. "
+            "Use `CorrelatedStack.frame_timestamp_ranges` instead."
+        ),
+        action="always",
+        version="0.11.1",
+    )
     def timestamps(self):
+        return self.frame_timestamp_ranges
+
+    @property
+    def frame_timestamp_ranges(self):
         """List of time stamps."""
         return [
             (self._get_frame(idx).start, self._get_frame(idx).stop)


### PR DESCRIPTION
**Why this PR?**

The values of `CorrelatedStack.timestamps` was inconsistent with those from `Scan.timestamps`. The frame start/stop timestamp pairs were returned for the former while individual pixel timestamps are returned for the latter.  Instead, `Scan.frame_timestamp_ranges` (added in #229) is in line with the values available for camera based images. With this change, the two APIs are now consistent