### PR TITLE
Add cropping to WIT image editor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 
 * Added `CorrelatedStack.define_tether()` which can be used to define the endpoints of the tether between two beads and return image data rotated such that the tether is horizontal. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html) for more information.
 * Added function to correlate `Scan` frames to channel data. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html#correlating-scans).
-* Added `CorrelatedStack.crop_and_rotate()` for interactive editing of the image stack. Actions include scrolling through image frames with the mouse wheel, and left-clicking to define the tether coordinates. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html#image-stack-editor) for more information.
+* Added `CorrelatedStack.crop_and_rotate()` for interactive editing of the image stack. Actions include scrolling through image frames with the mouse wheel, and left-clicking to define the tether coordinates, and right-click/drag to define a cropping region. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html#image-stack-editor) for more information.
 
 #### Bug fixes
 

--- a/docs/tutorial/nbwidgets.rst
+++ b/docs/tutorial/nbwidgets.rst
@@ -167,20 +167,30 @@ You can interactively define the location of a tether for a `CorrelatedStack` by
     editor = stack.crop_and_rotate()
     plt.show()
 
-Simply click on the start of the tether
+Simply left-click on the start of the tether
 
-    .. image:: widget_stack_editor_1.png
+.. image:: widget_stack_editor_1.png
 
 and then on the end of the tether
 
-    .. image:: widget_stack_editor_2.png
+.. image:: widget_stack_editor_2.png
 
 After a tether is defined, the view will update showing the location of the tether and the
-image rotated such that the tether is horizontal. Note that `CorrelatedStack.crop_and_rotate()` accepts
-all of the arguments that can be used for `CorrelatedStack.plot()`.
+image rotated such that the tether is horizontal.
+
+To crop an image, right-click and drag a rectangle around the region of interest. Once the rectangle is defined,
+you can edit the shape by right-clicking and dragging the various handles.
+
+.. image:: widget_stack_editor_3.png
 
 You can also use the mouse wheel to scroll through the individual frames (if using Jupyter Lab, hold `Shift` while scrolling).
+
+*Note that* `CorrelatedStack.crop_and_rotate()` *accepts all of the arguments that can be used for* `CorrelatedStack.plot()`.
 
 To obtain a copy of the edited `CorrelatedStack` object, use::
 
     new_stack = editor.image
+    new_stack.plot()
+    new_stack.plot_tether()
+
+.. image:: widget_stack_editor_4.png

--- a/docs/tutorial/widget_stack_editor_3.png
+++ b/docs/tutorial/widget_stack_editor_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f860e7f5114ec2c286bc732f0b4322cc22063027a6151defb4e7a8173ccdf0a2
+size 283302

