### PR TITLE
Interactive cropping and calibration for kymos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 * Added option to specify a custom label when plotting fit with `FdFit.plot()`. See the tutorial section on [Fd Fitting](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/fdfitting.html#plotting-the-data) for more information.
 * Added functionality to slice `Scan` objects by frame indices. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html).
 * Added convenience function which allows users to perform a force calibration procedure with a single function call `calibrate_force()`. See [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html#more-convenient-calibration).
+* Added `Kymo.crop_and_calibrate()` for interactive cropping of a kymograph. If the optional `tether_length_kbp` argument is supplied, the resulting kymograph will be automatically calibrated to this length. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html#calibrating-to-base-pairs) for more information.
 
 #### Bug fixes
 

--- a/docs/tutorial/figures/kymographs/kymo_calibrated.png
+++ b/docs/tutorial/figures/kymographs/kymo_calibrated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:576b16456c45c0bde132ca75b11cbd7b998e642ce68f5d819052f148107ab2c4
+size 197296

--- a/docs/tutorial/figures/kymographs/kymo_cropped.png
+++ b/docs/tutorial/figures/kymographs/kymo_cropped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7372339d6a807907db91c03c1d18f743f429618153abf6fbc42cd681c4c46f8
+size 154077

--- a/docs/tutorial/figures/kymographs/kymo_cropped_and_sliced.png
+++ b/docs/tutorial/figures/kymographs/kymo_cropped_and_sliced.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e162920d93575ec3a0d921416a28a351d1faafa48bf99297d497dade4c245adb
+size 198430

--- a/docs/tutorial/figures/kymographs/kymo_downsampled_position.png
+++ b/docs/tutorial/figures/kymographs/kymo_downsampled_position.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca8ed9fbeccc4f7772fe63338b89aad7193c8bad6c0313a2833b6f47a0cb0fd7
+size 188040

--- a/docs/tutorial/figures/kymographs/kymo_downsampled_time.png
+++ b/docs/tutorial/figures/kymographs/kymo_downsampled_time.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61fc83ba60f3696752fce966f60d8e082359f11b209c8dda82071330fdfc13a0
+size 230997

--- a/docs/tutorial/figures/kymographs/kymo_downsampled_time_and_position.png
+++ b/docs/tutorial/figures/kymographs/kymo_downsampled_time_and_position.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9ef60d63d0bb110dc8b824cb3feed4e86767928983f441574f13926453ee2bc
+size 217062

--- a/docs/tutorial/figures/kymographs/kymo_interactive.png
+++ b/docs/tutorial/figures/kymographs/kymo_interactive.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29b512e9c561ad99f05d894c12b7b3b271fc1fe53b9c322257ae7cf74b069603
+size 188492

--- a/docs/tutorial/figures/kymographs/kymo_interactive_result.png
+++ b/docs/tutorial/figures/kymographs/kymo_interactive_result.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2453490c0325f49110b0e032f1acba20afd3497b30218157cf0f165b5b9e6b31
+size 174994

--- a/docs/tutorial/figures/kymographs/kymo_intro.png
+++ b/docs/tutorial/figures/kymographs/kymo_intro.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4210156d51daed983fff2104a36037ac1a0b143c5422b39cd86c2d01e30502e
+size 169437

--- a/docs/tutorial/figures/kymographs/kymo_manual_plotting.png
+++ b/docs/tutorial/figures/kymographs/kymo_manual_plotting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a95414d38a8221e7bde020481b086e7828ab2cdefe63a4ba7968609a844c59c4
+size 262168

--- a/docs/tutorial/figures/kymographs/kymo_sliced.png
+++ b/docs/tutorial/figures/kymographs/kymo_sliced.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21ff270df337750c4efac2704e82607f17d61930ef9cb31318b1e353a8c4eed2
+size 213917

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -10,40 +10,43 @@ To load an HDF5 file and lists all of the kymographs inside of it, run::
     import lumicks.pylake as lk
 
     file = lk.File("example.h5")
-    list(file.kymos)  # e.g. shows: "['reference', 'sytox']"
+    list(file.kymos)  # e.g. shows: "['cas9', 'reference']"
 
 Once again, `.kymos` is a regular Python dictionary so we can easily iterate over it::
 
     # Plot all kymos in a file
-    for name, kymo in file.kymos.items():
-        kymo.plot(channel="rgb")
-        plt.savefig(name)
+    >>> for name, kymo in file.kymos.items():
+            print(f"{name}, starts at {kymo.start} ns")
+    cas9, starts at 1586776312560250200 ns
+    reference, starts at 1586777007674285402 ns
 
 Or just pick a single one::
 
-    kymo = file.kymos["name"]
-    kymo.plot("red")
+    kymo = file.kymos["cas9"]
+    kymo.plot(channel="green", aspect="auto", vmax=5)
+
+.. image:: figures/kymographs/kymo_intro.png
+
+Here we see the `plot()` convenience function. The `channel` argument accepts the strings "red", "green",
+"blue", or "rgb". This function accepts keyword arguments that are passed to `plt.imshow()` internally.
+Note also, the axes are labeled with the appropriate time and position units.
+
+The kymograph can also be exported to TIFF format::
+
+    kymo.save_tiff("image.tiff")
 
 Kymo data and details
 ---------------------
 
-Access the raw image data::
+We can access the raw image data as `numpy` arrays::
 
     rgb = kymo.rgb_image  # matrix with `shape == (h, w, 3)`
     blue = kymo.blue_image  # single color so `shape == (h, w)`
 
     # Plot manually
-    plt.imshow(rgb)
+    plt.imshow(kymo.green_image, aspect="auto", vmax=5)
 
-It is possible to crop a kymograph to a specific coordinate range, by using the function :meth:`~lumicks.pylake.Kymo.crop_by_distance`::
-For example, we can crop the region from `2` micron to `7` micron using the following command::
-
-    kymo.crop_by_distance(2, 7)
-
-Kymographs can also be sliced in order to obtain a specific time range.
-For example, one can plot the region of the kymograph between 175 and 180 seconds using::
-
-    kymo["175s":"180s"].plot("red")
+.. image:: figures/kymographs/kymo_manual_plotting.png
 
 There are also several properties available for convenient access to the kymograph metadata:
 
@@ -54,47 +57,96 @@ There are also several properties available for convenient access to the kymogra
 * `kymo.fast_axis` provides the axis that was scanned (x or y)
 * `kymo.line_time_seconds` provides the time between successive lines
 
+Cropping and slicing
+--------------------
+
+It is possible to crop a kymograph to a specific coordinate range, by using the function `Kymo.crop_by_distance`
+For example, we can crop the region from `6` micron to `24` micron using the following command::
+
+    kymo.crop_by_distance(6, 24).plot("green)
+
+.. image:: figures/kymographs/kymo_cropped.png
+
+Kymographs can also be sliced in order to obtain a specific time range.
+For example, one can plot the region of the kymograph between 114.2 and 164.6 seconds using::
+
+    kymo["114.2s":"164.6s"].plot("green")
+
+.. image:: figures/kymographs/kymo_sliced.png
+
+Note, slicing in time is currently only supported for unprocessed kymographs. If you want to both crop and slice a kymo,
+the order of operations is important::
+
+    kymo_sliced = kymo["114.2s":"164.6s"]
+    kymo_cropped = kymo_sliced.crop_by_distance(6, 24)
+
+    kymo_cropped.plot("green")
+
+.. image:: figures/kymographs/kymo_cropped_and_sliced.png
+
+Calibrating to base pairs
+-------------------------
+
 By default, kymographs are constructed with units of microns for the position axis. If, however, the kymograph spans a known length of DNA (for example,
 lambda DNA) we can calibrate the position axis to kilobase pairs::
 
-    kymo.calibrate_to_kbp(14.850)
+    kymo_kbp = kymo_cropped.calibrate_to_kbp(48.502)
 
-Now if we plot the image, the y-axis will be labeled in kbp. These units are also carried forward to any downstream operations such as cropping,
-kymotracking algorithms, MSD analysis, etc. *Note: currently this is a static calibration, meaning it is only valid if the traps do not
-change position during the time of the kymograph.*
+Now if we plot the image, the y-axis will be labeled in kbp::
 
-Downsampling kymograph
-----------------------
+    kymo_kbp.plot("green")
+
+.. image:: figures/kymographs/kymo_calibrated.png
+
+These units are also carried forward to any downstream operations such as
+kymotracking algorithms and MSD analysis, . *Note: currently this is a static calibration, meaning it is only valid
+if the traps do not change position during the time of the kymograph.*
+
+We can also interactively slice, crop, and calibrate kymographs using::
+
+    widget = kymo.crop_and_calibrate(channel="green", tether_length_kbp=48.502)
+    plt.show()
+
+.. image:: figures/kymographs/kymo_interactive.png
+
+Simply click and drag the rectangle selector to the desired ROI. After closing the widget, we can access the edited kymograph
+with::
+
+    new_kymo = widget.kymo
+    new_kymo.plot("green")
+
+.. image:: figures/kymographs/kymo_interactive_result.png
+
+If the optional `tether_length_kbp` argument is supplied, the kymograph is automatically calibrated to the desired
+length in kilobase pairs. If this argument is missing (the default value `None`) the edited kymograph is only
+sliced and cropped.
+
+
+Downsampling
+------------
 
 We can downsample a kymograph in time by invoking::
 
-    kymo_ds = kymo.downsampled_by(time_factor=2)
+    kymo_ds = kymo_cropped.downsampled_by(time_factor=2)
+
+.. image:: figures/kymographs/kymo_downsampled_time.png
 
 Or in space by invoking::
 
-    kymo_ds = kymo.downsampled_by(position_factor=2)
+    kymo_ds = kymo_cropped.downsampled_by(position_factor=2)
+
+.. image:: figures/kymographs/kymo_downsampled_position.png
 
 Or both::
 
-    kymo_ds = kymo.downsampled_by(time_factor=2, position_factor=2)
+    kymo_ds = kymo_cropped.downsampled_by(time_factor=2, position_factor=2)
+
+.. image:: figures/kymographs/kymo_downsampled_time_and_position.png
 
 Note however, that not all functionalities are present anymore when downsampling a kymograph. For
 example, if we downsample a kymograph by time, we can no longer access the per pixel timestamps::
 
     >>> kymo_ds.timestamps
-    AttributeError: Per pixel timestamps are no longer available after downsampling a kymograph in time since they are not well defined (the downsampling occurs over a non contiguous time window).
-    Line timestamps are still available however. See: `Kymo.line_time_seconds`.
-
-Plotting and exporting
-----------------------
-
-There are also convenience functions to plot individual color channels and the full RGB image::
-
-    plt.subplot(2, 1, 1)
-    kymo.plot("rgb")
-    plt.subplot(2, 1, 2)
-    kymo.plot("blue")
-
-The images can also be exported in the TIFF format::
-
-    kymo.save_tiff("image.tiff")
+    AttributeError: Per pixel timestamps are no longer available after downsampling a kymograph in time since they
+    are not well defined (the downsampling occurs over a non contiguous time window). Line timestamps are still
+    available however. See: `Kymo.line_time_seconds`.

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -4,7 +4,6 @@ import tifffile
 import warnings
 from deprecated.sphinx import deprecated
 from .detail.widefield import TiffStack
-from .nb_widgets.image_editing import ImageEditorWidget
 
 
 class CorrelatedStack:
@@ -236,6 +235,8 @@ class CorrelatedStack:
         # Grab the updated image stack
         new_stack = widget.image
         """
+        from .nb_widgets.image_editing import ImageEditorWidget
+
         return ImageEditorWidget(self, frame, channel, show_title, **kwargs)
 
     def _get_frame(self, frame=0):

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -431,6 +431,46 @@ class Kymo(ConfocalImage):
 
         return result
 
+    def crop_and_calibrate(self, channel="rgb", tether_length_kbp=None, **kwargs):
+        """Open a widget to interactively edit the image stack.
+
+        Actions include:
+            * left-click and drag to define the cropped ROI
+
+        Parameters
+        ----------
+        channel : 'rgb', 'red', 'green', 'blue', None; optional
+            Channel to plot for RGB images (None defaults to 'rgb')
+            Not used for grayscale images
+        tether_length_kbp : float
+            Length of the tether in the cropped region in kilobase pairs.
+            If provided, the kymo returned from the `image` property will be automatically
+            calibrated to this tether length.
+        **kwargs
+            Forwarded to :func:`Kymo.plot()`.
+
+        Examples
+        --------
+        ::
+
+        from lumicks import pylake
+        import matplotlib.pyplot as plt
+
+        # Loading a stack.
+        h5_file = pylake.File("example.h5")
+        _, kymo = h5_file.kymos.popitem()
+        widget = kymo.crop_and_calibrate("green", 48.502)
+        plt.show()
+
+        # Select cropping ROI by left-click drag
+
+        # Grab the updated image stack
+        new_kymo = widget.kymo
+        """
+        from .nb_widgets.image_editing import KymoEditorWidget
+
+        return KymoEditorWidget(self, channel, tether_length_kbp, **kwargs)
+
 
 class EmptyKymo(Kymo):
     def plot_rgb(self):


### PR DESCRIPTION
**Why this PR?**
Interactive plots are nice. The interactive plot works essentially the same as the recently added one for widefield data (#236 and #239)

I also re-arranged some of the [docs](https://lumicks-pylake.readthedocs.io/en/interactive_kymo/tutorial/kymographs.html) and added images, as these docs were pretty barren before. 