### PR TITLE
Catch some touchdown failure modes

### DIFF
--- a/lumicks/pylake/force_calibration/tests/conftest.py
+++ b/lumicks/pylake/force_calibration/tests/conftest.py
@@ -46,3 +46,24 @@ def integration_test_parameters():
         "driving_sinusoid": (500, 31.95633),
         "diode": (0.4, 15000),
     }
+
+
+@pytest.fixture
+def mack_parameters():
+    return {
+        "wavelength_nm": 1064.0,
+        "refractive_index_medium": 1.333,
+        "surface_position": 101.65754300557573,
+        "displacement_sensitivity": 9.724913160609043,
+        "intensity_amplitude": -0.10858224326787835,
+        "intensity_phase_shift": 1.6535670092299886,
+        "intensity_decay_length": 0.308551871490813,
+        "scattering_polynomial_coeffs": [
+            -0.043577454353825644,
+            0.22333743993836863,
+            -0.33331150250090585,
+            0.1035148152731559,
+        ],
+        "focal_shift": 0.921283446497108,
+        "nonlinear_shift": 0.0,
+    }

--- a/lumicks/pylake/force_calibration/tests/test_touchdown.py
+++ b/lumicks/pylake/force_calibration/tests/test_touchdown.py
@@ -19,6 +19,7 @@ from lumicks.pylake.force_calibration.touchdown import (
         [0.1, 7.5, 0.0, 5.0, -7.0, 0.0],
     ],
 )
+@pytest.mark.filterwarnings("ignore:Denominator in F-Test is zero")
 def test_piecewise_linear_fit(direction, surface, slope1, slope2, offset, p_value):
     def y_func(x):
         return (
@@ -29,6 +30,7 @@ def test_piecewise_linear_fit(direction, surface, slope1, slope2, offset, p_valu
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "Covariance of the parameters could not be estimated")
+        warnings.filterwarnings("ignore", "Denominator in F-Test is zero")
         independent = np.arange(5.0, 10.0, 0.1)
         pars, p_value = fit_piecewise_linear(independent, y_func(independent))
         np.testing.assert_allclose(pars, [surface, offset, slope1, slope2], atol=1e-12)
@@ -80,6 +82,8 @@ def test_touchdown(mack_parameters):
 def test_plot():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "Covariance of the parameters could not be estimated")
+        warnings.filterwarnings("ignore", "Denominator in F-Test is zero")
+        warnings.filterwarnings("ignore", "Insufficient data available to reliably fit touchdown")
         touchdown_result = touchdown(np.array([1, 2, 3, 4]), np.array([1, 2, 3, 4]))
         touchdown_result.plot()
 

--- a/lumicks/pylake/force_calibration/touchdown.py
+++ b/lumicks/pylake/force_calibration/touchdown.py
@@ -227,7 +227,7 @@ def touchdown(
     stage_trimmed, force_trimmed = nanostage[mask], axial_force[mask]
     expected_wavelength = wavelength_nm * 1e-3 / 2 / refractive_index_medium
 
-    bounds = np.array([0.5, 1.0001]) / expected_wavelength
+    bounds = np.array([0.7, 1.0001]) / expected_wavelength
     par, simulation = fit_sine_with_polynomial(
         surface_position - stage_trimmed,
         force_trimmed,

--- a/lumicks/pylake/force_calibration/touchdown.py
+++ b/lumicks/pylake/force_calibration/touchdown.py
@@ -76,9 +76,18 @@ def f_test(sse_restricted, sse_unrestricted, num_data, num_pars_difference, num_
     """Determine p-value whether the bigger model describes the variance significantly better"""
     nominator = (sse_restricted - sse_unrestricted) / num_pars_difference
     denominator = sse_unrestricted / (num_data - num_pars_unrestricted)
-    f_statistic = nominator / denominator
-    p_value = 1.0 - stats.f.cdf(f_statistic, num_pars_difference, num_pars_unrestricted)
-    return p_value
+    if denominator == 0:
+        warnings.warn(
+            RuntimeWarning(
+                "Denominator in F-Test is zero. "
+                "This may be caused by using noise-free data or fewer than 4 data points."
+            )
+        )
+        return 0.0
+    else:
+        f_statistic = nominator / denominator
+        p_value = 1.0 - stats.f.cdf(f_statistic, num_pars_difference, num_pars_unrestricted)
+        return p_value
 
 
 def fit_piecewise_linear(x, y):


### PR DESCRIPTION
### Why this PR?
This PR is intended to catch a few of the failure cases that we observe when applying the touchdown procedure.

It adds three things (images of the failure modes are shown below).
- It sets the minimum for the focal shift to `0.7` (valid focal shifts for our objectives are between `0.7` and `1.0`.
- It ensures that there is sufficient data to compute the focal shift. At least two periods of the interference pattern are required.
![image](https://user-images.githubusercontent.com/19836026/155002212-d55b572d-d8ad-4abb-8869-453fe33ed20a.png)
The reason is that despite the fit shown here looking very good, the computed focal shift is actually complete nonsense. The focal shift model is given as a background polynomial plus a sine wave contribution. When you have only a partial period of the sine wave, the polynomial simply captures all the data (resulting in a sine wave amplitude of zero and an arbitrary frequency and phase).
- It validates that the piecewise linear fit is significantly better than a single linear fit. This guards against the case where we do not actually see the change in slope expected from the touchdown.
![image](https://user-images.githubusercontent.com/19836026/155002088-ce6a0694-bdea-48b4-869d-6805caf640dd.png)
![image](https://user-images.githubusercontent.com/19836026/155002182-c833a88a-70a5-4e83-89f7-ff8ea4d72b63.png)