### PR TITLE
Add copy method for confocal classes

### DIFF
--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -126,6 +126,15 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
 
         return cls(name, file, start, stop, json_data)
 
+    def __copy__(self):
+        return self.__class__(
+            name=self.name,
+            file=self.file,
+            start=self.start,
+            stop=self.stop,
+            json=self._json,
+        )
+
     @property
     @deprecated(
         reason=(


### PR DESCRIPTION
**Why this PR?**
Specifically for `Kymo` we ended up with 4 methods which require copying `self` and modifying only a few attributes resulting in duplication of the rather long `__init__()` call. This way is cleaner.

Note: inside `BaseScan.__copy__()` we call the `__init__()` method such that the cache is not propagated to the copied instances.