### PR TITLE
ci: clean up two warnings from the error log

### DIFF
--- a/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
+++ b/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
@@ -241,7 +241,6 @@ def test_diffusion_estimate_ols(
 @pytest.mark.parametrize(
     "diffusion,num_points,max_lag,time_step,obs_noise,diff_est,std_err_est",
     [
-        (0, 30, 3, 3, 0.0, 0.0, 0.0),
         (2, 500, 5, 0.01, 1.0, 1.9834877726431195, 1.5462259288408835),
         (1.5, 30, 3, 3, 1.0, 2.0372156730720934, 0.9522810729354054),
         (1.5, 30, 3, 3, 0.0, 2.248704975395052, 0.9790286899037831),

--- a/lumicks/pylake/kymotracker/tests/test_kymoline.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymoline.py
@@ -213,7 +213,6 @@ def test_diffusion_msd(time_idx, coordinate, pixel_size, time_step, max_lag, dif
     )
     k = KymoLine(time_idx, coordinate / pixel_size, kymo, "red")
 
-    np.testing.assert_allclose(k.estimate_diffusion_ols(max_lag=max_lag), diffusion_const)
     np.testing.assert_allclose(
         k.estimate_diffusion("ols", max_lag=max_lag).value, diffusion_const
     )


### PR DESCRIPTION
**Why this PR?**
We should probably not use ill-posed data or API we deprecated in the tests. This cleans up two warnings that pop up during the tests.