### PR TITLE
gaussian_mle: make refine gaussian take into account multiple peaks in close proximity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 * Added `Kymo.crop_and_calibrate()` for interactive cropping of a kymograph. If the optional `tether_length_kbp` argument is supplied, the resulting kymograph will be automatically calibrated to this length. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html#calibrating-to-base-pairs) for more information.
 * Added fallback to the function `Kymo.plot_with_force()` when only low-frequency force data is available.
 * Added option to undo/redo actions in the kymotracker widget.
+* Added option to fit peaks simultaneously in `refine_lines_gaussian()` using the flag `overlap_strategy="fit_multiple"`. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
 
 #### Bug fixes
 
@@ -25,6 +26,7 @@
 * Improved default scaling behaviour for `CorrelatedStack.plot_correlated()` and `Scan.plot_correlated()`. It now ensures the ratio between the image and temporal plot is according to the aspect ratio of the scan or stack.
 * Slicing `CorrelatedStack` in reverse (i.e., `stack[5:3]`) or resulting in an empty stack (i.e., `stack[5:5]`) now throws an exception.
 * Resolved `DeprecationWarning` for `tifffile.imsave()` and `tifffile.TiffWriter.save()` with `tifffile >= 2020.9.30`.
+* Fixed a bug in `refine_lines_gaussian()` which incorrectly rounded the pixel position instead of flooring it. For pixels with a subpixel position larger than half the pixel, this resulted in shifting the window by one pixel in the positive direction. Typically, this would have little or no effect since the majority of the peak should still be covered.
 
 #### Deprecations
 

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -155,11 +155,13 @@ we can optionally interpolate an initial guess for these frames before the Gauss
 may not be well fit by this algorithm.
 
 Additionally, the presence of a nearby trace wherein the sampled pixels of the two traces overlap may interfere with the
-refinement algorithm. How the algorithm handles this situation is determined by the `overlap_strategy` argument. Setting `overlap_strategy="ignore"`
-simply ignores the situation and fits the data. A problem with the refinement in this case will manifest as the peak of the second trace
-is found rather than that of the current trace. Sometimes this can be avoided by decreasing the size of the `window` argument such that overlap no longer occurs.
-Alternatively we can simply ignore these frames by using `overlap_strategy="skip"`, in which case these frames
-are simply dropped from the trace.
+refinement algorithm. How the algorithm handles this situation is determined by the `overlap_strategy` argument.
+Setting `overlap_strategy="ignore"` simply ignores the situation and fits the data.
+A problem with the refinement in this case will manifest as the peak of the second trace is found rather than that of the current trace.
+Sometimes this can be avoided by decreasing the size of the `window` argument such that overlap no longer occurs.
+A better alternative is to use `overlap_strategy="fit_multiple"`.
+When this option is specified, peaks where the windows overlap are fitted simultaneously (using a shared offset parameter).
+Alternatively, we can simply ignore these frames by using `overlap_strategy="skip"`, in which case these frames are simply dropped from the trace.
 
 There is also an optional keyword argument `initial_sigma` that can be used to pass an initial guess for :math:`\sigma` in micrometers
 in the above expectation equation to the optimizer. The default value is `1.1*pixel_size`.

--- a/lumicks/pylake/kymotracker/detail/gaussian_mle.py
+++ b/lumicks/pylake/kymotracker/detail/gaussian_mle.py
@@ -3,6 +3,33 @@ from functools import partial
 from scipy.optimize import minimize
 
 
+def overlapping_pixels(coordinates, width):
+    """Determine which fitting regions are expected to overlap.
+
+    Returns a list of indices grouped by overlapping coordinates within a window 2 * width.
+
+    This function constructs a list of lists. Each inner list contains the indices of the
+    coordinates which are separated by < 2 * width. The outer list is sorted by spatial position.
+
+    Parameters
+    ----------
+    coordinates : array_like
+        coordinates
+    width : float
+        width in either direction
+    """
+    if not len(coordinates):
+        return []
+
+    coordinates = np.asarray(coordinates)
+    indices = np.argsort(coordinates)
+    sorted_coordinates = coordinates[indices]
+    differences = np.diff(sorted_coordinates)
+    groups = np.split(indices, np.flatnonzero(differences > 2 * width) + 1)
+
+    return groups
+
+
 def poisson_log_likelihood(params, expectation_fun, photon_count):
     """Calculates the log likelihood of Poisson distributed values.
 

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -293,7 +293,8 @@ def refine_lines_gaussian(
     overlap_strategy : {'ignore', 'skip'}
         How to deal with frames in which the fitting window of two `KymoLine`'s overlap.
 
-        - 'ignore' : do nothing, fit the frame as-is.
+        - 'multiple' : fit the peaks simultaneously.
+        - 'ignore' : do nothing, fit the frame as-is (ignoring overlaps).
         - 'skip' : skip optimization of the frame; remove from returned `KymoLine`.
     initial_sigma : float
         Initial guess for the `sigma` parameter.
@@ -301,7 +302,7 @@ def refine_lines_gaussian(
         Fixed background parameter in photons per second.
         When supplied, the background is not estimated but fixed at this value.
     """
