### PR TITLE
fitting: make `FdFit` 🥒-able

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * Added function `Kymo.line_timestamp_ranges()` to obtain the start and stop timestamp of each scan line in a `Kymo`. Please refer to [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html) for more information.
 * Added `Kymo.flip()` to flip a Kymograph along its positional axis.
 * Propagate `Slice` axis labels when performing arithmetic (when possible).
+* It is now possible to pickle `FdFit` objects. Prior to this change, unpickling an `FdFit` would fail since model identification relied on a stored `id` for each of the models used. The `id` of a variable changes whenever a new variable is created however. After this change, each model is associated with a universally unique identifier (uuid) that is used for identification instead. This uuid is serialized with the `Model` and used by `FdFit` thereby preserving their relationship when pickled/unpickled.
 
 #### Breaking changes
 

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -42,8 +42,8 @@ class Fit:
     """
 
     def __init__(self, *models):
-        self.models = {id(m): m for m in models}
-        self.datasets = {id(m): self._dataset(m) for m in models}
+        self.models = {m.uuid: m for m in models}
+        self.datasets = {m.uuid: self._dataset(m) for m in models}
         self._params = Params()
         self._invalidate_build()
 
@@ -66,7 +66,7 @@ class Fit:
 
     def __getitem__(self, item):
         if isinstance(item, Model):
-            return self.datasets[id(item)]
+            return self.datasets[item.uuid]
         elif len(self.datasets) == 1 and item in front(self.datasets.values()).names:
             return self.params[front(self.datasets.values()).data[item]]
         else:
@@ -346,7 +346,9 @@ class Fit:
         residual_idx = 0
         residual = np.zeros(self.n_residuals)
         for model in self.models.values():
-            current_residual = model._calculate_residual(self.datasets[id(model)], parameter_values)
+            current_residual = model._calculate_residual(
+                self.datasets[model.uuid], parameter_values
+            )
             current_n = len(current_residual)
             residual[residual_idx : residual_idx + current_n] = current_residual
             residual_idx += current_n
@@ -361,7 +363,9 @@ class Fit:
         residual_idx = 0
         jacobian = np.zeros((self.n_residuals, len(parameter_values)))
         for model in self.models.values():
-            current_jacobian = model._calculate_jacobian(self.datasets[id(model)], parameter_values)
+            current_jacobian = model._calculate_jacobian(
+                self.datasets[model.uuid], parameter_values
+            )
             current_n = current_jacobian.shape[0]
             jacobian[residual_idx : residual_idx + current_n, :] = current_jacobian
             residual_idx += current_n
@@ -476,7 +480,7 @@ class Fit:
         self._rebuild()
 
         params, _ = self._override_params(overrides)
-        dataset = self.datasets[id(model)]
+        dataset = self.datasets[model.uuid]
 
         def plot(fit_data):
             x_values = fit_data.x if independent is None else independent
@@ -640,7 +644,7 @@ class Fit:
         out_string = "<h4>Fit</h4>\n"
 
         for model in self.models.values():
-            datasets = "".join(f"{self.datasets[id(model)]._repr_html_()}<br>\n")
+            datasets = "".join(f"{self.datasets[model.uuid]._repr_html_()}<br>\n")
             out_string += f"<h5>Model: {model.name}</h5>\n"
             eqn = model.get_formatted_equation_string(tex=True)
             if eqn:
@@ -661,7 +665,7 @@ class Fit:
         out_string = "Fit\n"
 
         for model in self.models.values():
-            datasets = (" " * indent + "- " + self.datasets[id(model)].__str__()).splitlines(True)
+            datasets = (" " * indent + "- " + self.datasets[model.uuid].__str__()).splitlines(True)
             datasets = (" " * (2 * indent)).join(datasets)
 
             out_string += f"{' ' * indent}- Model: {model.name}\n"

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -17,6 +17,7 @@ from .detail.derivative_manipulation import (
 from collections import OrderedDict
 from copy import deepcopy
 
+import uuid
 import inspect
 import types
 import numpy as np
@@ -99,6 +100,7 @@ class Model:
             return f"{name}/{x}"
 
         self.name = name
+        self.uuid = uuid.uuid1()
         (self.eqn, self.eqn_tex) = (eqn, eqn_tex)
         self.model_function = model_function
 
@@ -462,6 +464,7 @@ class CompositeModel(Model):
         ), f"Error: Models contain different dependent variables {self.lhs.dependent} and {self.rhs.dependent}"
 
         self.name = self.lhs.name + "_with_" + self.rhs.name
+        self.uuid = uuid.uuid1()
         self._params = OrderedDict()
         for i, v in self.lhs._params.items():
             self._params[i] = v
@@ -561,6 +564,7 @@ class InverseModel(Model):
         """
         self.model = model
         self.name = "inv(" + model.name + ")"
