### PR TITLE
channel: allow slicing by item with start and stop property

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Support negating channels (e.g. `neg_force = - file.force1x`). See [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#exporting-h5-files) for more information.
 * Allow applying color intensity adjustments on images using `lk.ColorAdjustment()`. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html#correlating-scans) and [Correlated stacks](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html#correlated-stacks) for more information.
 * Added `DwelltimeModel` to fit dwelltimes to an exponential (mixture) distribution. For more information, see the tutorials section on [Population Dynamics](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/population_dynamics.html)
+* Allow slicing directly with an object with a `.start` and `.stop` property. See [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#markers) for more information.
 
 #### Bug fixes
 

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -267,6 +267,11 @@ We can find the start and stop time with ``.start`` and ``.stop``.
     >>> print(file.markers["FRAP 3"].stop)
     1573136602571107585
 
+Note that you can slice channel data directly using markers (or any other item that has a ``.start`` and ``.stop`` property::
+
+    >>> file.force1x[file.markers["FRAP 3"]]
+    <lumicks.pylake.channel.Slice at 0x1f262a27220>
+
 Exporting h5 files
 ------------------
 


### PR DESCRIPTION
**Why this PR?**
It's a small workflow improvement when dealing with slicing. With this improvement, properties that have a `start` and `stop` property can be used directly to slice data channels.

Before:
```python
f = lk.File("my_file.h5")
marker = f.markers["my_marker"]
f.force1x[marker.start : marker.stop]
```
After:
```python
f = lk.File("my_file.h5")
marker = f.markers["my_marker"]
f.force1x[marker]
```
Or:
```python
f = lk.File("my_file.h5")
f.force1x[f.markers["my_marker"]]
```