### PR TITLE
Histogram kymotrack binding events

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Added `CorrelatedStack.define_tether()` which can be used to define the endpoints of the tether between two beads and return image data rotated such that the tether is horizontal. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html) for more information.
 * Added function to correlate `Scan` frames to channel data. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html#correlating-scans).
 * Added `CorrelatedStack.crop_and_rotate()` for interactive editing of the image stack. Actions include scrolling through image frames with the mouse wheel, and left-clicking to define the tether coordinates, and right-click/drag to define a cropping region. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html#image-stack-editor) for more information.
+* Added 'KymoLineGroup.plot_binding_histogram()` to plot histograms of binding events for tracked lines. See [Kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#plotting-binding-histograms) for more details.
 
 #### Bug fixes
 

--- a/docs/tutorial/kymo_bind_histogram_1.png
+++ b/docs/tutorial/kymo_bind_histogram_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2b7836e1859f269d0089c2d22b038f8116e9895858a9ba08d44bc73f33c5136
+size 10412

--- a/docs/tutorial/kymo_bind_histogram_2.png
+++ b/docs/tutorial/kymo_bind_histogram_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64f350a884b19be458e7c2895f9a8adafce6dd624539236e4c6a111435a8ddca
+size 12249

--- a/docs/tutorial/kymo_bind_histogram_3.png
+++ b/docs/tutorial/kymo_bind_histogram_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5af7912916aad24c8ab66c85bfeaf96691dcaa265220ce881621fcefc1884b7
+size 13841

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -224,6 +224,39 @@ Here `num_pixels` is the number of pixels to sum on either side of the trace.
 .. image:: kymo_sumcounts.png
 
 
+Plotting binding histograms
+---------------------------
+
+We can easily plot some histograms of the binding events located with the kymotracker. Simply use::
+
+    plt.figure()
+    traces.plot_binding_histogram(kind="binding")
+
+.. image:: kymo_bind_histogram_1.png
+
+Here, the `kind="binding"` argument indicates that we only wish to analyze the initial binding events (the first
+position of each track). We can optionally supply a `bins` argument, which is forwarded to `np.histogram()`.
+For instance, we can increase the number of bins from 10 (the default) to 50::
+
+    plt.figure()
+    traces.plot_binding_histogram("binding", bins=50)
+
+.. image:: kymo_bind_histogram_2.png
+
+When an integer is supplied to the `bins` argument, the full position range is used to calculate the bin edges (this is
+equivalent to using `np.histogram(data, bins=n, range=(0, max_position))`). This facilitates comparison of histograms calculated
+from different kymographs, as the absolute x-scale is dependent on the kymograph acquisition options, rather than the positions
+of the tracked lines. Alternatively, it is possible to supply a custom array of bin edges, as demonstrated below::
+
+    plt.figure()
+    traces.plot_binding_histogram("kind=all", bins=np.linspace(12, 18, 75), fc="#dcdcdc", ec="tab:blue")
+
+.. image:: kymo_bind_histogram_3.png
+
+Notice that here we use `kind="all"` to include all of the bound positions for each track. This snippet also demonstrates
+how we can pass keyword arguments (forwarded to `plt.bar()`) to format the histogram.
+
+
 Exporting kymograph traces
 --------------------------
 

--- a/lumicks/pylake/kymotracker/tests/test_kymoline.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymoline.py
@@ -229,3 +229,34 @@ def test_kymoline_msd_plot(max_lag, x_data, y_data):
     k.plot_msd(max_lag=max_lag)
     np.testing.assert_allclose(plt.gca().lines[0].get_xdata(), x_data)
     np.testing.assert_allclose(plt.gca().lines[0].get_ydata(), y_data)
+
+
+def test_binding_histograms():
+    channel = CalibratedKymographChannel("test_data", np.zeros((10, 10)), 1e9, 1)
+
+    k1 = KymoLine(np.array([1, 2, 3]), np.array([2.5, 3.5, 4.5]), channel)
+    k2 = KymoLine(np.array([2, 3, 4]), np.array([3.5, 4.5, 5.5]), channel)
+    k3 = KymoLine(np.array([3, 4, 5]), np.array([4.5, 5.5, 6.5]), channel)
+    k4 = KymoLine(np.array([4, 5, 6]), np.array([5.5, 6.5, 7.5]), channel)
+
+    lines = KymoLineGroup([k1, k2, k3, k4])
+
+    # Counting only the first position of each track with the default number of bins
+    counts, edges = lines._histogram_binding_events("binding")
+    np.testing.assert_equal(counts, [0, 0, 1, 1, 1, 1, 0, 0, 0, 0])
+    np.testing.assert_allclose(edges, [0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10])
+
+    # Counting all points of each track with the default number of bins
+    counts, edges = lines._histogram_binding_events("all")
+    np.testing.assert_equal(counts, [0, 0, 1, 2, 3, 3, 2, 1, 0, 0])
+    np.testing.assert_allclose(edges, [0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10])
+
+    # Counting only the first position of each track with custom bin edges
+    counts, edges = lines._histogram_binding_events("binding", bins=[2, 3, 4, 5, 6, 7, 8])
+    np.testing.assert_equal(counts, [1, 1, 1, 1, 0, 0])
+    np.testing.assert_allclose(edges, [2, 3, 4, 5, 6, 7, 8])
+
+    # Counting all points of each track with custom bin edges
+    counts, edges = lines._histogram_binding_events("all", bins=[2, 3, 4, 5, 6, 7, 8])
+    np.testing.assert_equal(counts, [1, 2, 3, 3, 2, 1])
+    np.testing.assert_allclose(edges, [2, 3, 4, 5, 6, 7, 8])


### PR DESCRIPTION
**Why this PR?**
Requested convenience function from users. I split this up into an internal backend function that actually calculates the data needed to construct the histogram (for use in other places) and a public function for actually generating the plot.

The original ticket requested a histogram of only the initial binding events (the first position of each track); however it was straightforward to also include histogramming all of the positions of each track, which is also a useful metric, so I wrapped it in this PR.

Docs are [here](https://lumicks-pylake.readthedocs.io/en/hist_bind_events/tutorial/kymotracking.html#plotting-binding-histograms)