### PR TITLE
Alternative option for default Kymotracker parameters/ranges

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 * Changed default in `lk.calibrate_force()` to 38 Hz.
 * To disable image alignment for `lk.CorrelatedStack`, the alignment argument has to be provided as a keyword argument (e.g. `lk.CorrelatedStack("filename.tiff", align=False)` rather than `lk.CorrelatedStack("filename.tiff", False)`).
 * Changed the error type when attempting to access undefined per-pixel timestamps in `Kymo` from `AttributeError` to `NotImplementedError`.
+* Made `KymoWidget.algorithm_parameters` a private attribute.
 
 ## v0.12.1 | 2022-06-21
 

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -76,7 +76,7 @@ class KymoWidget:
         self._line_connector = None
 
         self._algorithm = algorithm
-        self.algorithm_parameters = algorithm_parameters
+        self._algorithm_parameters = algorithm_parameters
 
         self.show(use_widgets=use_widgets, **kwargs)
 
@@ -90,7 +90,7 @@ class KymoWidget:
 
     @property
     def _line_width_pixels(self):
-        return np.ceil(self.algorithm_parameters["line_width"].value / self._kymo.pixelsize[0])
+        return np.ceil(self._algorithm_parameters["line_width"].value / self._kymo.pixelsize[0])
 
     def track_kymo(self, click, release):
         """Handle mouse release event.
@@ -119,7 +119,7 @@ class KymoWidget:
         return self._algorithm(
             self._kymo,
             self._channel,
-            **{key: item.value for key, item in self.algorithm_parameters.items()},
+            **{key: item.value for key, item in self._algorithm_parameters.items()},
             rect=rect,
         )
 
@@ -280,7 +280,7 @@ class KymoWidget:
         import ipywidgets
 
         def set_value(value):
-            self.algorithm_parameters[name].value = value
+            self._algorithm_parameters[name].value = value
 
         slider_types = {"int": ipywidgets.IntSlider, "float": ipywidgets.FloatSlider}
 
@@ -292,7 +292,7 @@ class KymoWidget:
                 min=parameter.lower_bound,
                 max=parameter.upper_bound,
                 step=parameter.step_size,
-                value=self.algorithm_parameters[name].value,
+                value=self._algorithm_parameters[name].value,
             ),
         )
 

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -23,15 +23,15 @@ def test_parameters_kymo(kymograph):
     """Test whether the parameter setting is passed correctly to the algorithm. By setting the threshold to different
     values we can check which lines are detected and use that to verify that the parameter is used."""
     kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
-    kymo_widget.algorithm_parameters["pixel_threshold"].value = 30
+    kymo_widget._algorithm_parameters["pixel_threshold"].value = 30
     kymo_widget.track_all()
     assert len(kymo_widget.lines) == 0
 
-    kymo_widget.algorithm_parameters["pixel_threshold"].value = 7
+    kymo_widget._algorithm_parameters["pixel_threshold"].value = 7
     kymo_widget.track_all()
     assert len(kymo_widget.lines) == 1
 
-    kymo_widget.algorithm_parameters["pixel_threshold"].value = 2
+    kymo_widget._algorithm_parameters["pixel_threshold"].value = 2
     kymo_widget.track_all()
     assert len(kymo_widget.lines) == 3
 
@@ -40,15 +40,15 @@ def test_parameters_kymo(kymograph):
 def test_invalid_algorithm_parameter(kymograph):
     kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
     with pytest.raises(KeyError):
-        kymo_widget.algorithm_parameters["bob"].value = 5
+        kymo_widget._algorithm_parameters["bob"].value = 5
         kymo_widget.track_all()
 
     with pytest.raises(AttributeError):
-        kymo_widget.algorithm_parameters["bob"] = 5
+        kymo_widget._algorithm_parameters["bob"] = 5
         kymo_widget.track_all()
 
     with pytest.raises(TypeError):
-        kymo_widget.algorithm_parameters["bob"] = KymotrackerParameter(
+        kymo_widget._algorithm_parameters["bob"] = KymotrackerParameter(
             "bob", "nonsense", "int", 5, (1, 10)
         )
         kymo_widget.track_all()
@@ -78,7 +78,7 @@ def test_track_kymo(kymograph, region_select):
     in_um, in_s = calibrate_to_kymo(kymograph)
 
     # Track a line in a particular region. Only a single line exists in this region.
-    kymo_widget.algorithm_parameters["pixel_threshold"].value = 4
+    kymo_widget._algorithm_parameters["pixel_threshold"].value = 4
     kymo_widget.track_kymo(*region_select(in_s(10), in_um(8), in_s(20), in_um(9)))
     np.testing.assert_allclose(kymo_widget.lines[0].time_idx, np.arange(10, 20))
     np.testing.assert_allclose(kymo_widget.lines[0].coordinate_idx, [8] * 10)
@@ -106,7 +106,7 @@ def test_save_load_from_ui(kymograph, tmpdir_factory):
     testfile = f"{tmpdir_factory.mktemp('pylake')}/kymo.csv"
 
     kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
-    kymo_widget.algorithm_parameters["pixel_threshold"].value = 4
+    kymo_widget._algorithm_parameters["pixel_threshold"].value = 4
     kymo_widget.track_all()
     kymo_widget.output_filename = testfile
     kymo_widget._save_from_ui()
@@ -140,7 +140,7 @@ def test_refine_from_widget(kymograph, region_select):
         "refine them"
     )
 
-    kymo_widget.algorithm_parameters["pixel_threshold"].value = 4
+    kymo_widget._algorithm_parameters["pixel_threshold"].value = 4
     kymo_widget.track_kymo(*region_select(in_s(5), in_um(12), in_s(20), in_um(13)))
     np.testing.assert_allclose(kymo_widget.lines[0].time_idx, np.hstack(([5, 6], np.arange(9, 20))))
     np.testing.assert_allclose(kymo_widget.lines[0].coordinate_idx, [12] * 13)
@@ -243,7 +243,7 @@ def test_refine_line_width_units(kymograph, region_select):
     kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, line_width=2, use_widgets=False)
     in_um, in_s = calibrate_to_kymo(kymograph)
 
-    kymo_widget.algorithm_parameters["pixel_threshold"].value = 4
+    kymo_widget._algorithm_parameters["pixel_threshold"].value = 4
     kymo_widget.track_kymo(*region_select(in_s(5), in_um(12), in_s(20), in_um(13)))
     kymo_widget.refine()
 
@@ -258,17 +258,17 @@ def test_refine_line_width_units(kymograph, region_select):
 def test_widget_with_calibration(kymograph):
     widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
     np.testing.assert_allclose(
-        widget.algorithm_parameters["line_width"].value, kymograph.pixelsize[0] * 4
+        widget._algorithm_parameters["line_width"].value, kymograph.pixelsize[0] * 4
     )
-    np.testing.assert_allclose(widget.algorithm_parameters["line_width"].value, 1.6)
+    np.testing.assert_allclose(widget._algorithm_parameters["line_width"].value, 1.6)
     assert widget._axes.get_ylabel() == r"position ($\mu$m)"
 
     kymo_bp = kymograph.calibrate_to_kbp(10.000)
     widget = KymoWidgetGreedy(kymo_bp, "red", 1, use_widgets=False)
     np.testing.assert_allclose(
-        widget.algorithm_parameters["line_width"].value, kymo_bp.pixelsize[0] * 4
+        widget._algorithm_parameters["line_width"].value, kymo_bp.pixelsize[0] * 4
     )
-    np.testing.assert_allclose(widget.algorithm_parameters["line_width"].value, 2.0)
+    np.testing.assert_allclose(widget._algorithm_parameters["line_width"].value, 2.0)
     assert widget._axes.get_ylabel() == "position (kbp)"
 
 


### PR DESCRIPTION
**Why this PR?**
This PR takes all of the lists/dictionaries of values dealing with algorithm/slider parameters, ranges, descriptions, etc and centralizes everything into a small dataclass. Beyond data organization, this provides a template for future widgets that may implement other algorithms and allows for easy refactoring/de-duplication of the slider widget generation code.

The final commit makes the `algorithm_parameters` attribute private, which it likely should have been in the first place. Since we are on a breaking release, this is a good time to make the change.

This PR replaces #333 and #334.

Note: as `KymoWidgetGreedy.create_algorithm_sliders()` is now written generically we could easily move it directly into the parent class; however, we would lose the `NotImplementedError` there warning users to not use the parent. Thoughts?