### PR TITLE
Spring cleaning and Python 3.10

### DIFF
--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 #### New features
 
+* Added support for Python 3.10.
 * Added `CorrelatedStack.define_tether()` which can be used to define the endpoints of the tether between two beads and return image data rotated such that the tether is horizontal. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html) for more information.
 * Added function to correlate `Scan` frames to channel data. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html#correlating-scans).
 * Added `CorrelatedStack.crop_and_rotate()` for interactive editing of the image stack. Actions include scrolling through image frames with the mouse wheel, and left-clicking to define the tether coordinates, and right-click/drag to define a cropping region. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html#image-stack-editor) for more information.

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -501,8 +501,8 @@ class Tether:
             # in the coordinate system of the raw image data
             self._ends = self.offsets.warp_coordinates(points)
             # calculate rotation matrix
-            slope, _ = np.polyfit(*np.vstack(self._ends).T, deg=1)
-            theta = np.degrees(np.arctan(slope))
+            dy, dx = self._ends[1][1] - self._ends[0][1], self._ends[1][0] - self._ends[0][0]
+            theta = np.degrees(np.arctan2(dy, dx))
             center = np.mean(np.vstack(self._ends), axis=0)
             self.rot_matrix = TransformMatrix.rotation(theta, center)
 

--- a/lumicks/pylake/force_calibration/tests/test_convenience.py
+++ b/lumicks/pylake/force_calibration/tests/test_convenience.py
@@ -50,11 +50,17 @@ def test_active_force_calibration_active(reference_models):
     """This test tests merely whether values were handed to the low level API correctly, not whether
     the calibration results are correct."""
     data, f_sample = reference_models.lorentzian_td(4000, 1, 0.4, 14000, 78125)
+    oscillation = np.sin(77 * 2 * np.pi * np.arange(data.size) / 78125)
+
+    # We need a driving peak in the power spectrum, otherwise we obtain a negative value for the
+    # peak power which leads to a downstream warning.
+    data += oscillation
+
     fit = calibrate_force(
         data,
         2,
         9,
-        driving_data=np.sin(77 * 2 * np.pi * np.arange(data.size) / 78125),
+        driving_data=oscillation,
         driving_frequency_guess=77,
         viscosity=6,
         active_calibration=True,

--- a/lumicks/pylake/force_calibration/tests/test_touchdown.py
+++ b/lumicks/pylake/force_calibration/tests/test_touchdown.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 import numpy as np
 from matplotlib.testing.decorators import cleanup
 from lumicks.pylake.force_calibration.touchdown import (
@@ -26,12 +27,14 @@ def test_piecewise_linear_fit(direction, surface, slope1, slope2, offset):
             + offset
         )
 
-    independent = np.arange(5.0, 10.0, 0.1)
-    pars = fit_piecewise_linear(independent, y_func(independent))
-    np.testing.assert_allclose(pars, [surface, offset, slope1, slope2], atol=1e-12)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "Covariance of the parameters could not be estimated")
+        independent = np.arange(5.0, 10.0, 0.1)
+        pars = fit_piecewise_linear(independent, y_func(independent))
+        np.testing.assert_allclose(pars, [surface, offset, slope1, slope2], atol=1e-12)
 
-    pars = fit_piecewise_linear(np.flip(independent), np.flip(y_func(independent)))
-    np.testing.assert_allclose(pars, [surface, offset, slope1, slope2], atol=1e-12)
+        pars = fit_piecewise_linear(np.flip(independent), np.flip(y_func(independent)))
+        np.testing.assert_allclose(pars, [surface, offset, slope1, slope2], atol=1e-12)
 
 
 @pytest.mark.parametrize(
@@ -82,8 +85,10 @@ def test_touchdown():
 
 @cleanup
 def test_plot():
-    touchdown_result = touchdown(np.array([1, 2, 3, 4]), np.array([1, 2, 3, 4]))
-    touchdown_result.plot()
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "Covariance of the parameters could not be estimated")
+        touchdown_result = touchdown(np.array([1, 2, 3, 4]), np.array([1, 2, 3, 4]))
+        touchdown_result.plot()
 
 
 @pytest.mark.parametrize(

--- a/lumicks/pylake/tests/data/mock_widefield.py
+++ b/lumicks/pylake/tests/data/mock_widefield.py
@@ -192,7 +192,7 @@ def write_tiff_file(image_args, n_frames, filename):
         for n, frame in enumerate(movie):
             str_datetime = f"{n*10+10}:{n*10+18}"
             tag_datetime = (306, "s", len(str_datetime), str_datetime, False)
-            tif.save(
+            tif.write(
                 frame,
                 description=json.dumps(description, indent=4),
                 software="Bluelake Unknown",

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "ipywidgets>=7.0.0",
         "cachetools>=3.1",
         "deprecated>=1.2.8",
-        "scikit-learn>=0.18.0, <1.0",
+        "scikit-learn>=0.18.0",
         "scikit-image>=0.17.2",
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "scipy>=1.1, <2",
         "matplotlib>=2.2",
         "tifffile>=2020.9.30",
-        "tabulate==0.8.6",
+        "tabulate>=0.8.8, <0.9",
         "opencv-python-headless>=3.0",
         "ipywidgets>=7.0.0",
         "cachetools>=3.1",


### PR DESCRIPTION
**Why this PR?**
This PR adds Python `3.10` support to CI. It also bumps the `tabulate` dependency which prevented use of Python 3.10 (see https://github.com/lumicks/pylake/issues/266).

Since we were generating a few warnings when running the tests, I decided to delve into these a little bit and clean them up. Therefore this PR also consists of a few small fixups. I have described the reason for each minor fix in the relevant commit message.

Note that we still generate some warnings from matplotlib renaming an argument in the constructor of the `RectangleSelector`. We will fix that on the next breaking release by bumping the `mpl` dependency.

The fix in `crop_and_rotate()` hasn't actually been in a release yet, so it doesn't warrant a changelog entry. The other fixes merely affect tests.