### PR TITLE
force_calibration: add private API for taking aliasing into account

### DIFF
--- a/lumicks/pylake/force_calibration/detail/power_models.py
+++ b/lumicks/pylake/force_calibration/detail/power_models.py
@@ -167,6 +167,7 @@ def alias_spectrum(psd, sample_rate, num_alias=10):
     num_alias : int
         Number of aliases to simulate. The default of 10 typically gives less than 1% error.
     """
+
     def aliased(freq, *args, **kwargs):
         """Aliased PSD
 
@@ -178,8 +179,7 @@ def alias_spectrum(psd, sample_rate, num_alias=10):
             Forwarded to the power spectral density function being wrapped.
         """
         return sum(
-            psd(freq + i * sample_rate, *args, **kwargs)
-            for i in range(-num_alias, num_alias + 1)
+            psd(freq + i * sample_rate, *args, **kwargs) for i in range(-num_alias, num_alias + 1)
         )
 
     return aliased

--- a/lumicks/pylake/force_calibration/detail/power_models.py
+++ b/lumicks/pylake/force_calibration/detail/power_models.py
@@ -152,3 +152,34 @@ def theoretical_driving_power_lorentzian(fc, driving_frequency, driving_amplitud
         Driving amplitude [m]
     """
     return driving_amplitude**2 / (2 * (1 + (fc / driving_frequency) ** 2))
+
+
+def alias_spectrum(psd, sample_rate, num_alias=10):
+    """
+    Produce an aliased version of the input PSD function.
+
+    Parameters
+    ----------
+    psd : callable
+        Function which takes a numpy array of frequencies and returns a power spectral density.
+    sample_rate : float
+        Sampling frequency.
+    num_alias : int
+        Number of aliases to simulate. The default of 10 typically gives less than 1% error.
+    """
+    def aliased(freq, *args, **kwargs):
+        """Aliased PSD
+
+        Parameters
+        ----------
+        freq : numpy.ndarray
+            Frequency values.
+        *args, **kwargs
+            Forwarded to the power spectral density function being wrapped.
+        """
+        return sum(
+            psd(freq + i * sample_rate, *args, **kwargs)
+            for i in range(-num_alias, num_alias + 1)
+        )
+
+    return aliased

