### PR TITLE
fdfitting: better handling around valid model boundaries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 * Force-distance models now raise a `ValueError` exception when simulated for invalid parameter values.
 * Force distance models now have a non-zero lower bound for the contour length (`Lc`), persistence length (`Lp`), stretch modulus (`St`) and boltzmann constant times temperature (`kT`) instead of a lower bound of zero.
 * Force distance fits now raise a `RuntimeError` if any of the returned simulation values are NaN.
+* Fixed bug that resulted in profile likelihood automatically failing when an attempted step exceeded the bounds where the model could be simulated.
 
 #### Breaking changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@
 * Fixed bug which prevented the range selector widget from updating when the dataset to be plotted is changed. Previously, on some supported versions of `matplotlib` it would no longer update the figure. This is now fixed.
 * Force-distance models now raise a `ValueError` exception when simulated for invalid parameter values.
 * Force distance models now have a non-zero lower bound for the contour length (`Lc`), persistence length (`Lp`), stretch modulus (`St`) and boltzmann constant times temperature (`kT`) instead of a lower bound of zero.
+* Force distance fits now raise a `RuntimeError` if any of the returned simulation values are NaN.
 
 #### Breaking changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@
 * Added calls to manually redraw the axes in kymotracker widget during horizontal pan and line connection callbacks. Without this, plot did not update correctly when using newer versions of `ipywidgets` and `matplotlib`.
 * Fixed bug in video export that led to one frame less being exported than intended.
 * Fixed bug which prevented the range selector widget from updating when the dataset to be plotted is changed. Previously, on some supported versions of `matplotlib` it would no longer update the figure. This is now fixed.
+* Force-distance models now raise a `ValueError` exception when simulated for invalid parameter values.
 
 #### Breaking changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 * Fixed bug in video export that led to one frame less being exported than intended.
 * Fixed bug which prevented the range selector widget from updating when the dataset to be plotted is changed. Previously, on some supported versions of `matplotlib` it would no longer update the figure. This is now fixed.
 * Force-distance models now raise a `ValueError` exception when simulated for invalid parameter values.
+* Force distance models now have a non-zero lower bound for the contour length (`Lc`), persistence length (`Lp`), stretch modulus (`St`) and boltzmann constant times temperature (`kT`) instead of a lower bound of zero.
 
 #### Breaking changes
 

--- a/lumicks/pylake/fitting/detail/model_implementation.py
+++ b/lumicks/pylake/fitting/detail/model_implementation.py
@@ -7,11 +7,17 @@ import warnings
 
 class Defaults:
     kT = Parameter(
-        value=4.11, lower_bound=0.0, upper_bound=8.0, fixed=True, shared=True, unit="pN*nm"
+        value=4.11,
+        lower_bound=3.77,  # Corresponds to 0 degrees Celsius
+        upper_bound=8.0,
+        fixed=True,
+        shared=True,
+        unit="pN*nm",
     )
-    Lp = Parameter(value=40.0, lower_bound=0.0, upper_bound=100, unit="nm")
-    Lc = Parameter(value=16.0, lower_bound=0.0, upper_bound=np.inf, unit="micron")
-    St = Parameter(value=1500.0, lower_bound=0.0, upper_bound=np.inf, unit="pN")
+    Lp = Parameter(value=40.0, lower_bound=1e-3, upper_bound=100, unit="nm")
+    # Lower bound is a single base pair
+    Lc = Parameter(value=16.0, lower_bound=3.4e-4, upper_bound=np.inf, unit="micron")
+    St = Parameter(value=1500.0, lower_bound=1.0, upper_bound=np.inf, unit="pN")
     offset = Parameter(value=0.0, lower_bound=-0.1, upper_bound=0.1, unit="pN")
 
 
@@ -61,8 +67,8 @@ def marko_siggia_simplified(d, Lp, Lc, kT):
         1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
         8759-8770 (1995).
     """
-    if Lc <= 0 or Lp <= 0 or kT <= 0:
-        raise ValueError("Contour length, persistence length and kT must be bigger than 0")
+    if Lp <= 0 or Lc <= 0 or kT <= 0:
+        raise ValueError("Persistence length, contour length and kT must be bigger than 0")
 
     if np.any(d > Lc):
         warnings.warn(

--- a/lumicks/pylake/fitting/detail/model_implementation.py
+++ b/lumicks/pylake/fitting/detail/model_implementation.py
@@ -61,6 +61,9 @@ def marko_siggia_simplified(d, Lp, Lc, kT):
         1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
         8759-8770 (1995).
     """
