### PR TITLE
ci: fix tifffile.imsave deprecation warning

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 * Removed `axial` parameter from `lk.ActiveCalibrationModel()` as we do not support active force calibration in the axial direction.
 * Improved default scaling behaviour for `CorrelatedStack.plot_correlated()` and `Scan.plot_correlated()`. It now ensures the ratio between the image and temporal plot is according to the aspect ratio of the scan or stack.
 * Slicing `CorrelatedStack` in reverse (i.e., `stack[5:3]`) or resulting in an empty stack (i.e., `stack[5:5]`) now throws an exception.
+* Resolved `DeprecationWarning` for `tifffile.imsave()` and `tifffile.TiffWriter.save()` with `tifffile >= 2020.9.30`.
 
 #### Deprecations
 

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -349,7 +349,7 @@ class CorrelatedStack:
         # write frames sequentially
         with tifffile.TiffWriter(file_name) as tif:
             for frame in to_save:
-                tif.save(
+                tif.write(
                     frame.data,
                     description=description,
                     software=software,

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -255,7 +255,7 @@ def save_tiff(image, filename, dtype, clip=False, metadata=ImageMetadata()):
             f" or pass `force=True` to clip the data."
         )
 
-    tifffile.imsave(
+    tifffile.imwrite(
         filename,
         image.astype(dtype),
         resolution=metadata.resolution,

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "numpy>=1.20, <2",
         "scipy>=1.1, <2",
         "matplotlib>=2.2",
-        "tifffile>=2019.7.26",
+        "tifffile>=2020.9.30",
         "tabulate==0.8.6",
         "opencv-python-headless>=3.0",
         "ipywidgets>=7.0.0",


### PR DESCRIPTION
**Why this PR?**
Fixes a `DeprecationWarning` regarding `TiffFile`.

`imwrite` was introduced in 2018.11.6 (https://github.com/cgohlke/tifffile/blob/master/CHANGES.rst).
Unfortunately `TiffWriter.save` was introduced in `2020.9.30` and will require a version bump.