### PR TITLE
docs: add logo to docs and readme

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,4 @@
 *.png filter=lfs diff=lfs merge=lfs -text
 *.ipynb filter=lfs diff=lfs merge=lfs -text
 *.npz filter=lfs diff=lfs merge=lfs -text
+*.ico filter=lfs diff=lfs merge=lfs -text

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,7 +146,7 @@ html_theme = "sphinx_rtd_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {"logo_only": True}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
@@ -160,12 +160,12 @@ html_title = project
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-# html_logo = None
+html_logo = "logo_mono.png"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-# html_favicon = None
+html_favicon = "fav.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/fav.ico
+++ b/docs/fav.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d268ec447c5ac1f3c491b15a7a42e9bd293e055f766a8cc6f6b4c281ef2802ab
+size 4286

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,16 @@
-.. title:: Bluelake data analysis tools
+.. title:: Pylake: Data analysis for single-molecule optical tweezer data
 
-This Python package includes data analysis tools for Bluelake HDF5 data.
+.. container:: lkheader
 
-The source code repository is `located on Github <https://github.com/lumicks/pylake>`_
-where you can also post any questions, comments or issues that you might have.
+    .. image:: logo_notext.png
+        :class: lklogo
+
+    Pylake is a Python package for analyzing single-molecule optical tweezer data.
+    The :doc:`tutorial/index` section is a good place to start.
+    It gives a good overview of the most important features with lots of code examples.
+    The source code repository is `located on Github <https://github.com/lumicks/pylake>`_
+    where you can also post any questions, comments or issues that you might have.
+
 
 .. to build html, go in anaconda prompt and type python -m sphinx -b html docs build
 
@@ -38,3 +45,25 @@ where you can also post any questions, comments or issues that you might have.
 .. only:: html
 
     * :ref:`genindex`
+
+
+.. raw:: html
+
+    <style type="text/css" >
+        @media screen and (min-width: 990px) {
+            .rst-content p { clear: both; }
+
+            .lklogo {
+                margin: 20px 10px 16px 10px;
+                float: left;
+                width: 105px;
+            }
+
+            .lkheader p {
+                margin-left: 140px;
+                padding-top: 2%;
+                padding-bottom: 2%;
+                clear: none;
+            }
+        }
+    </style>

--- a/docs/logo_dark.png
+++ b/docs/logo_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09563148c7b57a1fb7221d57c0cc5061ee49923aa5e328fdd6d0314f46955791
+size 31066

--- a/docs/logo_light.png
+++ b/docs/logo_light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fe7111828ce61eae2c2ed1bc6a2fd3ae7a32961234b63e4209f3d3e0c44951e
+size 32712

--- a/docs/logo_mono.png
+++ b/docs/logo_mono.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da5248b5991e76e1d7a7c4e54b2e22246e4e7848103b1dc36c98a601e00cd250
+size 32048

--- a/docs/logo_notext.png
+++ b/docs/logo_notext.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ba5486df2b4b5eb59859e450e0cad93c85d461b7b9b38a51e8065463622d1b3
+size 18812

