### PR TITLE
Kymotracker: allow manual connection between any nodes in tracks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
 * Added fallback to the function `Kymo.plot_with_force()` when only low-frequency force data is available.
 * Added option to undo/redo actions in the kymotracker widget.
 * Added option to fit peaks simultaneously in `refine_lines_gaussian()` using the flag `overlap_strategy="fit_multiple"`. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
+* Added ability to manually connect two lines from any points (not just the ends) in the kymotracker widget.
 
 #### Bug fixes
 

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -349,6 +349,26 @@ class KymoLineGroup:
         self._src[self._src.index(starting_line)] = starting_line + ending_line
         self._src.remove(ending_line)
 
+    def _merge_lines(self, starting_line, starting_node, ending_line, ending_node):
+        starting_node = int(starting_node) + 1
+        ending_node = int(ending_node)
+
+        first_half = KymoLine(
+            starting_line.time_idx[:starting_node],
+            starting_line.coordinate_idx[:starting_node],
+            starting_line._image,
+        )
+
+        last_half = KymoLine(
+            ending_line.time_idx[ending_node:],
+            ending_line.coordinate_idx[ending_node:],
+            ending_line._image,
+        )
+
+        self._src[self._src.index(starting_line)] = first_half + last_half
+        if starting_line != ending_line:
+            self._src.remove(ending_line)
+
     def __len__(self):
         return len(self._src)
 


### PR DESCRIPTION
**Why this PR?**
Request from multiple users. Sometime you want to connect two nearby tracks that are slightly overlapped in time (by a couple frames). Previously this was impossible as we only supported connecting between the track ends. Now you can connect between any two nodes; the ends of the tracks are trimmed to these points and then concatenated

![tracker_connect_demo](https://user-images.githubusercontent.com/61475504/153608064-7d08f515-1e1f-495d-be0e-f0dc800fec32.gif)
.