### PR TITLE
docs: use `sphinx_lfs_content`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,14 +33,6 @@ version = ".".join(pylake.__version__.split(".")[:2])
 # The full version, including alpha/beta/rc tags
 release = pylake.__version__
 
-# Make sure we have git-lfs support on rtd
-if os.environ.get("READTHEDOCS", None):
-    from git_lfs import fetch
-
-    docs_dir = os.path.dirname(os.path.abspath(__file__))
-    project_dir = os.path.dirname(docs_dir)
-    fetch(project_dir)
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -61,6 +53,7 @@ extensions = [
     "numpydoc",
     "matplotlib.sphinxext.plot_directive",
     "nbexport",
+    "sphinx_lfs_content",
 ]
 
 autodoc_member_order = "groupwise"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-git-lfs==1.5
+sphinx_lfs_content==1.0.0
 matplotlib
 nbconvert
 nbformat


### PR DESCRIPTION
**Why this PR?**
Because of the size of the images on `readthedocs` version 1.5 of the python package `git-lfs` (not to be confused with actual `git-lfs`) started failing because it was pulling them as one big request. The requests exceeded some limit and returned HTTP error 413.

That package does have a newer version which introduced splitting requests (see https://github.com/liberapay/git-lfs-fetch.py/pull/7). However, this version requires auth tokens now (https://github.com/liberapay/git-lfs-fetch.py/pull/5).

This is why I propose switching to https://github.com/ssciwr/sphinx_lfs_content which maintains a simple workaround for installing `git-lfs`.