### PR TITLE
Create kymographs from image arrays

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 
 * Changed default in `lk.calibrate_force()` to 38 Hz.
 * To disable image alignment for `lk.CorrelatedStack`, the alignment argument has to be provided as a keyword argument (e.g. `lk.CorrelatedStack("filename.tiff", align=False)` rather than `lk.CorrelatedStack("filename.tiff", False)`).
+* Changed the error type when attempting to access undefined per-pixel timestamps in `Kymo` from `AttributeError` to `NotImplementedError`.
 
 ## v0.12.1 | 2022-06-21
 

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -386,7 +386,7 @@ class ConfocalImage(BaseScan):
         """
         try:
             pixel_time_seconds = self.pixel_time_seconds
-        except AttributeError:
+        except NotImplementedError:
             warnings.warn(
                 f"Pixel times are not defined for this {self.__class__.__name__}. "
                 "The corresponding metadata in the output file is set to `None`."

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -213,13 +213,14 @@ def save_tiff(
         pixel_sizes_um[1] if len(pixel_sizes_um) == 2 else pixel_sizes_um[0],
     )
 
-    tifffile.imwrite(
-        filename,
-        image.astype(dtype),
-        resolution=(1e4 / pixel_size_x, 1e4 / pixel_size_y, "CENTIMETER"),
-        metadata={"PixelTime": pixel_time_seconds, "PixelTimeUnit": "s"},
-        photometric="rgb",
-    )
+    tiff_kwargs = {
+        "metadata": {"PixelTime": pixel_time_seconds, "PixelTimeUnit": "s"},
+        "photometric": "rgb",
+    }
+    if pixel_size_x:
+        tiff_kwargs["resolution"] = (1e4 / pixel_size_x, 1e4 / pixel_size_y, "CENTIMETER")
+
+    tifffile.imwrite(filename, image.astype(dtype), **tiff_kwargs)
 
 
 def histogram_rows(image, pixels_per_bin, pixel_width):

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -467,7 +467,7 @@ class Kymo(ConfocalImage):
             ]
 
         def timestamp_factory_ill_defined(_, reduce_timestamps=np.mean):
-            raise AttributeError(
+            raise NotImplementedError(
                 "Per-pixel timestamps are no longer available after downsampling a kymograph in "
                 "time since they are not well defined (the downsampling occurs over a "
                 "non-contiguous time window). Line timestamps are still available, however. See: "
@@ -713,7 +713,7 @@ def _kymo_from_array(
             return rgb_image[:, :, index]
 
     def timestamp_factory_ill_defined(_, reduce_timestamps=np.mean):
-        raise AttributeError(
+        raise NotImplementedError(
             "Per-pixel timestamps are not implemented. Line timestamps are "
             "still available, however. See: `Kymo.line_time_seconds`."
         )

--- a/lumicks/pylake/nb_widgets/image_editing.py
+++ b/lumicks/pylake/nb_widgets/image_editing.py
@@ -285,12 +285,7 @@ class KymoEditorWidget:
             If provided, the kymo returned from the `image` property will be automatically
             calibrated to this tether length.
         """
-        # check if kymo has already been processed
-        if not kymo._has_default_factories():
-            raise NotImplementedError(
-                "Slicing is not implemented for processed kymographs. Please slice prior to "
-                "processing the data."
-            )
+        kymo._check_is_sliceable()
 
         plt.figure()
         self._ax = plt.subplot(1, 1, 1, projection=KymoEditorProjection(kymo, channel, kwargs))

--- a/lumicks/pylake/tests/test_imaging_confocal/conftest.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/conftest.py
@@ -4,7 +4,7 @@ from lumicks.pylake.point_scan import PointScan
 from lumicks.pylake.kymo import Kymo
 from lumicks.pylake.scan import Scan
 from ..data.mock_file import MockDataFile_v2
-from ..data.mock_confocal import MockConfocalFile, generate_scan_json
+from ..data.mock_confocal import MockConfocalFile, generate_scan_json, generate_image_data
 
 
 start = np.int64(20e9)