--- a/readme.md
+++ b/readme.md
@@ -1,142 +1,30 @@
-# Lumicks pylake 
+<img src="./docs/logo_light.png#gh-light-mode-only" alt="logo" width="489px"/>
+<img src="./docs/logo_dark.png#gh-dark-mode-only" alt="logo" width="489px"/>
 
 [![DOI](https://zenodo.org/badge/133832492.svg)](https://zenodo.org/badge/latestdoi/133832492)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](license.md)
 ![Build Status](https://github.com/lumicks/pylake/workflows/pytest/badge.svg)
-[![Documentation Status](https://readthedocs.org/projects/lumicks-pylake/badge/?version=latest)](https://lumicks-pylake.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/lumicks-pylake/badge/?version=latest)](https://lumicks-pylake.readthedocs.io/)
 
-This Python package includes data analysis tools for Bluelake HDF5 data.
+Pylake is a Python package for analyzing single-molecule optical tweezer data.
 
-## Install
+Its main features include:
 
-For general use, all you need to do is enter the following on the command line:
+- **Analyzing HDF5 and TIFF data obtained with Bluelake**: Pylake provides a convenient interface to read, analyze and plot data obtained with Bluelake.
+- **Correlating data**: Provides functionality to correlate optical tweezer and imaging data.
+- **Fitting force-extension curves**: Pylake provides tools to (globally) fit polymer models to force-extension data.
+- **Force calibration routines**: The package contains algorithms to calibrate optical tweezer data using power spectral density estimation.
+- **Kymotracker**: Tracks single molecules in a kymograph and computes binding rates and diffusion constants.
 
-```bash
-pip install lumicks.pylake
-```
+Please see the [documentation](https://lumicks-pylake.readthedocs.io/) for more information.
 
-To upgrade to the latest version:
+## Citing
 
-```bash
-pip install -U lumicks.pylake
-```
+Pylake is free to use under the conditions of the [Apache-2.0 open source license](license.md).
 
-## Reading HDF5 files
+If you wish to publish results produced with this package, please mention the package name and cite the Zenodo DOI for this project:
 
-```python
-from lumicks import pylake
+[![DOI](https://zenodo.org/badge/133832492.svg)](https://zenodo.org/badge/latestdoi/133832492)
 
-h5file = pylake.File("example.h5")
-```
-
-### FD curves
-
-```python
-import matplotlib.pyplot as plt
-
-# Plot all FD curves in a file
-for name, fd in h5file.fdcurves.items():
-    fd.plot_scatter()
-    plt.savefig(name)
-
-# Pick a single FD curve
-fd = h5file.fdcurves["name"]
-# By default, the FD channel pair is `downsampled_force2` and `distance1`
-fd.with_channels(force='1x', distance='2').plot_scatter()
-
-# Access the raw data: defaults
-force = fd.f
-distance = fd.d
-# Access the raw data: specific
-force = fd.downsampled_force1y
-distance = fd.distance2
-
-# Plot manually: FD curve
-plt.scatter(distance.data, force.data)
-# Plot manually: force timetrace
-plt.plot(force.timestamps, force.data)
-
-# By default `f` is `downsampled_force2` and `d` is `distance1`
-altenative_fd = fd.with_channels(force='1x', distance='2')
-
-# Baseline subtraction
-fd_baseline = h5file.fdcurves["Baseline"]
-fd_measured = h5file.fdcurves["Measurement"]
-fd = fd_measured - fd_baseline
-fd.plot_scatter()
-```
-
-### Force vs. time
-
-```python
-# Simple force plotting
-h5file.force1x.plot()
-plt.savefig("force1x")
-
-# Accessing the raw data
-f1x_data = h5file.force1x.data
-f1x_timestamps = h5file.force1x.timestamps
-plt.plot(f1x_timestamps, f1x_data)
-```
-
-### Slicing data channels
-
-```python
-# Take the entire channel
-everything = h5file.force1x
-everything.plot()
-
-# Get the data between 1 and 1.5 seconds
-part = h5file.force1x['1s':'1.5s']
-part.plot()
-# Or manually
-f1x_data = part.data
-f1x_timestamps = part.timestamps
-plt.plot(f1x_timestamps, f1x_data)
-
-# More slicing examples
-a = h5file.force1x[:'-5s']  # everything except the last 5 seconds
-b = h5file.force1x['-1m':]  # take the last minute
-c = h5file.force1x['-1m':'-500ms']  # last minute except the last 0.5 seconds
-d = h5file.force1x['1.2s':'-4s']  # between 1.2 seconds and 4 seconds from the end
-e = h5file.force1x['5.7m':'1h 40m']  # 5.7 minutes to an hour and 40 minutes
-```
-
-### Scans and kymographs
-
-The following code uses kymographs as an example. 
-Scans work the same way -- just substitute `h5file.kymos` with `h5file.scans`.
-
-```python
-# Plot all kymographs in a file
-for name, kymo in h5file.kymos.items():
-    kymo.plot_rgb()
-    plt.savefig(name)
-
-# Pick a single kymograph
-kymo = h5file.kymos["name"]
-# Plot a single color channel
-kymo.plot_red()
-
-# Access the raw image data
-rgb = kymo.rgb_image  # matrix
-blue = kymo.blue_image
-# Plot manually
-plt.imshow(rgb)
-
-# Low-level raw data
-photons = kymo.red_photons
-plt.plot(photons.timestamps, photons.data)
-
-# Saving photon counts to TIFF
-kymo.save_tiff("kymograph.tiff")
-```
-
-```python
-scan = h5file.scans["name"]
-
-# A scan can have multiple frames
-print(scan.num_frames)
-print(scan.blue_image.shape)  # (self.num_frames, h, w) -> single color channel
-print(scan.rgb_image.shape)  # (self.num_frames, h, w, 3) -> three color channels
-```
+You'll find a *"Cite as"* section at the bottom right of the Zenodo page. You can select a citation
+style from the dropdown menu or export the data in BibTeX and similar formats.


### PR DESCRIPTION
**Why this PR?**
Now that we have an actual logo, we should use it.
Went with the logo with text, since the one without looked quite imposing when displayed large.
Also updated the `readme.md` a bit to not distract from the actual docs like they used to. I tried to summarize the main features best I could, but comments on this are very welcome.
As an added bonus, I added a little favicon with the logo to the docs.

Docs build here: https://lumicks-pylake.readthedocs.io/en/logo_readme/