-    assert overlap_strategy in ("ignore", "skip")
+    assert overlap_strategy in ("ignore", "skip", "multiple")
     if refine_missing_frames:
         lines = [line.interpolate() for line in lines]
 
@@ -326,7 +327,11 @@ def refine_lines_gaussian(
             int(lines[line_index].coordinate_idx[idx]) for (line_index, idx) in frame
         ]
 
-        groups = overlapping_pixels(pixel_coordinates, window)
+        groups = (
+            [[idx] for idx in range(len(pixel_coordinates))]
+            if overlap_strategy == "ignore"
+            else overlapping_pixels(pixel_coordinates, window)
+        )
         for group in groups:
             if len(group) > 1 and overlap_strategy == "skip":
                 overlap_count += 1

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -315,7 +315,7 @@ def refine_lines_gaussian(
     lines_per_frame = [[] for _ in range(lines[0]._image.data.shape[1])]
     for line_index, line in enumerate(lines):
         for idx, time_idx in enumerate(line.time_idx):
-            lines_per_frame[time_idx].append((line_index, idx))
+            lines_per_frame[int(time_idx)].append((line_index, idx))
 
     # Prepare storage for the refined lines
     refined_lines_time_idx = [[] for _ in range(len(lines))]

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -62,3 +62,17 @@ def kymogroups_2lines():
     mixed_lines = KymoLineGroup([truncated_lines[0], lines[1]])
 
     return lines, gapped_lines, mixed_lines
+
+
+@pytest.fixture
+def kymogroups_close_lines():
+    _, _, photon_count, parameters = read_dataset_gaussian("two_gaussians_1d.npz")
+    pixel_size = parameters[0].pixel_size
+    centers = [p.center / pixel_size for p in parameters]
+
+    image = CalibratedKymographChannel.from_array(photon_count, pixel_size=pixel_size)
+    _, n_frames = image.data.shape
+
+    lines = KymoLineGroup([KymoLine(np.arange(0.0, n_frames), np.full(n_frames, c), image) for c in centers])
+
+    return lines

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -50,7 +50,7 @@ def kymogroups_2lines():
     image = CalibratedKymographChannel.from_array(photon_count, pixel_size=pixel_size)
     _, n_frames = image.data.shape
 
-    lines = KymoLineGroup([KymoLine(np.arange(n_frames), np.full(n_frames, c), image) for c in centers])
+    lines = KymoLineGroup([KymoLine(np.arange(0.0, n_frames), np.full(n_frames, c), image) for c in centers])
 
     # introduce gaps into tracked lines
     use_frames = np.array([0, 1, -2, -1])
@@ -58,7 +58,7 @@ def kymogroups_2lines():
                                   for line in lines])
 
     # crop the ends of initial lines and make new set of lines with one cropped and the second full
-    truncated_lines = KymoLineGroup([KymoLine(np.arange(1, n_frames-2), np.full(n_frames-3, c), image) for c in centers])
+    truncated_lines = KymoLineGroup([KymoLine(np.arange(1.0, n_frames-2), np.full(n_frames-3, c), image) for c in centers])
     mixed_lines = KymoLineGroup([truncated_lines[0], lines[1]])
 
     return lines, gapped_lines, mixed_lines

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -60,12 +60,13 @@ def test_refinement_line(loc, inv_sigma=0.3):
     np.testing.assert_allclose(line.coordinate_idx, loc, rtol=1e-2)
 
 
