### PR TITLE
Confocal / CorrelatedStack: make tiff export API more homogeneous

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 * It is now mandatory to supply a `sample_rate` when calling `lumicks.pylake.force_calibration.touchdown.touchdown()`.
 * Removed public attributes `CorrelatedStack.start_idx` and `CorrelatedStack.stop_idx` and made them protected.
 * The property `sample_rate` of `Continuous` data now returns a `float` instead of an `int``
+* Removed deprecated argument `roi` from `CorrelatedStack.export_tiff`. Use `CorrelatedStack.crop_by_pixels()` to select the ROI before exporting.
 
 #### Deprecations
 

--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,7 @@
 #### Deprecations
 
 * Deprecated `export_video_red()`, `export_video_green()`, `export_video_blue()`, and `export_video_rgb()` methods for `Scan`. These methods have been replaced with a single `export_video(channel=color)` method.
+* `Scan.save_tiff()` and `Kymo.save_tiff()` were deprecated and replaced with `Scan.export_tiff()` and `Kymo.export_tiff()` to more clearly communicate that the data is exported to a different format.
 * In the functions `Scan.frame_timestamp_ranges()` and `Kymo.line_timestamp_ranges()`, the parameter `exclude` was deprecated in favor of `include_dead_time` for clarity.
 
 ## v0.12.1 | 2022-06-21

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -107,7 +107,7 @@ The limits can also be specified in percentiles when this is more practical::
 
 The images can also be exported in the TIFF format::
 
-    scan.save_tiff("image.tiff")
+    scan.export_tiff("image.tiff")
 
 Scans can also be exported to video formats.
 Exporting the red channel of a multi-scan GIF can be done as follows for example::

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -33,7 +33,7 @@ Note also, the axes are labeled with the appropriate time and position units.
 
 The kymograph can also be exported to TIFF format::
 
-    kymo.save_tiff("image.tiff")
+    kymo.export_tiff("image.tiff")
 
 Kymo data and details
 ---------------------
@@ -166,7 +166,7 @@ There are also convenience functions to plot individual color channels and the f
 
 The images can also be exported in the TIFF format::
 
-    kymo.save_tiff("image.tiff")
+    kymo.export_tiff("image.tiff")
 
 Correlating with force
 ----------------------

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -407,16 +407,13 @@ class CorrelatedStack(VideoExport):
             post_update=post_update,
         )
 
-    def export_tiff(self, file_name, roi=None):
+    def export_tiff(self, file_name):
         """Export a video of a particular scan plot
 
         Parameters
         ----------
         file_name : str
             File name to export to.
-        roi : list_like
-            region of interest in pixel values [xmin, xmax, ymin, ymax]
-            *Deprecated since v0.10.1* Instead, use `CorrelatedStack.crop_by_pixels()` to select the ROI before exporting."
         """
         from . import __version__ as version
 
@@ -440,31 +437,18 @@ class CorrelatedStack(VideoExport):
 
             return (orientation, sample_format, datetime)
 
-        # crop to ROI if applicable
-        if roi is not None:
-            warnings.warn(
-                (
-                    "The `roi` argument is deprecated since v0.10.1 "
-                    "Instead, use `CorrelatedStack.crop_by_pixels()` to select the ROI before exporting."
-                ),
-                DeprecationWarning,
-            )
-            to_save = self.crop_by_pixels(*roi)
-        else:
-            to_save = self
-
         # re-name alignment matrices fields in image description
         # to reflect the fact that the image has already been processed
-        description = to_save.src._description.for_export
+        description = self.src._description.for_export
 
         # add pylake to Software tag
-        software = to_save.src._description.software
+        software = self.src._description.software
         if "pylake" not in software:
             software += f", pylake v{version}"
 
         # write frames sequentially
         with tifffile.TiffWriter(file_name) as tif:
-            for frame in to_save:
+            for frame in self:
                 tif.write(
                     frame.data,
                     description=description,

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -385,7 +385,7 @@ class ConfocalImage(BaseScan):
 
         return frame_image
 
-    def export_tiff(self, filename, dtype=np.float32, clip=False):
+    def export_tiff(self, filename, *, dtype=np.float32, clip=False):
         """Save the RGB photon counts to a TIFF image
 
         Parameters
@@ -427,7 +427,7 @@ class ConfocalImage(BaseScan):
         version="0.13.0",
     )
     def save_tiff(self, filename, dtype=np.float32, clip=False):
-        return self.export_tiff(filename, dtype, clip)
+        return self.export_tiff(filename, dtype=dtype, clip=clip)
 
     save_tiff.__doc__ = export_tiff.__doc__
 

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -385,7 +385,7 @@ class ConfocalImage(BaseScan):
 
         return frame_image
 
-    def save_tiff(self, filename, dtype=np.float32, clip=False):
+    def export_tiff(self, filename, dtype=np.float32, clip=False):
         """Save the RGB photon counts to a TIFF image
 
         Parameters
@@ -417,6 +417,19 @@ class ConfocalImage(BaseScan):
             )
         else:
             raise RuntimeError("Can't export TIFF if there are no pixels")
+
+    @deprecated(
+        reason=(
+            "This method has been renamed to `export_tiff` to more accurately reflect that it is "
+            "exporting to a different format."
+        ),
+        action="always",
+        version="0.13.0",
+    )
+    def save_tiff(self, filename, dtype=np.float32, clip=False):
+        return self.export_tiff(filename, dtype, clip)
+
+    save_tiff.__doc__ = export_tiff.__doc__
 
     @property
     def infowave(self):

--- a/lumicks/pylake/tests/test_imaging_camera/test_export.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_export.py
@@ -35,22 +35,15 @@ def test_export_roi(rgb_tiff_file, rgb_tiff_file_multi, gray_tiff_file, gray_tif
 
     for filename in (rgb_tiff_file, rgb_tiff_file_multi, gray_tiff_file, gray_tiff_file_multi):
         savename = str(filename.new(purebasename=f"roi_out_{filename.purebasename}"))
-        stack = CorrelatedStack(str(filename))
-        with pytest.warns(DeprecationWarning):
-            stack.export_tiff(savename, roi=[10, 190, 20, 80])
+        stack = CorrelatedStack(str(filename))[:, 20:80, 10:190]
+
+        stack.export_tiff(savename)
         assert stat(savename).st_size > 0
 
         with tifffile.TiffFile(savename) as tif:
             assert tif.pages[0].tags["ImageWidth"].value == 180
             assert tif.pages[0].tags["ImageLength"].value == 60
 
-        with pytest.raises(ValueError):
-            with pytest.warns(DeprecationWarning):
-                stack.export_tiff(savename, roi=[-10, 190, 20, 80])
-
-        with pytest.raises(ValueError):
-            with pytest.warns(DeprecationWarning):
-                stack.export_tiff(savename, roi=[190, 10, 20, 80])
         stack.src.close()
 
 

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -111,7 +111,7 @@ def test_kymo_slicing(test_kymos):
         empty_kymograph.timestamps
 
     with pytest.raises(RuntimeError):
-        empty_kymograph.save_tiff("test")
+        empty_kymograph.export_tiff("test")
 
     with pytest.raises(RuntimeError):
         empty_kymograph.plot_rgb()
@@ -366,8 +366,12 @@ def test_save_tiff(tmpdir_factory, test_kymos):
     tmpdir = tmpdir_factory.mktemp("pylake")
 
     kymo = test_kymos["Kymo1"]
-    kymo.save_tiff(f"{tmpdir}/kymo1.tiff")
+    kymo.export_tiff(f"{tmpdir}/kymo1.tiff")
     assert stat(f"{tmpdir}/kymo1.tiff").st_size > 0
+
+    with pytest.warns(DeprecationWarning, match="This method has been renamed to `export_tiff`"):
+        kymo.save_tiff(f"{tmpdir}/kymo2.tiff")
+        assert stat(f"{tmpdir}/kymo2.tiff").st_size > 0
 
 
 def test_downsampled_kymo():

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
@@ -78,7 +78,7 @@ def test_save_tiff(tmpdir_factory, test_kymos):
         arr_kymo = make_kymo_from_array(kymo, kymo.get_image("rgb"), "rgb", no_pxsize=no_pxsize)
 
         with pytest.warns(UserWarning):
-            arr_kymo.save_tiff(f"{tmpdir}/kymo1.tiff")
+            arr_kymo.export_tiff(f"{tmpdir}/kymo1.tiff")
             assert stat(f"{tmpdir}/kymo1.tiff").st_size > 0
 
 

--- a/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
@@ -247,18 +247,23 @@ def test_deprecated_plotting(test_scans):
         scan.plot_rgb()
 
 
-def test_save_tiff(tmpdir_factory, test_scans):
+def test_export_tiff(tmpdir_factory, test_scans):
     from os import stat
 
     tmpdir = tmpdir_factory.mktemp("pylake")
 
     scan = test_scans["fast Y slow X"]
-    scan.save_tiff(f"{tmpdir}/single_frame.tiff")
+    scan.export_tiff(f"{tmpdir}/single_frame.tiff")
     assert stat(f"{tmpdir}/single_frame.tiff").st_size > 0
 
     scan = test_scans["fast Y slow X multiframe"]
-    scan.save_tiff(f"{tmpdir}/multi_frame.tiff")
+    scan.export_tiff(f"{tmpdir}/multi_frame.tiff")
     assert stat(f"{tmpdir}/multi_frame.tiff").st_size > 0
+
+    scan = test_scans["fast Y slow X"]
+    with pytest.warns(DeprecationWarning, match="This method has been renamed to `export_tiff`"):
+        scan.save_tiff(f"{tmpdir}/single_frame_dep.tiff")
+        assert stat(f"{tmpdir}/single_frame_dep.tiff").st_size > 0
 
 
 def test_movie_export(tmpdir_factory, test_scans):


### PR DESCRIPTION
**Why this PR?**
It homogenizes the API for tiff export between scan and confocal. It also removes some deprecated code.

I've also taken the liberty of enforcing keyword arguments for the more rarely used arguments of `export_tiff`. Reason being that they are not frequently used and have meanings which are difficult to glance from their values if used positionally. Also, more important arguments may be added in the future, and we might want to reserve earlier positions for those.