### PR TITLE
Add `Kymo._line_timestamp_ranges()`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## v0.13.0 | t.b.d.
 
+#### New features
+
+* Added function `Kymo.line_timestamp_ranges()` to obtain the start and stop timestamp of each scan line in a `Kymo`. Please refer to [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html) for more information.
+
 #### Breaking changes
 
 * Changed default in `lk.calibrate_force()` to 38 Hz.

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -126,7 +126,7 @@ For other video formats such as `.mp4` or `.avi`, ffmpeg must be installed. See
 Correlating scans
 -----------------
 
-We can downsample a scan according to the frames in a scan. We can use :func:`~lumicks.pylake.scan.Scan.frame_timestamp_ranges()` for this::
+We can downsample channel data according to the frames in a scan. We can use :func:`~lumicks.pylake.scan.Scan.frame_timestamp_ranges()` for this::
 
     frame_timestamp_ranges = scan.frame_timestamp_ranges()
 

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -170,7 +170,16 @@ The images can also be exported in the TIFF format::
 Correlating with force
 ----------------------
 
-We can plot a kymograph along its force trace using::
+We can downsample channel data according to the lines in a kymo. We can use :func:`~lumicks.pylake.scan.Kymo.line_timestamp_ranges()` for this::
+
+    line_timestamp_ranges = kymo.line_timestamp_ranges()
+
+This returns a list of start and stop timestamps that can be passed directly to :func:`~lumicks.pylake.channel.Slice.downsampled_to`,
+which will then return a :class:`~lumicks.pylake.channel.Slice` with a datapoint per line::
+
+    downsampled = f.force1x.downsampled_over(line_timestamp_ranges)
+
+There is also a convenience function to plot a kymograph along with a downsampled force trace::
 
     kymo.plot_with_force("1x", "green")
 


### PR DESCRIPTION
**Why this PR?**
For kymos generated from camera movies, per-pixel timestamps don't make much sense; however it would still be nice to know the start/stop timestamps for the frame integration. Additionally, a method to determine the kymo line ranges makes it simple to downsample channel data to the frequency of the lines; the functionality is similar to `Scan.frame_timestamp_ranges()`. I've kept it private for now, but it may be better as a public method.

I've implemented this as (yet another) factory because camera-based kymos will need a different implementation. Additionally, I've removed `Kymo._downsample_channel()` since that functionality is now achievable in 2 lines with this addition.