### PR TITLE
Convenient calibrations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * Allow fixing the photon background parameter in `refine_lines_gaussian()`. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#maximum-likelihood-estimation) for more information.
 * Added option to specify a custom label when plotting fit with `FdFit.plot()`. See the tutorial section on [Fd Fitting](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/fdfitting.html#plotting-the-data) for more information.
 * Added functionality to slice `Scan` objects by frame indices. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html).
+* Added convenience function which allows users to perform a force calibration procedure with a single function call `calibrate_force()`. See [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html#more-convenient-calibration).
 
 #### Bug fixes
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,7 +24,7 @@ Force calibration
 .. autosummary::
     :toctree: _api
 
-
+    calibrate_force
     calculate_power_spectrum
     fit_power_spectrum
     PassiveCalibrationModel

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -363,3 +363,16 @@ This uses the same expression as listed in the section on the :ref:`hydrodynamic
 
 One thing to note is that when using the hydrodynamically correct model, the equation for the drag _does_ include the viscosity and bead diameter.
 However, they now appear in a term which already amounts to a small correction therefore the impact of any errors in these is reduced :cite:`tolic2006calibration`.
+
+More convenient calibration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For convenience, we also provide a function named :func:`~lumicks.pylake.calibrate_force` which executes the entire calibration procedure::
+
+    fit = lk.calibrate_force(volts, bead_diameter, temperature)
+
+It takes the same arguments as the aforementioned methods to calibrate.
+This function can help quickly compare the effect of varying calibration parameters or switching between active and passive calibration.
+Note that most arguments have to be provided as keyworded arguments to prevent errors. For example::
+
+    fit = lk.calibrate_force(volts, bead_diameter, temperature, active_calibration=True, hydrodynamically_correct=True, fit_range=(10e2, 20e3))

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -20,6 +20,7 @@ from .kymotracker.kymotracker import *
 from .nb_widgets.kymotracker_widgets import KymoWidgetGreedy
 from .fdensemble import FdEnsemble
 from .population.mixture import GaussianMixtureModel
+from .force_calibration.convenience import calibrate_force
 from .force_calibration.calibration_models import (
     PassiveCalibrationModel,
     ActiveCalibrationModel,

--- a/lumicks/pylake/force_calibration/convenience.py
+++ b/lumicks/pylake/force_calibration/convenience.py
@@ -1,0 +1,155 @@
+import numpy as np
+from lumicks.pylake.force_calibration.calibration_models import (
+    ActiveCalibrationModel,
+    PassiveCalibrationModel,
+    FixedDiodeModel,
+)
+from lumicks.pylake.force_calibration.power_spectrum_calibration import (
+    fit_power_spectrum,
+    calculate_power_spectrum,
+)
+
+
+def calibrate_force(
+    force_voltage_data,
+    bead_diameter,
+    temperature,
+    *,
+    viscosity=None,
+    active_calibration=False,
+    driving_data=np.asarray([]),
+    driving_frequency_guess=37,
+    axial=False,
+    hydrodynamically_correct=False,
+    rho_sample=None,
+    rho_bead=1060.0,
+    distance_to_surface=None,
+    fast_sensor=False,
+    sample_rate=78125,
+    num_points_per_block=2000,
+    fit_range=(1e2, 23e3),
+    excluded_ranges=[],
+    fixed_diode=None,
+    drag=None,
+):
+    """Determine force calibration factors.
+
+    The power spectrum calibration algorithm implemented here is based on [1]_, [2]_, [3]_, [4]_,
+    [5]_, [6]_.
+
+    References
+    ----------
+    .. [1] Berg-Sørensen, K. & Flyvbjerg, H. Power spectrum analysis for optical tweezers. Rev. Sci.
+           Instrum. 75, 594 (2004).
+    .. [2] Tolić-Nørrelykke, I. M., Berg-Sørensen, K. & Flyvbjerg, H. MatLab program for precision
+           calibration of optical tweezers. Comput. Phys. Commun. 159, 225–240 (2004).
+    .. [3] Hansen, P. M., Tolic-Nørrelykke, I. M., Flyvbjerg, H. & Berg-Sørensen, K.
+           tweezercalib 2.1: Faster version of MatLab package for precise calibration of optical
+           tweezers. Comput. Phys. Commun. 175, 572–573 (2006).
+    .. [4] Berg-Sørensen, K., Peterman, E. J. G., Weber, T., Schmidt, C. F. & Flyvbjerg, H. Power
+           spectrum analysis for optical tweezers. II: Laser wavelength dependence of parasitic
+           filtering, and how to achieve high bandwidth. Rev. Sci. Instrum. 77, 063106 (2006).
+    .. [5] Tolić-Nørrelykke, S. F, and Flyvbjerg, H, "Power spectrum analysis with least-squares
+           fitting: amplitude bias and its elimination, with application to optical tweezers and
+           atomic force microscope cantilevers." Review of Scientific Instruments 81.7 (2010)
+    .. [6] Tolić-Nørrelykke S. F, Schäffer E, Howard J, Pavone F. S, Jülicher F and Flyvbjerg, H.
+           Calibration of optical tweezers with positional detection in the back focal plane,
+           Review of scientific instruments 77, 103101 (2006).
+
+    Parameters
+    ----------
+    force_voltage_data : array_like
+        Uncalibrated force data in volts.
+    bead_diameter : float
+        Bead diameter [um].
+    temperature : float
+        Liquid temperature [Celsius].
+    viscosity : float, optional
+        Liquid viscosity [Pa*s].
+        When omitted, the temperature will be used to look up the viscosity of water at that
+        particular temperature.
+    active_calibration : bool, optional
+        Active calibration, when set to True, driving_data must also be provided.
+    driving_data : array_like, optional
+        Array of driving data.
+    driving_frequency_guess : float, optional
+         Guess of the driving frequency.
+    axial : bool, optional
+        Is this an axial calibration? Only valid for a passive calibration.
+    hydrodynamically_correct : bool, optional
+        Enable hydrodynamically correct model.
+    rho_sample : float, optional
+        Density of the sample [kg/m**3]. Only used when using hydrodynamically correct model.
+    rho_bead : float, optional
+        Density of the bead [kg/m**3]. Only used when using hydrodynamically correct model.
+    distance_to_surface : float, optional
+        Distance from bead center to the surface [um]
+        When specifying `None`, the model will use an approximation which is only suitable for
+        measurements performed deep in bulk.
+    fast_sensor : bool, optional
+         Fast sensor? Fast sensors do not have the diode effect included in the model.
+    sample_rate : float, optional
+         Sample rate at which the signals were acquired.
+    fit_range : tuple of float, optional
+        Tuple of two floats (f_min, f_max), indicating the frequency range to use for the full model
+        fit. [Hz]
+    num_points_per_block : int, optional
+        The spectrum is first block averaged by this number of points per block.
+        Default: 2000.
+    excluded_ranges : list of tuple of float, optional
+        List of ranges to exclude specified as a list of (frequency_min, frequency_max).
+    drag : float, optional
+        Overrides the drag coefficient to this particular value.
+    fixed_diode : float, optional
+        Fix diode frequency to a particular frequency.
+    """
+    if active_calibration:
+        if axial:
+            raise ValueError("Active calibration is not supported for axial force.")
+        if drag:
+            raise ValueError("Drag coefficient cannot be carried over to active calibration.")
+
+    if fixed_diode and fast_sensor:
+        raise ValueError("When using fast_sensor=True, there is no diode model to fix.")
+
+    if active_calibration and driving_data.size == 0:
+        raise ValueError("Active calibration requires the driving_data to be defined.")
+
+    model_params = {
+        "bead_diameter": bead_diameter,
+        "viscosity": viscosity,
+        "temperature": temperature,
+        "fast_sensor": fast_sensor,
+        "distance_to_surface": distance_to_surface,
+        "hydrodynamically_correct": hydrodynamically_correct,
+        "rho_sample": rho_sample,
+        "rho_bead": rho_bead,
+    }
+
+    model = (
+        ActiveCalibrationModel(
+            driving_data,
+            force_voltage_data,
+            sample_rate,
+            driving_frequency_guess=driving_frequency_guess,
+            **model_params,
+        )
+        if active_calibration
+        else PassiveCalibrationModel(**model_params, axial=axial)
+    )
+
+    if drag:
+        model._set_drag(drag)
+
+    if fixed_diode:
+        model._filter = FixedDiodeModel(fixed_diode)
+
+    ps = calculate_power_spectrum(
+        force_voltage_data,
+        sample_rate,
+        fit_range,
+        num_points_per_block,
+        excluded_ranges=excluded_ranges,
+    )
+
+    return fit_power_spectrum(ps, model)

--- a/lumicks/pylake/force_calibration/tests/test_convenience.py
+++ b/lumicks/pylake/force_calibration/tests/test_convenience.py
@@ -1,0 +1,111 @@
+import pytest
+import numpy as np
+from lumicks.pylake.force_calibration.convenience import calibrate_force
+from lumicks.pylake.force_calibration.calibration_models import (
+    PassiveCalibrationModel,
+    ActiveCalibrationModel,
+)
+
+
+def test_passive_force_calibration_active(reference_models):
+    """This test tests merely whether values were handed to the low level API correctly, not whether
+    the calibration results are correct."""
+    data, f_sample = reference_models.lorentzian_td(4000, 1, 0.4, 14000, 78125)
+    fit = calibrate_force(
+        data,
+        2,
+        9,
+        viscosity=6,
+        active_calibration=False,
+        hydrodynamically_correct=True,
+        rho_sample=600.0,
+        rho_bead=1000.0,
+        distance_to_surface=16,
+        fast_sensor=True,
+        fit_range=(1e1, 8e3),
+        num_points_per_block=64,
+        excluded_ranges=[[0, 100]],
+        drag=42,
+    )
+    params = {
+        "Bead diameter": 2,
+        "Temperature": 9,
+        "Viscosity": 6,
+        "Sample density": 600.0,
+        "Bead density": 1000.0,
+        "Distance to surface": 16,
+        "Points per block": 64,
+    }
+    for key, value in params.items():
+        assert fit.params[key].value == value
+
+    assert isinstance(fit.model, PassiveCalibrationModel)
+    assert "f_diode" not in fit.results  # fast sensor
+    assert fit.results["gamma_ex_lateral"].value == 42  # verify the drag has been carried
+    assert fit.ps_data.frequency.min() > 100  # verify that the exclusion range was passed
+    assert fit.ps_data.frequency.max() < 8e3  # verify that the bounds were passed
+
+
+def test_active_force_calibration_active(reference_models):
+    """This test tests merely whether values were handed to the low level API correctly, not whether
+    the calibration results are correct."""
+    data, f_sample = reference_models.lorentzian_td(4000, 1, 0.4, 14000, 78125)
+    fit = calibrate_force(
+        data,
+        2,
+        9,
+        driving_data=np.sin(77 * 2 * np.pi * np.arange(data.size) / 78125),
+        driving_frequency_guess=77,
+        viscosity=6,
+        active_calibration=True,
+        hydrodynamically_correct=True,
+        rho_sample=600.0,
+        rho_bead=1000.0,
+        distance_to_surface=16,
+        fast_sensor=True,
+        fit_range=(1e1, 8e3),
+        num_points_per_block=64,
+        excluded_ranges=[[0, 100]],
+    )
+    params = {
+        "Bead diameter": 2,
+        "Temperature": 9,
+        "Viscosity": 6,
+        "Sample density": 600.0,
+        "Bead density": 1000.0,
+        "Distance to surface": 16,
+        "Points per block": 64,
+        "Driving frequency (guess)": 77,
+    }
+    for key, value in params.items():
+        assert fit.params[key].value == value
+
+    assert isinstance(fit.model, ActiveCalibrationModel)
+    assert "f_diode" not in fit.results  # fast sensor
+    assert fit.ps_data.frequency.min() > 100  # verify that the exclusion range was passed
+    assert fit.ps_data.frequency.max() < 8e3  # verify that the bounds were passed
+
+
+def test_invalid_options_calibration():
+    with pytest.raises(ValueError, match="Active calibration is not supported for axial force"):
+        calibrate_force([1], 1, 20, axial=True, active_calibration=True)
+
+    with pytest.raises(
+        ValueError, match="Drag coefficient cannot be carried over to active calibration"
+    ):
+        calibrate_force([1], 1, 20, drag=5, active_calibration=True)
+
+    with pytest.raises(
+        ValueError, match="When using fast_sensor=True, there is no diode model to fix"
+    ):
+        calibrate_force([1], 1, 20, fast_sensor=True, fixed_diode=150)
+
+    with pytest.raises(
+        ValueError, match="Active calibration requires the driving_data to be defined"
+    ):
+        calibrate_force([1], 1, 20, active_calibration=True)
+
+
+def test_mandatory_keyworded_arguments():
+    with pytest.raises(TypeError, match="takes 3 positional arguments but 5 were given"):
+        calibrate_force([], 1, 2, 3, 4)


### PR DESCRIPTION
**Why this PR?**
It can be convenient to just have a single function call for performing a calibration and have the backend worry about how to hook everything up in the low level API.

This allows some ease of use when writing notebooks where you generate dictionaries with calibration parameters or when you quickly want to switch between active and passive calibration and compare results.

I tried my best to order and group the parameters in a sensible way. I do enforce keyworded arguments, so that we could potentially iterate on the order of the optional ones if feedback arises.

A note on the testing. I tested that the non-default parameters came through correctly. I did not do a full spectrum simulation, because those are a bit costly to generate, and there's no added value considering that all the backend functions are separately tested for correctness.

From:
```python
model = lk.ActiveCalibrationModel(driving_data, force_voltage_data, sample_rate, **model_params)
ps = lk.calculate_power_spectrum(force_voltage_data, sample_rate, **spectral_pars)
fit = lk.fit_power_spectrum(ps, model)
```
To:
```python
fit = lk.force_calibration(force_voltage_data, driving_data=driving_data, sample_rate=sample_rate, **model_params, **spectral_pars)
```

Docs build here: https://lumicks-pylake.readthedocs.io/en/convenient_calibrations/tutorial/force_calibration.html#more-convenient-calibration