### PR TITLE
confocal: remove direct dependence json

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * Changed the internal calculation of the `extent` argument in `Kymo.plot()` such that the spatial limits are now defined at the center of the pixel (same functionality that is used for the temporal axis). Previously the limits were defined at the edge of the pixel and caused a subtle misalignment between the coordinates of the tracked lines and the actual image.
 * Changed the internal calculation of the hydrodynamically correct force spectrum. Before this change, the computation of the power spectral density relied on the frequencies always being positive. While this change does not affect any results, it allows evaluating the power spectral density for negative frequencies.
 * Fixed an issue where evaluating the hydrodynamically correct spectrum up to very high frequencies could lead to precision losses. These precision losses typically occur at frequencies upwards of 30 kHz and manifest themselves as visible discontinuities.
+* Fixed an issue where the pixel dwell time stored in TIFFs exported from Pylake could be incorrect. Prior to this fix, Pylake exported the value entered in the Bluelake UI as pixel dwell time. In reality, the true pixel dwell time is a multiple of the acquisition sample rate. After the fix, TIFF files correctly report the achieved pixel dwell time. 
 
 ## v0.12.0 | 2022-04-21
 
@@ -32,6 +33,7 @@
 * Fixed a bug in the kymotracker in which the plotted aspect ratio did not match the requested `axis_aspect_ratio` argument.
 
 #### Deprecations
+
 * Deprecated `red_image`, `green_image`, `blue_image`, and `rgb_image` properties for `Scan` and `Kymo`. These data should now be accessed using the `get_image(channel="{color}")` method (where `"{color}"` can be `"red"`, `"green"`, `"blue"`, or `"rgb"`).
 
 #### Breaking changes

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## v0.12.1 | t.b.d.
 
+#### New features
+
+* Added `Scan.pixel_time_seconds` and `Kymo.pixel_time_seconds` to obtain the pixel dwell time. See [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/images.html).
+
 #### Bug fixes
 
 * Changed the internal calculation of the `extent` argument in `Kymo.plot()` such that the spatial limits are now defined at the center of the pixel (same functionality that is used for the temporal axis). Previously the limits were defined at the edge of the pixel and caused a subtle misalignment between the coordinates of the tracked lines and the actual image.

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -70,6 +70,7 @@ There are also several properties available for convenient access to the scan me
 * `scan.pixels_per_line` provides the number of pixels in each line of the scan (number of columns in the raw data array)
 * `scan.fast_axis` provides the fastest axis that was scanned (x or y)
 * `scan.num_frames` provides the number of frames available
+* `kymo.pixel_time_seconds` provides the pixel dwell time.
 
 
 Plotting and Exporting

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -56,6 +56,8 @@ There are also several properties available for convenient access to the kymogra
 * `kymo.pixels_per_line` provides the number of pixels in each line of the kymograph
 * `kymo.fast_axis` provides the axis that was scanned (x or y)
 * `kymo.line_time_seconds` provides the time between successive lines
+* `kymo.pixel_time_seconds` provides the pixel dwell time.
+
 
 Cropping and slicing
 --------------------

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -73,7 +73,7 @@ def _default_pixelcount_factory(self: "ConfocalImage"):
     return [axes.num_pixels for axes in self._metadata.ordered_axes]
 
 
-@dataclass
+@dataclass(frozen=True)
 class ScanAxis:
     axis: int
     num_pixels: int
@@ -84,7 +84,7 @@ class ScanAxis:
         return ("X", "Y", "Z")[self.axis]
 
 
