### PR TITLE
Add `min_length` parameter to tracking algorithms

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Added function `Kymo.line_timestamp_ranges()` to obtain the start and stop timestamp of each scan line in a `Kymo`. Please refer to [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html) for more information.
 * Added `Kymo.flip()` to flip a Kymograph along its positional axis.
+* Added a `min_length` argument to `lk.track_greedy()` to automatically filter out tracked lines shorter than a minimum length.
 
 #### Breaking changes
 

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -65,9 +65,13 @@ The result of tracking is a list of kymograph traces::
     >>> print(len(traces))  # the number of traces found in the kymo
     7417
 
-Sometimes, we can have very short spurious traces. To remove these from the list of detected traces we can use
-:func:`~lumicks.pylake.filter_lines`. To omit all traces with fewer than 4 detected points, we
+Sometimes, we can have very short spurious traces. To remove these from the list of detected traces we can pass the `min_length` argument to the
+tracking algorithm. To omit all traces with fewer than 4 detected points, we
 can invoke::
+
+    long_traces = lk.track_greedy(kymo, "green", line_width=0.3, pixel_threshold=3, min_length=4)
+
+The default value is `None` in which case no filtering will be performed. We can still filter after tracking by invoking::
 
     >>> traces = lk.filter_lines(traces, 4)
 

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -53,6 +53,7 @@ def track_greedy(
     diffusion=0.0,
     sigma_cutoff=2.0,
     rect=None,
+    min_length=None,
 ):
     """Track particles on an image using a greedy algorithm.
 
@@ -110,6 +111,8 @@ def track_greedy(
         detection and refinement is performed over the full image, but the results are then filtered
         to omit the peaks that fall outside of the rect. Coordinates should be given as:
         ((min_time, min_coord), (max_time, max_coord)).
+    min_length : int
+        If supplied, the minimum length (in data points) of the resulting tracked lines.
 
     References
     ----------
@@ -170,9 +173,11 @@ def track_greedy(
         sigma_cutoff=sigma_cutoff,
     )
 
-    lines = [KymoLine(line.time_idx, line.coordinate_idx, kymograph, channel) for line in lines]
+    lines = KymoLineGroup(
+        [KymoLine(line.time_idx, line.coordinate_idx, kymograph, channel) for line in lines]
+    )
 
-    return KymoLineGroup(lines)
+    return lines if min_length is None else filter_lines(lines, min_length)
 
 
 def track_lines(
@@ -184,6 +189,7 @@ def track_lines(
     continuation_threshold=0.005,
     angle_weight=10.0,
     rect=None,
+    min_length=None,
 ):
     """Track particles on an image using an algorithm that looks for line-like structures.
 
@@ -227,6 +233,8 @@ def track_lines(
     rect : tuple of two coordinates
         Only perform tracking over a subset of the image. Coordinates should be given as:
         ((min_time, min_coord), (max_time, max_coord)).
+    min_length : int
+        If supplied, the minimum length (in data points) of the resulting tracked lines.
 
     References
     ----------
@@ -252,9 +260,10 @@ def track_lines(
         roi=roi,
     )
 
-    return KymoLineGroup(
+    lines = KymoLineGroup(
         [KymoLine(line.time_idx, line.coordinate_idx, kymograph, channel) for line in lines]
     )
+    return lines if min_length is None else filter_lines(lines, min_length)
 
 
 def filter_lines(lines, minimum_length):

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -17,17 +17,32 @@ def raw_test_data():
     return test_data
 
 
+def raw_test_data_lengths():
+    test_data = np.ones((30, 30))
+    test_data[10, 5:20] = 10
+    test_data[11, 5:20] = 30
+    test_data[12, 5:20] = 10
+
+    test_data[20, 15:25] = 10
+    test_data[21, 15:25] = 20
+    test_data[22, 15:25] = 10
+    return test_data
+
+
 @pytest.fixture
 def kymo_integration_test_data():
-    return generate_kymo(
-        "test",
-        raw_test_data(),
-        pixel_size_nm=5000,
-        start=int(4e9),
-        dt=int(5e9 / 100),
-        samples_per_pixel=3,
-        line_padding=5,
-    )
+    def make_kymo(data):
+        return generate_kymo(
+            "test",
+            data,
+            pixel_size_nm=5000,
+            start=int(4e9),
+            dt=int(5e9 / 100),
+            samples_per_pixel=3,
+            line_padding=5,
+        )
+
+    return {"standard": make_kymo(raw_test_data()), "diff_len": make_kymo(raw_test_data_lengths())}
 
 
 @pytest.fixture

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -44,7 +44,7 @@ def test_refinement_2d():
         start=np.int64(20e9),
         dt=np.int64(1e9),
         samples_per_pixel=1,
-        line_padding=0
+        line_padding=0,
     )
 
     line = KymoLine(time_idx[::2], coordinate_idx[::2], kymo, "red")
@@ -75,7 +75,7 @@ def test_refinement_line(loc, inv_sigma=0.3):
         start=np.int64(20e9),
         dt=np.int64(1e9),
         samples_per_pixel=1,
-        line_padding=0
+        line_padding=0,
     )
 
     line = refine_lines_centroid([KymoLine([0], [25], kymo, "red")], 5)[0]
@@ -84,7 +84,9 @@ def test_refinement_line(loc, inv_sigma=0.3):
 
 def test_refinement_line(kymo_integration_test_data):
     with pytest.raises(ValueError, match="line_width may not be smaller than 1"):
-        refine_lines_centroid([KymoLine([0], [25], kymo_integration_test_data, "red")], 0)[0]
+        refine_lines_centroid(
+            [KymoLine([0], [25], kymo_integration_test_data["standard"], "red")], 0
+        )[0]
 
 
 @pytest.mark.parametrize("fit_mode", ["ignore", "multiple"])

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -294,4 +294,4 @@ def test_valid_override(kymograph):
     kw = KymoWidgetGreedy(
         kymograph, "red", 1, use_widgets=False, slider_ranges={"min_length": (5, 10)}
     )
-    assert kw._min_length_range == (5, 10)
+    assert kw._slider_ranges["min_length"] == (5, 10)


### PR DESCRIPTION
**Why this PR?**
It's common to filter tracked lines for a minimum length and this extra argument allows you to do that straight from the tracking algorithm rather than having to manually call `filter_lines()` after the tracking. The default `None` leaves the behavior unchanged compared to before. Also, this change allows us to de-duplicate some code in the Kymotracker widget.