### PR TITLE
Handle missing channels in `scan.get_image("rgb")` gracefully

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,13 +5,14 @@
 #### New features
 
 * Allow reading multiple files with `lk.CorrelatedStack` (e.g. `lk.CorrelatedStack("image1.tiff", "image2.tiff")`).
-
-#### New features
-
 * Added function `Kymo.line_timestamp_ranges()` to obtain the start and stop timestamp of each scan line in a `Kymo`. Please refer to [Confocal images](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html) for more information.
 * Added `Kymo.flip()` to flip a Kymograph along its positional axis.
 * Propagate `Slice` axis labels when performing arithmetic (when possible).
 * It is now possible to pickle `FdFit` objects. Prior to this change, unpickling an `FdFit` would fail since model identification relied on a stored `id` for each of the models used. The `id` of a variable changes whenever a new variable is created however. After this change, each model is associated with a universally unique identifier (uuid) that is used for identification instead. This uuid is serialized with the `Model` and used by `FdFit` thereby preserving their relationship when pickled/unpickled.
+
+#### Bug fixes
+
+* Improved `scan.get_image("rgb")` to handle missing channel data. Missing channels are now handled gracefully. Missing channels are zero filled matching the dimensions of the remaining channels.
 
 #### Breaking changes
 

--- a/lumicks/pylake/tests/data/mock_confocal.py
+++ b/lumicks/pylake/tests/data/mock_confocal.py
@@ -1,9 +1,8 @@
 import numpy as np
-import json
 from .mock_json import mock_json
 from lumicks.pylake.detail.confocal import ScanMetaData
 from lumicks.pylake.detail.image import InfowaveCode
-from lumicks.pylake.channel import Continuous, Slice
+from lumicks.pylake.channel import Continuous, Slice, empty_slice
 from lumicks.pylake.kymo import Kymo
 from lumicks.pylake.scan import Scan
 
@@ -155,7 +154,12 @@ class MockConfocalFile:
         blue_photon_counts=None,
         green_photon_counts=None,
     ):
-        make_slice = lambda data: None if data is None else Slice(Continuous(data, start, dt))
+        def make_slice(data):
+            if data is None:
+                return empty_slice
+            else:
+                return Slice(Continuous(data, start, dt))
+
         if axes == [] and num_pixels == [] and pixel_sizes_nm == []:
             json_string = generate_scan_json([])
         else:

--- a/lumicks/pylake/tests/test_imaging_confocal/conftest.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/conftest.py
@@ -205,6 +205,45 @@ def test_scans(reference_counts):
     )
     scans["multiframe_poisson"] = Scan("multiframe_poisson", mock_file, start, stop, metadata)
 
+    mock_file, metadata, stop = MockConfocalFile.from_streams(
+        start,
+        dt,
+        [1, 0],
+        [4, 5],
+        [191.0, 197.0],
+        infowave=reference_infowave,
+        red_photon_counts=None,
+        green_photon_counts=reference_counts,
+        blue_photon_counts=reference_counts,
+    )
+    scans["red channel missing"] = Scan("red channel missing", mock_file, start, stop, metadata)
+
+    mock_file, metadata, stop = MockConfocalFile.from_streams(
+        start,
+        dt,
+        [1, 0],
+        [4, 5],
+        [191.0, 197.0],
+        infowave=reference_infowave,
+        red_photon_counts=None,
+        green_photon_counts=reference_counts,
+        blue_photon_counts=None,
+    )
+    scans["rb channels missing"] = Scan("rb channels missing", mock_file, start, stop, metadata)
+
+    mock_file, metadata, stop = MockConfocalFile.from_streams(
+        start,
+        dt,
+        [1, 0],
+        [4, 5],
+        [191.0, 197.0],
+        infowave=reference_infowave,
+        red_photon_counts=None,
+        green_photon_counts=None,
+        blue_photon_counts=None,
+    )
+    scans["all channels missing"] = Scan("all channels missing", mock_file, start, stop, metadata)
+
     return scans
 
 


### PR DESCRIPTION
**Why this PR?**
Missing channels in `scan.rgb_image` should be handled gracefully so that users still could see remaining channels.