### PR TITLE
make KymoLine immutable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 
 * Changed titles for all plots of `Scan` and `CorrelatedStack` images to be consistent. First frame is titled as `"[frame 1 / N]"` and last frame is titled as `"[frame N / N]"`.
 * The returned type from `KymoLineGroup.fit_binding_times()` has been changed to `DwelltimeModel`. Note, this class has the same public attributes and methods as the previously returned `BindingDwelltimes` class; however the `plot()` method has been deprecated and renamed to `DwelltimeModel.hist()`. This new method name more closely describes the actual functionality and also unifies the API with `GaussianMixtureModel`.
+* `KymoLine` is now immutable.
 
 ## v0.11.1 | 2022-02-22
 

--- a/lumicks/pylake/kymotracker/kymoline.py
+++ b/lumicks/pylake/kymotracker/kymoline.py
@@ -90,11 +90,11 @@ def import_kymolinegroup_from_csv(filename, kymo, channel, delimiter=";"):
 class KymoLine:
     """A line on a kymograph"""
 
-    __slots__ = ["time_idx", "coordinate_idx", "_image"]
+    __slots__ = ["_time_idx", "_coordinate_idx", "_image"]
 
     def __init__(self, time_idx, coordinate_idx, image):
-        self.time_idx = np.asarray(time_idx)
-        self.coordinate_idx = np.asarray(coordinate_idx)
+        self._time_idx = np.asarray(time_idx)
+        self._coordinate_idx = np.asarray(coordinate_idx)
         self._image = image
 
     @classmethod
@@ -125,6 +125,14 @@ class KymoLine:
         return np.squeeze(
             np.array(np.vstack((self.time_idx[item], self.coordinate_idx[item]))).transpose()
         )
+
+    @property
+    def time_idx(self):
+        return self._time_idx
+
+    @property
+    def coordinate_idx(self):
+        return self._coordinate_idx
 
     @property
     def seconds(self):

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -262,14 +262,14 @@ def refine_lines_centroid(lines, line_width):
         interpolated_lines[0]._image.data, coordinate_idx, time_idx, np.ceil(0.5 * line_width)
     )
 
-    current = 0
-    for line in interpolated_lines:
-        line_length = len(line.time_idx)
-        line.time_idx = time_idx[current : current + line_length]
-        line.coordinate_idx = coordinate_idx[current : current + line_length]
-        current += line_length
-
-    return KymoLineGroup(interpolated_lines)
+    line_ids = np.hstack(
+        [np.full(len(line.time_idx), j) for j, line in enumerate(interpolated_lines)]
+    )
+    new_lines = [
+        KymoLine(time_idx[line_ids == j], coordinate_idx[line_ids == j], line._image)
+        for j, line in enumerate(interpolated_lines)
+    ]
+    return KymoLineGroup(new_lines)
 
 
 def refine_lines_gaussian(

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -43,6 +43,9 @@ def test_refinement_2d():
     np.testing.assert_allclose(refined_line.time_idx, time_idx)
     np.testing.assert_allclose(refined_line.coordinate_idx, coordinate_idx + offset)
 
+    # Test line group not modified in place
+    assert id(line) != id(refined_line)
+
     # Test whether concatenation still works after refinement
     np.testing.assert_allclose((refined_line + line).time_idx, np.hstack((time_idx, time_idx[::2])))
     np.testing.assert_allclose(


### PR DESCRIPTION
**Why this PR?**
Because any modifications to `KymoLine` instances should be made via refinement methods or specifically allowed manual editing

This change is pulled out from #262, which is on hold pending validation of the algorithm