### PR TITLE
kymo: plot with low frequency force channels

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * Added functionality to slice `Scan` objects by frame indices. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html).
 * Added convenience function which allows users to perform a force calibration procedure with a single function call `calibrate_force()`. See [force calibration](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html#more-convenient-calibration).
 * Added `Kymo.crop_and_calibrate()` for interactive cropping of a kymograph. If the optional `tether_length_kbp` argument is supplied, the resulting kymograph will be automatically calibrated to this length. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html#calibrating-to-base-pairs) for more information.
+* Added fallback to the function `Kymo.plot_with_force()` when only low-frequency force data is available.
 
 #### Bug fixes
 

--- a/docs/tutorial/figures/kymographs/kymo_correlated.png
+++ b/docs/tutorial/figures/kymographs/kymo_correlated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22bac622dfffb4ecf9bccb09fd6f6715172aad2e51f335e850f13f11e8ce4a5f
+size 87487

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -150,3 +150,34 @@ example, if we downsample a kymograph by time, we can no longer access the per p
     AttributeError: Per pixel timestamps are no longer available after downsampling a kymograph in time since they
     are not well defined (the downsampling occurs over a non contiguous time window). Line timestamps are still
     available however. See: `Kymo.line_time_seconds`.
+
+Plotting and exporting
+----------------------
+
+There are also convenience functions to plot individual color channels and the full RGB image::
+
+    plt.subplot(2, 1, 1)
+    kymo.plot("rgb")
+    plt.subplot(2, 1, 2)
+    kymo.plot("blue")
+
+The images can also be exported in the TIFF format::
+
+    kymo.save_tiff("image.tiff")
+
+Correlating with force
+----------------------
+
+We can plot a kymograph along its force trace using::
+
+    kymo.plot_with_force("1x", "green")
+
+This will average the forces over each Kymograph line and plot them in a correlated fashion.
+The function can also take a dictionary of extra arguments to customize the kymograph plot.
+These parameter values get forwarded to :func:`matplotlib.pyplot.imshow`.
+For instance, if a few pixels dominate the image, it might be preferable to set the scale by hand.
+This can be accomplished by setting `vmax`::
+
+    kymo.plot_with_force("1x", "green", kymo_args={"vmax": 3})
+
+.. image:: ./figures/kymographs/kymo_correlated.png

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -194,7 +194,13 @@ class Kymo(ConfocalImage):
         return channel.downsampled_over(time_ranges, reduce=reduce, where="center")
 
     def plot_with_force(
-        self, force_channel, color_channel, aspect_ratio=0.25, reduce=np.mean, **kwargs
+        self,
+        force_channel,
+        color_channel,
+        aspect_ratio=0.25,
+        reduce=np.mean,
+        kymo_args={},
+        **kwargs,
     ):
         """Plot kymo with force channel downsampled over scan lines
 
@@ -211,6 +217,8 @@ class Kymo(ConfocalImage):
         reduce : callable
             The `numpy` function which is going to reduce multiple samples into one.
             Forwarded to :func:`Slice.downsampled_over`
+        kymo_args : dict
+            Forwarded to :func:`matplotlib.pyplot.imshow`
         **kwargs
             Forwarded to :func:`Slice.plot`.
         """
@@ -224,7 +232,7 @@ class Kymo(ConfocalImage):
         _, (ax1, ax2) = plt.subplots(2, 1, sharex="all")
 
         # plot kymo
-        self.plot(channel=color_channel, axes=ax1)
+        self.plot(channel=color_channel, axes=ax1, **kymo_args)
         ax1.set_xlabel(None)
         xlim_kymo = ax1.get_xlim()  # Stored since plotting the force channel will change the limits
 


### PR DESCRIPTION
### Why this PR?
This PR combines two small tickets. The first is to document `kymo.plot_with_force`. The second is to use low frequency force as a fallback when high frequency force is unavailable (this was a requested feature).

I've piggybacked forwarding custom arguments to `imshow` as well, since without this feature, most kymographs will simply be too dark.