### PR TITLE
Lazily load `TimeSeries` `data` and `timestamps`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 * Made piezo tracking functionality public and added [piezo tracking tutorial](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/piezotracking.html).
 * Added support for steps when slicing frames from `CorrelatedStack`s.
 * Added `CorrelatedStack.export_video()` to export videos to export multi-frame videos to video formats or GIFs.
+* Lazily load `data` and `timestamps` for `TimeSeries` data
 
 #### Bug fixes
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.typing as npt
 import numbers
 
 from .detail.utilities import downsample
@@ -176,12 +177,12 @@ class Slice:
         return self._src.stop
 
     @property
-    def data(self):
+    def data(self) -> npt.ArrayLike:
         """The primary values of this channel slice"""
         return self._src.data
 
     @property
-    def timestamps(self):
+    def timestamps(self) -> npt.ArrayLike:
         """Absolute timestamps (since epoch) which correspond to the channel data"""
         return self._src.timestamps
 
@@ -495,13 +496,13 @@ class Continuous:
         )
 
     @property
-    def data(self):
+    def data(self) -> npt.ArrayLike:
         if self._cached_data is None:
             self._cached_data = np.asarray(self._src_data)
         return self._cached_data
 
     @property
-    def timestamps(self):
+    def timestamps(self) -> npt.ArrayLike:
         return np.arange(self.start, self.stop, self.dt)
 
     @property
@@ -545,9 +546,10 @@ class TimeSeries:
 
     def __init__(self, data, timestamps):
         assert len(data) == len(timestamps)
-        # TODO: should be lazily evaluated
-        self.data = np.asarray(data)
-        self.timestamps = np.asarray(timestamps)
+        self._src_data = data
+        self._cached_data = None
+        self._src_timestamps = timestamps
+        self._cached_timestamps = None
 
     def __len__(self):
         return len(self.data)
@@ -567,6 +569,18 @@ class TimeSeries:
             labels={"title": dset.name.strip("/"), "y": y_label},
             calibration=calibration,
         )
+
+    @property
+    def data(self) -> npt.ArrayLike:
+        if self._cached_data is None:
+            self._cached_data = np.asarray(self._src_data)
+        return self._cached_data
+
+    @property
+    def timestamps(self) -> npt.ArrayLike:
+        if self._cached_timestamps is None:
+            self._cached_timestamps = np.asarray(self._src_timestamps)
+        return self._cached_timestamps
 
     @property
     def start(self):
@@ -626,7 +640,7 @@ class TimeTags:
         return Slice(TimeTags(dset))
 
     @property
-    def timestamps(self):
+    def timestamps(self) -> npt.ArrayLike:
         # For time tag data, the data is the timestamps!
         return self.data
 
@@ -653,11 +667,11 @@ class Empty:
         return 0
 
     @property
-    def data(self):
+    def data(self) -> npt.ArrayLike:
         return np.empty(0)
 
     @property
-    def timestamps(self):
+    def timestamps(self) -> npt.ArrayLike:
         return np.empty(0)
 
     @property


### PR DESCRIPTION
**Why this PR?**
Found a comment in the source code stating that `data` and `timestamps` should be lazily loaded and took this as an opportunity to implement it.