+        self.uuid = uuid.uuid1()
         self.interpolate = interpolate
         self.independent_min = independent_min
         self.independent_max = independent_max
@@ -660,6 +664,7 @@ class SubtractIndependentOffset(Model):
         offset_name = parameter_name
 
         self.name = self.model.name + "(x-d)"
+        self.uuid = uuid.uuid1()
         self._params = OrderedDict()
         self._params[offset_name] = Parameter(
             value=0.01, lower_bound=-0.1, upper_bound=0.1, unit=unit

--- a/lumicks/pylake/fitting/tests/test_fit.py
+++ b/lumicks/pylake/fitting/tests/test_fit.py
@@ -93,14 +93,14 @@ def test_model_fit_object_linking():
 
     # Check the parameters included in the model
     np.testing.assert_allclose(
-        fit.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8]
+        fit.datasets[m.uuid]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8]
     )
     assert np.all(
-        fit.datasets[id(m)]._conditions[0].p_local
+        fit.datasets[m.uuid]._conditions[0].p_local
         == [None, None, None, None, 4, None, None, None, None]
     )
     params = ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e", "M/f", "M/q"]
-    assert fetch_params(fit.params, fit.datasets[id(m)]._conditions[0]._p_global_indices) == params
+    assert fetch_params(fit.params, fit.datasets[m.uuid]._conditions[0]._p_global_indices) == params
 
     # Loading data should make it dirty again
     fit[m]._add_data("test2", [1, 2, 3], [2, 3, 4], {"M/c": 4, "M/e": "M/e_new"})
@@ -109,24 +109,24 @@ def test_model_fit_object_linking():
     # Check the parameters included in the model
     fit._rebuild()
     np.testing.assert_allclose(
-        fit.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8]
+        fit.datasets[m.uuid]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8]
     )
     assert np.all(
-        fit.datasets[id(m)]._conditions[0].p_local
+        fit.datasets[m.uuid]._conditions[0].p_local
         == [None, None, None, None, 4, None, None, None, None]
     )
     params = ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e", "M/f", "M/q"]
-    assert fetch_params(fit.params, fit.datasets[id(m)]._conditions[0]._p_global_indices) == params
+    assert fetch_params(fit.params, fit.datasets[m.uuid]._conditions[0]._p_global_indices) == params
 
     np.testing.assert_allclose(
-        fit.datasets[id(m)]._conditions[1].p_external, [0, 1, 2, 3, 5, 6, 7, 8]
+        fit.datasets[m.uuid]._conditions[1].p_external, [0, 1, 2, 3, 5, 6, 7, 8]
     )
     assert np.all(
-        fit.datasets[id(m)]._conditions[1].p_local
+        fit.datasets[m.uuid]._conditions[1].p_local
         == [None, None, None, None, 4, None, None, None, None]
     )
     params = ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e_new", "M/f", "M/q"]
-    assert fetch_params(fit.params, fit.datasets[id(m)]._conditions[1]._p_global_indices) == params
+    assert fetch_params(fit.params, fit.datasets[m.uuid]._conditions[1]._p_global_indices) == params
 
     # Load data into model 2
     fit[m2]._add_data("test", [1, 2, 3], [2, 3, 4], {"M/c": 4, "M/r": 6})
@@ -140,32 +140,32 @@ def test_model_fit_object_linking():
     fit[m2]._add_data("test2", [1, 2, 3], [2, 3, 4], {"M/c": 4, "M/e": 5})
     assert set(fit.params.keys()) == set(all_params)
     np.testing.assert_allclose(
-        fit.datasets[id(m)]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8]
+        fit.datasets[m.uuid]._conditions[0].p_external, [0, 1, 2, 3, 5, 6, 7, 8]
     )
     assert np.all(
-        fit.datasets[id(m)]._conditions[0].p_local
+        fit.datasets[m.uuid]._conditions[0].p_local
         == [None, None, None, None, 4, None, None, None, None]
     )
     params = ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e", "M/f", "M/q"]
-    assert fetch_params(fit.params, fit.datasets[id(m)]._conditions[0]._p_global_indices) == params
+    assert fetch_params(fit.params, fit.datasets[m.uuid]._conditions[0]._p_global_indices) == params
 
     np.testing.assert_allclose(
-        fit.datasets[id(m)]._conditions[1].p_external, [0, 1, 2, 3, 5, 6, 7, 8]
+        fit.datasets[m.uuid]._conditions[1].p_external, [0, 1, 2, 3, 5, 6, 7, 8]
     )
     assert np.all(
-        fit.datasets[id(m)]._conditions[1].p_local
+        fit.datasets[m.uuid]._conditions[1].p_local
         == [None, None, None, None, 4, None, None, None, None]
     )
     params = ["M/mu", "M/sig", "M/a", "M/b", None, "M/d", "M/e_new", "M/f", "M/q"]
