### PR TITLE
Scan/Kymo: add shape property to `Scan` and `Kymo`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 * Added `CorrelatedStack.export_video()` to export videos to export multi-frame videos to video formats or GIFs.
 * Lazily load `data` and `timestamps` for `TimeSeries` data
 * Added possibility to access property `sample_rate` for `TimeSeries` data with constant sample rate.
+* Added shape property to `Scan` and `Kymo`.
 
 #### Bug fixes
 

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -531,15 +531,6 @@ class ConfocalImage(BaseScan):
             The color channel of the requested data.
         """
         if channel == "rgb":
-            images = [self.get_image(color) for color in ("red", "green", "blue")]
-            try:
-                # Get first non-zero shape
-                image_shape = next(image.shape for image in images if image.size)
-                return np.stack(
-                    [image if image.size else np.zeros(image_shape) for image in images],
-                    axis=-1,
-                )
-            except StopIteration:
-                raise ValueError("No image data available")
+            return np.stack([self.get_image(color) for color in ("red", "green", "blue")], axis=-1)
         else:
             return self._image(channel)

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -209,7 +209,9 @@ class Kymo(ConfocalImage):
         return data.T
 
     @property
-    def _shape(self):
+    def _reconstruction_shape(self):
+        """Shape used when reconstructing the image from raw photon counts (ordered by axis scan
+        speed slow to fast)."""
         return (self.pixels_per_line,)
 
     @property

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -623,7 +623,6 @@ class EmptyKymo(Kymo):
         return np.empty(shape)
 
     def get_image(self, channel="rgb"):
-        im = self._image(channel)
         return self._image(channel)
 
     @property

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -94,14 +94,7 @@ class Scan(ConfocalImage, VideoExport):
             )
 
         def image_factory(_, channel):
-            img = self._image(channel)
-
-            # Early out if this color channel is missing (slicing will otherwise fail) and
-            # we need to handle this gracefully because of files with missing color channels
-            if not img.size:
-                return img
-
-            return img[slices]
+            return self._image(channel)[slices]
 
         def timestamp_factory(_, reduce_timestamps):
             ts = self._timestamps("timestamps", reduce_timestamps)

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -352,7 +352,15 @@ class Scan(ConfocalImage, VideoExport):
 
     @property
     def _shape(self):
+        # Note that this is not the shape of the image property, but rather the shape in terms of
+        # [slow axis, fast axis].
         return (self.lines_per_frame, self.pixels_per_line)
+
+    @property
+    def shape(self):
+        """Shape of the reconstructed `Scan` image"""
+        shape = reversed(self._num_pixels)
+        return (self.num_frames, *shape, 3) if self.num_frames > 1 else (*shape, 3)
 
     def _fix_incorrect_start(self):
         """Resolve error when confocal scan starts before the timeline information.

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -344,9 +344,9 @@ class Scan(ConfocalImage, VideoExport):
         return self._num_pixels[self._metadata.scan_order[1]]
 
     @property
-    def _shape(self):
-        # Note that this is not the shape of the image property, but rather the shape in terms of
-        # [slow axis, fast axis].
+    def _reconstruction_shape(self):
+        """Shape used when reconstructing the image from raw photon counts (ordered by axis scan
+        speed slow to fast)."""
         return (self.lines_per_frame, self.pixels_per_line)
 
     @property

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -510,6 +510,7 @@ def test_downsampled_kymo_both_axes():
     for kymo_ds in downsampled_kymos:
         assert kymo_ds.name == "Mock"
         np.testing.assert_allclose(kymo_ds.get_image("red"), ds)
+        np.testing.assert_allclose(kymo_ds.get_image("green"), np.zeros(ds.shape))  # missing
         np.testing.assert_allclose(kymo_ds.start, 100)
         np.testing.assert_allclose(kymo_ds.pixelsize_um, 2 / 1000)
         np.testing.assert_allclose(kymo_ds.pixelsize, 2 / 1000)
@@ -595,8 +596,14 @@ def test_kymo_crop():
         line_padding=2
     )
     cropped = kymo.crop_by_distance(4e-3, 8e-3)
