### PR TITLE
Bugfix: ignore ambiguous dwelltimes in kymotracking binding time analysis

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## v0.12.0 | t.b.d.
 
+#### Bug fixes
+* Fixed a minor bug in `KymoLineGroup.fit_binding_times()`. Previously, the binding time for all lines in the group were used for the analysis. However, lines which start in the first frame of the kymo or end in the last frame have ambiguous dwelltimes as the start or end of the line is not known definitively. Now, the default behavior is to exclude these lines from the analysis. This behavior can be overridden with the keyword argument `exclude_ambiguous_dwells=False`. In general, this bug would lead to only very minor biases in the results unless the number of dwells to be excluded is large relative to the total number.
+
 #### Breaking changes
 * Changed the frame indexing convention for plotting confocal scans to match `CorrelatedStack.plot()`. Previously, `Scan.plot(frame=1)` referred to the first frame in the stack. Now, indexing starts at `0`.
 * Requesting a frame outside of the available range for `Scan.plot()` now throws an `IndexError`.

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -449,7 +449,7 @@ It's not hard to see from this graph why taking too many lags results in unaccep
 
 
 Dwelltime analysis
-------------------------
+------------------
 
 The lifetime of the bound state(s) can be determined using `KymoLineGroup.fit_binding_times()`. This method defines
 the bound dwelltime as the length of each tracked line (in seconds). The lifetimes are then determined using
@@ -480,6 +480,11 @@ a track. Note that when :math:`t_{min}=0` and :math:`t_{max}=\infty`, :math:`N=1
 there are physical limitations on the measurement times (such as pixel integration time). Additionally, the minimum length of tracked lines
 here is dependent on the specific input parameters used for the tracking algorithm. Therefore, in order to estimate these bounds,
 the method uses the shortest track time and the length of the experiment, respectively.
+
+Note: tracks which start in the first frame of the kymograph or end in the last frame are excluded from the analysis. This is because, such tracks have
+ambiguous binding times as the start or end of the track is not known definitively. If these tracks were included in the analysis, this could lead to minor
+biases in the results, especially if the number of tracks that meet this criteriion is large relative to the total number.
+This behavior can be overridden with the keyword argument `exclude_ambiguous_dwells=False`.
 
 
 First let's try to fit the dwelltime distribution to a single exponential (the simplest case). To do this we

--- a/lumicks/pylake/kymotracker/tests/test_kymoline.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymoline.py
@@ -307,3 +307,20 @@ def test_binding_profile_histogram():
     # no bins requested
     with pytest.raises(ValueError, match="Number of time bins must be > 0."):
         lines._histogram_binding_profile(0, 0.2, 4)
+
+
+def test_fit_binding_times():
+    channel = CalibratedKymographChannel("test_data", np.ones((10, 10)), 1e9, 1)
+
+    k1 = KymoLine(np.array([0, 1, 2]), np.zeros(3), channel)
+    k2 = KymoLine(np.array([2, 3, 4, 5, 6]), np.zeros(5), channel)
+    k3 = KymoLine(np.array([3, 4, 5]), np.zeros(3), channel)
+    k4 = KymoLine(np.array([8, 9]), np.zeros(2), channel)
+
+    lines = KymoLineGroup([k1, k2, k3, k4])
+
+    dwells = lines.fit_binding_times(1)
+    np.testing.assert_allclose(dwells.lifetimes, [1.002547])
+
+    dwells = lines.fit_binding_times(1, exclude_ambiguous_dwells=False)
+    np.testing.assert_allclose(dwells.lifetimes, [1.25710457])


### PR DESCRIPTION
**Why this PR?**
There is a minor bug in `KymoLineGroup.fit_binding_times()` in which tracks with ambiguous dwelltimes are included in the analysis. Tracks which begin on the first frame or end on the last frame of the kymo should be excluded since, in general, we do not know the true start/stop times of the track.

Now the default behavior is to ignore these tracks, but I added a keyword argument to override the behavior. In some cases this is desirable. For example if the user incubates the tether in a channel with the protein of interest to allow binding and then moves to a different channel and starts imaging immediately, the exact start is known and defined to be the first frame.

Also added a private property to `KymoLine` to check if the ends are the first/last frame since this information may be useful for other analyses