### PR TITLE
correlatedstack: add video export analogous to `Scan`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 * Allow downloading files directly from Zenodo using `lk.download_from_doi()`. See the [example on Cas9 binding](https://lumicks-pylake.readthedocs.io/en/latest/examples/cas9_kymotracking/cas9_kymotracking.html) for an example of its use.
 * Made piezo tracking functionality public and added [piezo tracking tutorial](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/piezotracking.html).
 * Added support for steps when slicing frames from `CorrelatedStack`s.
+* Added `CorrelatedStack.export_video()` to export videos to export multi-frame videos to video formats or GIFs.
 
 #### Bug fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,10 @@
 * It is now mandatory to supply a `sample_rate` when calling `lumicks.pylake.force_calibration.touchdown.touchdown()`.
 * Removed public attributes `CorrelatedStack.start_idx` and `CorrelatedStack.stop_idx` and made them protected.
 
+#### Deprecations
+
+* Deprecated `export_video_red()`, `export_video_green()`, `export_video_blue()`, and `export_video_rgb()` methods for `Scan`. These methods have been replaced with a single `export_video(channel=color)` method.
+
 ## v0.12.1 | 2022-06-21
 
 #### New features

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 
 * Improved `scan.get_image("rgb")` to handle missing channel data. Missing channels are now handled gracefully. Missing channels are zero filled matching the dimensions of the remaining channels.
 * Added calls to manually redraw the axes in kymotracker widget during horizontal pan and line connection callbacks. Without this, plot did not update correctly when using newer versions of `ipywidgets` and `matplotlib`.
+* Fixed bug in video export that led to one frame less being exported than intended.
 
 #### Breaking changes
 

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -112,12 +112,12 @@ The images can also be exported in the TIFF format::
 Scans can also be exported to video formats.
 Exporting the red channel of a multi-scan GIF can be done as follows for example::
 
-    scan.export_video_red("test_red.gif")
+    scan.export_video("red", "test_red.gif")
 
 Or if we want to export a subset of frames (the first frame being 10, and the last frame being 40) of all three channels
 at a frame rate of 40 frames per second, we can do this::
 
-    scan.export_video_rgb("test_rgb.gif", start_frame=10, end_frame=40, fps=40)
+    scan.export_video("rgb", "test_rgb.gif", start_frame=10, end_frame=40, fps=40)
 
 For other video formats such as `.mp4` or `.avi`, ffmpeg must be installed. See
 :ref:`installation instructions <ffmpeg_installation>` for more information on this.

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -3,12 +3,13 @@ import os
 import tifffile
 import warnings
 from deprecated.sphinx import deprecated
+from .detail.imaging_mixins import VideoExport
 from .adjustments import ColorAdjustment
 from .detail.widefield import TiffStack
 from .detail.image import make_image_title
 
 
-class CorrelatedStack:
+class CorrelatedStack(VideoExport):
     """CorrelatedStack acquired with Bluelake. Bluelake can export stacks of images to various
     formats. These can be opened and correlated to timeline data using CorrelatedStack.
 

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -1,0 +1,84 @@
+from lumicks.pylake.adjustments import ColorAdjustment
+
+
+class VideoExport:
+    def export_video(
+        self,
+        channel,
+        file_name,
+        start_frame=None,
+        end_frame=None,
+        fps=15,
+        adjustment=ColorAdjustment.nothing(),
+        **kwargs,
+    ):
+        """Export a video
+
+        Parameters
+        ----------
+        channel : str
+            Color channel(s) to use "red", "green", "blue" or "rgb".
+        file_name : str
+            File name to export to.
+        start_frame : int
+            First frame in exported video.
+        end_frame : int
+            Last frame in exported video.
+        fps : int
+            Frame rate.
+        adjustment : lk.ColorAdjustment
+            Color adjustments to apply to the output image.
+        **kwargs
+            Forwarded to :func:`matplotlib.pyplot.imshow`."""
+        from matplotlib import animation, rcParams
+        from matplotlib.colors import to_rgba
+        import matplotlib.pyplot as plt
+
+        channels = ("red", "green", "blue", "rgb")
+        if channel not in channels:
+            raise ValueError(f"Channel should be {', '.join(channels[:-1])} or {channels[-1]}")
+
+        metadata = dict(title=self.name)
+        if "ffmpeg" in animation.writers:
+            writer = animation.writers["ffmpeg"](fps=fps, metadata=metadata)
+        elif "pillow" in animation.writers:
+            writer = animation.writers["pillow"](fps=fps, metadata=metadata)
+        else:
+            raise RuntimeError("You need either ffmpeg or pillow installed to export videos.")
+
+        start_frame = start_frame if start_frame else 0
+        end_frame = end_frame if end_frame else self.num_frames - 1
+
+        # On some notebook backends, figures render with a transparent background by default. This
+        # leads to very poor image quality, since it prevents font anti-aliasing (at the cost of
+        # not having transparent regions outside the axes part of figures).
+        face_color = rcParams["figure.facecolor"]
+        face_color_rgba = to_rgba(face_color)
+        if face_color_rgba[3] < 1.0:
+            rcParams["figure.facecolor"] = face_color_rgba[:3] + (1.0,)
+        else:
+            face_color = None
+
+        plot_func = lambda frame, image_handle: self.plot(
+            channel=channel,
+            frame=frame,
+            image_handle=image_handle,
+            adjustment=adjustment,
+            **kwargs,
+        )
+        image_handle = None
+
+        def plot(num):
+            nonlocal image_handle
+            image_handle = plot_func(frame=start_frame + num, image_handle=image_handle)
+            return plt.gca().get_children()
+
+        fig = plt.gcf()
+        line_ani = animation.FuncAnimation(
+            fig, plot, end_frame - start_frame, interval=1, blit=True
+        )
+        line_ani.save(file_name, writer=writer)
+        plt.close(fig)
+
+        if face_color:
+            rcParams["figure.facecolor"] = face_color

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -6,8 +6,9 @@ class VideoExport:
         self,
         channel,
         file_name,
+        *,
         start_frame=None,
-        end_frame=None,
+        stop_frame=None,
         fps=15,
         adjustment=ColorAdjustment.nothing(),
         **kwargs,
@@ -22,7 +23,7 @@ class VideoExport:
             File name to export to.
         start_frame : int
             First frame in exported video.
-        end_frame : int
+        stop_frame : int
             Last frame in exported video.
         fps : int
             Frame rate.
@@ -46,15 +47,17 @@ class VideoExport:
             raise RuntimeError("You need either ffmpeg or pillow installed to export videos.")
 
         start_frame = start_frame if start_frame else 0
-        end_frame = end_frame if end_frame else self.num_frames
+        stop_frame = stop_frame if stop_frame else self.num_frames
 
-        plot_func = lambda frame, image_handle: self.plot(
-            channel=channel,
-            frame=frame,
-            image_handle=image_handle,
-            adjustment=adjustment,
-            **kwargs,
-        )
+        def plot_func(frame, image_handle):
+            return self.plot(
+                channel=channel,
+                frame=frame,
+                image_handle=image_handle,
+                adjustment=adjustment,
+                **kwargs,
+            )
+
         image_handle = None
 
         def plot(num):
@@ -65,7 +68,7 @@ class VideoExport:
         fig = plt.gcf()
         fig.patch.set_alpha(1.0)
         line_ani = animation.FuncAnimation(
-            fig, plot, end_frame - start_frame, interval=1, blit=True
+            fig, plot, stop_frame - start_frame, interval=1, blit=True
         )
         line_ani.save(file_name, writer=writer)
         plt.close(fig)

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -30,8 +30,7 @@ class VideoExport:
             Color adjustments to apply to the output image.
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`."""
-        from matplotlib import animation, rcParams
-        from matplotlib.colors import to_rgba
+        from matplotlib import animation
         import matplotlib.pyplot as plt
 
         channels = ("red", "green", "blue", "rgb")
@@ -49,16 +48,6 @@ class VideoExport:
         start_frame = start_frame if start_frame else 0
         end_frame = end_frame if end_frame else self.num_frames
 
-        # On some notebook backends, figures render with a transparent background by default. This
-        # leads to very poor image quality, since it prevents font anti-aliasing (at the cost of
-        # not having transparent regions outside the axes part of figures).
-        face_color = rcParams["figure.facecolor"]
-        face_color_rgba = to_rgba(face_color)
-        if face_color_rgba[3] < 1.0:
-            rcParams["figure.facecolor"] = face_color_rgba[:3] + (1.0,)
-        else:
-            face_color = None
-
         plot_func = lambda frame, image_handle: self.plot(
             channel=channel,
             frame=frame,
@@ -74,11 +63,9 @@ class VideoExport:
             return plt.gca().get_children()
 
         fig = plt.gcf()
+        fig.patch.set_alpha(1.0)
         line_ani = animation.FuncAnimation(
             fig, plot, end_frame - start_frame, interval=1, blit=True
         )
         line_ani.save(file_name, writer=writer)
         plt.close(fig)
-
-        if face_color:
-            rcParams["figure.facecolor"] = face_color

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -47,7 +47,7 @@ class VideoExport:
             raise RuntimeError("You need either ffmpeg or pillow installed to export videos.")
 
         start_frame = start_frame if start_frame else 0
-        end_frame = end_frame if end_frame else self.num_frames - 1
+        end_frame = end_frame if end_frame else self.num_frames
 
         # On some notebook backends, figures render with a transparent background by default. This
         # leads to very poor image quality, since it prevents font anti-aliasing (at the cost of

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -314,7 +314,13 @@ class Scan(ConfocalImage, VideoExport):
             Forwarded to :func:`matplotlib.pyplot.imshow`.
         """
         self.export_video(
-            "rgb", file_name, start_frame, end_frame, fps, adjustment=adjustment, **kwargs
+            "rgb",
+            file_name,
+            start_frame=start_frame,
+            stop_frame=end_frame,
+            fps=fps,
+            adjustment=adjustment,
+            **kwargs,
         )
 
     @deprecated(
@@ -351,7 +357,13 @@ class Scan(ConfocalImage, VideoExport):
             Forwarded to :func:`matplotlib.pyplot.imshow`.
         """
         self.export_video(
-            "red", file_name, start_frame, end_frame, fps, adjustment=adjustment, **kwargs
+            "red",
+            file_name,
+            start_frame=start_frame,
+            stop_frame=end_frame,
+            fps=fps,
+            adjustment=adjustment,
+            **kwargs,
         )
 
     @deprecated(
@@ -388,7 +400,13 @@ class Scan(ConfocalImage, VideoExport):
             Forwarded to :func:`matplotlib.pyplot.imshow`.
         """
         self.export_video(
-            "green", file_name, start_frame, end_frame, fps, adjustment=adjustment, **kwargs
+            "green",
+            file_name,
+            start_frame=start_frame,
+            stop_frame=end_frame,
+            fps=fps,
+            adjustment=adjustment,
+            **kwargs,
         )
 
     @deprecated(
@@ -425,5 +443,11 @@ class Scan(ConfocalImage, VideoExport):
             Forwarded to :func:`matplotlib.pyplot.imshow`.
         """
         self.export_video(
-            "blue", file_name, start_frame, end_frame, fps, adjustment=adjustment, **kwargs
+            "blue",
+            file_name,
+            start_frame=start_frame,
+            stop_frame=end_frame,
+            fps=fps,
+            adjustment=adjustment,
+            **kwargs,
         )

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -2,12 +2,13 @@ import numpy as np
 from copy import copy
 from deprecated import deprecated
 
+from .detail.imaging_mixins import VideoExport
 from .adjustments import ColorAdjustment
 from .detail.confocal import ConfocalImage, linear_colormaps
 from .detail.image import reconstruct_num_frames, make_image_title
 
 
-class Scan(ConfocalImage):
+class Scan(ConfocalImage, VideoExport):
     """A confocal scan exported from Bluelake
 
     Parameters
@@ -278,87 +279,6 @@ class Scan(ConfocalImage):
         axes.set_title(make_image_title(self, frame))
 
         return image_handle
-
-    def export_video(
-        self,
-        channel,
-        file_name,
-        start_frame=None,
-        end_frame=None,
-        fps=15,
-        adjustment=ColorAdjustment.nothing(),
-        **kwargs,
-    ):
-        """Export a video of a particular scan plot
-
-        Parameters
-        ----------
-        channel : str
-            Color channel(s) to use "red", "green", "blue" or "rgb".
-        file_name : str
-            File name to export to.
-        start_frame : int
-            First frame in exported video.
-        end_frame : int
-            Last frame in exported video.
-        fps : int
-            Frame rate.
-        adjustment : lk.ColorAdjustment
-            Color adjustments to apply to the output image.
-        **kwargs
-            Forwarded to :func:`matplotlib.pyplot.imshow`."""
-        from matplotlib import animation, rcParams
-        from matplotlib.colors import to_rgba
-        import matplotlib.pyplot as plt
-
-        channels = ("red", "green", "blue", "rgb")
-        if channel not in channels:
-            raise ValueError(f"Channel should be {', '.join(channels[:-1])} or {channels[-1]}")
-
-        metadata = dict(title=self.name)
-        if "ffmpeg" in animation.writers:
-            writer = animation.writers["ffmpeg"](fps=fps, metadata=metadata)
-        elif "pillow" in animation.writers:
-            writer = animation.writers["pillow"](fps=fps, metadata=metadata)
-        else:
-            raise RuntimeError("You need either ffmpeg or pillow installed to export videos.")
-
-        start_frame = start_frame if start_frame else 0
-        end_frame = end_frame if end_frame else self.num_frames - 1
-
-        # On some notebook backends, figures render with a transparent background by default. This
-        # leads to very poor image quality, since it prevents font anti-aliasing (at the cost of
-        # not having transparent regions outside the axes part of figures).
-        face_color = rcParams["figure.facecolor"]
-        face_color_rgba = to_rgba(face_color)
-        if face_color_rgba[3] < 1.0:
-            rcParams["figure.facecolor"] = face_color_rgba[:3] + (1.0,)
-        else:
-            face_color = None
-
-        plot_func = lambda frame, image_handle: self.plot(
-            channel=channel,
-            frame=frame,
-            image_handle=image_handle,
-            adjustment=adjustment,
-            **kwargs,
-        )
-        image_handle = None
-
-        def plot(num):
-            nonlocal image_handle
-            image_handle = plot_func(frame=start_frame + num, image_handle=image_handle)
-            return plt.gca().get_children()
-
-        fig = plt.gcf()
-        line_ani = animation.FuncAnimation(
-            fig, plot, end_frame - start_frame, interval=1, blit=True
-        )
-        line_ani.save(file_name, writer=writer)
-        plt.close(fig)
-
-        if face_color:
-            rcParams["figure.facecolor"] = face_color
 
     @deprecated(
         reason=(

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -1,5 +1,6 @@
 import numpy as np
 from copy import copy
+from deprecated import deprecated
 
 from .adjustments import ColorAdjustment
 from .detail.confocal import ConfocalImage, linear_colormaps
@@ -278,13 +279,13 @@ class Scan(ConfocalImage):
 
         return image_handle
 
-    def _export_video(
+    def export_video(
         self,
-        plot_type,
+        channel,
         file_name,
-        start_frame,
-        end_frame,
-        fps,
+        start_frame=None,
+        end_frame=None,
+        fps=15,
         adjustment=ColorAdjustment.nothing(),
         **kwargs,
     ):
@@ -292,8 +293,8 @@ class Scan(ConfocalImage):
 
         Parameters
         ----------
-        plot_type : str
-            One of the plot types "red", "green", "blue" or "rgb".
+        channel : str
+            Color channel(s) to use "red", "green", "blue" or "rgb".
         file_name : str
             File name to export to.
         start_frame : int
@@ -309,6 +310,10 @@ class Scan(ConfocalImage):
         from matplotlib import animation, rcParams
         from matplotlib.colors import to_rgba
         import matplotlib.pyplot as plt
+
+        channels = ("red", "green", "blue", "rgb")
+        if channel not in channels:
+            raise ValueError(f"Channel should be {', '.join(channels[:-1])} or {channels[-1]}")
 
         metadata = dict(title=self.name)
         if "ffmpeg" in animation.writers:
@@ -332,7 +337,7 @@ class Scan(ConfocalImage):
             face_color = None
 
         plot_func = lambda frame, image_handle: self.plot(
-            channel=plot_type,
+            channel=channel,
             frame=frame,
             image_handle=image_handle,
             adjustment=adjustment,
@@ -355,6 +360,13 @@ class Scan(ConfocalImage):
         if face_color:
             rcParams["figure.facecolor"] = face_color
 
+    @deprecated(
+        reason=(
+            "This property will be removed in a future release. Use `export_video('rgb')` instead."
+        ),
+        action="always",
+        version="0.13.0",
+    )
     def export_video_rgb(
         self,
         file_name,
@@ -381,10 +393,17 @@ class Scan(ConfocalImage):
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`.
         """
-        self._export_video(
+        self.export_video(
             "rgb", file_name, start_frame, end_frame, fps, adjustment=adjustment, **kwargs
         )
 
+    @deprecated(
+        reason=(
+            "This property will be removed in a future release. Use `export_video('red')` instead."
+        ),
+        action="always",
+        version="0.13.0",
+    )
     def export_video_red(
         self,
         file_name,
@@ -411,10 +430,17 @@ class Scan(ConfocalImage):
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`.
         """
-        self._export_video(
+        self.export_video(
             "red", file_name, start_frame, end_frame, fps, adjustment=adjustment, **kwargs
         )
 
+    @deprecated(
+        reason=(
+            "This property will be removed in a future release. Use `export_video('green')` instead."
+        ),
+        action="always",
+        version="0.13.0",
+    )
     def export_video_green(
         self,
         file_name,
@@ -441,10 +467,17 @@ class Scan(ConfocalImage):
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`.
         """
-        self._export_video(
+        self.export_video(
             "green", file_name, start_frame, end_frame, fps, adjustment=adjustment, **kwargs
         )
 
+    @deprecated(
+        reason=(
+            "This property will be removed in a future release. Use `export_video('blue')` instead."
+        ),
+        action="always",
+        version="0.13.0",
+    )
     def export_video_blue(
         self,
         file_name,
@@ -471,6 +504,6 @@ class Scan(ConfocalImage):
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`.
         """
-        self._export_video(
+        self.export_video(
             "blue", file_name, start_frame, end_frame, fps, adjustment=adjustment, **kwargs
         )

--- a/lumicks/pylake/tests/test_imaging_camera/test_export.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_export.py
@@ -64,7 +64,7 @@ def test_stack_movie_export(
     for idx, filename in enumerate((rgb_tiff_file_multi, gray_tiff_file_multi)):
         stack = CorrelatedStack(str(filename))
         fn = f"{tmpdir}/cstack{idx}.gif"
-        stack.export_video("red", fn, 0, 2)
+        stack.export_video("red", fn, start_frame=0, stop_frame=2)
         assert stat(fn).st_size > 0
 
         with pytest.raises(ValueError, match="Channel should be red, green, blue or rgb"):

--- a/lumicks/pylake/tests/test_imaging_camera/test_export.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_export.py
@@ -52,3 +52,22 @@ def test_export_roi(rgb_tiff_file, rgb_tiff_file_multi, gray_tiff_file, gray_tif
             with pytest.warns(DeprecationWarning):
                 stack.export_tiff(savename, roi=[190, 10, 20, 80])
         stack.src.close()
+
+
+def test_stack_movie_export(
+    tmpdir_factory, rgb_tiff_file, rgb_tiff_file_multi, gray_tiff_file, gray_tiff_file_multi
+):
+    from os import stat
+
+    tmpdir = tmpdir_factory.mktemp("pylake")
+
+    for idx, filename in enumerate((rgb_tiff_file_multi, gray_tiff_file_multi)):
+        stack = CorrelatedStack(str(filename))
+        fn = f"{tmpdir}/cstack{idx}.gif"
+        stack.export_video("red", fn, 0, 2)
+        assert stat(fn).st_size > 0
+
+        with pytest.raises(ValueError, match="Channel should be red, green, blue or rgb"):
+            stack.export_video("gray", "dummy.gif")  # Gray is not a color!
+
+        stack.src.close()

--- a/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
@@ -265,14 +265,14 @@ def test_movie_export(tmpdir_factory, test_scans):
     tmpdir = tmpdir_factory.mktemp("pylake")
 
     scan = test_scans["fast Y slow X multiframe"]
-    scan.export_video("red", f"{tmpdir}/red.gif", 0, 2)
+    scan.export_video("red", f"{tmpdir}/red.gif", start_frame=0, stop_frame=2)
     assert stat(f"{tmpdir}/red.gif").st_size > 0
-    scan.export_video("rgb", f"{tmpdir}/rgb.gif", 0, 2)
+    scan.export_video("rgb", f"{tmpdir}/rgb.gif", start_frame=0, stop_frame=2)
     assert stat(f"{tmpdir}/rgb.gif").st_size > 0
 
-    # test end frame > num frames
+    # test stop frame > num frames
     with pytest.raises(IndexError):
-        scan.export_video("rgb", f"{tmpdir}/rgb.gif", 0, 4)
+        scan.export_video("rgb", f"{tmpdir}/rgb.gif", start_frame=0, stop_frame=4)
 
     with pytest.raises(ValueError, match="Channel should be red, green, blue or rgb"):
         scan.export_video("gray", "dummy.gif")  # Gray is not a color!
@@ -285,7 +285,9 @@ def test_deprecated_movie_export(tmpdir_factory, test_scans):
     scan = test_scans["fast Y slow X multiframe"]
     for channel in ("red", "green", "blue", "rgb"):
         with pytest.warns(DeprecationWarning):
-            getattr(scan, f"export_video_{channel}")(f"{tmpdir}/dep_{channel}.gif", 0, 2)
+            getattr(scan, f"export_video_{channel}")(
+                f"{tmpdir}/dep_{channel}.gif", start_frame=0, end_frame=2
+            )
             assert stat(f"{tmpdir}/dep_{channel}.gif").st_size > 0
 
 


### PR DESCRIPTION
**Why this PR?**
We want to homogenize the API between `Scan` and `CorrelatedStack`. This PR spins out the video export and makes it work for both `CorrelatedStack` (dealing with TIFF images) and `Scan` (dealing with confocal scans). I've also taken the liberty to fix a bug in the video export and simplify the disabling of the alpha transparency.

I've manually tested it with cropping, color adjustment, tiff alignment on/off on rgb stacks, single color stacks and confocal stacks.

![test_no_align](https://user-images.githubusercontent.com/19836026/181297264-33e29411-bdc8-4918-b624-fafc295fadf9.gif)

![test_gray](https://user-images.githubusercontent.com/19836026/181297237-e70c31cb-1984-42f1-91d5-57e63b95381e.gif)