### PR TITLE
stack: allow multidimensional indexing with `CorrelatedStack`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Added `Scan.pixel_time_seconds` and `Kymo.pixel_time_seconds` to obtain the pixel dwell time. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html).
 * Added a few performance benchmarks.
 * Added offline piezo tracking functionality (documentation pending).
+* Allow cropping `CorrelatedStack` using multidimensional indexing, i.e. `stack[start_frame : end_frame, start_row : end_row, start_column : end_column]`. See [Correlated stacks](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html#correlated-stacks) for more information.
 
 #### Bug fixes
 

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -53,7 +53,14 @@ You can also spatially crop to select a smaller region of interest::
 
 .. image:: correlatedstack_cropped.png
 
-This can be useful, for instance, after applying color alignment to RGB images as the edges
+Alternatively, you can crop directly by slicing the stack::
+
+    stack_roi = stack[:, 150:245, 45:420]
+
+Here the first index can be used to select a subset of frames and the second and third indices perform a cropping operation.
+Note how the axes are switched when compared to `crop_by_pixels` to follow the numpy convention (rows and then columns).
+
+Cropping can be useful, for instance, after applying color alignment to RGB images as the edges
 can become corrupted due to interpolation artifacts.
 
 You can also plot only a single color channel. Note that here we pass some additional formatting arguments, which are

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -110,13 +110,13 @@ class CorrelatedStack:
         Parameters
         ----------
         x_min : int
-            minimum x pixel (inclusive)
+            minimum x pixel (inclusive, optional)
         x_max : int
-            maximum x pixel (exclusive)
+            maximum x pixel (exclusive, optional)
         y_min : int
-            minimum y pixel (inclusive)
+            minimum y pixel (inclusive, optional)
         y_max : int
-            maximum y pixel (exclusive)
+            maximum y pixel (exclusive, optional)
         """
         data = self.src.with_roi(np.array([x_min, x_max, y_min, y_max]))
         return self.from_dataset(data, self.name, self.start_idx, self.stop_idx)

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -353,14 +353,20 @@ class Roi:
 
     def crop(self, roi):
         """Crop again, taking into account origin of current ROI."""
-        roi = [
-            pos if pos is not None else default
-            for pos, default in zip(roi, (0, self.shape[1], 0, self.shape[0]))
-        ]
+        roi = np.array(
+            [
+                pos if pos is not None else default
+                for pos, default in zip(roi, (0, self.shape[1], 0, self.shape[0]))
+            ]
+        )
+
+        # Support negative indexing
+        roi_max = np.asarray([self.shape[x] for x in (1, 1, 0, 0)])
+        negative_indices = roi < 0
+        roi[negative_indices] += roi_max[negative_indices]
 
         # Clip to image
-        roi[1] = min(roi[1], self.shape[1])
-        roi[3] = min(roi[3], self.shape[0])
+        roi = [np.clip(x, 0, dim_max) for (x, dim_max) in zip(roi, roi_max)]
 
         roi = np.array(roi) + [self.x_min, self.x_min, self.y_min, self.y_min]
         return Roi(*roi)

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -349,8 +349,15 @@ class Roi:
 
     def crop(self, roi):
         """Crop again, taking into account origin of current ROI."""
-        if roi[1] > self.shape[1] or roi[3] > self.shape[0]:
-            raise ValueError("Pixel indices cannot exceed image size.")
+        roi = [
+            pos if pos is not None else default
+            for pos, default in zip(roi, (0, self.shape[1], 0, self.shape[0]))
+        ]
+
+        # Clip to image
+        roi[1] = min(roi[1], self.shape[1])
+        roi[3] = min(roi[3], self.shape[0])
+
         roi = np.array(roi) + [self.x_min, self.x_min, self.y_min, self.y_min]
         return Roi(*roi)
 

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -137,6 +137,10 @@ class TiffStack:
 
         self._tether = Tether(self._roi.origin) if tether is None else tether
 
+    @property
+    def is_rgb(self):
+        return self._description.is_rgb
+
     def get_frame(self, frame):
         return TiffFrame(
             self._tiff_file.pages[frame],

--- a/lumicks/pylake/tests/test_imaging_camera/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_correlated_stack.py
@@ -677,6 +677,7 @@ def test_invalid_slicing():
     "frame_slice,axis1_slice,axis2_slice, dims",
     (
         (slice(1, 3), slice(3, 6), slice(3, 5), (8, 9)),
+        # Test open ranges
         (slice(None, 3), slice(3, 6), slice(3, 5), (8, 9)),
         (slice(1, None), slice(3, 6), slice(3, 5), (8, 9)),
         (slice(1, 3), slice(None, 6), slice(3, 5), (8, 9)),
@@ -684,15 +685,25 @@ def test_invalid_slicing():
         (slice(1, 3), slice(3, 6), slice(None, 5), (8, 9)),
         (slice(1, 3), slice(3, 6), slice(3, None), (8, 9)),
         (slice(1, 3), slice(3, 6), slice(3, 5), (8, 9, 3)),
+        # Test three color images
         (slice(None, 3), slice(3, 6), slice(3, 5), (8, 9, 3)),
         (slice(1, None), slice(3, 6), slice(3, 5), (8, 9, 3)),
         (slice(1, 3), slice(None, 6), slice(3, 5), (8, 9, 3)),
         (slice(1, 3), slice(3, None), slice(3, 5), (8, 9, 3)),
         (slice(1, 3), slice(3, 6), slice(None, 5), (8, 9, 3)),
         (slice(1, 3), slice(3, 6), slice(3, None), (8, 9, 3)),
+        # Test ranges over the end
         (slice(1, 13), slice(3, 6), slice(3, 5), (8, 9)),
         (slice(1, 3), slice(3, 16), slice(3, 5), (8, 9)),
         (slice(1, 3), slice(3, 6), slice(3, 15), (8, 9)),
+        # Test negative indices
+        (slice(1, -1), slice(3, 6), slice(3, 5), (8, 9)),
+        (slice(1, 3), slice(3, -2), slice(3, 5), (8, 9)),
+        (slice(1, 3), slice(3, 6), slice(3, -2), (8, 9)),
+        # Test negative indices beyond the start
+        (slice(-100, 3), slice(-100, 6), slice(3, 15), (8, 9)),
+        (slice(-100, -1), slice(-100, 6), slice(3, 5), (8, 9)),
+        (slice(-100, -1), slice(3, 6), slice(-100, 5), (8, 9)),
     ),
 )
 def test_multidim_slicing(frame_slice, axis1_slice, axis2_slice, dims):

--- a/lumicks/pylake/tests/test_imaging_camera/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_correlated_stack.py
@@ -220,6 +220,19 @@ def test_stack_roi():
         stack_5 = stack_0.with_roi([0, 11, 1, 2])
 
 
+def test_roi_defaults():
+    first_page = np.arange(60).reshape((6, 10))
+    data = np.stack([first_page + (j * 60) for j in range(3)], axis=2)
+    stack_0 = TiffStack(MockTiffFile([data], times=make_frame_times(1)), align_requested=False)
+
+    np.testing.assert_equal(stack_0.with_roi([None, 7, 3, 6]).get_frame(0).data, data[3:6, :7])
+    np.testing.assert_equal(stack_0.with_roi([1, None, 3, 6]).get_frame(0).data, data[3:6, 1:])
+    np.testing.assert_equal(stack_0.with_roi([1, 7, None, 6]).get_frame(0).data, data[:6, 1:7])
+    np.testing.assert_equal(stack_0.with_roi([1, 7, 3, None]).get_frame(0).data, data[3:, 1:7])
+    np.testing.assert_equal(stack_0.with_roi([None, None, 3, 6]).get_frame(0).data, data[3:6, :])
+    np.testing.assert_equal(stack_0.with_roi([1, 7, None, None]).get_frame(0).data, data[:, 1:7])
+
+
 def test_deprecate_raw():
     fake_tiff = TiffStack(
         MockTiffFile(data=[np.ones((5, 4, 3))], times=make_frame_times(1)), align_requested=False

--- a/lumicks/pylake/tests/test_imaging_camera/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_correlated_stack.py
@@ -677,6 +677,9 @@ def test_invalid_slicing():
     "frame_slice,axis1_slice,axis2_slice, dims",
     (
         (slice(1, 3), slice(3, 6), slice(3, 5), (8, 9)),
+        # Test single element access
+        (slice(1, 3), 3, slice(3, 5), (8, 9)),
+        (slice(1, 3), slice(3, 6), 3, (8, 9)),
         # Test open ranges
         (slice(None, 3), slice(3, 6), slice(3, 5), (8, 9)),
         (slice(1, None), slice(3, 6), slice(3, 5), (8, 9)),
@@ -715,7 +718,11 @@ def test_multidim_slicing(frame_slice, axis1_slice, axis2_slice, dims):
 
     def validate_img_and_shape(stack, img):
         np.testing.assert_allclose(stack.get_image(), img)
-        np.testing.assert_allclose(stack.shape, img.shape)
+
+        # Note that when indexing the numpy array, all dimensions with length one get dropped when
+        # slicing the raw image.
+        stack_shape = np.array(stack.shape)
+        np.testing.assert_allclose(stack_shape[stack_shape > 1], img.shape)
 
     # Frame stack
     validate_img_and_shape(


### PR DESCRIPTION
**Why this PR?**
This PR adds some convenience when it comes to cropping and slicing stacks.

Notably, it allows one to directly use multidimensional indexing to select frames and crop the image. It also adds the ability to use negative indices to indicate "from end".

I also added a `.shape` property to quickly check the shape of a `CorrelatedStack`. Previously this required either collecting these pieces of information from various sources, or grabbing the entire stack's contents and calling `.shape` on it. This was very tedious and slow.

![image](https://user-images.githubusercontent.com/19836026/169089820-7234ad51-7764-41f8-892b-4a470ba51eb0.png)