### PR TITLE
Scan: support cropping.

### DIFF
--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -71,8 +71,32 @@ class CorrelatedStack(VideoExport):
         return self.src.with_roi(np.array([columns, rows]).flatten()), item[0]
 
     def __getitem__(self, item):
-        """All indexing is in frames"""
+        """Returns specific frame(s) and/or cropped stacks.
 
+        The first item refers to the camera frames; both indexing (by integer) and slicing are
+        allowed, but using steps or slicing by a list is not.
+        The last two items refer to the spatial dimensions in pixel rows and columns. Only full
+        slices (without steps) are allowed. All values should be given in pixels.
+
+        Examples
+        --------
+        ::
+
+            import lumicks.pylake as lk
+
+            stack = lk.CorrelatedStack("test.tiff")
+
+            stack[5]  # Gets the 6th frame of the scan (0 is the first).
+            stack[1:5]  # Get scan frames 1, 2, 3 and 4.
+            stack[:, 10:50, 20:50]  # Gets all frames cropped from row 11 to 50 and column 21 to 50.
+            stack[:, 10:50]  # Gets all frames and all columns, but crops from row 11 to 50.
+            stack[5, 10:20, 10:20]  # Obtains the 6th frame and crops it.
+
+            stack[[1, 3, 4]]  # Produces an error, lists are not allowed.
+            stack[1:5:2]  # Produces an error, steps are not allowed.
+            stack[1, 3, 5]   # Error, integer indices are not allowed for the spatial dimensions.
+            stack[1, 3:5:2]  # Produces an error, steps are not allowed when slicing.
+        """
         src, item = self._handle_cropping(item) if isinstance(item, tuple) else (self.src, item)
 
         if isinstance(item, slice):

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -213,13 +213,20 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
         raise NotImplementedError("Pixel dwell times have not been implemented for this class.")
 
     def __copy__(self):
-        return self.__class__(
+        instance = self.__class__(
             name=self.name,
             file=self._file,
             start=self.start,
             stop=self.stop,
             metadata=self._metadata,
         )
+
+        # Preserve custom factories
+        instance._image_factory = self._image_factory
+        instance._timestamp_factory = self._timestamp_factory
+        instance._pixelsize_factory = self._pixelsize_factory
+        instance._pixelcount_factory = self._pixelcount_factory
+        return instance
 
     def _get_photon_count(self, name):
         """Grab the portion of the photon count that overlaps with the scan."""

--- a/lumicks/pylake/tests/data/mock_confocal.py
+++ b/lumicks/pylake/tests/data/mock_confocal.py
@@ -102,9 +102,9 @@ def generate_image_data(image_data, samples_per_pixel, line_padding):
 class MockConfocalFile:
     def __init__(self, infowave, red_channel=None, blue_channel=None, green_channel=None):
         self.infowave = infowave
-        self.red_photon_count = red_channel
-        self.green_photon_count = green_channel
-        self.blue_photon_count = blue_channel
+        self.red_photon_count = red_channel if red_channel is not None else empty_slice
+        self.green_photon_count = green_channel if green_channel is not None else empty_slice
+        self.blue_photon_count = blue_channel if blue_channel is not None else empty_slice
 
     def __getitem__(self, key):
         if key == "Info wave":

--- a/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
@@ -328,11 +328,11 @@ def test_single_frame_times(dim_x, dim_y, line_padding, start, dt, samples_per_p
     [
         (5, 6, 3, 3, 14, 4, 4),
         (3, 4, 4, 60, 1592916040906356300, 12800, 30),
-        (3, 2, 2, 60, 1592916040906356300, 12800, 3000),
+        (3, 2, 3, 60, 1592916040906356300, 12800, 3000),
     ],
 )
 def test_multiple_frame_times(dim_x, dim_y, frames, line_padding, start, dt, samples_per_pixel):
-    img = np.ones((dim_x, dim_y, frames))
+    img = np.ones((frames, dim_x, dim_y))
     scan = generate_scan(
         "test",
         img,
@@ -345,6 +345,7 @@ def test_multiple_frame_times(dim_x, dim_y, frames, line_padding, start, dt, sam
     frame_times = scan.frame_timestamp_ranges()
 
     line_time = dt * (img.shape[2] * samples_per_pixel + 2 * line_padding) * img.shape[1]
+    assert scan.num_frames == frames
     assert len(frame_times) == scan.num_frames
     assert frame_times[0][0] == start + line_padding * dt
     assert frame_times[0][1] == start + line_time - line_padding * dt
@@ -487,6 +488,11 @@ def test_scan_pixel_time(test_scans, scan, pixel_time):
         (None, 3, None, 2),
         (0, None, 1, None),
         (1, 4, 1, 5),
+        (1, 3, None, None),
+        (None, None, 1, 3),
+        (1, 2, 1, 2),  # Single pixel
+        (1, 2, None, None),
+        (None, None, 1, 2),
     ],
 )
 def test_scan_cropping(x_min, x_max, y_min, y_max, test_scans):


### PR DESCRIPTION
**Why this PR?**
We offer the functionality to crop `CorrelatedStacks`, this PR introduces the same behaviour for `Scans`.

One thing to note is that I had to overhaul the slicing by frame to achieve the correct behaviour. Reason being that the old slicing relied on always reconstructing the array. Slicing by frame resetting the crop seems unacceptable to me, as I could see that to be a regular use case (crop first, select frames later).

This comes at a penalty, namely that reconstruction takes place for the entire image array when selecting a range of frames, whereas before, if you sliced frames, you would only reconstruct what you use. In practice, I think for most use cases, the change is still warranted for two reasons:

1. I think it is rare that you know exactly which frames you want in advance, meaning that you will end up reconstructing the whole array at first anyway. In this use case, the current implementation is actually _faster_ since it'll reuse the cache from that first reconstruction for your subsequent crops.
2. The slicing time is dominated by obtained the `frame_timestamp_ranges()` anyhow (which involves two `timestamp` reconstructions).

Note, `crop_by_pixels` is specifically made public API because it is used by some of our cropping widgets.