### PR TITLE
kymotracker: allow a fixed offset for the Gaussian refinement.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * Added function to correlate `Scan` frames to channel data. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html#correlating-scans).
 * Added `CorrelatedStack.crop_and_rotate()` for interactive editing of the image stack. Actions include scrolling through image frames with the mouse wheel, and left-clicking to define the tether coordinates, and right-click/drag to define a cropping region. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html#image-stack-editor) for more information.
 * Added 'KymoLineGroup.plot_binding_histogram()` to plot histograms of binding events for tracked lines. See [Kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#plotting-binding-histograms) for more details.
+* Allow fixing the photon background parameter in `refine_lines_gaussian()`. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#maximum-likelihood-estimation) for more information.
 
 #### Bug fixes
 

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -273,7 +273,12 @@ def refine_lines_centroid(lines, line_width):
 
 
 def refine_lines_gaussian(
-    lines, window, refine_missing_frames, overlap_strategy, initial_sigma=None
+    lines,
+    window,
+    refine_missing_frames,
+    overlap_strategy,
+    initial_sigma=None,
+    fixed_background=None,
 ):
     """Refine the lines by gaussian peak MLE.
 
@@ -292,6 +297,9 @@ def refine_lines_gaussian(
         - 'skip' : skip optimization of the frame; remove from returned `KymoLine`.
     initial_sigma : float
         Initial guess for the `sigma` parameter.
+    fixed_background : float
+        Fixed background parameter in photons per second.
+        When supplied, the background is not estimated but fixed at this value.
     """
     assert overlap_strategy in ("ignore", "skip")
     if refine_missing_frames:
@@ -332,6 +340,7 @@ def refine_lines_gaussian(
                 image._pixel_size,
                 initial_position=line.position[j],
                 initial_sigma=initial_sigma,
+                fixed_background=fixed_background,
             )
             tmp_positions.append(r.x[1] / image._pixel_size)
             tmp_times.append(line.time_idx[j])

--- a/lumicks/pylake/kymotracker/tests/test_gaussian_mle.py
+++ b/lumicks/pylake/kymotracker/tests/test_gaussian_mle.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from functools import partial
 
@@ -39,3 +40,23 @@ def test_gaussian_1d(gaussian_1d):
     result = gaussian_mle.gaussian_mle_1d(coordinates, photon_count[:,0], parameters.pixel_size)
     assert np.allclose(result.x, [54.3777483, 3.50778329,  0.2836636, 0.80622237])
     assert np.allclose(result.x, p, rtol=0.2)
+
+
+def test_gaussian_1d_fixed_offset(gaussian_1d):
+    """Providing the true background we get closer to the truth values of 50, 3.5 and 0.25"""
+    coordinates, expectation, photon_count, [parameters, *_] = gaussian_1d
+    result = gaussian_mle.gaussian_mle_1d(
+        coordinates,
+        photon_count[:, 0],
+        fixed_background=1.0,
+        pixel_size=parameters.pixel_size,
+    )
+    assert np.allclose(result.x, [51.46192613, 3.50342814, 0.272388])
+
+
+def test_gaussian_1d_invalid_background_value():
+    with pytest.raises(ValueError, match="Fixed background should be larger than zero"):
+        gaussian_mle.gaussian_mle_1d([], [], fixed_background=-1.0, pixel_size=1.0)
+
+    with pytest.raises(ValueError, match="Fixed background should be larger than zero"):
+        gaussian_mle.gaussian_mle_1d([], [], fixed_background=0.0, pixel_size=1.0)

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -108,3 +108,23 @@ def test_gaussian_refinement(kymogroups_2lines):
     assert len(refined) == 1
     # 2 frames in mixed_lines[1] overlap with first track, 2 skipped, 3 fitted
     assert np.allclose(refined[0].position, [4.94659924, 5.00920806, 4.97724526])
+
+
+def test_gaussian_refinement_fixed_background(kymogroups_2lines):
+    lines, _, _ = kymogroups_2lines
+
+    refined = refine_lines_gaussian(
+        lines,
+        window=3,
+        refine_missing_frames=True,
+        overlap_strategy="ignore",
+        fixed_background=1.0,
+    )
+    assert np.allclose(
+        refined[0].position,
+        [3.54875771, 3.52793245, 3.56789807, 3.46844518, 3.48508813],
+    )
+    assert np.allclose(
+        refined[1].position,
+        [4.96956982, 4.99811141, 5.02009032, 5.01614766, 4.99094119],
+    )


### PR DESCRIPTION
**Why this PR?**
Estimating both a Gaussian and offset parameter can introduce unnecessarily high variance when the region used for fitting is narrow. An alternative is to estimate the background separately in a pre-processing step and just use that as a fixed parameter in the model.

This PR allows that option.
Note that a widget to determine the offset is planned and therefore explicitly omitted from this PR.

![image](https://user-images.githubusercontent.com/19836026/148397464-01d2e11f-2bec-48e8-99b4-c556fbecd318.png)

Docs build here: https://lumicks-pylake.readthedocs.io/en/fixed_gaussian/