### PR TITLE
channel: mask slices

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * Allow applying color intensity adjustments on images using `lk.ColorAdjustment()`. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html#correlating-scans) and [Correlated stacks](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html#correlated-stacks) for more information.
 * Added `DwelltimeModel` to fit dwelltimes to an exponential (mixture) distribution. For more information, see the tutorials section on [Population Dynamics](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/population_dynamics.html)
 * Allow slicing directly with an object with a `.start` and `.stop` property. See [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#markers) for more information.
+* Allow boolean array indexing on `Slice` (e.g. `file.force1x[file.force1x.data > 5]`. See [files and channels](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#boolean-array-indexing) for more information.
 
 #### Bug fixes
 

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -166,6 +166,21 @@ Plotting is typically performed with the origin of the plot set to the timestamp
     first_slice.plot()
     second_slice.plot(start=first_slice.start)  # we want to use the start of first_slice as time point "zero"
 
+Boolean array indexing
+^^^^^^^^^^^^^^^^^^^^^^
+
+Similarly, a subset of the data can be selected using boolean array indexing.
+For example, forces above 5 pN can be excluded as follows::
+
+    mask = file.force1x.data <= 5
+    masked = file.force1x[mask]
+
+Multiple criteria can be combined by using `numpy`'s logic operators.
+For example, restricting the forces between 2 and 5 can be accomplished as follows::
+
+    mask = np.logical_and(file.force1x.data > 2, file.force1x.data < 5)
+    masked = file.force1x[mask]
+
 Arithmetic
 ^^^^^^^^^^
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -34,6 +34,8 @@ class Slice:
 
     def __getitem__(self, item):
         """All indexing is in timestamp units (ns)"""
+        if isinstance(item, np.ndarray) and (item.dtype == bool):
+            return self._apply_mask(item)
         if isinstance(item, slice) and item.step is not None:
             raise IndexError("Slice steps are not supported")
         if not hasattr(item, "start") or not hasattr(item, "stop"):

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -60,6 +60,10 @@ class Slice:
         """Return a copy of this slice with a different data source, but keep other properties"""
         return self.__class__(data_source, self.labels, self._calibration)
 
+    def _apply_mask(self, mask):
+        """Apply a logical mask to the data"""
+        return self._with_data_source(self._src._apply_mask(mask))
+
     def _unpack_other(self, other):
         if np.isscalar(other):
             return other
@@ -419,6 +423,11 @@ class Continuous:
     def _with_data(self, data):
         return self.__class__(data, self.start, self.dt)
 
+    def _apply_mask(self, mask):
+        if len(mask) != len(self.data):
+            raise IndexError("Length of the logical mask did not match length of the data.")
+        return TimeSeries(self.data[mask], self.timestamps[mask])
+
     def __len__(self):
         return len(self._src_data)
 
@@ -493,6 +502,11 @@ class TimeSeries:
     def _with_data(self, data):
         return self.__class__(data, self.timestamps)
 
+    def _apply_mask(self, mask):
+        if len(mask) != len(self.data):
+            raise IndexError("Length of the logical mask did not match length of the data.")
+        return TimeSeries(self.data[mask], self.timestamps[mask])
+
     @staticmethod
     def from_dataset(dset, y_label="y", calibration=None):
         return Slice(
@@ -549,6 +563,9 @@ class TimeTags:
         return self.data.size
 
     def _with_data(self, data):
+        raise NotImplementedError("Time tags do not currently support this operation")
+
+    def _apply_mask(self, mask):
         raise NotImplementedError("Time tags do not currently support this operation")
 
     @staticmethod

--- a/lumicks/pylake/tests/test_channels/test_channels.py
+++ b/lumicks/pylake/tests/test_channels/test_channels.py
@@ -212,11 +212,12 @@ def test_timeseries_mask():
     )
 
     mask = np.asarray([False, True, False, True])
-    masked = s._apply_mask(mask)
-    np.testing.assert_equal(masked.data, s.data[mask])
-    np.testing.assert_equal(masked.timestamps, s.timestamps[mask])
-    assert masked.calibration == s.calibration
-    assert masked.labels == s.labels
+    masked_raw, masked_slice = s._apply_mask(mask), s[mask]
+    for masked in (masked_raw, masked_slice):
+        np.testing.assert_equal(masked.data, s.data[mask])
+        np.testing.assert_equal(masked.timestamps, s.timestamps[mask])
+        assert masked.calibration == s.calibration
+        assert masked.labels == s.labels
 
     masked = s._apply_mask([False, False, False, False])
     np.testing.assert_equal(masked.data, [])
@@ -289,11 +290,12 @@ def test_continuous_mask():
     )
 
     mask = np.asarray([False, True, False, True])
-    masked = s._apply_mask(mask)
-    np.testing.assert_equal(masked.data, s.data[mask])
-    np.testing.assert_equal(masked.timestamps, s.timestamps[mask])
-    assert masked.calibration == s.calibration
-    assert masked.labels == s.labels
+    masked_raw, masked_slice = s._apply_mask(mask), s[mask]
+    for masked in (masked_raw, masked_slice):
+        np.testing.assert_equal(masked.data, s.data[mask])
+        np.testing.assert_equal(masked.timestamps, s.timestamps[mask])
+        assert masked.calibration == s.calibration
+        assert masked.labels == s.labels
 
     masked = s._apply_mask([False, False, False, False])
     np.testing.assert_equal(masked.data, [])


### PR DESCRIPTION
**Why this PR?**
A fairly frequent operation is to mask some `Slice` data. Currently, we always have to import `TimeSeries` manually and basically construct a new slice when we need to do this. Technically, there is no way for users to do this at the moment.

This PR introduces an extra option to the `__getitem__` dunder that allows slicing by a logical boolean numpy array.

(While working on implementing piezo tracking in Pylake, I encountered a few things that were missing from the `Slice` API. Rather than appending them on an already sizable PR, I've decided to spin them out and put them up for review separately).

Note: Currently, this doesn't accept a `List` of booleans.  We could consider extending the feature to also allow this.