### PR TITLE
Removing sample rate defaults

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 * To disable image alignment for `lk.CorrelatedStack`, the alignment argument has to be provided as a keyword argument (e.g. `lk.CorrelatedStack("filename.tiff", align=False)` rather than `lk.CorrelatedStack("filename.tiff", False)`).
 * Changed the error type when attempting to access undefined per-pixel timestamps in `Kymo` from `AttributeError` to `NotImplementedError`.
 * Made `KymoWidget.algorithm_parameters` a private attribute.
+* It is now mandatory to supply a `sample_rate` when calling `lk.calibrate_force()`.
 
 
 ## v0.12.1 | 2022-06-21

--- a/changelog.md
+++ b/changelog.md
@@ -26,7 +26,7 @@
 * Changed the error type when attempting to access undefined per-pixel timestamps in `Kymo` from `AttributeError` to `NotImplementedError`.
 * Made `KymoWidget.algorithm_parameters` a private attribute.
 * It is now mandatory to supply a `sample_rate` when calling `lk.calibrate_force()`.
-
+* It is now mandatory to supply a `sample_rate` when calling `lumicks.pylake.force_calibration.touchdown.touchdown()`.
 
 ## v0.12.1 | 2022-06-21
 

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -28,11 +28,11 @@ We can do this using the previous calibration performed in Bluelake (in this cas
 
     offset = f.force1x.calibration[0]["Offset (pN)"]
     response = f.force1x.calibration[0]["Rf (pN/V)"]
-    volts = (force_slice.data - offset) / response
+    volts = (force_slice - offset) / response
 
 Force calibration models are fit to power spectra. To compute a power spectrum from our data::
 
-    power_spectrum = lk.calculate_power_spectrum(volts, sample_rate=force_slice.sample_rate)
+    power_spectrum = lk.calculate_power_spectrum(volts.data, sample_rate=volts.sample_rate)
 
 This function returns a power_spectrum which we can plot::
 
@@ -44,7 +44,7 @@ Note that the computation of the power spectrum involves some downsampling.
 
 Additional parameters can be specified to change the amount of downsampling applied (`num_points_per_block`), the range over which to compute the spectrum (`fit_range`) or to exclude specific frequency ranges from the spectrum (`excluded_ranges`)::
 
-    power_spectrum = lk.calculate_power_spectrum(volts, sample_rate=force_slice.sample_rate, fit_range=(1e2, 23e3), num_points_per_block=2000, excluded_ranges=[(700, 800), (14500, 14600)])
+    power_spectrum = lk.calculate_power_spectrum(volts.data, sample_rate=volts.sample_rate, fit_range=(1e2, 23e3), num_points_per_block=2000, excluded_ranges=[(700, 800), (14500, 14600)])
 
 To fit the passive calibration data, we will use a model based on a number of publications by the Flyvbjerg group :cite:`berg2004power,tolic2004matlab,hansen2006tweezercalib,berg2006power`.
 Passive calibration is also often referred to as thermal calibration.
@@ -338,7 +338,7 @@ In this tutorial, we're going to assume the nanostage was used as driving input:
 We also need to provide the sample rate at which the data was acquired, and a rough guess for the driving frequency.
 `pylake` will find an accurate estimate of the driving frequency based on this initial estimate (provided that it is close enough)::
 
-    active_model = lk.ActiveCalibrationModel(driving_data.data, volts, driving_data.sample_rate, bead_diameter, driving_frequency_guess=37)
+    active_model = lk.ActiveCalibrationModel(driving_data.data, volts.data, driving_data.sample_rate, bead_diameter, driving_frequency_guess=37)
 
 To check the determined frequency, we can look at the determined driving frequency::
 
@@ -371,10 +371,10 @@ More convenient calibration
 
 For convenience, we also provide a function named :func:`~lumicks.pylake.calibrate_force` which executes the entire calibration procedure::
 
-    fit = lk.calibrate_force(volts, bead_diameter, temperature)
+    fit = lk.calibrate_force(volts.data, bead_diameter, temperature, sample_rate=volts.sample_rate)
 
 It takes the same arguments as the aforementioned methods to calibrate.
 This function can help quickly compare the effect of varying calibration parameters or switching between active and passive calibration.
 Note that most arguments have to be provided as keyworded arguments to prevent errors. For example::
 
-    fit = lk.calibrate_force(volts, bead_diameter, temperature, active_calibration=True, hydrodynamically_correct=True, fit_range=(10e2, 20e3))
+    fit = lk.calibrate_force(volts.data, bead_diameter, temperature, sample_rate=volts.sample_rate, active_calibration=True, hydrodynamically_correct=True, fit_range=(10e2, 20e3))

--- a/lumicks/pylake/force_calibration/convenience.py
+++ b/lumicks/pylake/force_calibration/convenience.py
@@ -7,6 +7,7 @@ from lumicks.pylake.force_calibration.calibration_models import (
 from lumicks.pylake.force_calibration.power_spectrum_calibration import (
     fit_power_spectrum,
     calculate_power_spectrum,
+    CalibrationResults,
 )
 
 
@@ -15,6 +16,7 @@ def calibrate_force(
     bead_diameter,
     temperature,
     *,
+    sample_rate,
     viscosity=None,
     active_calibration=False,
     driving_data=np.asarray([]),
@@ -25,14 +27,13 @@ def calibrate_force(
     rho_bead=1060.0,
     distance_to_surface=None,
     fast_sensor=False,
-    sample_rate=78125,
     num_points_per_block=2000,
     fit_range=(1e2, 23e3),
     excluded_ranges=[],
     fixed_diode=None,
     fixed_alpha=None,
     drag=None,
-):
+) -> CalibrationResults:
     """Determine force calibration factors.
 
     The power spectrum calibration algorithm implemented here is based on [1]_, [2]_, [3]_, [4]_,
@@ -65,6 +66,8 @@ def calibrate_force(
         Bead diameter [um].
     temperature : float
         Liquid temperature [Celsius].
+    sample_rate : float
+        Sample rate at which the signals were acquired.
     viscosity : float, optional
         Liquid viscosity [Pa*s].
         When omitted, the temperature will be used to look up the viscosity of water at that
@@ -89,8 +92,6 @@ def calibrate_force(
         measurements performed deep in bulk.
     fast_sensor : bool, optional
          Fast sensor? Fast sensors do not have the diode effect included in the model.
-    sample_rate : float, optional
-         Sample rate at which the signals were acquired.
     fit_range : tuple of float, optional
         Tuple of two floats (f_min, f_max), indicating the frequency range to use for the full model
         fit. [Hz]

--- a/lumicks/pylake/force_calibration/tests/test_convenience.py
+++ b/lumicks/pylake/force_calibration/tests/test_convenience.py
@@ -15,6 +15,7 @@ def test_passive_force_calibration_active(reference_models):
         data,
         2,
         9,
+        sample_rate=78125,
         viscosity=6,
         active_calibration=False,
         hydrodynamically_correct=True,
@@ -60,6 +61,7 @@ def test_active_force_calibration_active(reference_models):
         data,
         2,
         9,
+        sample_rate=78125,
         driving_data=oscillation,
         driving_frequency_guess=77,
         viscosity=6,
@@ -94,27 +96,27 @@ def test_active_force_calibration_active(reference_models):
 
 def test_invalid_options_calibration():
     with pytest.raises(ValueError, match="Active calibration is not supported for axial force"):
-        calibrate_force([1], 1, 20, axial=True, active_calibration=True)
+        calibrate_force([1], 1, 20, axial=True, active_calibration=True, sample_rate=78125)
 
     with pytest.raises(
         ValueError, match="Drag coefficient cannot be carried over to active calibration"
     ):
-        calibrate_force([1], 1, 20, drag=5, active_calibration=True)
+        calibrate_force([1], 1, 20, drag=5, active_calibration=True, sample_rate=78125)
 
     with pytest.raises(
         ValueError, match="When using fast_sensor=True, there is no diode model to fix"
     ):
-        calibrate_force([1], 1, 20, fast_sensor=True, fixed_diode=150)
+        calibrate_force([1], 1, 20, fast_sensor=True, fixed_diode=150, sample_rate=78125)
 
     with pytest.raises(
             ValueError, match="When using fast_sensor=True, there is no diode model to fix"
     ):
-        calibrate_force([1], 1, 20, fast_sensor=True, fixed_alpha=0.4)
+        calibrate_force([1], 1, 20, fast_sensor=True, fixed_alpha=0.4, sample_rate=78125)
 
     with pytest.raises(
         ValueError, match="Active calibration requires the driving_data to be defined"
     ):
-        calibrate_force([1], 1, 20, active_calibration=True)
+        calibrate_force([1], 1, 20, active_calibration=True, sample_rate=78125)
 
 
 def test_mandatory_keyworded_arguments():
@@ -124,21 +126,21 @@ def test_mandatory_keyworded_arguments():
 
 def test_diode_fixing(reference_models):
     data, f_sample = reference_models.lorentzian_td(4000, 1, 0.4, 14000, 78125)
-    fit = calibrate_force(data, 1, 20, fixed_diode=1000)
+    fit = calibrate_force(data, 1, 20, fixed_diode=1000, sample_rate=78125)
     assert "f_diode" in fit.params
     assert "alpha" not in fit.params
 
-    fit = calibrate_force(data, 1, 20, fixed_alpha=0.5)
+    fit = calibrate_force(data, 1, 20, fixed_alpha=0.5, sample_rate=78125)
     assert "f_diode" not in fit.params
     assert "alpha" in fit.params
 
-    fit = calibrate_force(data, 1, 20, fixed_diode=14000, fixed_alpha=0.5)
+    fit = calibrate_force(data, 1, 20, fixed_diode=14000, fixed_alpha=0.5, sample_rate=78125)
     assert "f_diode" in fit.params
     assert "alpha" in fit.params
 
-    fit = calibrate_force(data, 1, 20, fixed_alpha=0)
+    fit = calibrate_force(data, 1, 20, fixed_alpha=0, sample_rate=78125)
     assert "f_diode" not in fit.params
     assert "alpha" in fit.params
 
     with pytest.raises(ValueError, match="Fixed diode frequency must be larger than zero."):
-        calibrate_force(data, 1, 20, fixed_diode=0)
+        calibrate_force(data, 1, 20, fixed_diode=0, sample_rate=78125)

--- a/lumicks/pylake/force_calibration/tests/test_touchdown.py
+++ b/lumicks/pylake/force_calibration/tests/test_touchdown.py
@@ -94,7 +94,7 @@ def simulate_touchdown(
 
 def test_touchdown(mack_parameters):
     stage_positions, simulation = simulate_touchdown(99.5, 103.5, 0.01, mack_parameters)
-    touchdown_result = touchdown(stage_positions, simulation)
+    touchdown_result = touchdown(stage_positions, simulation, 78125)
     np.testing.assert_allclose(touchdown_result.surface_position, 101.65989249166964)
     np.testing.assert_allclose(touchdown_result.focal_shift, 0.9212834464971221)
 
@@ -151,7 +151,7 @@ def test_insufficient_data(mack_parameters):
     with pytest.warns(
         RuntimeWarning, match="Insufficient data available to reliably fit touchdown curve"
     ):
-        touchdown_result = touchdown(stage_positions, simulation)
+        touchdown_result = touchdown(stage_positions, simulation, 78125)
         assert touchdown_result.focal_shift is None
 
 
@@ -163,7 +163,7 @@ def test_fail_touchdown_too_little_data():
         match="Surface detection failed [(]piecewise linear fit not better than linear fit[)]",
     ):
         touchdown_result = touchdown(
-            stage_positions, stage_positions**2 + 100 * np.sin(10 * stage_positions)
+            stage_positions, stage_positions**2 + 100 * np.sin(10 * stage_positions), 78125
         )
         assert touchdown_result.surface_position is None
 
@@ -171,5 +171,5 @@ def test_fail_touchdown_too_little_data():
         RuntimeWarning,
         match="Surface detection failed [(]piecewise linear fit not better than linear fit[)]",
     ):
-        touchdown_result = touchdown(stage_positions, 100 * np.sin(10 * stage_positions))
+        touchdown_result = touchdown(stage_positions, 100 * np.sin(10 * stage_positions), 78125)
         assert touchdown_result.surface_position is None

--- a/lumicks/pylake/force_calibration/touchdown.py
+++ b/lumicks/pylake/force_calibration/touchdown.py
@@ -238,12 +238,12 @@ class TouchdownResult:
 def touchdown(
     nanostage,
     axial_force,
+    sample_rate,
     wavelength_nm=1064,
     refractive_index_medium=1.333,
     omit_microns=0.5,
     background_degree=3,
     maximum_p_value=0.0001,
-    sample_rate=78125,
     analysis_rate=52,
 ):
     """This function determines the surface and focal shift from an approach curve.
@@ -257,6 +257,8 @@ def touchdown(
         Nanostage Z position.
     axial_force : np.ndarray
         Axial force.
+    sample_rate : int
+        Sample rate of the given `nanostage` and `axial_force` data in Hz.
     wavelength_nm : float
         Wavelength of the trapping laser in nanometers.
     refractive_index_medium : float
@@ -271,8 +273,6 @@ def touchdown(
         Maximum p-value of F-test that compares the fit of a linear model to the piecewise linear
         model. If the fit is not significantly better, it means that the procedure likely did
         not find the surface.
-    sample_rate : int
-        Sample rate of the given `nanostage` and `axial_force` data in Hz.
     analysis_rate : int
         Sampling rate at which the data is analyzed in Hz.
     """


### PR DESCRIPTION
**Why this PR?**
Considering that not all systems have the same acquisition rate, providing a default `sample_rate` is risky. For this reason, we refrain from providing a default now.