--- a/lumicks/pylake/force_calibration/tests/test_active_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_active_calibration.py
@@ -90,7 +90,9 @@ def test_integration_active_calibration(
     np.testing.assert_allclose(fit["Viscosity"].value, viscosity)
     np.testing.assert_allclose(fit["num_windows"].value, 5)
 
-    np.testing.assert_allclose(fit["driving_amplitude"].value, driving_sinusoid[0] * 1e-3, rtol=1e-5)
+    np.testing.assert_allclose(
+        fit["driving_amplitude"].value, driving_sinusoid[0] * 1e-3, rtol=1e-5
+    )
     np.testing.assert_allclose(fit["driving_frequency"].value, driving_sinusoid[1], rtol=1e-5)
     np.testing.assert_allclose(fit["driving_power"].value, response_power, rtol=1e-6)
 

--- a/lumicks/pylake/force_calibration/tests/test_convenience.py
+++ b/lumicks/pylake/force_calibration/tests/test_convenience.py
@@ -109,7 +109,7 @@ def test_invalid_options_calibration():
         calibrate_force([1], 1, 20, fast_sensor=True, fixed_diode=150, sample_rate=78125)
 
     with pytest.raises(
-            ValueError, match="When using fast_sensor=True, there is no diode model to fix"
+        ValueError, match="When using fast_sensor=True, there is no diode model to fix"
     ):
         calibrate_force([1], 1, 20, fast_sensor=True, fixed_alpha=0.4, sample_rate=78125)
 

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -103,6 +103,7 @@ def test_fit_analytic_curve():
 
 def test_aliasing():
     """Test the little wrapper function that can be used to simulate aliasing"""
+
     def psd(freq, a, b, *, c):
         return a + (b + c / freq) / freq
 
@@ -111,11 +112,11 @@ def test_aliasing():
 
     # Verify kwargs get passed correctly
     with pytest.raises(
-            TypeError, match=re.escape("psd() takes 3 positional arguments but 4 were given")
+        TypeError, match=re.escape("psd() takes 3 positional arguments but 4 were given")
     ):
         aliased(f, 5, 3, 4)
 
     np.testing.assert_allclose(aliased(f, 5, 3, c=4), [535.114708, 107.443689, 105.757919])
 
     aliased = alias_spectrum(psd, 8, num_alias=2)
-    np.testing.assert_allclose(aliased(f, 5, 3, c=4), [455.144592,  27.436246,  25.715556])
+    np.testing.assert_allclose(aliased(f, 5, 3, c=4), [455.144592, 27.436246, 25.715556])

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
@@ -25,24 +25,34 @@ def test_power_spectrum_attrs(frequency, num_data, sample_rate):
 
     # Functional test
     determined_frequency = power_spectrum.frequency[np.argmax(power_spectrum.power)]
-    np.testing.assert_allclose(determined_frequency, frequency)  # Is the frequency at the right position?
+    np.testing.assert_allclose(
+        determined_frequency, frequency
+    )  # Is the frequency at the right position?
 
     # Is all the power at this frequency? (Valid when dealing with multiples of the sample rate)
-    np.testing.assert_allclose(power_spectrum.power[np.argmax(power_spectrum.power)], np.sum(power_spectrum.power), atol=1e-16)
+    np.testing.assert_allclose(
+        power_spectrum.power[np.argmax(power_spectrum.power)],
+        np.sum(power_spectrum.power),
+        atol=1e-16,
+    )
     np.testing.assert_allclose(power_spectrum.total_duration, num_data / sample_rate)
 
 
 @pytest.mark.parametrize(
     "frequency, num_data, sample_rate, num_blocks, f_blocked, p_blocked",
     [
+        # fmt: off
         [200, 50, 2000, 4, [100, 340, 580, 820], [1.04166667e-3, 0, 0, 0]],
         [400, 50, 2000, 4, [100, 340, 580, 820], [0, 1.04166667e-3, 0, 0]],
         [400, 50, 4000, 4, [200, 680, 1160, 1640], [5.20833333e-04, 0, 0, 0]],
         [400, 50, 4000, 8, [80, 320, 560, 800, 1040, 1280, 1520, 1760], [0, 1.04166667e-03, 0, 0, 0, 0, 0, 0]],
         [400, 50, 4000, 7, [80, 320, 560, 800, 1040, 1280, 1520, 1760], [0, 1.04166667e-03, 0, 0, 0, 0, 0, 0]],
+        # fmt: on
     ],
 )
-def test_power_spectrum_blocking(frequency, num_data, sample_rate, num_blocks, f_blocked, p_blocked):
+def test_power_spectrum_blocking(
+    frequency, num_data, sample_rate, num_blocks, f_blocked, p_blocked
+):
     """Functional test whether the results of blocking the power spectrum are correct"""
     data = np.sin(2.0 * np.pi * frequency / sample_rate * np.arange(num_data)) / np.sqrt(2)
     power_spectrum = PowerSpectrum(data, sample_rate)
@@ -53,7 +63,9 @@ def test_power_spectrum_blocking(frequency, num_data, sample_rate, num_blocks, f
     np.testing.assert_allclose(blocked.power, p_blocked, atol=1e-16)
     np.testing.assert_allclose(blocked.num_samples(), len(f_blocked))
     np.testing.assert_allclose(len(power_spectrum.power), num_data // 2 + 1)
-    np.testing.assert_allclose(blocked.num_points_per_block, np.floor(len(power_spectrum.power) / num_blocks))
+    np.testing.assert_allclose(
+        blocked.num_points_per_block, np.floor(len(power_spectrum.power) / num_blocks)
+    )
 
     # Downsample again and make sure the num_points_per_block is correct
     dual_blocked = blocked.downsampled_by(2)
@@ -87,7 +99,7 @@ def test_windowing_sine_wave(amp, frequency, data_duration, sample_rate, multipl
     max_idx = np.argmax(power_spectrum_windowed.power)
     power, freq = power_spectrum_windowed.power[max_idx], power_spectrum_windowed.frequency[max_idx]
     np.testing.assert_allclose(freq, frequency, atol=delta_freq)
-    np.testing.assert_allclose(power * delta_freq, amp ** 2 / 2, rtol=1e-4)
+    np.testing.assert_allclose(power * delta_freq, amp**2 / 2, rtol=1e-4)
 
     # Check whether we report the correct amount of averaging
     num_points_per_window = int(np.round((window_duration * sample_rate)))


### PR DESCRIPTION
**Why this PR?**
Most systems have aliasing suppression in hardware, but it is still good to have the option to take it into account in the model for alternative detection methods.

![image](https://user-images.githubusercontent.com/19836026/168846924-33078015-0f9b-4479-a238-47f9030de8c1.png)
