### PR TITLE
arithmetic: forward labels appropriately

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 
 * Added function `Kymo.line_timestamp_ranges()` to obtain the start and stop timestamp of each scan line in a `Kymo`. Please refer to [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html) for more information.
 * Added `Kymo.flip()` to flip a Kymograph along its positional axis.
+* Propagate `Slice` axis labels when performing arithmetic (when possible).
 
 #### Breaking changes
 

--- a/lumicks/pylake/tests/test_channels/test_arithmetic.py
+++ b/lumicks/pylake/tests/test_channels/test_arithmetic.py
@@ -12,18 +12,19 @@ slice_continuous_2 = Slice(Continuous([2, 2, 2, 2, 2], start=start, dt=1), calib
 slice_timeseries_1 = Slice(TimeSeries([1, 2, 3, 4, 5], time_series), calibration=calibration)
 slice_timeseries_2 = Slice(TimeSeries([2, 2, 2, 2, 2], time_series), calibration=calibration)
 
-# Operators and whether they preserve force calibration when operated with a scalar
+# Operators, whether they preserve force calibration when operated with a scalar,
+# their string representation and whether they keep their unit under this operation
 operators = [
-    ["__add__", True],
-    ["__sub__", True],
-    ["__truediv__", False],
-    ["__mul__", False],
-    ["__pow__", False],
-    ["__radd__", True],
-    ["__rsub__", False],
-    ["__rtruediv__", False],
-    ["__rmul__", False],
-    ["__rpow__", False],
+    ["__add__", True, "+", True],
+    ["__sub__", True, "-", True],
+    ["__truediv__", False, "/", False],
+    ["__mul__", False, "*", False],
+    ["__pow__", False, "**", False],
+    ["__radd__", True, "+", True],
+    ["__rsub__", False, "-", True],
+    ["__rtruediv__", False, "/", False],
+    ["__rmul__", False, "*", False],
+    ["__rpow__", False, "**", False],
 ]
 
 
@@ -52,7 +53,7 @@ def test_operations_slice(slice1, slice2):
         # With slices, force calibration should never be carried over (since it's invalid)
         assert not getattr(first_slice, operation)(second_slice).calibration
 
-    for operator, _ in operators:
+    for operator, *_ in operators:
         test_operator(slice1, slice2, operator)
 
 
@@ -81,7 +82,7 @@ def test_operations_scalar(slice1, scalar):
         else:
             assert not getattr(current_slice, operation)(scalar_val).calibration
 
-    for operator, preserve_calibration in operators:
+    for operator, preserve_calibration, *_ in operators:
         test_operator(slice1, scalar, operator, preserve_calibration)
 
 
@@ -104,7 +105,7 @@ slice_timeseries_different_timestamps = Slice(
 )
 def test_incompatible_timestamps(slice1, slice2):
     # Test whether the timestamps are correctly compared
-    for operator, _ in operators:
+    for operator, *_ in operators:
         with pytest.raises(RuntimeError):
             getattr(slice1, operator)(slice2)
 
@@ -128,7 +129,7 @@ slice_timeseries_different_length = Slice(
 )
 def test_incompatible_length(slice1, slice2):
     # The data sets need to be the same length. We explicitly raise an exception when they are not.
-    for operator, _ in operators:
+    for operator, *_ in operators:
         with pytest.raises(RuntimeError):
             getattr(slice1, operator)(slice2)
 
@@ -143,7 +144,7 @@ def test_incompatible_length(slice1, slice2):
     ],
 )
 def test_incompatible_types(slice1, slice2):
-    for operator in operators:
+    for operator, *_ in operators:
         with pytest.raises(TypeError):
             getattr(slice1, operator)(slice2)
 
@@ -163,7 +164,7 @@ timetags = Slice(TimeTags(time_series))
 def test_timetags_not_implemented(data1, data2):
     # This is not implemented for time tags at this point (we need to determine what are sensible
     # operations on those first).
-    for operator, _ in operators:
+    for operator, *_ in operators:
         with pytest.raises(NotImplementedError):
             getattr(data1, operator)(data2)
 
@@ -179,3 +180,43 @@ def test_negation(channel_slice):
 def test_negation_timetags_not_implemented():
     with pytest.raises(NotImplementedError):
         negated_timetags = -timetags
+
+
+def test_labels_slices():
+    """Test whether the plot labels are appropriately constructed if valid"""
+    x = Slice(Continuous([1, 2, 3], start=start, dt=1), labels={"y": "Force [pN]", "title": "x"})
+    y = Slice(Continuous([1, 2, 3], start=start, dt=1), labels={"y": "Force [pN]", "title": "y"})
+
+    for operation, _, operator_str, keep_dims in operators:
+        if operation.startswith("__r"):
+            assert getattr(x, operation)(y).labels["title"] == f"(y {operator_str} x)"
+        else:
+            assert getattr(x, operation)(y).labels["title"] == f"(x {operator_str} y)"
+
+        if keep_dims:
+            assert getattr(x, operation)(y).labels["y"] == "Force [pN]"
+        else:
+            assert "y" not in getattr(x, operation)(y).labels
+
+
+def test_labels_scalars():
+    """Test whether the plot labels are appropriately constructed if valid"""
+    x = Slice(Continuous([1, 2, 3], start=start, dt=1), labels={"y": "Force [pN]", "title": "x"})
+    y = 5
+
+    for operation, _, operator_str, keep_dims in operators:
+        if operation.startswith("__r"):
+            assert getattr(x, operation)(y).labels["title"] == f"(5 {operator_str} x)"
+        else:
+            assert getattr(x, operation)(y).labels["title"] == f"(x {operator_str} 5)"
+
+        if keep_dims:
+            assert getattr(x, operation)(y).labels["y"] == "Force [pN]"
+        else:
+            assert "y" not in getattr(x, operation)(y).labels
+
+
+def test_negation_label():
+    x = Slice(Continuous([1, 2, 3], start=start, dt=1), labels={"y": "Force [pN]", "title": "x"})
+    assert (-x).labels["title"] == "-x"
+    assert (-x).labels["y"] == "Force [pN]"


### PR DESCRIPTION
**Why this PR?**
I noticed during documenting the piezo tracking functionality that currently, whenever we do arithmetic on a slice, we lose all the labels. This is not necessary. Quite a few operations (subtraction, addition, negation) will preserve the units and thereby the y label. Additionally, we can construct titles for these slices by using the existing title strings and adding the operator.

`(f.force1x - f.force2x).plot()` results in:

Before:
![image](https://user-images.githubusercontent.com/19836026/176680257-8d34cd59-a23f-46d3-a59a-569e06613f9d.png)

After:
![image](https://user-images.githubusercontent.com/19836026/176680148-e7baa839-b924-49f4-b3eb-6b8d8a4097a5.png)

While I'm not a huge fan of the brackets, they are needed to ensure correctness if users were to repeatedly apply operations on a slice.