### PR TITLE
channel: preserve calibration if valid

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * Added `DwelltimeModel` to fit dwelltimes to an exponential (mixture) distribution. For more information, see the tutorials section on [Population Dynamics](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/population_dynamics.html)
 * Allow slicing directly with an object with a `.start` and `.stop` property. See [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#markers) for more information.
 * Allow boolean array indexing on `Slice` (e.g. `file.force1x[file.force1x.data > 5]`. See [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#boolean-array-indexing) for more information.
+* When doing arithmetic on `Slice`, propagate the calibration if it is still valid.
 
 #### Bug fixes
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -84,13 +84,19 @@ class Slice:
     def __neg__(self):
         if isinstance(self._src, TimeTags):
             raise NotImplementedError("This operation is not supported for TimeTag data")
-        return Slice(self._src._with_data(-self.data))
+        return Slice(self._src._with_data(-self.data), calibration=self._calibration)
 
     def __add__(self, other):
-        return Slice(self._src._with_data(self.data + self._unpack_other(other)))
+        return Slice(
+            self._src._with_data(self.data + self._unpack_other(other)),
+            calibration=self._calibration if np.isscalar(other) else None,
+        )
 
     def __sub__(self, other):
-        return Slice(self._src._with_data(self.data - self._unpack_other(other)))
+        return Slice(
+            self._src._with_data(self.data - self._unpack_other(other)),
+            calibration=self._calibration if np.isscalar(other) else None,
+        )
 
     def __truediv__(self, other):
         return Slice(self._src._with_data(self.data / self._unpack_other(other)))

--- a/lumicks/pylake/tests/test_channels/test_arithmetic.py
+++ b/lumicks/pylake/tests/test_channels/test_arithmetic.py
@@ -1,25 +1,29 @@
 import pytest
 import numpy as np
 from lumicks.pylake.channel import Slice, Continuous, TimeSeries, TimeTags
+from lumicks.pylake.calibration import ForceCalibration
 
-t_start = 1 + int(1e18)
+
+start = 1 + int(1e18)
+calibration = ForceCalibration("Stop time (ns)", [{"Stop time (ns)": start, "kappa (pN/nm)": 0.45}])
 time_series = np.array([1, 2, 3, 4, 5], dtype=np.int64) + int(1e18)
-slice_continuous_1 = Slice(Continuous([1, 2, 3, 4, 5], start=t_start, dt=1))
-slice_continuous_2 = Slice(Continuous([2, 2, 2, 2, 2], start=t_start, dt=1))
-slice_timeseries_1 = Slice(TimeSeries([1, 2, 3, 4, 5], time_series))
-slice_timeseries_2 = Slice(TimeSeries([2, 2, 2, 2, 2], time_series))
+slice_continuous_1 = Slice(Continuous([1, 2, 3, 4, 5], start=start, dt=1), calibration=calibration)
+slice_continuous_2 = Slice(Continuous([2, 2, 2, 2, 2], start=start, dt=1), calibration=calibration)
+slice_timeseries_1 = Slice(TimeSeries([1, 2, 3, 4, 5], time_series), calibration=calibration)
+slice_timeseries_2 = Slice(TimeSeries([2, 2, 2, 2, 2], time_series), calibration=calibration)
 
+# Operators and whether they preserve force calibration when operated with a scalar
 operators = [
-    "__add__",
-    "__sub__",
-    "__truediv__",
-    "__mul__",
-    "__pow__",
-    "__radd__",
-    "__rsub__",
-    "__rtruediv__",
-    "__rmul__",
-    "__rpow__",
+    ["__add__", True],
+    ["__sub__", True],
+    ["__truediv__", False],
+    ["__mul__", False],
+    ["__pow__", False],
+    ["__radd__", True],
+    ["__rsub__", False],
+    ["__rtruediv__", False],
+    ["__rmul__", False],
+    ["__rpow__", False],
 ]
 
 
@@ -45,7 +49,10 @@ def test_operations_slice(slice1, slice2):
             getattr(first_slice, operation)(second_slice).timestamps, first_slice.timestamps
         )
 
-    for operator in operators:
+        # With slices, force calibration should never be carried over (since it's invalid)
+        assert not getattr(first_slice, operation)(second_slice).calibration
+
+    for operator, _ in operators:
         test_operator(slice1, slice2, operator)
 
 
@@ -57,7 +64,7 @@ def test_operations_slice(slice1, slice2):
     ],
 )
 def test_operations_scalar(slice1, scalar):
