### PR TITLE
Fix kymotracker aspect ratio bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 
 * Fixed a minor bug in `KymoLineGroup.fit_binding_times()`. Previously, the binding time for all lines in the group were used for the analysis. However, lines which start in the first frame of the kymo or end in the last frame have ambiguous dwelltimes as the start or end of the line is not known definitively. Now, the default behavior is to exclude these lines from the analysis. This behavior can be overridden with the keyword argument `exclude_ambiguous_dwells=False`. In general, this bug would lead to only very minor biases in the results unless the number of dwells to be excluded is large relative to the total number.
 * Fixed bug in `vmax` handling for `CorrelatedStack`. Before `vmax` values were scaled to the maximally possible range of values for the image instead of the actual intensity value. Note that use of `vmax` and `vmin` is deprecated and one should use `adjustment=lk.ColorAdjustment(min, max)` for color adjustments. See [Correlated stacks](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html#correlated-stacks) for more information.
+* Fixed a bug in the kymotracker in which the plotted aspect ratio did not match the requested `axis_aspect_ratio` argument.
 
 #### Breaking changes
 

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -35,7 +35,8 @@ class KymoWidget:
             Kymograph channel to use.
         axis_aspect_ratio : float
             Desired aspect ratio of the viewport. Sometimes kymographs can be very long and thin.
-            This helps you visualize them.
+            This helps you visualize them. The aspect ratio is defined in physical spatial and
+            temporal units (rather than pixels).
         min_length : int
             Minimum length of a trace. Traces shorter than this are discarded.
         use_widgets : bool
@@ -57,8 +58,8 @@ class KymoWidget:
         self.axis_aspect_ratio = (
             min(
                 axis_aspect_ratio,
-                calibrated_image.to_position(calibrated_image.data.shape[1])
-                / calibrated_image.to_seconds(calibrated_image.data.shape[0]),
+                calibrated_image.to_seconds(calibrated_image.data.shape[1])
+                / calibrated_image.to_position(calibrated_image.data.shape[0]),
             )
             if axis_aspect_ratio
             else None
@@ -477,7 +478,7 @@ class KymoWidget:
                 [
                     0,
                     self.axis_aspect_ratio
-                    * calibrated_image.to_seconds(calibrated_image.data.shape[0]),
+                    * calibrated_image.to_position(calibrated_image.data.shape[0]),
                 ]
             )
 
@@ -529,8 +530,9 @@ class KymoWidgetGreedy(KymoWidget):
         channel : str
             Kymograph channel to use.
         axis_aspect_ratio : float, optional
-            Desired aspect ratio of the viewport. Sometimes kymographs can be very long and thin. This helps you
-            visualize them anyway.
+            Desired aspect ratio of the viewport. Sometimes kymographs can be very long and thin.
+            This helps you visualize them. The aspect ratio is defined in physical spatial and
+            temporal units (rather than pixels).
         line_width : float, optional
             Expected width of the particles in physical units. Defaults to 4 * pixel size.
         pixel_threshold : float, optional

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -46,6 +46,22 @@ def test_invalid_algorithm_parameter(kymograph):
 
 
 @cleanup
+def test_aspect_ratio(kymograph, region_select):
+    for requested_aspect in (2, 3, 5):
+        kymo_widget = KymoWidgetGreedy(
+            kymograph, "red", use_widgets=False, axis_aspect_ratio=requested_aspect
+        )
+        ax = kymo_widget._axes
+        aspect = ax.get_xlim()[1] / ax.get_ylim()[0]
+        np.testing.assert_allclose(
+            aspect,
+            requested_aspect,
+            rtol=0.05,
+            err_msg=f"aspect ratio = {requested_aspect} failed.",
+        )
+
+
+@cleanup
 def test_track_kymo(kymograph, region_select):
     kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
     assert len(kymo_widget.lines) == 0


### PR DESCRIPTION
**Why this PR?**
While working on analysis with kymos acquired under different pixel sizes, I noticed that sometimes the image in the kymotracker did not make any sense with the requested `axis_aspect_ratio` argument.  Finally I found that the aspect ratio was actually being calculated as `height/width` rather than `width/height`. This is fixed now, and a specific test added.

*In the following, the bug in the images aren't very apparent, but look at the printed values at the bottom of each figure*

Before:

![image](https://user-images.githubusercontent.com/61475504/158200673-54f17e27-ae39-4e64-8791-5cb2f99097d7.png)

After:

![image](https://user-images.githubusercontent.com/61475504/158200708-da67998f-9da9-4394-8294-2505683b8724.png)
