### PR TITLE
docs: update sphinx

### DIFF
--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -28,5 +28,5 @@ jobs:
         python pylake_test.py
     - name: Black
       run: |
-        pip install black==22.1.0
+        pip install black==22.3.0
         black --check --diff --color .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,6 @@ import os
 import shutil
 import filecmp
 import sphinx_rtd_theme
-from recommonmark.parser import CommonMarkParser
 
 sys.path.insert(0, os.path.abspath("./_ext"))
 sys.path.insert(0, os.path.abspath(".."))
@@ -54,6 +53,7 @@ extensions = [
     "matplotlib.sphinxext.plot_directive",
     "nbexport",
     "sphinx_lfs_content",
+    "myst_parser",
 ]
 
 autodoc_member_order = "groupwise"
@@ -98,11 +98,13 @@ templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-source_suffix = [".rst", ".md"]
-
-source_parsers = {
-    ".md": CommonMarkParser,
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
 }
+
+# Suppress non-consecutive header level increase warnings
+suppress_warnings = ["myst.header"]
 
 # The master toctree document.
 master_doc = "index"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,7 +165,7 @@ html_favicon = "fav.ico"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []
 # html_context = {'extra_css_files': ['_static/extra.css']}
 
 # Add any extra paths that contain custom files (such as robots.txt or

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,7 @@ release = pylake.__version__
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "1.7"
+needs_sphinx = "4.5.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,6 +233,8 @@ htmlhelp_basename = project + "doc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
+bibtex_bibfiles = ["refs.bib"]
+
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     "papersize": "a4paper",

--- a/docs/examples/cas9_kymotracking/cas9_kymotracking.rst
+++ b/docs/examples/cas9_kymotracking/cas9_kymotracking.rst
@@ -67,7 +67,7 @@ What we can observe in this data is that as more force is applied, we get an inc
 if we can put the kymotracker to some good use and quantify these.
 
 Computing the background
-------------------
+------------------------
 First, we select a small region without traces to determine the background signal::
 
     background = kymo["100s":"200s"].crop_by_distance(28, 31)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,9 +4,9 @@ nbconvert
 nbformat
 numpy
 numpydoc
-recommonmark
 scipy
 sphinx==4.5.0
 sphinx_rtd_theme
 sphinxcontrib-bibtex==2.4.1
 docutils<0.18
+myst-parser

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,5 +8,5 @@ recommonmark
 scipy
 sphinx==4.5.0
 sphinx_rtd_theme
-sphinxcontrib-bibtex==0.4.2
+sphinxcontrib-bibtex==2.4.1
 docutils<0.18

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ numpy
 numpydoc
 recommonmark
 scipy
-sphinx
+sphinx==4.5.0
 sphinx_rtd_theme
 sphinxcontrib-bibtex==0.4.2
 docutils<0.18

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ numpy
 numpydoc
 scipy
 sphinx==4.5.0
-sphinx_rtd_theme
+sphinx_rtd_theme==1.0.0
 sphinxcontrib-bibtex==2.4.1
 docutils<0.18
 myst-parser

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -359,7 +359,7 @@ This fits the thermal part with the hydrodynamically correct power spectrum and 
 
 We can also include a distance to the surface like before.
 This results in the expression for `\gamma` becoming dependent on the distance to the surface.
-This uses the same expression as listed in the section on the :ref:`hydrodynamically correct model<Hydrodynamically correct model>`.
+This uses the same expression as listed in the section on the hydrodynamically correct model.
 
 One thing to note is that when using the hydrodynamically correct model, the equation for the drag _does_ include the viscosity and bead diameter.
 However, they now appear in a term which already amounts to a small correction therefore the impact of any errors in these is reduced :cite:`tolic2006calibration`.

--- a/lumicks/pylake/adjustments.py
+++ b/lumicks/pylake/adjustments.py
@@ -21,6 +21,7 @@ class ColorAdjustment:
             - "percentile" : color limits are given as percentiles of the image in question.
               Percentiles are calculated for each color channel separately
             - "absolute" : color limits are given as absolute values.
+
             Note: When providing bounds in percentiles, limits will change depending on which image
             you are looking at. When scrolling through a stack of images, the limits will not remain
             constant.


### PR DESCRIPTION
**Why?**
We were getting build failures on RtD. See: http://github.com/readthedocs/readthedocs.org/issues/9037
That link actually mentions that we could have also solved it by pinning `jinja`. I did try this initially, but unfortunately, installing `pylake` afterwards bumps it again and makes the build fail. I figured it's a good idea to just update `sphinx` and get us up to date.

I also took the liberty of clearing out all the warnings Sphinx was producing. Reason being that  it's difficult to see real ones when they're drowned in noise.

Docs build can be found here: https://lumicks-pylake.readthedocs.io/en/update_sphinx/index.html