-@dataclass
+@dataclass(frozen=True)
 class ScanMetaData:
     """Scan metadata
 
@@ -100,7 +100,11 @@ class ScanMetaData:
 
     scan_axes: List[ScanAxis]
     center_point_um: np.ndarray
-    num_frames: int
+    num_frames: int  # can be 0 for Scan, in which case it needs to be reconstructed from infowave
+
+    def with_num_frames(self, num_frames):
+        """Returns new scan metadata with different number of frames"""
+        return ScanMetaData(self.scan_axes, self.center_point_um, num_frames)
 
     @property
     def num_axes(self):

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -7,7 +7,7 @@ from typing import List
 
 from .mixin import PhotonCounts
 from .mixin import ExcitationLaserPower
-from .image import reconstruct_image_sum, reconstruct_image, save_tiff, ImageMetadata
+from .image import reconstruct_image_sum, reconstruct_image, save_tiff
 from .utilities import could_sum_overflow
 from ..adjustments import ColorAdjustment
 from matplotlib.colors import LinearSegmentedColormap
@@ -382,13 +382,8 @@ class ConfocalImage(BaseScan):
                 filename,
                 dtype,
                 clip,
-                ImageMetadata(
-                    pixel_size_x=self.pixelsize_um[0] * 1000,  # um => nm
-                    pixel_size_y=self.pixelsize_um[1] * 1000
-                    if len(self.pixelsize_um) > 1
-                    else None,
-                    pixel_time=self.pixel_time_seconds,
-                ),
+                pixel_sizes_um=self.pixelsize_um,
+                pixel_time_seconds=self.pixel_time_seconds,
             )
         else:
             raise RuntimeError("Can't export TIFF if there are no pixels")

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -128,6 +128,11 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
 
         return cls(name, file, start, stop, json_data)
 
+    @property
+    def pixel_time_seconds(self):
+        """Pixel dwell time in seconds"""
+        raise NotImplementedError("Pixel dwell times have not been implemented for this class.")
+
     def __copy__(self):
         return self.__class__(
             name=self.name,

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -26,23 +26,6 @@ class ImageMetadata:
         else:
             self._pixel_size_y = pixel_size_x
 
-    @staticmethod
-    def from_dataset(json):
-        """
-        Fetch metadata from json structure
-
-        Parameters
-        ----------
-        json : dict
-            json structure containing kymograph metadata
-        """
-        if json:
-            pixel_size = json["scan volume"]["scan axes"][0]["pixel size (nm)"]
-            pixel_time = json["scan volume"]["pixel time (ms)"]
-            return ImageMetadata(pixel_size_x=pixel_size, pixel_time=pixel_time)
-        else:
-            return ImageMetadata()
-
     @property
     def resolution(self):
         """X, Y resolution in pixels per cm followed by unit specification accepted by Tifffile"""

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -112,6 +112,11 @@ class Kymo(ConfocalImage):
 
         return sliced_kymo
 
+    @property
+    def pixel_time_seconds(self):
+        """Pixel dwell time in seconds"""
+        return (self.timestamps[1, 0] - self.timestamps[0, 0]) / 1e9
+
     @cachetools.cachedmethod(lambda self: self._cache)
     def _line_start_timestamps(self):
         """Compute starting timestamp of each line (first DAQ sample corresponding to that line),

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -6,7 +6,7 @@ from copy import copy
 from skimage.measure import block_reduce
 from deprecated.sphinx import deprecated
 from .adjustments import ColorAdjustment
