### PR TITLE
range_selector: force redraw on update

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 * Improved `scan.get_image("rgb")` to handle missing channel data. Missing channels are now handled gracefully. Missing channels are zero filled matching the dimensions of the remaining channels.
 * Added calls to manually redraw the axes in kymotracker widget during horizontal pan and line connection callbacks. Without this, plot did not update correctly when using newer versions of `ipywidgets` and `matplotlib`.
 * Fixed bug in video export that led to one frame less being exported than intended.
+* Fixed bug which prevented the range selector widget from updating when the dataset to be plotted is changed. Previously, on some supported versions of `matplotlib` it would no longer update the figure. This is now fixed.
 
 #### Breaking changes
 

--- a/lumicks/pylake/nb_widgets/range_selector.py
+++ b/lumicks/pylake/nb_widgets/range_selector.py
@@ -60,7 +60,7 @@ class BaseRangeSelectorWidget:
 
         # Draw a vertical line for some immediate visual feedback
         self._axes.axvline(self.range_conversion_fcn(point))
-        self._axes.get_figure().canvas.draw()
+        self._axes.figure.canvas.draw_idle()
 
     def _remove_range(self, point):
         """Removes a range if the provided timestamp falls inside it."""
@@ -114,6 +114,7 @@ class BaseRangeSelectorWidget:
         plt.sca(self._axes)
         self._plot_data()
         self.connect_click_callback()
+        self._axes.figure.canvas.draw_idle()
         plt.sca(old_axis)
 
     def _plot_data(self):


### PR DESCRIPTION
**Why this PR?**
Aafke found that the range selector widget wasn't updating the plot anymore when the dataset was switched. This PR fixes that behaviour by adding a call to `draw_idle` analogously to https://github.com/lumicks/pylake/pull/337 .