### PR TITLE
calibration: express error in terms of diameter

### DIFF
--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -314,8 +314,8 @@ class PassiveCalibrationModel:
             ):
                 raise ValueError(
                     "The hydrodynamically correct model is only valid for distances to the surface "
-                    "larger than 1.5 times the bead radius. For distances closer to the surface, "
-                    "turn off the hydrodynamically correct model."
+                    "larger than 0.75 times the bead diameter. For distances closer to the "
+                    "surface, turn off the hydrodynamically correct model."
                 )
 
             if rho_sample is not None and rho_sample < 100.0:

--- a/lumicks/pylake/force_calibration/tests/test_hydro.py
+++ b/lumicks/pylake/force_calibration/tests/test_hydro.py
@@ -429,7 +429,7 @@ def test_distance_to_surface_input(integration_test_parameters):
     with pytest.raises(
         ValueError,
         match="The hydrodynamically correct model is only valid for distances to the surface "
-        "larger than 1.5 times the bead radius. For distances closer to the surface, "
+        "larger than 0.75 times the bead diameter. For distances closer to the surface, "
         "turn off the hydrodynamically correct model.",
     ):
         ActiveCalibrationModel(distance_to_surface=0.51, hydrodynamically_correct=True, **pars)


### PR DESCRIPTION
**Why this PR?**
This was user feedback from the training sessions. Users enter a diameter, therefore should be provided with an error message that relates to diameter for this particular criterion.