-def test_gaussian_refinement(kymogroups_2lines):
+@pytest.mark.parametrize("fit_mode", ["ignore", "multiple"])
+def test_gaussian_refinement(kymogroups_2lines, fit_mode):
     lines, gapped_lines, mixed_lines = kymogroups_2lines
 
     # full data, no overlap
     refined = refine_lines_gaussian(
-        lines, window=3, refine_missing_frames=True, overlap_strategy="ignore"
+        lines, window=3, refine_missing_frames=True, overlap_strategy=fit_mode
     )
     assert np.allclose(
         refined[0].position, [3.54796254, 3.52869381, 3.51225177, 3.38714711, 3.48588436]
@@ -76,7 +77,7 @@ def test_gaussian_refinement(kymogroups_2lines):
 
     # initial guess for sigma
     refined = refine_lines_gaussian(
-        lines, window=3, refine_missing_frames=True, overlap_strategy="ignore", initial_sigma=0.250
+        lines, window=3, refine_missing_frames=True, overlap_strategy=fit_mode, initial_sigma=0.250
     )
     assert np.allclose(
         refined[0].position, [3.54796279, 3.52869369, 3.51225138, 3.46877412, 3.48588434]
@@ -111,7 +112,7 @@ def test_gaussian_refinement(kymogroups_2lines):
 
     # gapped data, skip missing frames
     refined = refine_lines_gaussian(
-        gapped_lines, window=3, refine_missing_frames=False, overlap_strategy="ignore"
+        gapped_lines, window=3, refine_missing_frames=False, overlap_strategy=fit_mode
     )
     assert np.allclose(refined[0].position, [3.54796254, 3.52869381, 3.38714711, 3.48588436])
     assert np.allclose(refined[1].position, [4.96700319, 4.99771575, 5.0066495, 4.99092852])
@@ -136,14 +137,15 @@ def test_gaussian_refinement(kymogroups_2lines):
     assert np.allclose(refined[0].position, [4.94659924, 5.00920806, 4.97724526])
 
 
-def test_gaussian_refinement_fixed_background(kymogroups_2lines):
+@pytest.mark.parametrize("fit_mode", ["ignore", "multiple"])
+def test_gaussian_refinement_fixed_background(kymogroups_2lines, fit_mode):
     lines, _, _ = kymogroups_2lines
 
     refined = refine_lines_gaussian(
         lines,
         window=3,
         refine_missing_frames=True,
-        overlap_strategy="ignore",
+        overlap_strategy=fit_mode,
         fixed_background=1.0,
     )
     assert np.allclose(
@@ -153,6 +155,24 @@ def test_gaussian_refinement_fixed_background(kymogroups_2lines):
     assert np.allclose(
         refined[1].position,
         [4.96956982, 4.99811141, 5.02009032, 5.01614766, 4.99094119],
+    )
+
+
+def test_gaussian_refinement_overlap(kymogroups_close_lines):
+    refined = refine_lines_gaussian(
+        kymogroups_close_lines,
+        window=15,
+        refine_missing_frames=True,
+        overlap_strategy="multiple",
+        fixed_background=1.0,
+    )
+    assert np.allclose(
+        refined[0].position,
+        [5.24723138, 5.08524557, 4.6939314, 4.84496914, 4.78668516],
+    )
+    assert np.allclose(
+        refined[1].position,
+        [3.32775782, 3.42564736, 3.33315701, 3.60090496, 3.26356061],
     )
 
 


### PR DESCRIPTION
**Why this PR?**
Because we wish to correctly deal with overlapping lines in `refine_lines_gaussian()`. If two lines get close, the refinement will now do a simultaneous fit for these lines.

Notes:
Part 1 of this PR can be found in https://github.com/lumicks/pylake/pull/258
This PR also fixes a bug in `refine_lines_gaussian()` which incorrectly rounded the pixel position (`rint`) instead of flooring it. For pixels with a subpixel position larger than half the pixel, this resulted in shifting the window by one pixel in the positive direction. Typically, this would have little or no effect since the majority of the peak should still be covered.

![image](https://user-images.githubusercontent.com/19836026/151957121-cc582676-066e-48af-a265-6dbead0b7199.png)
Blue is when taking a big window and using `"ignore"` (blue) instead of `"fit_multiple"` (red)

*from Ray: I pushed 3 commits at the end to try to clean up the logic in `refine_lines_gaussian()` for detecting overlap. If approved these should all be squashed, but I wanted to keep a history of what I actually did because it's not straightforwardly obvious going between the two versions. The original code was good, but I tried to re-arrange/rename some things to hopefully make it clearer.*