### PR TITLE
msd: add uncertainty estimate and estimation parameters to `msd` return argument

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * Added a few performance benchmarks.
 * Added offline piezo tracking functionality (documentation pending).
 * Allow cropping `CorrelatedStack` using multidimensional indexing, i.e. `stack[start_frame : end_frame, start_row : end_row, start_column : end_column]`. See [Correlated stacks](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html#correlated-stacks) for more information.
+* Added `KymoLine.estimate_diffusion()` which provides additional information regarding the diffusion constant estimation. This dataclass can be converted to floating point to get just the estimate, but also contains the number of points used to compute the estimate, and the number of lags used in the analysis. In addition to that, it provides a `std_err` field which reports the standard error for the estimate.
 
 #### Bug fixes
 
@@ -19,6 +20,10 @@
 * Perform better input validation on `refine_lines_centroid`. Line width must now be at least one pixel. Previously, negative values produced a cryptic error message, while a line width smaller than one pixel would silently result in no refinement taking place.
 * Fixed bug in force calibration convenience function where setting `fixed_alpha` or `fixed_diode` to zero resulted in those parameters still being fitted.  After this change, setting `fixed_alpha` to zero will result in the diode model having a fixed `alpha` of zero, whereas setting `f_diode` to zero raises an exception.
 * Include one extra sample when requesting frame timestamp ranges from a scan (`Scan.frame_timestamp_ranges(exclude=True)`). Previously, when slicing using these timestamps, you would omit the last sample of the scan. Now this sample will be included.
+
+#### Deprecations
+
+* `KymoLine.estimate_diffusion_ols()` is now deprecated; use `KymoLine.estimate_diffusion(method="ols")` instead. This new method returns the same estimate of the diffusion coefficient as before but includes additional information about the fit.
 
 ## v0.12.0 | 2022-04-21
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -295,3 +295,14 @@ publisher = {Biophysical Society}
   year={2016},
   publisher={Am Soc Cell Biol}
 }
