### PR TITLE
correlated_stack: change `frame_timestamp_ranges` to method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 #### Breaking changes
 
 * Changed default in `lk.calibrate_force()` to 38 Hz.
+* `CorrelatedStack.frame_timestamp_ranges()` is now a method rather than a property. This was done for API consistency with the API for `Scan`. Please refer to [Correlated stacks](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/correlatedstacks.html#correlated-stacks) for more information.
 * To disable image alignment for `lk.CorrelatedStack`, the alignment argument has to be provided as a keyword argument (e.g. `lk.CorrelatedStack("filename.tiff", align=False)` rather than `lk.CorrelatedStack("filename.tiff", False)`).
 * Changed the error type when attempting to access undefined per-pixel timestamps in `Kymo` from `AttributeError` to `NotImplementedError`.
 * Made `KymoWidget.algorithm_parameters` a private attribute.

--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,7 @@
 #### Deprecations
 
 * Deprecated `export_video_red()`, `export_video_green()`, `export_video_blue()`, and `export_video_rgb()` methods for `Scan`. These methods have been replaced with a single `export_video(channel=color)` method.
+* In the functions `Scan.frame_timestamp_ranges()` and `Kymo.line_timestamp_ranges()`, the parameter `exclude` was deprecated in favor of `include_dead_time` for clarity.
 
 ## v0.12.1 | 2022-06-21
 

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -121,6 +121,6 @@ using timestamps obtained from the `CorrelatedStack`::
     file.force1x.downsampled_over(stack[2:10].frame_timestamp_ranges())
 
 By default, this averages only over the exposure time of the images in the stack.
-If you wish to average over the full time range from the start of the scan to the next scan, pass the extra parameter `exclude=False`::
+If you wish to average over the full time range from the start of the scan to the next scan, pass the extra parameter `include_dead_time=True`::
 
-    file.force1x.downsampled_over(stack[2:10].frame_timestamp_ranges(exclude=False))
+    file.force1x.downsampled_over(stack[2:10].frame_timestamp_ranges(include_dead_time=True))

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -118,4 +118,9 @@ downsampled over the video frames. This can be done using the function `Slice.do
 using timestamps obtained from the `CorrelatedStack`::
 
     # Determine the force trace averaged over frame 2...9.
-    file.force1x.downsampled_over(stack[2:10].frame_timestamp_ranges)
+    file.force1x.downsampled_over(stack[2:10].frame_timestamp_ranges())
+
+By default, this averages only over the exposure time of the images in the stack.
+If you wish to average over the full time range from the start of the scan to the next scan, pass the extra parameter `exclude=False`::
+
+    file.force1x.downsampled_over(stack[2:10].frame_timestamp_ranges(exclude=False))

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -242,7 +242,7 @@ class Slice:
 
             file = pylake.File("example.h5")
             stack = pylake.CorrelatedStack("example.tiff")
-            file.force1x.downsampled_over(stack.frame_timestamp_ranges)
+            file.force1x.downsampled_over(stack.frame_timestamp_ranges())
         """
         if not isinstance(range_list, list):
             raise TypeError("Did not pass timestamps to range_list.")

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -495,18 +495,16 @@ class CorrelatedStack(VideoExport):
     def timestamps(self):
         return self.frame_timestamp_ranges()
 
-    def frame_timestamp_ranges(self, exclude=True):
+    def frame_timestamp_ranges(self, *, include_dead_time=False):
         """Get start and stop timestamp of each frame in the stack.
 
         Parameters
         ----------
-        exclude : bool
-            Exclude dead time at the end of each frame.
+        include_dead_time : bool
+            Include dead time between frames.
         """
         ts_ranges = [frame.frame_timestamp_range for frame in self]
-        if exclude:
-            return ts_ranges
-        else:
+        if include_dead_time:
             frame_ts = [
                 (leading[0], trailing[0]) for leading, trailing in zip(ts_ranges, ts_ranges[1:])
             ]
@@ -517,3 +515,5 @@ class CorrelatedStack(VideoExport):
                 stop = ts_ranges[-1][1]
             frame_ts.append((ts_ranges[-1][0], stop))
             return frame_ts
+        else:
+            return ts_ranges

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -755,7 +755,7 @@ def _kymo_from_correlated_stack(
         :func:`numpy.mean`, but :func:`numpy.max` could also be appropriate for some cases.
     """
     # Ensure constant frame rate of the whole stack
-    ts_ranges = np.array(corrstack.frame_timestamp_ranges)
+    ts_ranges = np.array(corrstack.frame_timestamp_ranges())
     line_times = np.diff(ts_ranges[:, 0])
     line_time = line_times[0]
     if not np.all(line_times == line_time):

--- a/lumicks/pylake/tests/test_imaging_camera/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_correlated_stack.py
@@ -929,7 +929,7 @@ def test_alignment_multistack(rgb_alignment_image_data, gray_alignment_image_dat
     assert full_stack.num_frames == len(ref_ts)
 
 
-def test_frame_timestamp_ranges_exclude_false():
+def test_frame_timestamp_ranges_include_true():
     stack = CorrelatedStack.from_dataset(
         TiffStack(
             [MockTiffFile(data=[np.ones((5, 5))] * 4, times=make_frame_times(4, step=6))],
@@ -937,11 +937,11 @@ def test_frame_timestamp_ranges_exclude_false():
         )
     )
 
-    for exclude, ranges in zip(
-            [False, True],
+    for include, ranges in zip(
+            [True, False],
             [[(10, 20), (20, 30), (30, 40), (40, 50)], [(10, 16), (20, 26), (30, 36), (40, 46)]],
     ):
-        np.testing.assert_allclose(stack.frame_timestamp_ranges(exclude=exclude), ranges)
+        np.testing.assert_allclose(stack.frame_timestamp_ranges(include_dead_time=include), ranges)
 
 
 def test_frame_timestamp_ranges_snapshot():
@@ -952,5 +952,5 @@ def test_frame_timestamp_ranges_snapshot():
         )
     )
 
-    for exclude, ranges in zip([False, True], [[(10, 16)], [(10, 16)]]):
-        np.testing.assert_allclose(stack.frame_timestamp_ranges(exclude=exclude), ranges)
+    for include, ranges in zip([True, False], [[(10, 16)], [(10, 16)]]):
+        np.testing.assert_allclose(stack.frame_timestamp_ranges(include_dead_time=include), ranges)

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
@@ -15,7 +15,7 @@ colors = ("red", "green", "blue")
 
 def make_kymo_from_array(kymo, image, color_format, no_pxsize=False):
     start = kymo._timestamps("timestamps", np.min)[0, 0]
-    exposure_time_sec = np.diff(kymo.line_timestamp_ranges(exclude=True)[0])[0] * 1e-9
+    exposure_time_sec = np.diff(kymo.line_timestamp_ranges(include_dead_time=False)[0])[0] * 1e-9
 
     return _kymo_from_array(
         image,
@@ -40,10 +40,12 @@ def test_from_array(test_kymos):
 
     np.testing.assert_equal(kymo.line_time_seconds, arr_kymo.line_time_seconds)
     np.testing.assert_equal(
-        kymo.line_timestamp_ranges(exclude=True), arr_kymo.line_timestamp_ranges(exclude=True)
+        kymo.line_timestamp_ranges(include_dead_time=False),
+        arr_kymo.line_timestamp_ranges(include_dead_time=False)
     )
     np.testing.assert_equal(
-        kymo.line_timestamp_ranges(exclude=False), arr_kymo.line_timestamp_ranges(exclude=False)
+        kymo.line_timestamp_ranges(include_dead_time=True),
+        arr_kymo.line_timestamp_ranges(include_dead_time=True)
     )
 
     np.testing.assert_equal(kymo.pixelsize_um, arr_kymo.pixelsize_um)
@@ -92,10 +94,12 @@ def test_from_array_no_pixelsize(test_kymos):
 
     np.testing.assert_equal(kymo.line_time_seconds, arr_kymo.line_time_seconds)
     np.testing.assert_equal(
-        kymo.line_timestamp_ranges(exclude=True), arr_kymo.line_timestamp_ranges(exclude=True)
+        kymo.line_timestamp_ranges(include_dead_time=False),
+        arr_kymo.line_timestamp_ranges(include_dead_time=False)
     )
     np.testing.assert_equal(
-        kymo.line_timestamp_ranges(exclude=False), arr_kymo.line_timestamp_ranges(exclude=False)
+        kymo.line_timestamp_ranges(include_dead_time=True),
+        arr_kymo.line_timestamp_ranges(include_dead_time=True)
     )
 
     assert arr_kymo.pixelsize_um == [None]


### PR DESCRIPTION
**Why this PR?**
API uniformity basically. This way, it provides the exact same API as we have on `Scan` leading to fewer surprises for the user.