--- a/docs/tutorial/widget_stack_editor_4.png
+++ b/docs/tutorial/widget_stack_editor_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fdf3bc85d3ee51fc35d08b74396a0acca67f31b2b0a5a538090133737cea77f
+size 114264

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -211,6 +211,24 @@ class CorrelatedStack:
             Controls display of auto-generated plot title
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`.
+
+        Examples
+        --------
+        ::
+
+        from lumicks import pylake
+        import matplotlib.pyplot as plt
+
+        # Loading a stack.
+        stack = pylake.CorrelatedStack("example.tiff")
+        widget = stack.crop_and_rotate()
+        plt.show()
+
+        # Select cropping ROI by right-click drag
+        # Select tether ends by left-click
+
+        # Grab the updated image stack
+        new_stack = widget.image
         """
         return ImageEditorWidget(self, frame, channel, show_title, **kwargs)
 

--- a/lumicks/pylake/nb_widgets/tests/conftest.py
+++ b/lumicks/pylake/nb_widgets/tests/conftest.py
@@ -31,7 +31,7 @@ def mockevent():
 @pytest.fixture
 def region_select():
     def region(xs, ys, xe, ye):
-        return MockEvent(0, ys, xs, 0, 0), MockEvent(0, ye, xe, 0, 0)
+        return MockEvent(0, xs, ys, 0, 0), MockEvent(0, xe, ye, 0, 0)
 
     return lambda xs, ys, xe, ye: region(xs, ys, xe, ye)
 

--- a/lumicks/pylake/nb_widgets/tests/test_image_editing.py
+++ b/lumicks/pylake/nb_widgets/tests/test_image_editing.py
@@ -71,7 +71,7 @@ def test_editor_clicks(mockevent):
     ax = plt.gca()
 
     # test returned stack is same as currently plotted stack
-    assert id(w.image) == id(ax.current_image)
+    assert id(w.image) == id(ax._current_image)
     # returned stack is the original stack
     assert id(w.image) == id(stack)
     # no points currently defined
@@ -80,12 +80,23 @@ def test_editor_clicks(mockevent):
     # click first tether point
     event = mockevent(ax, 50, 50, 1, False)
     ax.handle_button_event(event)
-    assert id(w.image) == id(ax.current_image) # widget synced with axes
+    assert id(w.image) == id(ax._current_image) # widget synced with axes
     assert len(ax.current_points) == 1 # one click registered
 
     # click second tether point
     event = mockevent(ax, 50, 75, 1, False)
     ax.handle_button_event(event)
-    assert id(w.image) == id(ax.current_image) # widget synced with axes
+    assert id(w.image) == id(ax._current_image) # widget synced with axes
     assert id(w.image) != id(stack) # stack was updated
     assert len(ax.current_points) == 0 # tether defined, refresh points list
+
+
+def test_cropping_clicks(region_select):
+    stack = make_mock_stack()
+    w = ImageEditorWidget(stack)
+    ax = plt.gca()
+
+    events = region_select(50, 25, 150, 75)
+    ax.handle_crop(*events)
+    np.testing.assert_equal(ax.roi_limits, (50, 150, 25, 75))
+    np.testing.assert_equal(w.image.src._shape, (50, 100))

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -54,14 +54,14 @@ def test_track_kymo(kymograph, region_select):
 
     # Track a line in a particular region. Only a single line exists in this region.
     kymo_widget.algorithm_parameters["pixel_threshold"] = 4
-    kymo_widget.track_kymo(*region_select(in_um(8), in_s(10), in_um(9), in_s(20)))
+    kymo_widget.track_kymo(*region_select(in_s(10), in_um(8), in_s(20), in_um(9)))
     np.testing.assert_allclose(kymo_widget.lines[0].time_idx, np.arange(10, 20))
     np.testing.assert_allclose(kymo_widget.lines[0].coordinate_idx, [8] * 10)
     assert len(kymo_widget.lines) == 1
 
     # Verify that if we track the same region, the old one gets deleted and we track the same line
     # again.
-    kymo_widget.track_kymo(*region_select(in_um(8), in_s(15), in_um(9), in_s(20)))
+    kymo_widget.track_kymo(*region_select(in_s(15), in_um(8), in_s(20), in_um(9)))
     np.testing.assert_allclose(kymo_widget.lines[0].time_idx, np.arange(15, 20))
     np.testing.assert_allclose(kymo_widget.lines[0].coordinate_idx, [8] * 5)
     assert len(kymo_widget.lines) == 1
@@ -72,7 +72,7 @@ def test_track_kymo(kymograph, region_select):
 
     # Remove a single line
     kymo_widget.adding = False
-    kymo_widget.track_kymo(*region_select(in_um(8), in_s(15), in_um(9), in_s(20)))
+    kymo_widget.track_kymo(*region_select(in_s(15), in_um(8), in_s(20), in_um(9)))
     assert len(kymo_widget.lines) == 2
 
 
@@ -114,7 +114,7 @@ def test_refine_from_widget(kymograph, region_select):
                                        "refine them"
 
     kymo_widget.algorithm_parameters["pixel_threshold"] = 4
-    kymo_widget.track_kymo(*region_select(in_um(12), in_s(5), in_um(13), in_s(20)))
+    kymo_widget.track_kymo(*region_select(in_s(5), in_um(12), in_s(20), in_um(13)))
     np.testing.assert_allclose(kymo_widget.lines[0].time_idx, np.hstack(([5, 6], np.arange(9, 20))))
     np.testing.assert_allclose(kymo_widget.lines[0].coordinate_idx, [12] * 13)
     assert len(kymo_widget.lines) == 1
@@ -171,7 +171,7 @@ def test_refine_line_width_units(kymograph, region_select):
     in_um, in_s = calibrate_to_kymo(kymograph)
 
     kymo_widget.algorithm_parameters["pixel_threshold"] = 4
-    kymo_widget.track_kymo(*region_select(in_um(12), in_s(5), in_um(13), in_s(20)))
+    kymo_widget.track_kymo(*region_select(in_s(5), in_um(12), in_s(20), in_um(13)))
     kymo_widget.refine()
 
     # With this line_width we'll include the two dim pixels in the test data


### PR DESCRIPTION
**Why this PR?**
drag to crop is nice. Docs are [here](https://lumicks-pylake.readthedocs.io/en/interactive_crop/tutorial/nbwidgets.html#image-stack-editor)

*Note*: while writing the tests for this, I noticed that our mock event for rectangle selection had the coordinates backwards; it was receiving `(y, x)` pairs instead of `(x, y)` pairs. I piggybacked the fix for this here as I needed that even for tests anyway.