-    assert fetch_params(fit.params, fit.datasets[id(m)]._conditions[1]._p_global_indices) == params
+    assert fetch_params(fit.params, fit.datasets[m.uuid]._conditions[1]._p_global_indices) == params
 
-    np.testing.assert_allclose(fit.datasets[id(m2)]._conditions[0].p_external, [0, 1, 2])
-    assert np.all(fit.datasets[id(m2)]._conditions[0].p_local == [None, None, None, 4, 6])
+    np.testing.assert_allclose(fit.datasets[m2.uuid]._conditions[0].p_external, [0, 1, 2])
+    assert np.all(fit.datasets[m2.uuid]._conditions[0].p_local == [None, None, None, 4, 6])
     params = ["M/mu", "M/e", "M/q", None, None]
-    assert fetch_params(fit.params, fit.datasets[id(m2)]._conditions[0]._p_global_indices) == params
+    assert fetch_params(fit.params, fit.datasets[m2.uuid]._conditions[0]._p_global_indices) == params
 
     params = ["M/mu", None, "M/q", None, "M/r"]
-    assert fetch_params(fit.params, fit.datasets[id(m2)]._conditions[1]._p_global_indices) == params
+    assert fetch_params(fit.params, fit.datasets[m2.uuid]._conditions[1]._p_global_indices) == params
 
     fit.update_params(Params(**{"M/mu": 4, "M/sig": 6}))
     assert fit["M/mu"].value == 4

--- a/lumicks/pylake/fitting/tests/test_model_composition.py
+++ b/lumicks/pylake/fitting/tests/test_model_composition.py
@@ -1,4 +1,9 @@
-from lumicks.pylake.fitting.model import Model, InverseModel
+from lumicks.pylake.fitting.model import (
+    Model,
+    InverseModel,
+    CompositeModel,
+    SubtractIndependentOffset,
+)
 from lumicks.pylake.fitting.models import inverted_odijk, distance_offset, force_offset, odijk
 import pytest
 import numpy as np
@@ -120,3 +125,13 @@ def test_interpolation_inversion():
     parvec = [5.77336105517341, 7.014180463612673, 1500.0000064812095, 4.11]
     result = np.array([0.17843862, 0.18101283, 0.18364313, 0.18633117, 0.18907864])
     np.testing.assert_allclose(m._raw_call(np.arange(10, 250, 50) / 1000, parvec), result)
+
+
+def test_uuids():
+    m1, m2 = (Model(name, lambda x: x, dependent="x") for name in ("M1", "M2"))
+    m3 = CompositeModel(m1, m2)
+    m4 = InverseModel(m1)
+    m5 = SubtractIndependentOffset(m1, "x")
+
+    # Verify that all are unique
+    assert len(set([m1.uuid, m2.uuid, m3.uuid, m4.uuid, m5.uuid])) == 5

--- a/lumicks/pylake/fitting/tests/test_pickling.py
+++ b/lumicks/pylake/fitting/tests/test_pickling.py
@@ -1,0 +1,39 @@
+from lumicks.pylake.fitting.models import inverted_odijk
+from lumicks.pylake.fitting.fit import FdFit
+import numpy as np
+import pickle
+
+
+def test_pickle(tmpdir_factory):
+    tmpdir = tmpdir_factory.mktemp("pylake")
+
+    model = inverted_odijk("DNA")
+    fit = FdFit(model)
+    x = np.arange(1, 20, 5)
+    y = model(np.arange(1, 20, 5), params={"DNA/Lp": 50, "DNA/Lc": 24, "DNA/St": 1000, "kT": 4.12})
+    fit._add_data("test x", x, y)
+    fit["kT"].value = 4.12
+
+    fn = f"{tmpdir}/test.pkl"
+    with open(fn, "wb") as f:
+        pickle.dump(fit, f)
+        pickle.dump(model, f)
+
+    # Verify that we can open the model again
+    with open(fn, "rb") as f:
+        pickled_fit = pickle.load(f)
+        pickled_model = pickle.load(f)
+
+    # Test whether we can still fit
+    pickled_fit.fit()
+
+    # Test whether data is there and whether we can slice by the pickled model (should have its
+    # UUID stored).
+    np.testing.assert_allclose(x, fit[pickled_model].data["test x"].x)
+    np.testing.assert_allclose(y, fit[pickled_model].data["test x"].y)
+
+    # Verify fit result
+    np.testing.assert_allclose(
+        [x.value for x in dict(pickled_fit.params).values()],
+        [49.996726625805394, 24.00234442122973, 1415.9560551307495, 4.12],
+    )


### PR DESCRIPTION
**Why this PR?**
Using `id(model)` to identify models within an `FdFit` is not a good approach, since this value is only preserved over its lifetime. One consequence of this is that `FdFit` can't be pickled (see: https://github.com/lumicks/pylake/issues/327). This PR switches to associating a uuid with a model which is then used to uniquely identify it.