### PR TITLE
fdfit: allow using custom plot label

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * Added `CorrelatedStack.crop_and_rotate()` for interactive editing of the image stack. Actions include scrolling through image frames with the mouse wheel, and left-clicking to define the tether coordinates, and right-click/drag to define a cropping region. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html#image-stack-editor) for more information.
 * Added 'KymoLineGroup.plot_binding_histogram()` to plot histograms of binding events for tracked lines. See [Kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#plotting-binding-histograms) for more details.
 * Allow fixing the photon background parameter in `refine_lines_gaussian()`. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#maximum-likelihood-estimation) for more information.
+* Added option to specify a custom label when plotting fit with `FdFit.plot()`. See the tutorial section on [Fd Fitting](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/fdfitting.html#plotting-the-data) for more information.
 
 #### Bug fixes
 

--- a/docs/tutorial/fdfitting.rst
+++ b/docs/tutorial/fdfitting.rst
@@ -214,6 +214,10 @@ Fits can be plotted using the built-in plot functionality::
     plt.ylabel("Force [pN]")
     plt.xlabel("Distance [$\\mu$M]");
 
+If you wish to customize the label that appears in the legend, you can pass a custom `label` as an additional argument::
+
+    fit.plot(label="my_fit")
+
 Sometimes, more fine grained control over the plots is required. Let's say we want to plot the model over a range of
 values (in this case values from 2.0 to 5.0) for the conditions corresponding to the `Control` and `RecA` data. We can
 do this by supplying different arguments to the plot function::

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -480,13 +480,14 @@ class Fit:
 
         def plot(fit_data):
             x_values = fit_data.x if independent is None else independent
+            label = kwargs.pop("label", fit_data.name)
             model_lines = model.plot(
                 params[fit_data],
                 x_values,
                 fmt,
                 **kwargs,
                 zorder=1,
-                label=fit_data.name + " (model)",
+                label=label + " (model)",
             )
 
             if plot_data:
@@ -496,7 +497,7 @@ class Fit:
                     **kwargs,
                     color=lighten_color(color, -0.3),
                     zorder=0,
-                    label=fit_data.name + " (data)",
+                    label=label + " (data)",
                 )
 
         if data:

--- a/lumicks/pylake/fitting/tests/test_fit.py
+++ b/lumicks/pylake/fitting/tests/test_fit.py
@@ -662,3 +662,19 @@ def test_fit_reprs():
         "    DNA/St  1500     [pN]      True                  0            inf\n"
         "    kT         4.11  [pN*nm]   False                 0              8"
     )
+
+
+@cleanup
+def test_custom_legend_labels():
+    """Test whether users can provide a custom label for plotting"""
+    def test_labels(labels):
+        for legend_entry, label in zip(plt.gca().get_legend().texts, labels):
+            assert label == legend_entry.get_text()
+
+    fit = Fit(odijk("m"))
+    fit._add_data("data_1", [1, 2, 3], [2, 3, 4])
+    fit.plot()
+    test_labels(["data_1 (model)", "data_1 (data)"])
+    plt.gca().clear()
+    fit.plot(label="custom label")
+    test_labels(["custom label (model)", "custom label (data)"])


### PR DESCRIPTION
**Why this PR?**
Currently, when plotting a fit made with the FdFitter, we put the data name as default label. If a user tries to override this, they get an exception (since the label is provided both by us and the `**kwargs` then.

This PR adds the option to provide a `label` argument.

![image](https://user-images.githubusercontent.com/19836026/148969585-f5d2858f-9931-428a-8bcb-f1988a640169.png)