### PR TITLE
Kymotracker: warn on low threshold value

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * Lazily load `data` and `timestamps` for `TimeSeries` data
 * Added possibility to access property `sample_rate` for `TimeSeries` data with constant sample rate.
 * Added shape property to `Scan` and `Kymo`.
+* Added a warning to the Kymotracker widget if the threshold parameter is set too low, which may result in slow tracking and the widget hanging.
 
 #### Bug fixes
 

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -1,4 +1,3 @@
-import time
 from dataclasses import dataclass
 import inspect
 import numpy as np
@@ -70,8 +69,6 @@ class KymoWidget:
         self.show_lines = True
         self.output_filename = output_filename
 
-        self._dx = 0
-        self._last_update = 0
         self._area_selector = None
         self._line_connector = None
 
@@ -129,14 +126,8 @@ class KymoWidget:
         def set_xlim(drag_event):
             # Callback for dragging the field of view
             old_xlims = np.array(self._axes.get_xlim())
-            self._dx = self._dx + drag_event.dx
-
-            # We don't need to update more than 30 times per second (1/30 = 0.033).
-            if abs(time.time() - self._last_update) > 0.033:
-                self._axes.set_xlim(old_xlims - self._dx)
-                self._dx = 0
-                self._last_update = time.time()
-                canvas.draw_idle()
+            self._axes.set_xlim(old_xlims - drag_event.dx)
+            canvas.draw_idle()
 
         MouseDragCallback(self._axes, 1, set_xlim)
 
@@ -449,8 +440,6 @@ class KymoWidget:
             self._fig = plt.figure()
             self._axes = self._fig.add_subplot(111)
 
-        self._dx = 0
-        self._last_update = time.time()
         self._kymo.plot(channel=self._channel, interpolation="nearest", **kwargs)
 
         if self.axis_aspect_ratio:

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -133,10 +133,11 @@ def test_refine_from_widget(kymograph, region_select):
         def __init__(self):
             self.value = ""
 
-    kymo_widget._label = MockLabel()
+    kymo_widget._labels = {"status": MockLabel()}
     kymo_widget.refine()
     assert (
-        kymo_widget._label.value == "You need to track or load kymograph lines before you can "
+        kymo_widget._labels["status"].value
+        == "You need to track or load kymograph lines before you can "
         "refine them"
     )
 


### PR DESCRIPTION
**Why this PR?**
If the signal threshold value is set too low, the tracker will start to track noise which can results in upwards of thousands of lines. In the widget, this can appear as the widget hanging while the algorithm runs. This PR adds another label in which warnings can be displayed.

![tracker_warning](https://user-images.githubusercontent.com/61475504/185419869-e9e796d1-957e-412f-9534-1ab51701eb1d.gif)

Things to note
- The cutoff value for "low threshold value" is not well known at the moment, but some tests on normal sized kymographs suggests this slowdown could appear at values corresponding to the 95th percentile of the data. However this value is likely variable based on SNR and kymo length/size. Other suggestions for cutoffs are welcome
- I used an `HTML` widget rather than the simple `Label` in order to be able to differentiate this warning label (with red font) from the existing status label.
- The ticket mentions fixups to the value used in the Harbor notebook and docs; however, with that example dataset the value stated is actually what you would get if you didn't manually specify the default slider starting value. So I think this fixup is best left for when we change the dataset out for newer better quality data
- I also piggybacked removing some extraneous code dealing with panning. I can put this in a separate PR if better