### PR TITLE
KymoLine localization uncertainty

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * Allow slicing directly with an object with a `.start` and `.stop` property. See [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#markers) for more information.
 * Allow boolean array indexing on `Slice` (e.g. `file.force1x[file.force1x.data > 5]`. See [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#boolean-array-indexing) for more information.
 * When doing arithmetic on `Slice`, propagate the calibration if it is still valid.
+* Added `Kymoline.position_variance` to obtain an estimate of the variance on the localized track position. This value is only calculated for tracks that have been refined by the gaussian MLE method and do not overlap with other tracks. In other cases, this property will return `np.nan`.
 
 #### Bug fixes
 

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -185,6 +185,29 @@ In this case the parameter will not be fitted, but fixed to the user specified v
 This can help reduce the variance of the parameter estimates.
 Note that this method can only be used if the background can be assumed to be constant over time and position.
 
+Position uncertainty
+^^^^^^^^^^^^^^^^^^^^
+
+The variance of the position estimate is available for `KymoLine` refined by the MLE method, which is calculated according to :cite:`mortensen2010gauloc`
+(SI Equation 54)
+
+.. math::
+    \mathrm{Var} \left( \mu \right) = \frac{\sigma^2}{N} \left( 1 + \int_0^1 \frac{\ln{t}}{1 + t / \tau} dt \right)^{-1}
+
+where :math:`\tau` is defined as:
+
+.. math::
+    \tau = \frac{2 \pi \sigma^2 b}{N a}
+
+You can access these values for the full line with::
+
+    refined.position_variance
+
+Note that the variance estimtate is only available for lines that have been refined by the MLE method and were not fit as overlapping windows.
+For lines and/or time frames that do not meet these conditions, the value will be `np.nan`. Also, when two lines are manually connected
+(in the widget for instance), the gaussian model parameters are no longer considered valid and therefore the position variance will also return `np.nan`.
+
+
 Using the kymotracker widget
 ----------------------------
 

--- a/lumicks/pylake/kymotracker/detail/gaussian_mle.py
+++ b/lumicks/pylake/kymotracker/detail/gaussian_mle.py
@@ -244,4 +244,4 @@ def gaussian_mle_1d(
     sort_idx = np.argsort(peak_parameters[:, 1])
     peak_parameters = peak_parameters[sort_idx[reverse_idx], :]
 
-    return tuple(np.hstack((*param, background)) for param in peak_parameters)
+    return tuple((*param, background) for param in peak_parameters)

--- a/lumicks/pylake/kymotracker/detail/gaussian_mle.py
+++ b/lumicks/pylake/kymotracker/detail/gaussian_mle.py
@@ -244,4 +244,4 @@ def gaussian_mle_1d(
     sort_idx = np.argsort(peak_parameters[:, 1])
     peak_parameters = peak_parameters[sort_idx[reverse_idx], :]
 
-    return tuple((*param, background) for param in peak_parameters)
+    return tuple(np.hstack((*param, background)) for param in peak_parameters)

--- a/lumicks/pylake/kymotracker/detail/loc_models.py
+++ b/lumicks/pylake/kymotracker/detail/loc_models.py
@@ -6,6 +6,11 @@ from typing import ClassVar
 
 @dataclass(frozen=True)
 class LocalizationModel:
+    """Data structure to handle localization parameters.
+
+    All position/spatial values are in physical units (microns, kbp, etc).
+    """
+
     _name: ClassVar[str] = "default"
     pixel_size: float
     position: np.ndarray
@@ -21,6 +26,12 @@ class LocalizationModel:
 
 @dataclass(frozen=True)
 class GaussianLocalizationModel(LocalizationModel):
+    """
+    Mortensen, K. I., Churchman, L. S., Spudich, J. A., & Flyvbjerg, H. (2010).
+    Optimized localization analysis for single-molecule tracking and super-resolution microscopy.
+    Nature Methods, 7(5), 377-381.
+    """
+
     _name: ClassVar[str] = "gaussian"
     total_photons: np.ndarray
     sigma: np.ndarray
@@ -29,13 +40,7 @@ class GaussianLocalizationModel(LocalizationModel):
 
     @property
     def loc_variance(self):
-        """
-        [ ] Mortensen, K. I., Churchman, L. S., Spudich, J. A., & Flyvbjerg, H. (2010).
-        Optimized localization analysis for single-molecule tracking and super-resolution microscopy.
-        Nature Methods, 7(5), 377-381.
-        SI Eq. 54
-        """
-
+        # Mortensen et al. SI Eq. 54
         var = []
         for photons, sigma, background, overlap in zip(
             self.total_photons, self.sigma, self.background, self._overlap_fit
@@ -43,8 +48,8 @@ class GaussianLocalizationModel(LocalizationModel):
             if overlap:
                 var.append(np.nan)
             else:
-                tau = 2 * np.pi * sigma ** 2 * background / (photons * self.pixel_size)
+                tau = 2 * np.pi * sigma**2 * background / (photons * self.pixel_size)
                 fn = lambda t: np.log(t) / (1 + t / tau)
                 integral, _ = integrate.quad(fn, 0, 1)
-                var.append(sigma ** 2 / photons * (1 + integral) ** -1)
+                var.append(sigma**2 / photons * (1 + integral) ** -1)
         return var

--- a/lumicks/pylake/kymotracker/detail/loc_models.py
+++ b/lumicks/pylake/kymotracker/detail/loc_models.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy import integrate
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -13,3 +14,31 @@ class LocalizationModel:
     def pixel_coordinate(self):
         return self.position / self.pixel_size
 
+    @property
+    def loc_variance(self):
+        return np.full(self.position.size, np.nan)
+
+
+@dataclass(frozen=True)
+class GaussianLocalizationModel(LocalizationModel):
+    _name: ClassVar[str] = "gaussian"
+    total_photons: np.ndarray
+    sigma: np.ndarray
+    background: np.ndarray
+
+    @property
+    def loc_variance(self):
+        """
+        [ ] Mortensen, K. I., Churchman, L. S., Spudich, J. A., & Flyvbjerg, H. (2010).
+        Optimized localization analysis for single-molecule tracking and super-resolution microscopy.
+        Nature Methods, 7(5), 377-381.
+        SI Eq. 54
+        """
+
+        var = []
+        for p, s, b in zip(self.total_photons, self.sigma, self.background):
+            tau = 2 * np.pi * s ** 2 * b / (p * self.pixel_size)
+            fn = lambda t: np.log(t) / (1 + t / tau)
+            integral, _ = integrate.quad(fn, 0, 1)
+            var.append(s ** 2 / p * (1 + integral) ** -1)
+        return var

--- a/lumicks/pylake/kymotracker/detail/loc_models.py
+++ b/lumicks/pylake/kymotracker/detail/loc_models.py
@@ -1,0 +1,15 @@
+import numpy as np
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+@dataclass(frozen=True)
+class LocalizationModel:
+    _name: ClassVar[str] = "default"
+    pixel_size: float
+    position: np.ndarray
+
+    @property
+    def pixel_coordinate(self):
+        return self.position / self.pixel_size
+

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -162,7 +162,7 @@ class KymoLine:
     @property
     def position_variance(self):
         return self._localization.loc_variance
-        
+
     def _check_ends_are_defined(self):
         """Checks if beginning and end of the line are not in the first/last frame."""
         return self.time_idx[0] > 0 and self.time_idx[-1] < self._image.data.shape[1] - 1

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -90,11 +90,11 @@ def import_kymolinegroup_from_csv(filename, kymo, channel, delimiter=";"):
 class KymoLine:
     """A line on a kymograph"""
 
-    __slots__ = ["time_idx", "coordinate_idx", "_image"]
+    __slots__ = ["_time_idx", "_coordinate_idx", "_image"]
 
     def __init__(self, time_idx, coordinate_idx, image):
-        self.time_idx = np.asarray(time_idx)
-        self.coordinate_idx = np.asarray(coordinate_idx)
+        self._time_idx = np.asarray(time_idx)
+        self._coordinate_idx = np.asarray(coordinate_idx)
         self._image = image
 
     @classmethod
@@ -125,6 +125,14 @@ class KymoLine:
         return np.squeeze(
             np.array(np.vstack((self.time_idx[item], self.coordinate_idx[item]))).transpose()
         )
+
+    @property
+    def time_idx(self):
+        return self._time_idx
+
+    @property
+    def coordinate_idx(self):
+        return self._coordinate_idx
 
     @property
     def seconds(self):

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -1,7 +1,8 @@
 from copy import copy
 from sklearn.neighbors import KernelDensity
-from lumicks.pylake.kymotracker.detail.msd_estimation import *
-from lumicks.pylake.kymotracker.detail.calibrated_images import CalibratedKymographChannel
+from .detail.msd_estimation import *
+from .detail.calibrated_images import CalibratedKymographChannel
+from .detail.loc_models import LocalizationModel
 from lumicks.pylake.population.dwelltime import DwelltimeModel
 
 
@@ -88,13 +89,29 @@ def import_kymolinegroup_from_csv(filename, kymo, channel, delimiter=";"):
 
 
 class KymoLine:
-    """A line on a kymograph"""
+    """A line on a kymograph.
 
-    __slots__ = ["_time_idx", "_coordinate_idx", "_image"]
+    Parameters
+    ----------
+    time_idx : array-like
+        Frame time indices.
+    localization : LocalizationModel or array-like
+        LocalizationModel instance containing localization parameters
+        or list of (sub)pixel coordinates to be converted to spatial
+        position via calibration with pixel size.
+    image : CalibratedKymographChannel
+        Image data from kymograph.
+    """
 
-    def __init__(self, time_idx, coordinate_idx, image):
+    __slots__ = ["_time_idx", "_localization", "_image"]
+
+    def __init__(self, time_idx, localization, image):
         self._time_idx = np.asarray(time_idx)
-        self._coordinate_idx = np.asarray(coordinate_idx)
+        self._localization = (
+            localization
+            if isinstance(localization, LocalizationModel)
+            else LocalizationModel(image._pixel_size, np.array(localization) * image._pixel_size)
+        )
         self._image = image
 
     @classmethod
@@ -132,7 +149,7 @@ class KymoLine:
 
     @property
     def coordinate_idx(self):
-        return self._coordinate_idx
+        return self._localization.pixel_coordinate
 
     @property
     def seconds(self):
@@ -140,7 +157,7 @@ class KymoLine:
 
     @property
     def position(self):
-        return self._image.to_position(self.coordinate_idx)
+        return self._localization.position
 
     def _check_ends_are_defined(self):
         """Checks if beginning and end of the line are not in the first/last frame."""

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -159,6 +159,10 @@ class KymoLine:
     def position(self):
         return self._localization.position
 
+    @property
+    def position_variance(self):
+        return self._localization.loc_variance
+        
     def _check_ends_are_defined(self):
         """Checks if beginning and end of the line are not in the first/last frame."""
         return self.time_idx[0] > 0 and self.time_idx[-1] < self._image.data.shape[1] - 1

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -262,14 +262,14 @@ def refine_lines_centroid(lines, line_width):
         interpolated_lines[0]._image.data, coordinate_idx, time_idx, np.ceil(0.5 * line_width)
     )
 
-    current = 0
-    for line in interpolated_lines:
-        line_length = len(line.time_idx)
-        line.time_idx = time_idx[current : current + line_length]
-        line.coordinate_idx = coordinate_idx[current : current + line_length]
-        current += line_length
-
-    return KymoLineGroup(interpolated_lines)
+    line_ids = np.hstack(
+        [np.full(len(line.time_idx), j) for j, line in enumerate(interpolated_lines)]
+    )
+    new_lines = [
+        KymoLine(time_idx[line_ids == j], coordinate_idx[line_ids == j], line._image)
+        for j, line in enumerate(interpolated_lines)
+    ]
+    return KymoLineGroup(new_lines)
 
 
 def refine_lines_gaussian(

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -42,6 +42,11 @@ def two_gaussians_1d():
 
 
 @pytest.fixture
+def blank_channel():
+    return CalibratedKymographChannel("test_data", np.array([[]]), 1e9, 1)
+
+
+@pytest.fixture
 def kymogroups_2lines():
     _, _, photon_count, parameters = read_dataset_gaussian("kymo_data_2lines.npz")
     pixel_size = parameters[0].pixel_size

--- a/lumicks/pylake/kymotracker/tests/test_io.py
+++ b/lumicks/pylake/kymotracker/tests/test_io.py
@@ -21,8 +21,8 @@ def kymolinegroup_io_data():
     lines = KymoLineGroup([k1, k2, k3, k4])
 
     for k in lines:
-        test_data[k.coordinate_idx, k.time_idx] = 2
-        test_data[np.array(k.coordinate_idx) - 1, k.time_idx] = 1
+        test_data[np.array(k.coordinate_idx).astype(int), k.time_idx] = 2
+        test_data[np.array(k.coordinate_idx).astype(int) - 1, k.time_idx] = 1
 
     return test_img, lines
 

--- a/lumicks/pylake/kymotracker/tests/test_kymoline.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymoline.py
@@ -261,9 +261,9 @@ def test_binding_histograms():
     np.testing.assert_allclose(edges, [2, 3, 4, 5, 6, 7, 8])
 
 
-def test_kymolinegroup_copy():
-    k1 = KymoLine(np.array([1, 2, 3]), np.array([1, 1, 1]), [])
-    k2 = KymoLine(np.array([6, 7, 8]), np.array([2, 2, 2]), [])
+def test_kymolinegroup_copy(blank_channel):
+    k1 = KymoLine(np.array([1, 2, 3]), np.array([1, 1, 1]), blank_channel)
+    k2 = KymoLine(np.array([6, 7, 8]), np.array([2, 2, 2]), blank_channel)
     group = KymoLineGroup([k1, k2])
     assert id(group._src) != id(copy(group)._src)
 

--- a/lumicks/pylake/kymotracker/tests/test_loc_models.py
+++ b/lumicks/pylake/kymotracker/tests/test_loc_models.py
@@ -1,0 +1,41 @@
+import numpy as np
+from lumicks.pylake.kymotracker.detail.loc_models import (
+    LocalizationModel,
+    GaussianLocalizationModel,
+)
+
+
+def test_default_model():
+    m = LocalizationModel(0.15, np.arange(5) * 0.2)
+    np.testing.assert_allclose(m.pixel_coordinate, [0.0, 1.33333333, 2.66666667, 4.0, 5.33333333])
+    np.testing.assert_equal(m.loc_variance, np.full(5, np.nan))
+
+
+def test_gaussian_model():
+    m = GaussianLocalizationModel(
+        0.15,
+        np.arange(3) * 0.2,
+        np.array([5, 6, 8]),
+        np.array([0.5, 0.5, 0.6]),
+        np.array([1, 2, 1]),
+        np.full(3, False),
+    )
+
+    np.testing.assert_allclose(m.pixel_coordinate, [0.0, 1.33333333, 2.66666667])
+    ref_var = [0.5036671516579478, 0.6536440319302808, 0.4152688415531396]
+    np.testing.assert_allclose(m.loc_variance, ref_var)
+
+
+def test_gaussian_model_overlap():
+    m = GaussianLocalizationModel(
+        0.15,
+        np.arange(3) * 0.2,
+        np.array([5, 6, 8]),
+        np.array([0.5, 0.5, 0.6]),
+        np.array([1, 2, 1]),
+        np.array([False, True, False]),
+    )
+
+    np.testing.assert_allclose(m.pixel_coordinate, [0.0, 1.33333333, 2.66666667])
+    ref_var = [0.5036671516579478, np.nan, 0.4152688415531396]
+    np.testing.assert_allclose(m.loc_variance, ref_var)

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -9,10 +9,10 @@ from lumicks.pylake.kymotracker.kymotracker import (
 from lumicks.pylake.kymotracker.kymoline import KymoLine, KymoLineGroup
 
 
-def test_kymoline_interpolation():
+def test_kymoline_interpolation(blank_channel):
     time_idx = np.array([1.0, 3.0, 5.0])
     coordinate_idx = np.array([1.0, 3.0, 3.0])
-    kymoline = KymoLine(time_idx, coordinate_idx, [])
+    kymoline = KymoLine(time_idx, coordinate_idx, blank_channel)
     interpolated = kymoline.interpolate()
     np.testing.assert_allclose(interpolated.time_idx, [1.0, 2.0, 3.0, 4.0, 5.0])
     np.testing.assert_allclose(interpolated.coordinate_idx, [1.0, 2.0, 3.0, 3.0, 3.0])
@@ -176,12 +176,10 @@ def test_gaussian_refinement_overlap(kymogroups_close_lines):
     )
 
 
-def test_filter_lines():
-    channel = CalibratedKymographChannel("test_data", np.array([[]]), 1e9, 1)
-
-    k1 = KymoLine([1, 2, 3], [1, 2, 3], channel)
-    k2 = KymoLine([2, 3], [1, 2], channel)
-    k3 = KymoLine([2, 3, 4, 5], [1, 2, 4, 5], channel)
+def test_filter_lines(blank_channel):
+    k1 = KymoLine([1, 2, 3], [1, 2, 3], blank_channel)
+    k2 = KymoLine([2, 3], [1, 2], blank_channel)
+    k3 = KymoLine([2, 3, 4, 5], [1, 2, 4, 5], blank_channel)
     lines = KymoLineGroup([k1, k2, k3])
     assert len(filter_lines(lines, 5)) == 0
     assert all([line1 == line2 for line1, line2 in zip(filter_lines(lines, 5), [k1, k3])])

--- a/lumicks/pylake/kymotracker/tests/test_tracing.py
+++ b/lumicks/pylake/kymotracker/tests/test_tracing.py
@@ -10,8 +10,8 @@ from lumicks.pylake.kymotracker.kymoline import KymoLine
 from lumicks.pylake.kymotracker.detail.peakfinding import KymoPeaks
 
 
-def test_score_matrix():
-    lines = [KymoLine([0], [3], None)]
+def test_score_matrix(blank_channel):
+    lines = [KymoLine([0], [3], blank_channel)]
     unique_coordinates = np.arange(0, 7)
     unique_times = np.arange(1, 7)
 


### PR DESCRIPTION
**Why this PR?**
When tracked lines are refined by the gaussian method, it is possible to calculate the variance on the estimated localization parameters, which can give you information about the reliability of your tracking.

Docs are [here](https://lumicks-pylake.readthedocs.io/en/loc_uncertainty/tutorial/kymotracking.html#position-uncertainty)

**Notes**
- First commit makes `KymoLine` immutable. This was implicitly the behavior we expected before, but now it's actually enforced.
- I created a small dataclass (and subclass) to hold the localization parameters. I felt this was needed because depending on the type of refinement, certain parameters may or may not be available.
- Current functionality for instantiating `KymoLine` is unchanged. Initializing with a `np.array` of pixel coordinates automatically creates the appropriate data structure. This way, the only major change is in `refine_line_gaussian`.
- If lines are edited manually (concatenated), the lines are reset to the model parameters (ie, gaussian parameters are removed, as these are no longer valid)

**Update**
I ran a simulation to test the variance result. Here I generate a kymo image (with a certain number of frames) of a single line at a known position, and then run `refine_lines_gaussian()`. In the plot below, the blue is the mean and standard deviation across all frames of the refined localization. The orange is the `sqrt(mean(loc_variance))`. It seems that the variance estimate from the refinement consistently over-estimates the precision; however this discrepancy is less with more samples and/or more photons/frame.

![bootstrap_200](https://user-images.githubusercontent.com/61475504/158795013-9c6548fe-1553-4d45-a1e5-859acdac71a7.png)

![bootstrap_2000](https://user-images.githubusercontent.com/61475504/158795035-f578df63-f9f6-4bb3-9da7-80dc5048f0d6.png)

