### PR TITLE
force calibration: allowing fixing both diode frequency and relaxation factor

### DIFF
--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -127,6 +127,9 @@ class FixedDiodeModel(FilterBase):
     """Model with fixed diode parameters"""
 
     def __init__(self, diode_frequency=None, diode_alpha=None):
+        if diode_alpha is not None and not 0 <= diode_alpha <= 1.0:
+            raise ValueError("Diode relaxation factor should be between 0 and 1 (inclusive).")
+
         self.diode_frequency = diode_frequency
         self.diode_alpha = diode_alpha
 

--- a/lumicks/pylake/force_calibration/convenience.py
+++ b/lumicks/pylake/force_calibration/convenience.py
@@ -30,6 +30,7 @@ def calibrate_force(
     fit_range=(1e2, 23e3),
     excluded_ranges=[],
     fixed_diode=None,
+    fixed_alpha=None,
     drag=None,
 ):
     """Determine force calibration factors.
@@ -102,6 +103,8 @@ def calibrate_force(
         Overrides the drag coefficient to this particular value.
     fixed_diode : float, optional
         Fix diode frequency to a particular frequency.
+    fixed_alpha : float, optional
+        Fix diode relaxation factor to particular value.
     """
     if active_calibration:
         if axial:
@@ -109,7 +112,7 @@ def calibrate_force(
         if drag:
             raise ValueError("Drag coefficient cannot be carried over to active calibration.")
 
-    if fixed_diode and fast_sensor:
+    if (fixed_diode or fixed_alpha) and fast_sensor:
         raise ValueError("When using fast_sensor=True, there is no diode model to fix.")
 
     if active_calibration and driving_data.size == 0:
@@ -141,8 +144,8 @@ def calibrate_force(
     if drag:
         model._set_drag(drag)
 
-    if fixed_diode:
-        model._filter = FixedDiodeModel(fixed_diode)
+    if fixed_diode or fixed_alpha:
+        model._filter = FixedDiodeModel(fixed_diode, fixed_alpha)
 
     ps = calculate_power_spectrum(
         force_voltage_data,

--- a/lumicks/pylake/force_calibration/tests/test_alternate_diode_models.py
+++ b/lumicks/pylake/force_calibration/tests/test_alternate_diode_models.py
@@ -1,3 +1,4 @@
+import re
 import pytest
 import numpy as np
 from copy import deepcopy
@@ -82,3 +83,13 @@ def test_fixed_f_diode(model_params, fixed_params, free_params, reference_models
         fit = fit_power_spectrum(power_spectrum, model=model, bias_correction=False)
         assert abs(fit.results["fc"].value - 4000) > 1.0
         assert abs(fit.results["D"].value - 1.14632) > 1e-2
+
+
+def test_alpha_validity():
+    # Alpha should be between 0 and 1
+    for good_alpha in (0.0, 0.5, 1.0):
+        FixedDiodeModel(diode_alpha=good_alpha)
+
+    for bad_alpha in (1.000001, -0.000001):
+        with pytest.raises(ValueError, match=re.escape("Diode relaxation factor should be between 0 and 1 (inclusive).")):
+            FixedDiodeModel(diode_alpha=bad_alpha)

--- a/lumicks/pylake/force_calibration/tests/test_alternate_diode_models.py
+++ b/lumicks/pylake/force_calibration/tests/test_alternate_diode_models.py
@@ -1,4 +1,6 @@
+import pytest
 import numpy as np
+from copy import deepcopy
 from lumicks.pylake.force_calibration.calibration_models import (
     FixedDiodeModel,
     PassiveCalibrationModel,
@@ -45,23 +47,38 @@ def test_underfit_fast_sensor(reference_models):
         assert abs(fit.results["D"].value - 1.14632) > 0.1
 
 
-def test_fixed_diode(reference_models):
+@pytest.mark.parametrize(
+    "model_params, fixed_params, free_params",
+    [
+        [{"diode_frequency": 14000}, {"f_diode": 14000}, {"alpha": 0.4}],
+        [{"diode_alpha": 0.4}, {"alpha": 0.4}, {"f_diode": 14000}],
+        [{"diode_frequency": 14000, "diode_alpha": 0.4}, {"f_diode": 14000, "alpha": 0.4}, {}],
+    ],
+)
+def test_fixed_f_diode(model_params, fixed_params, free_params, reference_models):
     """Test fixed diode model"""
-    models, power_spectrum = model_and_data(reference_models, diode_alpha=0.4, fast_sensor=True)
+    models, power_spectrum = model_and_data(reference_models, diode_alpha=0.4, fast_sensor=False)
     for model in models:
-        model._filter = FixedDiodeModel(14000)
+        model._filter = FixedDiodeModel(**model_params)
         fit = fit_power_spectrum(power_spectrum, model=model, bias_correction=False)
 
+        # Test good fit
         np.testing.assert_allclose(fit.results["fc"].value, 4000, 1e-6)
         np.testing.assert_allclose(fit.results["D"].value, 1.14632, 1e-6)
-        np.testing.assert_allclose(fit.results["alpha"].value, 0.4, 1e-6)
+        for key, value in free_params.items():
+            np.testing.assert_allclose(fit.results[key].value, value, 1e-6)
 
-        # Diode frequency is a parameter now and not a result
-        assert fit.params["f_diode"].value == 14000
-        assert "f_diode" not in fit.results
+        # Check whether parameters are actually parameters and not results
+        for key, value in fixed_params.items():
+            np.testing.assert_allclose(fit.params[key].value, value, 1e-6)
+        for key in fixed_params.keys():
+            assert key not in fit.results
 
-        # Fix diode to the wrong frequency. We should not get a great fit that way.
-        model._filter = FixedDiodeModel(13000)
+        # Fix to the wrong value (this should mess up the fit)
+        bad_params = deepcopy(model_params)
+        for key in bad_params:
+            bad_params[key] *= 1.1
+        model._filter = FixedDiodeModel(**bad_params)
         fit = fit_power_spectrum(power_spectrum, model=model, bias_correction=False)
         assert abs(fit.results["fc"].value - 4000) > 1.0
         assert abs(fit.results["D"].value - 1.14632) > 1e-2

--- a/lumicks/pylake/force_calibration/tests/test_convenience.py
+++ b/lumicks/pylake/force_calibration/tests/test_convenience.py
@@ -107,6 +107,11 @@ def test_invalid_options_calibration():
         calibrate_force([1], 1, 20, fast_sensor=True, fixed_diode=150)
 
     with pytest.raises(
+            ValueError, match="When using fast_sensor=True, there is no diode model to fix"
+    ):
+        calibrate_force([1], 1, 20, fast_sensor=True, fixed_alpha=0.4)
+
+    with pytest.raises(
         ValueError, match="Active calibration requires the driving_data to be defined"
     ):
         calibrate_force([1], 1, 20, active_calibration=True)
@@ -115,3 +120,18 @@ def test_invalid_options_calibration():
 def test_mandatory_keyworded_arguments():
     with pytest.raises(TypeError, match="takes 3 positional arguments but 5 were given"):
         calibrate_force([], 1, 2, 3, 4)
+
+
+def test_diode_fixing(reference_models):
+    data, f_sample = reference_models.lorentzian_td(4000, 1, 0.4, 14000, 78125)
+    fit = calibrate_force(data, 1, 20, fixed_diode=1000)
+    assert "f_diode" in fit.params
+    assert "alpha" not in fit.params
+
+    fit = calibrate_force(data, 1, 20, fixed_alpha=0.5)
+    assert "f_diode" not in fit.params
+    assert "alpha" in fit.params
+
+    fit = calibrate_force(data, 1, 20, fixed_diode=14000, fixed_alpha=0.5)
+    assert "f_diode" in fit.params
+    assert "alpha" in fit.params


### PR DESCRIPTION
**Why this PR?**
This is in preparation of the pre-characterized diodes. The plan is to measure both the diode frequency and relaxation factor for our diodes. This PR allows fixing either or both (previously one could only fix `f_diode`).

It also deduplicates some parameter descriptions by using the diode model the fixed model is derived from to obtain the parameter descriptions.