### PR TITLE
ci: exclude zenodo downloads from ci

### DIFF
--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -7,24 +7,29 @@ from .data.mock_fdcurve import generate_fdcurve_with_baseline_offset
 
 
 def pytest_addoption(parser):
-    parser.addoption(
-        "--runslow", action="store_true", default=False, help="run slow tests"
-    )
+    for option in ("slow", "preflight"):
+        parser.addoption(
+            f"--run{option}", action="store_true", default=False, help=f"run {option} tests"
+        )
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runslow"):
-        return
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
-    for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
+    for option in ("slow", "preflight"):
+        if config.getoption(f"--run{option}"):
+            continue
+        skip_slow = pytest.mark.skip(reason=f"need --run{option} option to run")
+        for item in items:
+            if option in item.keywords:
+                item.add_marker(skip_slow)
 
 
 def pytest_configure(config):
     # Use a headless backend for testing
     plt.switch_backend('agg')
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line(
+        "markers", "preflight: mark preflight tests which should only be run manually"
+    )
 
 
 @pytest.fixture(scope="session")

--- a/lumicks/pylake/tests/test_file_download.py
+++ b/lumicks/pylake/tests/test_file_download.py
@@ -7,7 +7,7 @@ from lumicks.pylake.file_download import (
 )
 
 
-@pytest.mark.slow
+@pytest.mark.preflight
 def test_grab_record():
     assert get_url_from_doi("10.5281/zenodo.4247279") == "https://zenodo.org/record/4247279"
 
@@ -15,7 +15,7 @@ def test_grab_record():
         assert get_url_from_doi("10.55281/zenodo.4247279")
 
 
-@pytest.mark.slow
+@pytest.mark.preflight
 def test_download_record_metadata():
     record = download_record_metadata("4280789")  # Older version of Pylake
 
@@ -25,13 +25,13 @@ def test_download_record_metadata():
     assert record["files"][0]["links"]["self"].startswith("https://zenodo.org/")  # Link may change
 
 
-@pytest.mark.slow
+@pytest.mark.preflight
 def test_non_zenodo_doi():
     with pytest.raises(RuntimeError, match="Only Zenodo DOIs are supported"):
         assert download_from_doi("https://doi.org/10.1109/5.771073")
 
 
-@pytest.mark.slow
+@pytest.mark.preflight
 def test_download_from_doi(tmpdir_factory):
     tmpdir = tmpdir_factory.mktemp("download_testing")
     record = download_record_metadata("4247279")

--- a/release.md
+++ b/release.md
@@ -6,6 +6,7 @@
 - Review the changelog. Make sure everything is clear and informative for users.
 - Bump the version number in `__about__.py`.
 - Check whether any dependencies have changed.
+- Run `pytest` with `pytest --runpreflight --runslow` and verify that all tests pass (none may be skipped).
 
 ## Releasing
 


### PR DESCRIPTION
**Why this PR?**
The ci tests for the download of files from Zenodo are brittle and fail when there is a timeout. This is annoying. I propose disabling these tests on ci, but adding a step to the release procedure to run them on demand.