### PR TITLE
force_calibration: prevent some precision loss when computing hydrodynamically correct power spectral density

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Changed the internal calculation of the `extent` argument in `Kymo.plot()` such that the spatial limits are now defined at the center of the pixel (same functionality that is used for the temporal axis). Previously the limits were defined at the edge of the pixel and caused a subtle misalignment between the coordinates of the tracked lines and the actual image.
 * Changed the internal calculation of the hydrodynamically correct force spectrum. Before this change, the computation of the power spectral density relied on the frequencies always being positive. While this change does not affect any results, it allows evaluating the power spectral density for negative frequencies.
+* Fixed an issue where evaluating the hydrodynamically correct spectrum up to very high frequencies could lead to precision losses. These precision losses typically occur at frequencies upwards of 30 kHz and manifest themselves as visible discontinuities.
 
 ## v0.12.0 | 2022-04-21
 

--- a/lumicks/pylake/force_calibration/detail/hydrodynamics.py
+++ b/lumicks/pylake/force_calibration/detail/hydrodynamics.py
@@ -146,7 +146,8 @@ def passive_power_spectrum_model_hydro(
         f, gamma0, rho_sample, bead_radius, distance_to_surface
     )
     frequency_m = calculate_dissipation_frequency(gamma0, bead_radius, rho_bead)
-    denominator = (fc + f * im_drag - f**2 / frequency_m) ** 2 + (f * re_drag) ** 2
+    denominator = (fc + f * (im_drag - f / frequency_m)) ** 2 + (f * re_drag) ** 2
+
     power_spectrum = diffusion_constant / (np.pi**2) * re_drag / denominator  # Equation D2 [6]
     return power_spectrum
 

--- a/lumicks/pylake/force_calibration/tests/test_hydro.py
+++ b/lumicks/pylake/force_calibration/tests/test_hydro.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 from lumicks.pylake.force_calibration.power_spectrum_calibration import (
     calculate_power_spectrum,
     fit_power_spectrum,
@@ -213,6 +212,15 @@ def test_hydro_spectra(
     ) * g_diode(f, f_diode, alpha)
 
     np.testing.assert_allclose(power_spectrum, ref_power_spectrum)
+
+
+def test_hydro_precision_loss():
+    """For very high frequency precision losses could occur, this test specifically guards against
+    these"""
+    frequency_range = np.arange(10000, 800000, 200000)
+    pars = [frequency_range, 187, 0.000464748 * 100, 4.09335e-08, 4.88e-6, 997, 997, None]
+    reference_psd = np.array([9.82828137e-12, 8.11392808e-16, 8.63496544e-17, 2.24961617e-17])
+    np.testing.assert_allclose(passive_power_spectrum_model_hydro(*pars), reference_psd)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Why this PR?**
In the hydro power spectral density we subtract two values with widely varying magnitudes while this is not necessary. You can start noticing the effects of this by an apparent sawtooth pattern at high frequencies. This PR fixes that.

Note that this likely did not affect any users yet, since for regular 78 kHz systems, the frequency at which this happens happens well above Nyquist.

![image](https://user-images.githubusercontent.com/19836026/168634722-30033dd8-e564-4675-a41f-8ba4de42dfbd.png)
