### PR TITLE
Sample rates for HF and LF data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 * Allow downloading files directly from Zenodo using `lk.download_from_doi()`. See the [example on Cas9 binding](https://lumicks-pylake.readthedocs.io/en/latest/examples/cas9_kymotracking/cas9_kymotracking.html) for an example of its use.
 * Made piezo tracking functionality public and added [piezo tracking tutorial](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/piezotracking.html).
 * Added support for steps when slicing frames from `CorrelatedStack`s.
+* Add property `sample_rates` to `Continuous` and `TimeSeries` data
 
 #### Bug fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,7 @@
 * Allow downloading files directly from Zenodo using `lk.download_from_doi()`. See the [example on Cas9 binding](https://lumicks-pylake.readthedocs.io/en/latest/examples/cas9_kymotracking/cas9_kymotracking.html) for an example of its use.
 * Made piezo tracking functionality public and added [piezo tracking tutorial](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/piezotracking.html).
 * Added support for steps when slicing frames from `CorrelatedStack`s.
-* Add property `sample_rates` to `Continuous` and `TimeSeries` data
+* Add property `sample_intervals` to `Continuous` and `TimeSeries` data
 
 #### Bug fixes
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -3,7 +3,6 @@ import numbers
 
 from .detail.utilities import downsample
 from .detail.timeindex import to_timestamp
-from .calibration import ForceCalibration
 from .nb_widgets.range_selector import SliceRangeSelectorWidget
 
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -211,7 +211,7 @@ class Slice:
             return None
 
     @property
-    def sample_rates(self) -> npt.NDArray:
+    def sample_rates(self) -> npt.ArrayLike:
         """The unique data frequencies for `Continuous` and `TimeSeries` data sources"""
         try:
             return 1e9 / self._timesteps

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -211,13 +211,13 @@ class Slice:
             return None
 
     @property
-    def sample_rates(self) -> npt.ArrayLike:
-        """The unique data frequencies for `Continuous` and `TimeSeries` data sources"""
+    def sample_intervals(self) -> npt.ArrayLike:
+        """The unique sample intervals for `Continuous` and `TimeSeries` data sources"""
         try:
-            return 1e9 / self._timesteps
+            return self._timesteps * 1e-9
         except NotImplementedError:
             raise NotImplementedError(
-                f"`sample_rates` are not available for {self._src.__class__.__name__} data"
+                f"`sample_intervals` are not available for {self._src.__class__.__name__} data"
             )
 
     @property

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -211,7 +211,7 @@ class Slice:
             return None
 
     @property
-    def sample_rates(self) -> npt.NDArray[np.float64]:
+    def sample_rates(self) -> npt.NDArray:
         """The unique data frequencies for `Continuous` and `TimeSeries` data sources"""
         try:
             return 1e9 / self._timesteps

--- a/lumicks/pylake/tests/test_channels/test_channels.py
+++ b/lumicks/pylake/tests/test_channels/test_channels.py
@@ -117,6 +117,8 @@ def test_calibration_continuous_channels():
 
 def test_slice_properties():
     size = 10
+    rng = np.random.default_rng()
+    timestamps = np.unique(np.sort(rng.integers(1e9, 10e9, size=size)))
 
     s = channel.Slice(channel.Continuous(np.random.rand(size), start=0, dt=1))
     assert len(s) == size
@@ -125,8 +127,6 @@ def test_slice_properties():
     np.testing.assert_equal(s._timesteps, timesteps)
     np.testing.assert_equal(s.sample_rates, 1e9 / timesteps)
 
-    rng = np.random.default_rng()
-    timestamps = np.unique(np.sort(rng.integers(1e9, 10e9, size=size)))
     s = channel.Slice(channel.TimeSeries(rng.random(len(timestamps)), timestamps))
     assert len(s) == len(timestamps)
     assert s.sample_rate is None

--- a/lumicks/pylake/tests/test_channels/test_channels.py
+++ b/lumicks/pylake/tests/test_channels/test_channels.py
@@ -139,12 +139,12 @@ def test_slice_properties():
     assert s.sample_rate is None
     with pytest.raises(
         NotImplementedError,
-        match=f"`_timesteps` are not available for {s._src.__class__.__name__} data",
+        match="`_timesteps` are not available for TimeTags data",
     ):
         s._timesteps
     with pytest.raises(
         NotImplementedError,
-        match=f"`sample_rates` are not available for {s._src.__class__.__name__} data",
+        match="`sample_rates` are not available for TimeTags data",
     ):
         s.sample_rates
 
@@ -153,12 +153,12 @@ def test_slice_properties():
     assert s.sample_rate is None
     with pytest.raises(
         NotImplementedError,
-        match=f"`_timesteps` are not available for {s._src.__class__.__name__} data",
+        match="`_timesteps` are not available for Empty data",
     ):
         s._timesteps
     with pytest.raises(
         NotImplementedError,
-        match=f"`sample_rates` are not available for {s._src.__class__.__name__} data",
+        match="`sample_rates` are not available for Empty data",
     ):
         s.sample_rates
 

--- a/lumicks/pylake/tests/test_channels/test_channels.py
+++ b/lumicks/pylake/tests/test_channels/test_channels.py
@@ -125,14 +125,14 @@ def test_slice_properties():
     assert s.sample_rate == 1e9
     timesteps = np.asarray([1], dtype=int)
     np.testing.assert_equal(s._timesteps, timesteps)
-    np.testing.assert_equal(s.sample_rates, 1e9 / timesteps)
+    np.testing.assert_equal(s.sample_intervals, timesteps * 1e-9)
 
     s = channel.Slice(channel.TimeSeries(rng.random(len(timestamps)), timestamps))
     assert len(s) == len(timestamps)
     assert s.sample_rate is None
     timesteps = np.unique(np.diff(timestamps)).astype(int)
     np.testing.assert_equal(s._timesteps, timesteps)
-    np.testing.assert_equal(s.sample_rates, 1e9 / timesteps)
+    np.testing.assert_equal(s.sample_intervals, timesteps * 1e-9)
 
     s = channel.Slice(channel.TimeTags(np.arange(0, size, dtype=np.int64)))
     assert len(s) == size
@@ -144,9 +144,9 @@ def test_slice_properties():
         s._timesteps
     with pytest.raises(
         NotImplementedError,
-        match="`sample_rates` are not available for TimeTags data",
+        match="`sample_intervals` are not available for TimeTags data",
     ):
-        s.sample_rates
+        s.sample_intervals
 
     s = channel.empty_slice
     assert len(s) == 0
@@ -158,9 +158,9 @@ def test_slice_properties():
         s._timesteps
     with pytest.raises(
         NotImplementedError,
-        match="`sample_rates` are not available for Empty data",
+        match="`sample_intervals` are not available for Empty data",
     ):
-        s.sample_rates
+        s.sample_intervals
 
 
 def test_labels():


### PR DESCRIPTION
**Why this PR?**
As a user I want to be able to access the sample_rate(s) of HF and LF data _in the same way_. Therefore, I added a property `sample_rates` to the `Slice` class, which in turn calls `sample_rates` implementation of `Continuous` and `TimeSeries` data. The `sample_rates` are _all_ unique sample rates. As `TimeSeries` might have non whole number frequencies, `time_series` returns an array of type float.