### PR TITLE
Slice `Scan` objects by frame indices

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * Added 'KymoLineGroup.plot_binding_histogram()` to plot histograms of binding events for tracked lines. See [Kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#plotting-binding-histograms) for more details.
 * Allow fixing the photon background parameter in `refine_lines_gaussian()`. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#maximum-likelihood-estimation) for more information.
 * Added option to specify a custom label when plotting fit with `FdFit.plot()`. See the tutorial section on [Fd Fitting](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/fdfitting.html#plotting-the-data) for more information.
+* Added functionality to slice `Scan` objects by frame indices. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html).
 
 #### Bug fixes
 

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -29,13 +29,31 @@ Or just pick a single one::
 Scan data and details
 ---------------------
 
-You can access the raw image data::
+You can access the raw image data directly. For a `Scan` with only a single frame::
 
     rgb = scan.rgb_image  # matrix with `shape == (h, w, 3)`
     blue = scan.blue_image  # single color so `shape == (h, w)`
 
     # Plot manually
     plt.imshow(rgb)
+
+For scans with multiple frames::
+
+    # returned data has `shape == (n_frames, h, w, 3)`
+    rgb = multiframe_scan.rgb_image
+    # returned data has `shape == (n_frames, h, w)`
+    blue = multiframe_scan.blue_image
+
+    # Manually plot the RGB image of the first frame.
+    plt.imshow(rgb[0, :, :, :])
+
+We can also slice out a subset of frames from an image stack::
+
+    sliced_scan = multiframe_scan[5:10]
+
+This will return a new `Scan` containing data equivalent to:
+
+    multiframe_scan.rgb_image[5:10, :, :, :]
 
 The images contain pixel data where each pixel represents summed photon counts.
 For an even lower-level look at data, the raw photon count samples can be accessed::

--- a/lumicks/pylake/tests/test_imaging_confocal/conftest.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/conftest.py
@@ -173,6 +173,18 @@ def test_scans(reference_counts):
     middle = scans["fast Y slow X"].red_photon_count.timestamps[5]
     scans["sted bug"] = Scan("sted bug", mock_file, middle - 62400000, stop, metadata)
 
+    image = np.random.poisson(10, (10, 3, 4))
+    mock_file, metadata, stop = MockConfocalFile.from_image(
+        image,
+        pixel_sizes_nm=[5, 5],
+        start=start,
+        dt=dt,
+        axes=[0, 1],
+        samples_per_pixel=5,
+        line_padding=3,
+    )
+    scans["multiframe_poisson"] = Scan("multiframe_poisson", mock_file, start, stop, metadata)
+
     return scans
 
 


### PR DESCRIPTION
**Why this PR?**
This is a basic functionality that we've been putting off for a while, but the recent introduction of `Scan.frame_timestamp_ranges` makes it fairly simple to implement. Behavior is identical to that implemented for `CorrelatedStack`.

[Docs here](https://lumicks-pylake.readthedocs.io/en/scan_slicing/tutorial/images.html)