-from .detail.confocal import ConfocalImage, linear_colormaps
+from .detail.confocal import ConfocalImage, linear_colormaps, ScanMetaData
 from .detail.image import (
     line_timestamps_image,
     seek_timestamp_next_line,
@@ -41,16 +41,16 @@ class Kymo(ConfocalImage):
         Start point in the relevant info wave.
     stop : int
         End point in the relevant info wave.
-    json : dict
-        Dictionary containing kymograph-specific metadata.
+    metadata : ScanMetaData
+        Metadata for this Kymo.
     position_offset : float
         Coordinate position offset with respect to the original raw data.
     calibration : PositionCalibration
         Class defining calibration from microns to desired position units.
     """
 
-    def __init__(self, name, file, start, stop, json, position_offset=0, calibration=None):
-        super().__init__(name, file, start, stop, json)
+    def __init__(self, name, file, start, stop, metadata, position_offset=0, calibration=None):
+        super().__init__(name, file, start, stop, metadata)
         self._line_time_factory = _default_line_time_factory
         self._position_offset = position_offset
         self._calibration = PositionCalibration() if calibration is None else calibration
@@ -93,12 +93,12 @@ class Kymo(ConfocalImage):
 
         if i_min >= len(line_timestamps):
             return EmptyKymo(
-                self.name, self.file, line_timestamps[-1], line_timestamps[-1], self._json
+                self.name, self.file, line_timestamps[-1], line_timestamps[-1], self._metadata
             )
 
         if i_min >= i_max:
             return EmptyKymo(
-                self.name, self.file, line_timestamps[i_min], line_timestamps[i_min], self._json
+                self.name, self.file, line_timestamps[i_min], line_timestamps[i_min], self._metadata
             )
 
         if i_max < len(line_timestamps):

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -63,6 +63,17 @@ class Scan(ConfocalImage):
         return new_scan
 
     @property
+    def pixel_time_seconds(self):
+        """Pixel dwell time in seconds"""
+        indices = np.zeros(self.timestamps.ndim, dtype=int)
+
+        # The dimensions of the timestamp array are ordered according to physical axis rather than
+        # fast-axis / slow axis. If the fast axis is not the first one, then we must swap them back.
+        physical_axis = [axis["axis"] for axis in self._json["scan volume"]["scan axes"]]
+        indices[-2 if physical_axis[0] > physical_axis[1] else -1] = 1
+        return (self.timestamps.item(tuple(indices)) - self.timestamps.item(0)) / 1e9
+
+    @property
     def num_frames(self):
         if self._num_frames == 0:
             self._num_frames = reconstruct_num_frames(

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -25,7 +25,6 @@ class Scan(ConfocalImage):
 
     def __init__(self, name, file, start, stop, metadata):
         super().__init__(name, file, start, stop, metadata)
-        self._num_frames = self._metadata.num_frames
         if self._metadata.num_axes > 2:
             raise RuntimeError("3D scans are not supported")
 
@@ -54,7 +53,7 @@ class Scan(ConfocalImage):
         new_scan = copy(self)
         new_scan.start = start
         new_scan.stop = stop
-        new_scan._num_frames = num_frames
+        new_scan._metadata = self._metadata.with_num_frames(num_frames)
 
         return new_scan
 
@@ -70,11 +69,13 @@ class Scan(ConfocalImage):
 
     @property
     def num_frames(self):
-        if self._num_frames == 0:
-            self._num_frames = reconstruct_num_frames(
-                self.infowave.data, self.pixels_per_line, self.lines_per_frame
+        if self._metadata.num_frames == 0:
+            self._metadata = self._metadata.with_num_frames(
+                reconstruct_num_frames(
+                    self.infowave.data, self.pixels_per_line, self.lines_per_frame
+                )
             )
-        return self._num_frames
+        return self._metadata.num_frames
 
     def frame_timestamp_ranges(self, exclude=True):
         """Get start and stop timestamp of each frame in the scan.

--- a/lumicks/pylake/tests/data/mock_confocal.py
+++ b/lumicks/pylake/tests/data/mock_confocal.py
@@ -1,6 +1,7 @@
 import numpy as np
 import json
 from .mock_json import mock_json
+from lumicks.pylake.detail.confocal import ScanMetaData
 from lumicks.pylake.detail.image import InfowaveCode
 from lumicks.pylake.channel import Continuous, Slice
 from lumicks.pylake.kymo import Kymo
@@ -138,7 +139,7 @@ class MockConfocalFile:
                 Slice(Continuous(infowave, start=start, dt=dt)),
                 Slice(Continuous(photon_counts, start=start, dt=dt)),
             ),
-            json.loads(json_string)["value0"],
+            ScanMetaData.from_json(json_string),
             start + len(infowave) * dt,
         )
 
@@ -176,13 +177,13 @@ class MockConfocalFile:
                 blue_channel=make_slice(blue_photon_counts),
                 green_channel=make_slice(green_photon_counts),
             ),
-            json.loads(json_string)["value0"],
+            ScanMetaData.from_json(json_string),
             start + len(infowave) * dt,
         )
 
 
 def generate_kymo(name, image, pixel_size_nm, start=4, dt=7, samples_per_pixel=5, line_padding=3):
