### PR TITLE
kymowidget: add undo/redo functionality

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 * Added convenience function which allows users to perform a force calibration procedure with a single function call `calibrate_force()`. See [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html#more-convenient-calibration).
 * Added `Kymo.crop_and_calibrate()` for interactive cropping of a kymograph. If the optional `tether_length_kbp` argument is supplied, the resulting kymograph will be automatically calibrated to this length. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html#calibrating-to-base-pairs) for more information.
 * Added fallback to the function `Kymo.plot_with_force()` when only low-frequency force data is available.
+* Added option to undo/redo actions in the kymotracker widget.
 
 #### Bug fixes
 

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -1,3 +1,4 @@
+from copy import copy
 from lumicks.pylake.kymotracker.detail.msd_estimation import *
 from lumicks.pylake.kymotracker.detail.calibrated_images import CalibratedKymographChannel
 from lumicks.pylake.kymotracker.detail.binding_times import _kinetic_mle_optimize
@@ -326,6 +327,9 @@ class KymoLineGroup:
 
     def __setitem__(self, item, value):
         raise NotImplementedError("Cannot overwrite KymoLines.")
+
+    def __copy__(self):
+        return KymoLineGroup(copy(self._src))
 
     def _concatenate_lines(self, starting_line, ending_line):
         """Concatenate two lines together.

--- a/lumicks/pylake/kymotracker/tests/test_kymoline.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymoline.py
@@ -259,3 +259,10 @@ def test_binding_histograms():
     counts, edges = lines._histogram_binding_events("all", bins=[2, 3, 4, 5, 6, 7, 8])
     np.testing.assert_equal(counts, [1, 2, 3, 3, 2, 1])
     np.testing.assert_allclose(edges, [2, 3, 4, 5, 6, 7, 8])
+
+
+def test_kymolinegroup_copy():
+    k1 = KymoLine(np.array([1, 2, 3]), np.array([1, 1, 1]), [])
+    k2 = KymoLine(np.array([6, 7, 8]), np.array([2, 2, 2]), [])
+    group = KymoLineGroup([k1, k2])
+    assert id(group._src) != id(copy(group)._src)

--- a/lumicks/pylake/nb_widgets/detail/undostack.py
+++ b/lumicks/pylake/nb_widgets/detail/undostack.py
@@ -1,0 +1,32 @@
+from copy import copy
+
+
+class UndoStack:
+    """Keeps a state with an undo and redo list."""
+
+    def __init__(self, initial_state):
+        self._state = initial_state
+        self._redo_history = []
+        self._undo_history = []
+
+    @property
+    def state(self):
+        return self._state
+
+    @state.setter
+    def state(self, new_state):
+        self._undo_history.append(self.state)
+        self._redo_history = []
+        self._state = copy(new_state)
+
+    def undo(self):
+        if len(self._undo_history) > 0:
+            self._redo_history.append(self.state)
+            self._state = self._undo_history.pop()
+        return self.state
+
+    def redo(self):
+        if len(self._redo_history) > 0:
+            self._undo_history.append(self.state)
+            self._state = self._redo_history.pop()
+        return self.state

--- a/lumicks/pylake/nb_widgets/tests/test_undostack.py
+++ b/lumicks/pylake/nb_widgets/tests/test_undostack.py
@@ -1,0 +1,80 @@
+from lumicks.pylake.nb_widgets.detail.undostack import UndoStack
+
+
+def is_equal(test_list, ref):
+    return all(x == y for x, y in zip(test_list, ref))
+
+
+def test_empty_undo_redo():
+    """Test whether empty undo/redo stacks don't change history"""
+    state_item1 = [5, 3, 8, 10]
+    undostack = UndoStack(state_item1)
+
+    undostack.undo()
+    assert is_equal(undostack.state, state_item1)
+
+    undostack.redo()
+    assert is_equal(undostack.state, state_item1)
+
+
+def test_undo_redo():
+    state_item1 = [5, 3, 8, 10]
+    state_item2 = [2, 1, 8, 10]
+    state_item3 = [5, 3, 9, 10]
+
+    undostack = UndoStack(state_item1)
+    assert is_equal(undostack.state, state_item1)
+
+    undostack.state = state_item2
+    assert is_equal(undostack.state, state_item2)
+
+    undostack.state = state_item3
+    assert is_equal(undostack.state, state_item3)
+
+    undostack.undo()
+    assert is_equal(undostack.state, state_item2)
+
+    undostack.undo()
+    assert is_equal(undostack.state, state_item1)
+
+    # Stack is empty now, not undoing anything anymore
+    undostack.undo()
+    assert is_equal(undostack.state, state_item1)
+
+    undostack.redo()
+    assert is_equal(undostack.state, state_item2)
+
+    undostack.redo()
+    assert is_equal(undostack.state, state_item3)
+
+    undostack.redo()
+    assert is_equal(undostack.state, state_item3)
+
+    undostack.undo()
+    assert is_equal(undostack.state, state_item2)
+
+
+def test_removal_redo():
+    state_item1 = [1, 3, 8, 10]
+    state_item2 = [2, 3, 8, 10]
+    state_item3 = [3, 3, 3, 10]
+    state_item4 = [4, 3, 8, 10]
+
+    undostack = UndoStack(state_item1)
+    undostack.state = state_item2
+    undostack.state = state_item3
+    undostack.undo()
+    undostack.undo()
+
+    # Item 2 and 3 are in the redo stack, adding a new item will remove them
+    undostack.state = state_item4
+    assert is_equal(undostack.state, state_item4)
+
+    undostack.redo()
+    assert is_equal(undostack.state, state_item4)
+
+    undostack.undo()
+    assert is_equal(undostack.state, state_item1)
+
+    undostack.redo()
+    assert is_equal(undostack.state, state_item4)


### PR DESCRIPTION
### Why this PR?
This was fairly highly requested functionality for the kymotracker widget.

### What to look out for?
Since the tracking steps typically take long and the actual data being stored is very very small (just some coordinates), I opted for a model where a history stack of the entire state of all the lines is stored. This keeps things implementationally quite simple.

However, since the `KymoLineGroup` is not immutable, there were two places where I was forced to make an explicit copy before changing it. I have added a comment on the lines where this happens.

We could alternatively consider going for a model where the `KymoLineGroup` is immutable. This would simplify the code on the widget side, but induce unnecessary copies elsewhere. It would also be a breaking change.

![undoredo](https://user-images.githubusercontent.com/19836026/149536905-b538f1ea-7d08-4f8f-b931-6e6a1c168aaf.gif)