### PR TITLE
scans/stack: add slicing by timestamp and string

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 * Pylake now depends on `h5py>=3.4, <4`. This change is required to still support `len()` with the lazy loading fix for `TimeSeries`.
 * Added header line to exported track coordinate CSV files. The first header line now contains the version of `pylake` which generated the file and a version number for the CSV file itself (starting with `v2` from this release).
 * Allow slicing `CorrelatedStacks` with timestamps and time strings (e.g. `stack["5s":"10s"]` or `stack[f.force1x.start:f.force1x.stop]`).
+* Allow slicing `Scan` with timestamps and time strings (e.g. `scan["5s":"10s"]` or `scan[f.force1x.start:f.force1x.stop]`).
 
 #### Bug fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
 * Added a warning to the Kymotracker widget if the threshold parameter is set too low, which may result in slow tracking and the widget hanging.
 * Pylake now depends on `h5py>=3.4, <4`. This change is required to still support `len()` with the lazy loading fix for `TimeSeries`.
 * Added header line to exported track coordinate CSV files. The first header line now contains the version of `pylake` which generated the file and a version number for the CSV file itself (starting with `v2` from this release).
+* Allow slicing `CorrelatedStacks` with timestamps and time strings (e.g. `stack["5s":"10s"]` or `stack[f.force1x.start:f.force1x.stop]`).
 
 #### Bug fixes
 

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -11,6 +11,10 @@ These videos can be opened and sliced using `CorrelatedStack`::
     stack = lk.CorrelatedStack("wf.tiff")  # Loading a stack.
     stack_slice = stack[2:10]  # Grab frame 2 to 9
 
+You can also slice by time::
+
+    stack_slice = stack["2s":"10s"]  # Slice from second second up to tenth second
+
 You can easily load multiple TIFF files by simply listing them consecutively::
 
     stack = lk.CorrelatedStack("wf.tiff", "wf2.tiff")  # Loading two tiff files in a single stack.

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -13,7 +13,7 @@ These videos can be opened and sliced using `CorrelatedStack`::
 
 You can also slice by time::
 
-    stack_slice = stack["2s":"10s"]  # Slice from second second up to tenth second
+    stack_slice = stack["2s":"10s"]  # Slice from 2 to 10 seconds from beginning of the stack
 
 You can easily load multiple TIFF files by simply listing them consecutively::
 

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -55,6 +55,16 @@ This will return a new `Scan` containing data equivalent to::
 
     multiframe_scan.get_image("rgb")[5:10, :, :, :]
 
+We can also slice the frames by time::
+
+    # get frames corresponding to the time range 5 through 10 seconds
+    sliced_scan = multiframe_scan["5s":"10s"]
+
+Or directly using timestamps::
+
+    # get frames that fall between the start and stop of a force channel
+    multiframe_scan[f.force1x.start:f.force1x.stop]
+
 The images contain pixel data where each pixel represents summed photon counts.
 For an even lower-level look at data, the raw photon count samples can be accessed::
 

--- a/lumicks/pylake/tests/data/mock_widefield.py
+++ b/lumicks/pylake/tests/data/mock_widefield.py
@@ -46,8 +46,10 @@ class MockTiffFile:
         return len(self._src.pages)
 
 
-def make_frame_times(n_frames, step=8, start=10):
-    return [[f"{j}", f"{j+step}"] for j in range(start, start + (n_frames + 1) * 100, 10)]
+def make_frame_times(n_frames, step=8, start=10, frame_time=10):
+    return [
+        [f"{j}", f"{j+step}"] for j in range(start, start + (n_frames + 1) * frame_time, frame_time)
+    ]
 
 
 def apply_transform(spots, Tx, Ty, theta, offsets=None):


### PR DESCRIPTION
**Why this PR?**
It's very convenient to slice by time and timestamp, hence we want to extend this functionality to `Scan` and `Stack`.