-    np.testing.assert_allclose(cropped.get_image("red"),  [[12.0,  0.0,  0.0,  0.0, 12.0,  6.0,  0.0],
-                                                           [0.0, 12.0, 12.0, 12.0,  0.0,  6.0,  0.0]])
+    ref_img = np.array([
+        [12.0,  0.0,  0.0,  0.0, 12.0,  6.0,  0.0],
+        [0.0, 12.0, 12.0, 12.0,  0.0,  6.0,  0.0]
+    ])
+    np.testing.assert_allclose(cropped.get_image("red"), ref_img)
+    np.testing.assert_allclose(cropped.get_image("rgb")[:, :, 0], ref_img)
+    np.testing.assert_allclose(cropped.get_image("rgb")[:, :, 1], np.zeros(ref_img.shape))
+    np.testing.assert_allclose(cropped.get_image("green"), np.zeros(ref_img.shape))  # missing
     np.testing.assert_equal(
         cropped.timestamps,
         with_offset([[170, 315, 460, 605, 750, 895, 1040], [195, 340, 485, 630, 775, 920, 1065]]),

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -28,6 +28,7 @@ def test_kymo_properties(test_kymos):
     assert repr(kymo) == "Kymo(pixels=5)"
     assert kymo.pixels_per_line == 5
     assert len(kymo.infowave) == 64
+    assert kymo.shape == (5, 4, 3)
     assert kymo.get_image("rgb").shape == (5, 4, 3)
     assert kymo.get_image("red").shape == (5, 4)
     assert kymo.get_image("blue").shape == (5, 4)
@@ -57,6 +58,7 @@ def test_kymo_slicing(test_kymos):
     kymo_reference = np.transpose([[2, 0, 0, 0, 2], [0, 0, 0, 0, 0], [1, 0, 0, 0, 1], [0, 1, 1, 1, 0]])
 
     assert kymo.get_image("red").shape == (5, 4)
+    assert kymo.shape == (5, 4, 3)
     np.testing.assert_allclose(kymo.get_image("red").data, kymo_reference)
 
     sliced = kymo[:]
@@ -65,6 +67,7 @@ def test_kymo_slicing(test_kymos):
 
     sliced = kymo["1s":]
     assert sliced.get_image("red").shape == (5, 3)
+    assert sliced.shape == (5, 3, 3)
     np.testing.assert_allclose(sliced.get_image("red").data, kymo_reference[:, 1:])
 
     sliced = kymo["0s":]
@@ -73,6 +76,7 @@ def test_kymo_slicing(test_kymos):
 
     sliced = kymo["0s":"2s"]
     assert sliced.get_image("red").shape == (5, 2)
+    assert sliced.shape == (5, 2, 3)
     np.testing.assert_allclose(sliced.get_image("red").data, kymo_reference[:, :2])
 
     sliced = kymo["0s":"-1s"]
@@ -89,10 +93,12 @@ def test_kymo_slicing(test_kymos):
 
     sliced = kymo["1s":"2s"]
     assert sliced.get_image("red").shape == (5, 1)
+    assert sliced.shape == (5, 1, 3)
     np.testing.assert_allclose(sliced.get_image("red").data, kymo_reference[:, 1:2])
 
     sliced = kymo["0s":"10s"]
     assert sliced.get_image("red").shape == (5, 4)
+    assert sliced.shape == (5, 4, 3)
     np.testing.assert_allclose(sliced.get_image("red").data, kymo_reference[:, 0:10])
 
     with pytest.raises(IndexError):
@@ -118,6 +124,7 @@ def test_kymo_slicing(test_kymos):
 
     assert empty_kymograph.get_image("red").shape == (5, 0)
     assert empty_kymograph.infowave.data.size == 0
+    assert empty_kymograph.shape == (5, 0, 3)
     assert empty_kymograph.pixels_per_line == 5
     assert empty_kymograph.get_image("red").size == 0
     assert empty_kymograph.get_image("rgb").size == 0
@@ -408,6 +415,7 @@ def test_downsampled_kymo():
 
     assert kymo_ds.name == "Mock"
     np.testing.assert_allclose(kymo_ds.get_image("red"), ds)
+    np.testing.assert_allclose(kymo_ds.shape, kymo_ds.get_image("rgb").shape)
     np.testing.assert_allclose(kymo_ds.start, with_offset(0))
     np.testing.assert_allclose(kymo_ds.pixelsize_um, 1 / 1000)
     np.testing.assert_allclose(kymo_ds.pixelsize, 1 / 1000)

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
@@ -33,7 +33,7 @@ def test_from_array(test_kymos):
     arr_kymo = make_kymo_from_array(kymo, kymo.get_image("rgb"), "rgb")
 
     np.testing.assert_equal(kymo.get_image("rgb"), arr_kymo.get_image("rgb"))
-    np.testing.assert_equal(kymo._shape, arr_kymo._shape)
+    np.testing.assert_equal(kymo._reconstruction_shape, arr_kymo._reconstruction_shape)
 
     with pytest.raises(NotImplementedError, match=timestamp_err_msg):
         arr_kymo.pixel_time_seconds
@@ -87,7 +87,7 @@ def test_from_array_no_pixelsize(test_kymos):
     arr_kymo = make_kymo_from_array(kymo, kymo.get_image("rgb"), "rgb", no_pxsize=True)
 
     np.testing.assert_equal(kymo.get_image("rgb"), arr_kymo.get_image("rgb"))
-    np.testing.assert_equal(kymo._shape, arr_kymo._shape)
+    np.testing.assert_equal(kymo._reconstruction_shape, arr_kymo._reconstruction_shape)
 
     with pytest.raises(NotImplementedError, match=timestamp_err_msg):
         arr_kymo.pixel_time_seconds

--- a/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
@@ -521,6 +521,7 @@ def test_scan_cropping(x_min, x_max, y_min, y_max, test_scans):
 
         cropped_scan = scan.crop_by_pixels(x_min, x_max, y_min, y_max)
         np.testing.assert_allclose(cropped_scan.timestamps, scan.timestamps[numpy_slice])
+        np.testing.assert_allclose(cropped_scan.shape, scan.get_image("rgb")[numpy_slice].shape)
         np.testing.assert_allclose(scan[all_slices].timestamps, scan.timestamps[numpy_slice])
 
         for channel in ("rgb", "green"):
@@ -571,10 +572,12 @@ def test_scan_get_item_slicing(all_slices, test_scans):
         slices = tuple(all_slices if scan.num_frames > 1 else all_slices[1:])
         cropped_scan = scan[all_slices]
         np.testing.assert_allclose(cropped_scan.timestamps, scan.timestamps[slices])
+        np.testing.assert_allclose(cropped_scan.shape, scan.get_image("rgb")[slices].shape)
 
         for channel in ("rgb", "green"):
             ref_img = scan.get_image(channel)[slices]
             np.testing.assert_allclose(cropped_scan.get_image(channel), ref_img)
+
         # Numpy array is given as Y, X, while number of pixels is given sorted by spatial axis
         # i.e. X, Y
         np.testing.assert_allclose(
@@ -600,6 +603,7 @@ def test_slicing_cropping_separate_actions(test_scans):
     def assert_equal(first, second):
         np.testing.assert_allclose(first.get_image("red"), second.get_image("red"))
         np.testing.assert_allclose(first.get_image("rgb"), second.get_image("rgb"))
+        np.testing.assert_allclose(first.get_image("rgb").shape, second.get_image("rgb").shape)
         assert first.num_frames == second.num_frames
         assert first._num_pixels == second._num_pixels
 

--- a/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
@@ -113,7 +113,8 @@ def test_scan_attrs(test_scans):
     rgb = scan.get_image("rgb")
     assert rgb.shape == (4, 5, 3)
     assert not np.any(rgb[:, :, 0])
-    assert scan.get_image("red").shape == (0,)
+    np.testing.assert_equal(scan.get_image("red"), np.zeros((4, 5)))
+
     assert scan.get_image("blue").shape == (4, 5)
     assert scan.get_image("green").shape == (4, 5)
 
@@ -122,16 +123,14 @@ def test_scan_attrs(test_scans):
     assert rgb.shape == (4, 5, 3)
     assert not np.any(rgb[:, :, 0])
     assert not np.any(rgb[:, :, 2])
-    assert scan.get_image("red").shape == (0,)
-    assert scan.get_image("blue").shape == (0,)
+    np.testing.assert_equal(scan.get_image("red"), np.zeros((4, 5)))
+    np.testing.assert_equal(scan.get_image("blue"), np.zeros((4, 5)))
     assert scan.get_image("green").shape == (4, 5)
 
     scan = test_scans["all channels missing"]
-    with pytest.raises(ValueError, match="No image data available"):
-        scan.get_image("rgb")
-    assert scan.get_image("red").shape == (0,)
-    assert scan.get_image("blue").shape == (0,)
-    assert scan.get_image("green").shape == (0,)
+    np.testing.assert_equal(scan.get_image("red"), np.zeros((4, 5)))
+    np.testing.assert_equal(scan.get_image("green"), np.zeros((4, 5)))
+    np.testing.assert_equal(scan.get_image("blue"), np.zeros((4, 5)))
 
 
 def test_slicing(test_scans):
@@ -676,3 +675,11 @@ def test_slice_by_list_disallowed(test_scans):
 
     with pytest.raises(IndexError, match="Slicing by Dummy is not allowed"):
         test_scans["fast Y slow X multiframe"][Dummy(), :, :]
+
+
+def test_crop_missing_channel(test_scans):
+    """Make sure that missing channels are handled appropriately when cropping"""
+    np.testing.assert_equal(
+        test_scans["rb channels missing"][:, 0:2, 1:3].get_image("red"),
+        np.zeros((2, 2))
+    )


### PR DESCRIPTION
**Why this PR?**
This PR is part of making `Scan`, `Kymo` and `CorrelatedStack` have similar properties. It's convenient to have a `shape` property.

Note that in the process of developing this feature I noticed two bugs that resulted in an error when downsampling or cropping by distance an image where some of the color channels were not defined. I fixed these and left the fixes as separate commits. If approved, I would keep those separate from the shape feature, but merge the two fixes together.