### PR TITLE
Badge in the readme should link to workflows.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,7 +25,7 @@
 * Added `Kymo.crop_and_calibrate()` for interactive cropping of a kymograph. If the optional `tether_length_kbp` argument is supplied, the resulting kymograph will be automatically calibrated to this length. Check out the [documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html#calibrating-to-base-pairs) for more information.
 * Added fallback to the function `Kymo.plot_with_force()` when only low-frequency force data is available.
 * Added option to undo/redo actions in the kymotracker widget.
-* Added option to fit peaks simultaneously in `refine_lines_gaussian()` using the flag `overlap_strategy="fit_multiple"`. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
+* Added option to fit peaks simultaneously in `refine_lines_gaussian()` using the flag `overlap_strategy="multiple"`. See [kymotracking](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more information.
 * Added ability to manually connect two lines from any points (not just the ends) in the kymotracker widget.
 
 #### Bug fixes

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -159,7 +159,7 @@ refinement algorithm. How the algorithm handles this situation is determined by 
 Setting `overlap_strategy="ignore"` simply ignores the situation and fits the data.
 A problem with the refinement in this case will manifest as the peak of the second trace is found rather than that of the current trace.
 Sometimes this can be avoided by decreasing the size of the `window` argument such that overlap no longer occurs.
-A better alternative is to use `overlap_strategy="fit_multiple"`.
+A better alternative is to use `overlap_strategy="multiple"`.
 When this option is specified, peaks where the windows overlap are fitted simultaneously (using a shared offset parameter).
 Alternatively, we can simply ignore these frames by using `overlap_strategy="skip"`, in which case these frames are simply dropped from the trace.
 

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 
 [![DOI](https://zenodo.org/badge/133832492.svg)](https://zenodo.org/badge/latestdoi/133832492)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](license.md)
-![Build Status](https://github.com/lumicks/pylake/workflows/pytest/badge.svg)
+[![Build Status](https://github.com/lumicks/pylake/workflows/pytest/badge.svg?branch=main)](https://github.com/lumicks/pylake/actions/workflows/pylake_test.yml?query=branch%3Amain)
 [![Documentation Status](https://readthedocs.org/projects/lumicks-pylake/badge/?version=latest)](https://lumicks-pylake.readthedocs.io/)
 
 Pylake is a Python package for analyzing single-molecule optical tweezer data.


### PR DESCRIPTION
**Why this PR?**
The badge in the readme should point to the workflow builds.

I piggybacked a fixup to the documentation onto this PR.