+
+@article{bullerjahn2020optimal,
+  title={Optimal estimates of self-diffusion coefficients from molecular dynamics simulations},
+  author={Bullerjahn, Jakob T{\'o}mas and von B{\"u}low, S{\"o}ren and Hummer, Gerhard},
+  journal={The Journal of Chemical Physics},
+  volume={153},
+  number={2},
+  pages={024116},
+  year={2020},
+  publisher={AIP Publishing LLC}
+}

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -389,7 +389,7 @@ With Pylake, we can calculate the MSD from a :class:`~lumicks.pylake.kymotracker
 This returns a tuple of lags and MSD estimates. If we only wish MSDs up to a certain lag, we can provide a `max_lag` argument::
 
     >>> kymolines[0].msd(max_lag = 5)
-    (array([0.16, 0.32, 0.48, 0.64, 0.8 ]), array([12.48593965, 16.34844311, 17.21359513, 27.25210869, 32.34473104]))
+    (array([0.16, 0.32, 0.48, 0.64, 0.8 ]), array([ 3.63439512,  6.13181603,  9.08823918, 11.43574189, 12.61152129]))
 
 MSDs are typically used to calculate diffusion constants.
 With pure diffusive motion (a complete absence of drift) in an isotropic medium, 1-dimensional MSDs can be fitted by the following relation:
@@ -418,21 +418,28 @@ When localization is infinitely accurate, the optimal number of points is two :c
 At the optimal number of lags, it doesn't matter whether we use a weighted or unweighted least squares algorithm to fit the curve :cite:`michalet2010mean`, and therefore we opt for the latter, analogously to :cite:`michalet2012optimal`.
 With Pylake, you can obtain an estimated diffusion constant by invoking::
 
-    >>> kymolines[0].estimate_diffusion_ols()
-    7.386961688211464
+    >>> kymolines[0].estimate_diffusion(method="ols")
+    DiffusionEstimate(value=7.804440367653842, std_err=2.527045387449447, num_lags=2, num_points=80, method='ols')
+
+Note that Pylake gives you both an estimate for the diffusion constant, as well as its expected uncertainty and the number of lags used in the computation.
+The uncertainty estimate in this case is based on equation A1b in :cite:`bullerjahn2020optimal`.
 
 Let's get diffusion constants for all three :class:`~lumicks.pylake.kymotracker.kymoline.KymoLine` instances::
 
-    >>> [kymoline.estimate_diffusion_ols() for kymoline in kymolines]
-    [7.386961688211464, 9.052904296390873, 11.551531668363802]
+    >>> [kymoline.estimate_diffusion(method="ols").value for kymoline in kymolines]
+    [DiffusionEstimate(value=7.804440367653842, std_err=2.527045387449447, num_lags=2, num_points=80, method='ols'),
+    DiffusionEstimate(value=3.8728160788405055, std_err=1.5207837420729884, num_lags=3, num_points=80, method='ols'),
+    DiffusionEstimate(value=4.9236019911012745, std_err=1.7399505893645122, num_lags=3, num_points=80, method='ols')]
 
 We can see that there is considerable variation in the estimates, which is unfortunately typical for diffusion coefficient estimates.
-By default, `estimate_diffusion_ols` will use the optimal number of lags as specified in :cite:`michalet2012optimal`. You can however, override this optimal number of lags, by specifying a `max_lag` parameter::
+By default, `estimate_diffusion` will use the optimal number of lags as specified in :cite:`michalet2012optimal`. You can however, override this optimal number of lags, by specifying a `max_lag` parameter::
 
-    >>> [kymoline.estimate_diffusion_ols(max_lag=30) for kymoline in kymolines]
-    [3.064522711727202, 1.7564518650402365, 1.9175754533226452]
+    >>> [kymoline.estimate_diffusion(method="ols", max_lag=30) for kymoline in kymolines]
+    [DiffusionEstimate(value=11.949917925662831, std_err=10.394298104056345, num_lags=30, num_points=80, method='ols'),
+    DiffusionEstimate(value=4.904422868492953, std_err=4.3237670165379045, num_lags=30, num_points=80, method='ols'),
+    DiffusionEstimate(value=8.00626507619601, std_err=6.976860180814361, num_lags=30, num_points=80, method='ols')]
 
-Note however, that this will likely degrade your estimate.
+Note however, that this will likely degrade your estimate (which you also see reflected in the estimated standard error).
 We can also plot the MSD estimates::
 
     [kymoline.plot_msd(marker='.') for kymoline in kymolines]
@@ -445,7 +452,7 @@ By default, this will use the optimal number of lags (which in this case seems t
 
 .. image:: msdplot_100_lags.png
 
-It's not hard to see from this graph why taking too many lags results in unacceptably large variances.
+It's not hard to see from this graph why taking too many lags results in unacceptably large variances (note how the traces diverge).
 
 
 Dwelltime analysis

--- a/docs/tutorial/msdplot_100_lags.png
+++ b/docs/tutorial/msdplot_100_lags.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09fd655f59fdf1488b5b1f19bd391ceddd07b388899ede04d834775945dda680
-size 45073
+oid sha256:b02012e8f25b31147348b8afb8b450ce90316e86a4250b2c53e4a931f0a62d78
+size 19624

--- a/docs/tutorial/msdplot_default_lags.png
+++ b/docs/tutorial/msdplot_default_lags.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:69ff40e59efa7751fb46f12d2675c9233eb3f903455c67d7d3e41a9809bc66e6
-size 30061
+oid sha256:c0c6f0ccbe650b2efabdb6d87ae3ec8ae4045e88a83ac65f66d5662f7e715de3
+size 18104

--- a/lumicks/pylake/kymotracker/detail/msd_estimation.py
+++ b/lumicks/pylake/kymotracker/detail/msd_estimation.py
@@ -38,76 +38,63 @@ def calculate_msd(frame_idx, position, max_lag):
     return frame_lags, msd
 
 
-def _msd_diffusion_base_covariance(n, i, j, slope):
-    """Covariance matrix for the mean squared displacements assuming no localization uncertainty.
-
-    Covariance matrix for localization uncertainty = 0 (Equation 8b from [2]).
-
-    Parameters
-    ----------
-    n : int
-        number of points
-    i, j : int
-        element index
-    slope : float
-        estimate for the slope
-
-    [2] Bullerjahn, J. T., von Bülow, S., & Hummer, G. (2020). Optimal estimates of self-diffusion
-    coefficients from molecular dynamics simulations. The Journal of Chemical Physics, 153(2),
-    024116.
-    """
-    # Intercept corresponds to a^2 in the paper, slope refers to sigma^2 in the paper
-    term1 = 2.0 * min(i, j) * (1.0 + 3.0 * i * j - min(i, j) ** 2) / (n - min(i, j) + 1)
-    denominator = (n - i + 1.0) * (n - j + 1.0)
-    term2 = (min(i, j) ** 2 - min(i, j) ** 4) / denominator
-    heaviside = (i + j - n - 2) >= 0
-    term3 = heaviside * ((n + 1.0 - i - j) ** 4 - (n + 1.0 - i - j) ** 2) / denominator
-
-    return (slope**2 / 3) * (term1 + term2 + term3)
-
-
-def _msd_diffusion_covariance(n, i, j, intercept, slope):
-    """Covariance matrix for mean squared displacements for pure diffusion.
+def _msd_diffusion_covariance(max_lags, n, intercept, slope):
+    """Covariance matrix for the mean squared displacements.
 
     Equation 8a from [2].
 
     Parameters
     ----------
+    max_lags : max_lags
+        number of lags used in estimation.
     n : int
-        number of points
-    i, j : int
-        element index
+        number of trajectory points used
     intercept : float
         estimated localization uncertainty
     slope : float
-        MSD slope
+        estimate for the slope
 
-    [2] Bullerjahn, J. T., von Bülow, S., & Hummer, G. (2020). Optimal estimates of self-diffusion
+    2) Bullerjahn, J. T., von Bülow, S., & Hummer, G. (2020). Optimal estimates of self-diffusion
     coefficients from molecular dynamics simulations. The Journal of Chemical Physics, 153(2),
     024116.
     """
     # Intercept corresponds to a^2 in the paper, slope refers to sigma^2 in the paper
-    term1_nominator = intercept**2 * (1.0 + (i == j)) + 4 * intercept * slope * min(i, j)
-    term1_denominator = n - min(i, j) + 1.0
-    term2_nominator = intercept**2 * max(0.0, n - i - j + 1.0)
-    term2_denominator = (n - i + 1.0) * (n - j + 1.0)
+    i = np.tile(np.arange(max_lags) + 1, (max_lags, 1))
+    j = i.T
+    min_ij = np.minimum(i, j)
 
-    return (
-        _msd_diffusion_base_covariance(n, i, j, slope)
-        + term1_nominator / term1_denominator
-        + term2_nominator / term2_denominator
-    )
+    # Covariance matrix for localization uncertainty = 0
+    term1 = 2.0 * min_ij * (1.0 + 3.0 * i * j - min_ij**2) / (n - min_ij + 1)
+    denominator = (n - i + 1.0) * (n - j + 1.0)
+    term2 = (min_ij**2 - min_ij**4) / denominator
+    heaviside = (i + j - n - 2) >= 0
+    term3 = heaviside * ((n + 1.0 - i - j) ** 4 - (n + 1.0 - i - j) ** 2) / denominator
+
+    # Covariance matrix if there was no localization uncertainty (Eq 8b)
+    base_covariance = (slope**2 / 3) * (term1 + term2 + term3)
+
+    # Intercept corresponds to a^2 in the paper, slope refers to sigma^2 in the paper
+    term4_numerator = intercept**2 * (1.0 + (i == j)) + 4 * intercept * slope * min_ij
+    term4_denominator = n - min_ij + 1.0
+    term5_numerator = intercept**2 * np.maximum(0.0, n - i - j + 1.0)
+    term5_denominator = (n - i + 1.0) * (n - j + 1.0)
+    localization_part = term4_numerator / term4_denominator + term5_numerator / term5_denominator
+
+    # Equation 8a
+    return base_covariance + localization_part
 
 
 def _diffusion_ols(mean_squared_displacements, num_points):
-    """Estimate the diffusion constant and standard deviation based on msd
+    """Estimate the intercept, slope and standard deviation of the slope based on the msd
 
-    mean_squared_displacements : arraylike
+    Parameters
+    ----------
+    mean_squared_displacements : array_like
         mean squared displacements to fit
     num_points : int
         number of points used to compute the lags
 
-    [2] Bullerjahn, J. T., von Bülow, S., & Hummer, G. (2020). Optimal estimates of self-diffusion
+    2) Bullerjahn, J. T., von Bülow, S., & Hummer, G. (2020). Optimal estimates of self-diffusion
     coefficients from molecular dynamics simulations. The Journal of Chemical Physics, 153(2),
     024116.
     """
@@ -117,18 +104,20 @@ def _diffusion_ols(mean_squared_displacements, num_points):
 
     # Estimate intercept and slope (Eq 5 from [2])
     gamma = np.sum(mean_squared_displacements)
-    delta = np.sum(np.arange(1, num_lags + 1) * mean_squared_displacements)
+    lag_idx = np.arange(num_lags) + 1
+    delta = np.sum(lag_idx * mean_squared_displacements)
     inv_denominator = 1.0 / (num_lags * beta - alpha**2)
     intercept = (beta * gamma - alpha * delta) * inv_denominator
     slope = (num_lags * delta - alpha * gamma) * inv_denominator
 
     # Determine variance on slope estimator (Eq. A1a from Appendix A of [2]).
-    var_slope = 0
-    for i, j in product(np.arange(1, num_lags + 1), np.arange(1, num_lags + 1)):
-        covariance_element = _msd_diffusion_covariance(num_points, i, j, intercept, slope)
-        nominator = (i * num_lags - alpha) * (j * num_lags - alpha) * covariance_element
-        denominator = (num_lags * beta - alpha**2) ** 2
-        var_slope += nominator / denominator
+    covariance_matrix = _msd_diffusion_covariance(num_lags, num_points, intercept, slope)
+
+    i = np.tile(lag_idx, (num_lags, 1))
+    j = i.T
+    numerator = (i * num_lags - alpha) * (j * num_lags - alpha) * covariance_matrix
+    denominator = (num_lags * beta - alpha**2) ** 2
+    var_slope = np.sum(numerator / denominator)
 
     return intercept, slope, var_slope
 

--- a/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
+++ b/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
@@ -1,7 +1,10 @@
 import pytest
 import contextlib
 from lumicks.pylake.kymotracker.detail.msd_estimation import *
-from lumicks.pylake.kymotracker.detail.msd_estimation import _msd_diffusion_covariance, _diffusion_ols
+from lumicks.pylake.kymotracker.detail.msd_estimation import (
+    _msd_diffusion_covariance,
+    _diffusion_ols,
+)
 
 
 @contextlib.contextmanager
@@ -111,8 +114,8 @@ def test_localization_eq():
 )
 def test_optimal_points(N, ref_slopes, ref_intercepts):
     test_values = np.hstack((np.arange(-2, 7, 0.5), np.inf))
-    np.testing.assert_allclose(ref_slopes, [optimal_points(10 ** x, N)[0] for x in test_values])
-    np.testing.assert_allclose(ref_intercepts, [optimal_points(10 ** x, N)[1] for x in test_values])
+    np.testing.assert_allclose(ref_slopes, [optimal_points(10**x, N)[0] for x in test_values])
+    np.testing.assert_allclose(ref_intercepts, [optimal_points(10**x, N)[1] for x in test_values])
 
 
 @pytest.mark.parametrize(
@@ -151,18 +154,22 @@ def test_max_iterations():
 
 
 @pytest.mark.parametrize(
-    "n, intercept, slope, ref_matrix",
+    "lags, num_points, intercept, slope, ref_matrix",
     [
-        (2, 1.5, 2.5, [[16.5625, 21.125], [21.125, 84.5]]),
-        (3, 2.5, 3.5, [[25.38888889, 31.125, 38.25], [31.125, 102.5, 136.125], [38.25, 136.125, 338.0]]),
-        (2, 0.2, 0.5, [[0.5, 0.72], [0.72, 2.88]]),
-    ]
+        (2, 2, 1.5, 2.5, [[16.5625, 21.125], [21.125, 84.5]]),
+        (
+            3,
+            3,
+            2.5,
+            3.5,
+            [[25.38888889, 31.125, 38.25], [31.125, 102.5, 136.125], [38.25, 136.125, 338.0]],
+        ),
+        (2, 2, 0.2, 0.5, [[0.5, 0.72], [0.72, 2.88]]),
+        (2, 10, 0.2, 0.5, [[0.1016, 0.14755556], [0.14755556, 0.42222222]]),
+    ],
 )
-def test_covariance_matrix(n, intercept, slope, ref_matrix):
-    cov = np.zeros((n, n))
-    for i, j in product(np.arange(1, n + 1), np.arange(1, n + 1)):
-        cov[i - 1, j - 1] = _msd_diffusion_covariance(n, i, j, intercept, slope)
-
+def test_covariance_matrix(lags, num_points, intercept, slope, ref_matrix):
+    cov = _msd_diffusion_covariance(lags, num_points, intercept, slope)
     np.testing.assert_allclose(cov, ref_matrix)
 
 
@@ -172,7 +179,7 @@ def test_covariance_matrix(n, intercept, slope, ref_matrix):
         (
             [29.41107065, 49.10010613, 50.82447159, 60.589703],
             10,
-            [23.666272215, 9.526026251, 160.12828532251723]
+            [23.666272215, 9.526026251, 160.12828532251723],
         ),
         (
             [63.76387668, 113.59294396, 159.35299198, 199.92392186],
@@ -182,14 +189,14 @@ def test_covariance_matrix(n, intercept, slope, ref_matrix):
         (
             [63.76387668, 113.59294396, 159.35299198, 199.92392186, 190.05758296],
             50,
-            [43.66274634999994, 33.89183904600002, 276.2572452069317]
+            [43.66274634999994, 33.89183904600002, 276.2572452069317],
         ),
         (
             [86.95265981, 108.194084, 128.47057056, 146.25592639, 170.09528357, 185.86762662],
             100,
             [67.83297963266669, 19.94467967399999, 61.06172869734946],
-        )
-    ]
+        ),
+    ],
 )
 def test_ols_results(msd, num_points, ref_values):
     np.testing.assert_allclose(_diffusion_ols(msd, num_points), ref_values)

--- a/lumicks/pylake/kymotracker/tests/test_kymoline.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymoline.py
@@ -214,6 +214,7 @@ def test_diffusion_msd(time_idx, coordinate, pixel_size, time_step, max_lag, dif
     k = KymoLine(time_idx, coordinate / pixel_size, kymo, "red")
 
     np.testing.assert_allclose(k.estimate_diffusion_ols(max_lag=max_lag), diffusion_const)
+    np.testing.assert_allclose(k.estimate_diffusion("ols", max_lag=max_lag).value, diffusion_const)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Why this PR?**
This PR addresses two user requests:
1. It adds an uncertainty estimate for the diffusion constant.
2. It exposes the number of lags used to estimate the diffusion constant.

Note that I added new API since the function now returns a dataclass. I've decided to do this because grouping this information together is useful and more extensible without breaking the API again.  Note that another PR for a second method is incoming. Giving it a `__float__` dunder method allows us to still use it conveniently with `numpy`, i.e.:
```python
np.array([kymoline.estimate_diffusion() for kymoline in kymolines], dtype=float)
```