### PR TITLE
Manually redraw axes in kymotracker callbacks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 #### Bug fixes
 
 * Improved `scan.get_image("rgb")` to handle missing channel data. Missing channels are now handled gracefully. Missing channels are zero filled matching the dimensions of the remaining channels.
+* Added calls to manually redraw the axes in kymotracker widget during horizontal pan and line connection callbacks. Without this, plot did not update correctly when using newer versions of `ipywidgets` and `matplotlib`.
 
 #### Breaking changes
 
@@ -20,6 +21,7 @@
 * To disable image alignment for `lk.CorrelatedStack`, the alignment argument has to be provided as a keyword argument (e.g. `lk.CorrelatedStack("filename.tiff", align=False)` rather than `lk.CorrelatedStack("filename.tiff", False)`).
 * Changed the error type when attempting to access undefined per-pixel timestamps in `Kymo` from `AttributeError` to `NotImplementedError`.
 * Made `KymoWidget.algorithm_parameters` a private attribute.
+
 
 ## v0.12.1 | 2022-06-21
 

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -124,6 +124,8 @@ class KymoWidget:
         )
 
     def _connect_drag_callback(self):
+        canvas = self._axes.figure.canvas
+
         def set_xlim(drag_event):
             # Callback for dragging the field of view
             old_xlims = np.array(self._axes.get_xlim())
@@ -134,6 +136,7 @@ class KymoWidget:
                 self._axes.set_xlim(old_xlims - self._dx)
                 self._dx = 0
                 self._last_update = time.time()
+                canvas.draw_idle()
 
         MouseDragCallback(self._axes, 1, set_xlim)
 
@@ -142,6 +145,7 @@ class KymoWidget:
         return tuple(lims[1] - lims[0] for lims in (self._axes.get_xlim(), self._axes.get_ylim()))
 
     def _connect_line_callback(self):
+        canvas = self._axes.figure.canvas
         cutoff_radius = 0.05  # We use a connection cutoff of 5% of the axis ranges
         clicked_line_info = None
         plotted_line = None
@@ -193,6 +197,7 @@ class KymoWidget:
                 [line.position[int(node_index)], event.y],
                 "r",
             )
+            canvas.draw_idle()
 
         def finalize_line(event):
             nonlocal clicked_line_info, plotted_line


### PR DESCRIPTION
**Why this PR?**
After updating `jupyter/ipywidgets/mpl` I noticed that the interactive elements during horizontal panning and line connecting no longer worked. Manually calling `canvas.draw_idle()` seems to fix the problem without noticeable performance hit

Before:
![tracker_bug](https://user-images.githubusercontent.com/61475504/178265473-dcd73d30-3df8-4933-864f-5d2aee07109f.gif)

After:
![tracker_fix](https://user-images.githubusercontent.com/61475504/178265495-750da49e-3549-439c-95b8-06e78baea86f.gif)