@@ -80,6 +80,26 @@ def test_kymos(reference_counts):
         blue_photon_counts=reference_counts,
     )
     kymos["truncated_kymo"] = Kymo("truncated", mock_file, start - 62500000, stop, metadata)
+
+
+    # RGB Kymo with infowave as expected from BL
+    image = np.random.poisson(5, size=(5, 10, 3))
+    infowave, red_photon_count = generate_image_data(image[:, :, 0], 4, 50)
+    _, green_photon_count = generate_image_data(image[:, :, 1], 4, 50)
+    _, blue_photon_count = generate_image_data(image[:, :, 2], 4, 50)
+
+    mock_file, metadata, stop = MockConfocalFile.from_streams(
+        start,
+        dt,
+        [0],
+        [5],
+        [100],
+        infowave=infowave,
+        red_photon_counts=red_photon_count,
+        green_photon_counts=green_photon_count,
+        blue_photon_counts=blue_photon_count,
+    )
+    kymos["noise"] = Kymo("noise", mock_file, start, stop, metadata)
 
     return kymos
 

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -279,7 +279,7 @@ def test_downsample_channel_downsampled_kymo(kymo_h5_file):
 
     # Down-sampling by time should invalidate plot_with_force as it would correspond to
     # non-contiguous sampling
-    with pytest.raises(AttributeError, match="Per-pixel timestamps are no longer available"):
+    with pytest.raises(NotImplementedError, match="Per-pixel timestamps are no longer available"):
         kymo.downsampled_by(time_factor=2).plot_with_force("1x", "red")
 
 
@@ -399,7 +399,7 @@ def test_downsampled_kymo():
     np.testing.assert_allclose(kymo_ds.line_time_seconds, 2 * 7 * (5 * 4 + 2 + 2) / 1e9)
 
     with pytest.raises(
-            AttributeError,
+            NotImplementedError,
             match=re.escape("Per-pixel timestamps are no longer available after downsampling"),
     ):
         kymo_ds.timestamps
@@ -408,7 +408,7 @@ def test_downsampled_kymo():
     np.testing.assert_allclose(kymo.downsampled_by(time_factor=2, reduce=np.mean).get_image("red"), ds / 2)
 
     with pytest.raises(
-            AttributeError,
+            NotImplementedError,
             match="Per-pixel timestamps are no longer available after downsampling",
     ):
         kymo_ds.pixel_time_seconds
@@ -492,7 +492,7 @@ def test_downsampled_kymo_both_axes():
         np.testing.assert_allclose(kymo_ds.pixelsize, 2 / 1000)
         np.testing.assert_allclose(kymo_ds.line_time_seconds, 2 * 5 * (5 * 5 + 2 + 2) / 1e9)
         with pytest.raises(
-                AttributeError,
+                NotImplementedError,
                 match=re.escape("Per-pixel timestamps are no longer available after downsampling"),
         ):
             kymo_ds.timestamps

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
@@ -35,7 +35,7 @@ def test_from_array(test_kymos):
     np.testing.assert_equal(kymo.get_image("rgb"), arr_kymo.get_image("rgb"))
     np.testing.assert_equal(kymo._shape, arr_kymo._shape)
 
-    with pytest.raises(AttributeError, match=timestamp_err_msg):
+    with pytest.raises(NotImplementedError, match=timestamp_err_msg):
         arr_kymo.pixel_time_seconds
 
     np.testing.assert_equal(kymo.line_time_seconds, arr_kymo.line_time_seconds)
@@ -87,7 +87,7 @@ def test_from_array_no_pixelsize(test_kymos):
     np.testing.assert_equal(kymo.get_image("rgb"), arr_kymo.get_image("rgb"))
     np.testing.assert_equal(kymo._shape, arr_kymo._shape)
 