-    confocal_file, json, stop = MockConfocalFile.from_image(
+    confocal_file, metadata, stop = MockConfocalFile.from_image(
         image,
         pixel_sizes_nm=[pixel_size_nm],
         axes=[0],
@@ -192,13 +193,13 @@ def generate_kymo(name, image, pixel_size_nm, start=4, dt=7, samples_per_pixel=5
         line_padding=line_padding,
     )
 
-    return Kymo(name, confocal_file, start, stop, json)
+    return Kymo(name, confocal_file, start, stop, metadata)
 
 
 def generate_scan(
     name, scan_data, pixel_sizes_nm, start=4, dt=7, samples_per_pixel=5, line_padding=3
 ):
-    confocal_file, json, stop = MockConfocalFile.from_image(
+    confocal_file, metadata, stop = MockConfocalFile.from_image(
         np.swapaxes(scan_data, -1, -2),
         pixel_sizes_nm=pixel_sizes_nm,
         axes=np.arange(scan_data.ndim),
@@ -208,4 +209,4 @@ def generate_scan(
         line_padding=line_padding,
     )
 
-    return Scan(name, confocal_file, start, stop, json)
+    return Scan(name, confocal_file, start, stop, metadata)

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -1,8 +1,8 @@
 import pytest
 import numpy as np
 from lumicks.pylake.adjustments import ColorAdjustment
-from lumicks.pylake.detail.image import reconstruct_image, reconstruct_image_sum, reconstruct_num_frames, save_tiff,\
-    ImageMetadata, line_timestamps_image, histogram_rows
+from lumicks.pylake.detail.image import reconstruct_image, reconstruct_image_sum, \
+    reconstruct_num_frames, save_tiff, line_timestamps_image, histogram_rows
 
 
 @pytest.mark.parametrize("num_lines, pixels_per_line, pad_size", [(5, 3, 3), (5, 4, 2), (4, 7, 5)])
@@ -70,7 +70,35 @@ def test_reconstruct_multiframe():
     assert reconstruct_num_frames(infowave, 2, 5) == 1
 
 
-def test_int_tiff(tmpdir):
+def test_unsafe_int_export_tiff(tmpdir):
+    image16 = np.ones(shape=(10, 10, 3)) * np.iinfo(np.uint16).max
+
+    # Sufficient bit-depth
+    save_tiff(image16, str(tmpdir.join("uint16")), dtype=np.uint16)
+    save_tiff(image16, str(tmpdir.join("float32")), dtype=np.float32)
+
+    # Forced clamping
+    save_tiff(image16, str(tmpdir.join("clipped")), dtype=np.uint8, clip=True)
+
+    # Raise because unsafe
+    with pytest.raises(RuntimeError) as excinfo:
+        save_tiff(image16, str(tmpdir.join("uint8")), dtype=np.uint8)
+    assert "Can't safely export image with `dtype=uint8` channels" in str(excinfo.value)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        save_tiff(image16, str(tmpdir.join("float16")), dtype=np.float16)
+    assert "Can't safely export image with `dtype=float16` channels" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "export_sizes, export_pixel_time, resolution_x, resolution_y",
+    [
+        ([1.0e-3], 1.0e-3, 10000000, 10000000),
+        ([5.0e-3], 1.0e-3, 2000000, 2000000),
+        ([1.0e-3, 5.0e-3], 1.0e-3, 10000000, 2000000),
+    ],
+)
+def test_tiff_tags(export_sizes, export_pixel_time, resolution_x, resolution_y, tmpdir):
     def grab_tags(file):
         import tifffile
         from ast import literal_eval
@@ -83,37 +111,24 @@ def test_int_tiff(tmpdir):
                     tiff_tags[name] = literal_eval(value)
                 except (ValueError, SyntaxError):
                     tiff_tags[name] = value
-
             return tiff_tags
 
     image16 = np.ones(shape=(10, 10, 3)) * np.iinfo(np.uint16).max
-    save_tiff(image16, str(tmpdir.join("1")), dtype=np.uint16, metadata=ImageMetadata(pixel_size_x=1.0, pixel_time=1.0))
-    save_tiff(image16, str(tmpdir.join("2")), dtype=np.float32, metadata=ImageMetadata(pixel_size_x=5.0, pixel_time=5.0))
-    save_tiff(image16, str(tmpdir.join("3")), dtype=np.uint8, clip=True)
-
-    with pytest.raises(RuntimeError) as excinfo:
-        save_tiff(image16, str(tmpdir.join("4")), dtype=np.uint8)
-    assert "Can't safely export image with `dtype=uint8` channels" in str(excinfo.value)
-
-    with pytest.raises(RuntimeError) as excinfo:
-        save_tiff(image16, str(tmpdir.join("5")), dtype=np.float16)
-    assert "Can't safely export image with `dtype=float16` channels" in str(excinfo.value)
+    save_tiff(
+        image16,
+        str(tmpdir.join("1")),
+        dtype=np.uint16,
+        pixel_sizes_um=export_sizes,
+        pixel_time_seconds=export_pixel_time,
+    )
 
     tags = grab_tags(str(tmpdir.join("1")))
-    assert str(tags['ResolutionUnit']) == "RESUNIT.CENTIMETER"
-    np.testing.assert_allclose(tags['ImageDescription']['PixelTime'], 0.001)
-    assert tags['ImageDescription']['PixelTimeUnit'] == "s"
-    np.testing.assert_allclose(tags['ImageDescription']['shape'], [10, 10, 3])
-    np.testing.assert_allclose(tags['XResolution'][0], 10000000)
-    np.testing.assert_allclose(tags['YResolution'][0], 10000000)
-
-    tags = grab_tags(str(tmpdir.join("2")))
-    assert str(tags['ResolutionUnit']) == "RESUNIT.CENTIMETER"
-    np.testing.assert_allclose(tags['ImageDescription']['PixelTime'], 0.005)
-    assert tags['ImageDescription']['PixelTimeUnit'] == "s"
-    np.testing.assert_allclose(tags['ImageDescription']['shape'], [10, 10, 3])
-    np.testing.assert_allclose(tags['XResolution'][0], 2000000)
-    np.testing.assert_allclose(tags['YResolution'][0], 2000000)
+    assert str(tags["ResolutionUnit"]) == "RESUNIT.CENTIMETER"
+    np.testing.assert_allclose(tags["ImageDescription"]["PixelTime"], export_pixel_time)
+    assert tags["ImageDescription"]["PixelTimeUnit"] == "s"
+    np.testing.assert_allclose(tags["ImageDescription"]["shape"], [10, 10, 3])
+    np.testing.assert_allclose(tags["XResolution"][0], resolution_x)
+    np.testing.assert_allclose(tags["YResolution"][0], resolution_y)
 
 
 def test_float_tiff(tmpdir):

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -1,13 +1,19 @@
 import pytest
 import numpy as np
 from lumicks.pylake.adjustments import ColorAdjustment
-from lumicks.pylake.detail.image import reconstruct_image, reconstruct_image_sum, \
-    reconstruct_num_frames, save_tiff, line_timestamps_image, histogram_rows
+from lumicks.pylake.detail.image import (
+    reconstruct_image,
+    reconstruct_image_sum,
+    reconstruct_num_frames,
+    save_tiff,
+    line_timestamps_image,
+    histogram_rows,
+)
 
 
 @pytest.mark.parametrize("num_lines, pixels_per_line, pad_size", [(5, 3, 3), (5, 4, 2), (4, 7, 5)])
 def test_timestamps_image(num_lines, pixels_per_line, pad_size):
-    line_info_wave = np.tile(np.array([1, 1, 2], dtype=np.int32), (pixels_per_line, ))
+    line_info_wave = np.tile(np.array([1, 1, 2], dtype=np.int32), (pixels_per_line,))
     line_selector = np.zeros(line_info_wave.shape)
     line_selector[0] = True
     pad = np.zeros(pad_size, dtype=np.int32)
@@ -20,7 +26,7 @@ def test_timestamps_image(num_lines, pixels_per_line, pad_size):
     time = np.arange(len(infowave), dtype=np.int64) * int(700e9) + 1623965975045144000
 
     line_stamps = line_timestamps_image(time, infowave, pixels_per_line)
-    assert line_stamps.shape == (sum(start_indices), )
+    assert line_stamps.shape == (sum(start_indices),)
     np.testing.assert_equal(line_stamps, time[start_indices == 1])
 
 
@@ -28,19 +34,19 @@ def test_reconstruct():
     infowave = np.array([0, 1, 0, 1, 1, 0, 2, 1, 0, 1, 0, 0, 1, 2, 1, 1, 1, 2])
     the_data = np.array([1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3])
 
-    image = reconstruct_image(the_data, infowave, (5, ))
+    image = reconstruct_image(the_data, infowave, (5,))
     assert image.shape == (1, 5)
     assert np.all(image == [4, 8, 12, 0, 0])
 
-    image = reconstruct_image(the_data, infowave, (2, ))
+    image = reconstruct_image(the_data, infowave, (2,))
     assert image.shape == (2, 2)
     assert np.all(image == [[4, 8], [12, 0]])
 
-    image = reconstruct_image_sum(the_data, infowave, (5, ))
+    image = reconstruct_image_sum(the_data, infowave, (5,))
     assert image.shape == (1, 5)
     assert np.all(image == [4, 8, 12, 0, 0])
 
-    image = reconstruct_image_sum(the_data, infowave, (2, ))
+    image = reconstruct_image_sum(the_data, infowave, (2,))
     assert image.shape == (2, 2)
     assert np.all(image == [[4, 8], [12, 0]])
 
@@ -51,16 +57,16 @@ def test_reconstruct_multiframe():
     infowave[9::10] = 2
     the_data = np.arange(size)
 
-    assert reconstruct_image(the_data, infowave, (5, )).shape == (2, 5)
-    assert reconstruct_image(the_data, infowave, (2, )).shape == (5, 2)
-    assert reconstruct_image(the_data, infowave, (1, )).shape == (10, 1)
+    assert reconstruct_image(the_data, infowave, (5,)).shape == (2, 5)
+    assert reconstruct_image(the_data, infowave, (2,)).shape == (5, 2)
+    assert reconstruct_image(the_data, infowave, (1,)).shape == (10, 1)
     assert reconstruct_image(the_data, infowave, (2, 2)).shape == (3, 2, 2)
     assert reconstruct_image(the_data, infowave, (3, 2)).shape == (2, 3, 2)
     assert reconstruct_image(the_data, infowave, (5, 2)).shape == (1, 5, 2)
 
-    assert reconstruct_image_sum(the_data, infowave, (5, )).shape == (2, 5)
-    assert reconstruct_image_sum(the_data, infowave, (2, )).shape == (5, 2)
-    assert reconstruct_image_sum(the_data, infowave, (1, )).shape == (10, 1)
+    assert reconstruct_image_sum(the_data, infowave, (5,)).shape == (2, 5)
+    assert reconstruct_image_sum(the_data, infowave, (2,)).shape == (5, 2)
+    assert reconstruct_image_sum(the_data, infowave, (1,)).shape == (10, 1)
     assert reconstruct_image_sum(the_data, infowave, (2, 2)).shape == (3, 2, 2)
     assert reconstruct_image_sum(the_data, infowave, (3, 2)).shape == (2, 3, 2)
     assert reconstruct_image_sum(the_data, infowave, (5, 2)).shape == (1, 5, 2)
@@ -146,7 +152,7 @@ def test_float_tiff(tmpdir):
 
 
 def test_histogram_rows():
-    data = np.arange(36).reshape((6,6))
+    data = np.arange(36).reshape((6, 6))
 
     e, h, w = histogram_rows(data, 1, 0.1)
     np.testing.assert_allclose(e, [0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
@@ -173,6 +179,7 @@ def test_partial_pixel_image_reconstruction():
     from the timestamps prior to summing is smaller. This means that the timestamps more quickly
     get into the range where they are at risk of overflow (and therefore have to be summed in
     smaller blocks). This in turn can lead to unnecessarily long reconstruction times."""
+
     def size_test(x, axis):
         assert len(x) == 4, "The last pixel should have been dropped since it was partial"
         return np.array([1, 1, 1, 1])
@@ -208,11 +215,13 @@ def test_absolute_ranges(minimum, maximum, ref_minimum, ref_maximum):
 @pytest.mark.parametrize(
     "minimum, maximum, gamma, ref_minimum, ref_maximum, ref_gamma",
     [
+        # fmt: off
         (1.0, 5.0, [0.5, 2.0, 3.0], [1.0, 1.0, 1.0], [5.0, 5.0, 5.0], [0.5, 2.0, 3.0]),
         ([1.0, 2.0, 3.0], [3.0, 4.0, 5.0], 0.5, [1.0, 2.0, 3.0], [3.0, 4.0, 5.0], [0.5, 0.5, 0.5]),
         ([1.0], [3.0, 4.0, 5.0], [0.2, 1.0, 2.0], [1.0, 1.0, 1.0], [3.0, 4.0, 5.0], [0.2, 1.0, 2.0]),
         ([1.0, 2.0, 3.0], [5.0], None, [1.0, 2.0, 3.0], [5.0, 5.0, 5.0], [1, 1, 1]),  # none passed
         ([1.0, 2.0, 3.0], 5.0, 1, [1.0, 2.0, 3.0], [5.0, 5.0, 5.0], [1, 1, 1]),
+        # fmt: on
     ],
 )
 def test_gamma(minimum, maximum, gamma, ref_minimum, ref_maximum, ref_gamma):

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -5,34 +5,6 @@ from lumicks.pylake.detail.image import reconstruct_image, reconstruct_image_sum
     ImageMetadata, line_timestamps_image, histogram_rows
 
 
-def test_metadata_from_json():
-    json = { 'cereal_class_version': 1,
-             'fluorescence': True,
-             'force': False,
-             'scan count': 0,
-             'scan volume': {'center point (um)': {'x': 58.075877109272604,
-                                                   'y': 31.978375270573267,
-                                                   'z': 0},
-                             'cereal_class_version': 1,
-                             'pixel time (ms)': 0.5,
-                             'scan axes': [{'axis': 0,
-                                            'cereal_class_version': 1,
-                                            'num of pixels': 240,
-                                            'pixel size (nm)': 150,
-                                            'scan time (ms)': 0,
-                                            'scan width (um)': 36.07468112612217}]}}
-
-    image_metadata = ImageMetadata.from_dataset(json)
-
-    res = image_metadata.resolution
-    assert np.isclose(res[0], 1e7 / 150)
-    assert np.isclose(res[1], 1e7 / 150)
-    assert res[2] == 'CENTIMETER'
-
-    assert np.isclose(image_metadata.metadata['PixelTime'], .0005)
-    assert image_metadata.metadata['PixelTimeUnit'] == 's'
-
-
 @pytest.mark.parametrize("num_lines, pixels_per_line, pad_size", [(5, 3, 3), (5, 4, 2), (4, 7, 5)])
 def test_timestamps_image(num_lines, pixels_per_line, pad_size):
     line_info_wave = np.tile(np.array([1, 1, 2], dtype=np.int32), (pixels_per_line, ))

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -40,6 +40,7 @@ def test_kymo_properties(test_kymos):
     np.testing.assert_allclose(kymo.center_point_um["y"], 31.978375270573267)
     np.testing.assert_allclose(kymo.center_point_um["z"], 0)
     np.testing.assert_allclose(kymo.size_um, [0.050])
+    np.testing.assert_allclose(kymo.pixel_time_seconds, 0.1875)
 
     with pytest.deprecated_call():
         assert kymo.rgb_image.shape == (5, 4, 3)
@@ -356,6 +357,12 @@ def test_downsampled_kymo():
     # Verify that we can pass a different reduce function
     np.testing.assert_allclose(kymo.downsampled_by(time_factor=2, reduce=np.mean).get_image("red"), ds / 2)
 
+    with pytest.raises(
+            AttributeError,
+            match="Per-pixel timestamps are no longer available after downsampling",
+    ):
+        kymo_ds.pixel_time_seconds
+
 
 def test_downsampled_kymo_position():
     """Test downsampling over the spatial axis"""
@@ -398,6 +405,8 @@ def test_downsampled_kymo_position():
 
     # We lost one line while downsampling
     np.testing.assert_allclose(kymo_ds.size_um[0], kymo.size_um[0] - kymo.pixelsize_um[0])
+
+    np.testing.assert_allclose(kymo_ds.pixel_time_seconds, kymo.pixel_time_seconds * 2)
 
 
 def test_downsampled_kymo_both_axes():

--- a/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
@@ -153,6 +153,10 @@ def test_slicing(test_scans):
     with pytest.raises(NotImplementedError, match="Slice is empty."):
         scan0[5:5]
 
+    # Verify no side effects
+    scan0[0]
+    assert scan0.num_frames == 10
+
 
 def test_damaged_scan(test_scans):
     # Assume the user incorrectly exported only a partial scan (62500000 is the time step)

--- a/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
@@ -394,3 +394,16 @@ def test_plot_single_channel_percentile_color_adjustment(test_scans):
             np.testing.assert_allclose(plotted_image.get_array(), image[0])
             np.testing.assert_allclose(plotted_image.get_clim(), [lb_abs, ub_abs])
             plt.close(fig)
+
+
+@pytest.mark.parametrize("scan, pixel_time",
+                         [
+                             ("fast Y slow X", 0.1875),
+                             ("fast X slow Z multiframe", 0.1875),
+                             ("fast Y slow X multiframe", 0.1875),
+                             ("fast Y slow Z multiframe", 0.1875),
+                             ("fast Y slow X", 0.1875),
+                         ]
+                         )
+def test_scan_pixel_time(test_scans, scan, pixel_time):
+    np.testing.assert_allclose(test_scans[scan].pixel_time_seconds, pixel_time)


### PR DESCRIPTION
**Why this PR?**
We want to process the imaging metadata in a centralized place and expose only those fields that can be trusted.  This will help when we want to generate kymos from different sources for instance.

In the process of doing this I found a bug in the tiff export, which led to incorrect pixel times (so I took the liberty of fixing that up as well).