-    def test_operator(current_slice, scalar_val, operation):
+    def test_operator(current_slice, scalar_val, operation, preserve_calibration):
         # Operations in the containers must give the same result as operating on the data directly.
         assert np.array_equal(
             getattr(current_slice, operation)(scalar_val).data,
@@ -69,12 +76,21 @@ def test_operations_scalar(slice1, scalar):
             getattr(current_slice, operation)(scalar_val).timestamps, current_slice.timestamps
         )
 
-    for operator in operators:
-        test_operator(slice1, scalar, operator)
+        if preserve_calibration:
+            assert len(getattr(current_slice, operation)(scalar_val).calibration) == 1
+        else:
+            assert not getattr(current_slice, operation)(scalar_val).calibration
+
+    for operator, preserve_calibration in operators:
+        test_operator(slice1, scalar, operator, preserve_calibration)
 
 
-slice_continuous_different_timestamps = Slice(Continuous([2, 2, 2, 2, 2], start=t_start + 1, dt=1))
-slice_timeseries_different_timestamps = Slice(TimeSeries([2, 2, 2, 2, 2], time_series + 1))
+slice_continuous_different_timestamps = Slice(
+    Continuous([2, 2, 2, 2, 2], start=start + 1, dt=1), calibration=calibration
+)
+slice_timeseries_different_timestamps = Slice(
+    TimeSeries([2, 2, 2, 2, 2], time_series + 1), calibration=calibration
+)
 
 
 @pytest.mark.parametrize(
@@ -88,13 +104,17 @@ slice_timeseries_different_timestamps = Slice(TimeSeries([2, 2, 2, 2, 2], time_s
 )
 def test_incompatible_timestamps(slice1, slice2):
     # Test whether the timestamps are correctly compared
-    for operator in operators:
+    for operator, _ in operators:
         with pytest.raises(RuntimeError):
             getattr(slice1, operator)(slice2)
 
 
-slice_continuous_different_length = Slice(Continuous([2, 2, 2, 2], start=t_start, dt=1))
-slice_timeseries_different_length = Slice(TimeSeries([2, 2, 2, 2], [1, 2, 3, 4]))
+slice_continuous_different_length = Slice(
+    Continuous([2, 2, 2, 2], start=start, dt=1), calibration=calibration
+)
+slice_timeseries_different_length = Slice(
+    TimeSeries([2, 2, 2, 2], [1, 2, 3, 4]), calibration=calibration
+)
 
 
 @pytest.mark.parametrize(
@@ -108,7 +128,7 @@ slice_timeseries_different_length = Slice(TimeSeries([2, 2, 2, 2], [1, 2, 3, 4])
 )
 def test_incompatible_length(slice1, slice2):
     # The data sets need to be the same length. We explicitly raise an exception when they are not.
-    for operator in operators:
+    for operator, _ in operators:
         with pytest.raises(RuntimeError):
             getattr(slice1, operator)(slice2)
 
@@ -143,7 +163,7 @@ timetags = Slice(TimeTags(time_series))
 def test_timetags_not_implemented(data1, data2):
     # This is not implemented for time tags at this point (we need to determine what are sensible
     # operations on those first).
-    for operator in operators:
+    for operator, _ in operators:
         with pytest.raises(NotImplementedError):
             getattr(data1, operator)(data2)
 
@@ -153,6 +173,7 @@ def test_negation(channel_slice):
     neg_slice = -channel_slice
     np.testing.assert_allclose(neg_slice.data, -channel_slice.data)
     np.testing.assert_allclose(neg_slice.timestamps, channel_slice.timestamps)
+    assert len(neg_slice.calibration) == 1
 
 
 def test_negation_timetags_not_implemented():


### PR DESCRIPTION
**Why this PR?**
When adding a scalar value, subtracting a scalar value or negating a channel the force calibration is still valid and should be forwarded to the constructed `Slice`. This PR forwards the appropriate calibration items to the processed slice.