-    with pytest.raises(AttributeError, match=timestamp_err_msg):
+    with pytest.raises(NotImplementedError, match=timestamp_err_msg):
         arr_kymo.pixel_time_seconds
 
     np.testing.assert_equal(kymo.line_time_seconds, arr_kymo.line_time_seconds)

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
@@ -1,0 +1,174 @@
+import pytest
+import numpy as np
+import itertools
+import matplotlib.pyplot as plt
+from lumicks.pylake.kymo import _kymo_from_array
+
+
+timestamp_err_msg = (
+    "Per-pixel timestamps are not implemented. "
+    "Line timestamps are still available, however. See: `Kymo.line_time_seconds`."
+)
+
+colors = ("red", "green", "blue")
+
+
+def make_kymo_from_array(kymo, image, color_format, no_pxsize=False):
+    start = kymo._timestamps("timestamps", np.min)[0, 0]
+    exposure_time_sec = np.diff(kymo.line_timestamp_ranges(exclude=True)[0])[0] * 1e-9
+
+    return _kymo_from_array(
+        image,
+        color_format,
+        kymo.line_time_seconds,
+        start=start,
+        exposure_time_seconds=exposure_time_sec,
+        name="reconstructed",
+        pixel_size_um=None if no_pxsize else kymo.pixelsize_um[0],
+    )
+
+
+def test_from_array(test_kymos):
+    kymo = test_kymos["noise"]
+    arr_kymo = make_kymo_from_array(kymo, kymo.get_image("rgb"), "rgb")
+
+    np.testing.assert_equal(kymo.get_image("rgb"), arr_kymo.get_image("rgb"))
+    np.testing.assert_equal(kymo._shape, arr_kymo._shape)
+
+    with pytest.raises(AttributeError, match=timestamp_err_msg):
+        arr_kymo.pixel_time_seconds
+
+    np.testing.assert_equal(kymo.line_time_seconds, arr_kymo.line_time_seconds)
+    np.testing.assert_equal(
+        kymo.line_timestamp_ranges(exclude=True), arr_kymo.line_timestamp_ranges(exclude=True)
+    )
+    np.testing.assert_equal(
+        kymo.line_timestamp_ranges(exclude=False), arr_kymo.line_timestamp_ranges(exclude=False)
+    )
+
+    np.testing.assert_equal(kymo.pixelsize_um, arr_kymo.pixelsize_um)
+    np.testing.assert_equal(kymo.pixelsize, arr_kymo.pixelsize)
+
+    assert arr_kymo._metadata.center_point_um == {key: None for key in ("x", "y", "z")}
+    assert arr_kymo._metadata.num_frames == 0
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Slicing is not implemented for kymographs derived from image stacks.",
+    ):
+        arr_kymo["0s":"0.5s"]
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Slicing is not implemented for kymographs derived from image stacks.",
+    ):
+        arr_kymo.crop_and_calibrate("red")
+
+
+def test_save_tiff(tmpdir_factory, test_kymos):
+    from os import stat
+
+    tmpdir = tmpdir_factory.mktemp("pylake")
+
+    kymo = test_kymos["noise"]
+
+    for no_pxsize in (True, False):
+        arr_kymo = make_kymo_from_array(kymo, kymo.get_image("rgb"), "rgb", no_pxsize=no_pxsize)
+
+        with pytest.warns(UserWarning):
+            arr_kymo.save_tiff(f"{tmpdir}/kymo1.tiff")
+            assert stat(f"{tmpdir}/kymo1.tiff").st_size > 0
+
+
+def test_from_array_no_pixelsize(test_kymos):
+    kymo = test_kymos["noise"]
+    arr_kymo = make_kymo_from_array(kymo, kymo.get_image("rgb"), "rgb", no_pxsize=True)
+
+    np.testing.assert_equal(kymo.get_image("rgb"), arr_kymo.get_image("rgb"))
+    np.testing.assert_equal(kymo._shape, arr_kymo._shape)
+
+    with pytest.raises(AttributeError, match=timestamp_err_msg):
+        arr_kymo.pixel_time_seconds
+
+    np.testing.assert_equal(kymo.line_time_seconds, arr_kymo.line_time_seconds)
+    np.testing.assert_equal(
+        kymo.line_timestamp_ranges(exclude=True), arr_kymo.line_timestamp_ranges(exclude=True)
+    )
+    np.testing.assert_equal(
+        kymo.line_timestamp_ranges(exclude=False), arr_kymo.line_timestamp_ranges(exclude=False)
+    )
+
+    assert arr_kymo.pixelsize_um == [None]
+    assert arr_kymo.pixelsize == [1.0]
+    assert arr_kymo._calibration.unit == "pixel"
+
+    assert arr_kymo._metadata.center_point_um == {key: None for key in ("x", "y", "z")}
+    assert arr_kymo._metadata.num_frames == 0
+
+
+def test_throw_on_file_access(test_kymos):
+    kymo = test_kymos["noise"]
+    arr_kymo = make_kymo_from_array(kymo, kymo.get_image("rgb"), "rgb")
+
+    attributes = (
+        [f"{color}_power" for color in colors]
+        + [f"{color}_photon_count" for color in colors]
+        + ["infowave", "sted_power"]
+    )
+    for attribute in attributes:
+        with pytest.raises(ValueError, match="There is no .h5 file associated with this Kymo"):
+            getattr(arr_kymo, attribute)
+
+    with pytest.raises(ValueError, match="There is no force data associated with this Kymo"):
+        arr_kymo.plot_with_force("1x", "red")
+
+
+def test_from_array_fewer_channels(test_kymos):
+    kymo = test_kymos["noise"]
+    rgb_image = kymo.get_image("rgb")
+
+    # single-channel data
+    for j, color_channel in enumerate(colors):
+        arr_kymo = make_kymo_from_array(kymo, rgb_image[:, :, j], color_channel[0], no_pxsize=True)
+
+        for channel in colors:
+            if channel == color_channel:
+                np.testing.assert_equal(arr_kymo.get_image(channel), kymo.get_image(channel))
+            else:
+                np.testing.assert_equal(arr_kymo.get_image(channel), 0)
+
+    # two-channel data
+    for channels in itertools.permutations(colors, 2):
+        color_format = "".join([c[0] for c in channels])
+        sub_image = np.stack([rgb_image[:, :, "rgb".index(c)] for c in color_format], axis=2)
+        arr_kymo = make_kymo_from_array(kymo, sub_image, color_format, no_pxsize=True)
+
+        for channel in colors:
+            if channel in channels:
+                np.testing.assert_equal(arr_kymo.get_image(channel), kymo.get_image(channel))
+            else:
+                np.testing.assert_equal(arr_kymo.get_image(channel), 0)
+
+
+def test_color_format(test_kymos):
+    kymo = test_kymos["noise"]
+    image = kymo.get_image("rgb")
+    with pytest.raises(
+        ValueError, match="Invalid color format 'rgp'. Only 'r', 'g', and 'b' are valid components."
+    ):
+        arr_kymo = make_kymo_from_array(kymo, image, "rgp")
+
+    with pytest.raises(
+        ValueError, match="Color format 'r' specifies 1 channel for a 3 channel image."
+    ):
+        arr_kymo = make_kymo_from_array(kymo, image, "r")
+
+    with pytest.raises(
+        ValueError, match="Color format 'rb' specifies 2 channels for a 3 channel image."
+    ):
+        arr_kymo = make_kymo_from_array(kymo, image, "rb")
+
+    with pytest.raises(
+        ValueError, match="Color format 'rgb' specifies 3 channels for a 2 channel image."
+    ):
+        arr_kymo = make_kymo_from_array(kymo, image[:, :, :2], "rgb")


### PR DESCRIPTION
**Why this PR?**
Creating kymos from image data opens up multiple possibilities including creating kymographs from `CorrelatedStack`s and exploring kymotracking on new types of image transformations (eg., edge detection).  Per-pixel timestamps are not supported, but the line time (frame integration time in the case of camera-based images) must be supplied. This way, these kymos can be used in most downstream analysis including kymotracking