+    if Lc <= 0 or Lp <= 0 or kT <= 0:
+        raise ValueError("Contour length, persistence length and kT must be bigger than 0")
+
     if np.any(d > Lc):
         warnings.warn(
             "Marko Siggia model is only defined properly up to the contour length (d = Lc)",
@@ -117,6 +120,10 @@ def WLC(f, Lp, Lc, St, kT=4.11):
     kT : float
         Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
     """
+    if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
+        raise ValueError(
+            "Persistence length, contour length, stretch modulus and kT must be bigger than 0"
+        )
     return Lc * (1.0 - 1.0 / 2.0 * np.sqrt(kT / (f * Lp)) + f / St)
 
 
@@ -176,6 +183,10 @@ def tWLC(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     kT : float
         Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
     """
+    if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
+        raise ValueError(
+            "Persistence length, contour length, stretch modulus and kT must be bigger than 0"
+        )
     g = np.zeros(np.size(f))
     g[f < Fc] = g0 + g1 * Fc
     g[f >= Fc] = g0 + g1 * f[f >= Fc]
@@ -264,6 +275,10 @@ def FJC(f, Lp, Lc, St, kT=4.11):
     kT : float
         Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
     """
+    if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
+        raise ValueError(
+            "Persistence length, contour length, stretch modulus and kT must be bigger than 0"
+        )
     return Lc * (coth(2.0 * f * Lp / kT) - kT / (2.0 * f * Lp)) * (1.0 + f / St)
 
 
@@ -384,6 +399,11 @@ def invWLC(d, Lp, Lc, St, kT=4.11):
     #   c = - 0.25 * gamma / denom = - gamma / (4 * beta * beta)
     #
     # We can see now that parameterizing w.r.t. St is easier than b and define:
+    if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
+        raise ValueError(
+            "Persistence length, contour length, stretch modulus and kT must be bigger than 0"
+        )
+
     alpha = (d / Lc) - 1.0
     gamma = kT / Lp
 
@@ -637,6 +657,11 @@ def invtWLC(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     kT : float
         Boltzmann's constant times temperature (default = 4.11) [pN nm]
     """
+    if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
+        raise ValueError(
+            "Persistence length, contour length, stretch modulus and kT must be bigger than 0"
+        )
+
     f_min = 0
     f_max = (-g0 + np.sqrt(St * C)) / g1  # Above this force the model loses its validity
 
@@ -682,6 +707,11 @@ def invFJC(d, Lp, Lc, St, kT=4.11):
     kT : float
         Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
     """
+    if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
+        raise ValueError(
+            "Persistence length, contour length, stretch modulus and kT must be bigger than 0"
+        )
+
     f_min = 0
     f_max = np.inf
 
@@ -717,8 +747,13 @@ def marko_siggia_ewlc_solve_force_equation_tex(d, Lp, Lc, St, kT=4.11):
 
 
 def marko_siggia_ewlc_solve_force(d, Lp, Lc, St, kT=4.11):
-    """Margo-Siggia's Worm-like Chain model with distance as dependent parameter (useful for F < 10 pN).
+    """Marko-Siggia's Worm-like Chain model with distance as dependent parameter (useful for F < 10 pN).
     These equations were symbolically derived. The expressions are not pretty, but they work."""
+    if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
+        raise ValueError(
+            "Persistence length, contour length, stretch modulus and kT must be bigger than 0"
+        )
+
     c = -(St**3) * d * kT * (1.5 * Lc**2 - 2.25 * Lc * d + d**2) / (Lc**3 * (Lp * St + kT))
     b = (
         St**2
@@ -888,6 +923,9 @@ def inverted_marko_siggia_simplified_coefficients(f, Lp, Lc, kT):
 
 
 def inverted_marko_siggia_simplified(f, Lp, Lc, kT=4.11):
+    if Lp <= 0 or Lc <= 0 or kT <= 0:
+        raise ValueError("Persistence length, contour length and kT must be bigger than 0")
+
     a, b, c = inverted_marko_siggia_simplified_coefficients(f, Lp, Lc, kT)
 
     return solve_cubic_wlc(a, b, c, 1)
@@ -943,6 +981,11 @@ def inverted_marko_siggia_simplified_equation_tex(f, Lp, Lc, kT=4.11):
 
 
 def marko_siggia_ewlc_solve_distance(f, Lp, Lc, St, kT=4.11):
+    if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
+        raise ValueError(
+            "Persistence length, contour length, stretch modulus and kT must be bigger than 0"
+        )
+
     c = (
         -f
         * Lc**3

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -548,10 +548,14 @@ class Fit:
         self._rebuild()
         res = self._calculate_residual(params)
         sigma = sigma if np.any(sigma) else self.sigma
+        weighted_sum = -np.sum((res / sigma) ** 2) / 2.0
+        if np.isnan(weighted_sum):
+            raise RuntimeError(
+                "Residual returned NaN. Model cannot be evaluated at these parameter values."
+            )
+
         return (
-            -(self.n_residuals / 2.0) * np.log(2.0 * np.pi)
-            - np.sum(np.log(sigma))
-            - sum((res / sigma) ** 2) / 2.0
+            -(self.n_residuals / 2.0) * np.log(2.0 * np.pi) - np.sum(np.log(sigma)) + weighted_sum
         )
 
     @property

--- a/lumicks/pylake/fitting/tests/test_fit.py
+++ b/lumicks/pylake/fitting/tests/test_fit.py
@@ -678,3 +678,17 @@ def test_custom_legend_labels():
     plt.gca().clear()
     fit.plot(label="custom label")
     test_labels(["custom label (model)", "custom label (data)"])
+
+
+def test_nan():
+    def f(independent, a, b):
+        return np.asarray([1, np.nan, 1])
+
+    fit = Fit(Model("f", f))
+    data = np.asarray([1, 2, 3])
+    fit._add_data("data_name", data, data)
+    with pytest.raises(
+        RuntimeError,
+        match="Residual returned NaN. Model cannot be evaluated at these parameter values."
+    ):
+        fit.log_likelihood()

--- a/lumicks/pylake/fitting/tests/test_fit.py
+++ b/lumicks/pylake/fitting/tests/test_fit.py
@@ -657,10 +657,10 @@ def test_fit_reprs():
         "- Fitted parameters:\n"
         "    Name      Value  Unit      Fitted      Lower bound    Upper bound\n"
         "    ------  -------  --------  --------  -------------  -------------\n"
-        "    DNA/Lp    40     [nm]      True                  0            100\n"
-        "    DNA/Lc    16     [micron]  True                  0            inf\n"
-        "    DNA/St  1500     [pN]      True                  0            inf\n"
-        "    kT         4.11  [pN*nm]   False                 0              8"
+        "    DNA/Lp    40     [nm]      True            0.001              100\n"
+        "    DNA/Lc    16     [micron]  True            0.00034            inf\n"
+        "    DNA/St  1500     [pN]      True            1                  inf\n"
+        "    kT         4.11  [pN*nm]   False           3.77                 8"
     )
 
 

--- a/lumicks/pylake/fitting/tests/test_pickling.py
+++ b/lumicks/pylake/fitting/tests/test_pickling.py
@@ -35,5 +35,5 @@ def test_pickle(tmpdir_factory):
     # Verify fit result
     np.testing.assert_allclose(
         [x.value for x in dict(pickled_fit.params).values()],
-        [49.996726625805394, 24.00234442122973, 1415.9560551307495, 4.12],
+        [49.996726625805394, 24.00234442122973, 1415.93306, 4.12],
     )


### PR DESCRIPTION
**Why this PR?**
When making profile likelihoods for models, the procedure could simply fail without a helpful error message.

When a model (for example the Odijk model) is profiled, its parameters are traversed up to the parameter bounds. In this case, that lower bound was zero for contour length, which is not a valid value for that model (it actually returns NaNs there).

There are multiple fixes in this:
- When NaNs are detected, the log likelihood function throws to signal to the user that this simulation cannot be trusted.
- The bounds for the models are updated to have a minimum value that is nonzero, to make sure the models don't break down.
- The profile likelihood method now deals gracefully with the cases where the model may suddenly stop simulating for some parameter values:
1. If it is searching a step size, it will continue trying (but shorten the step size if the simulations fail).
2. If it has stopped searching an appropriate step size and fails during optimizing after that, it will break the loop, returning to the user the part of the profile that had been successfully computed.

*What to look out for?*
I was wondering whether to raise or not in the model functions or not. The model results become unreliable there, but it is entirely possible that an optimizer could get there and leave again and as long as the final optimized result is ok, the result would be ok. That said, I think it is better to just guarantee that the model does not set contour length, persistence length or stretch modulus to zero and enforce this via a hard bound. In the future we could think about optimizing in log-space, since that can often be beneficial when having strictly positive parameters, but I do not want to piggyback that on this PR since it would require quite a bit of additional investigation.