### PR TITLE
ci: clear warnings caused by `mpl` argument deprecation

### DIFF
--- a/.github/workflows/pylake_test.py
+++ b/.github/workflows/pylake_test.py
@@ -4,4 +4,4 @@ import os
 import pathlib
 
 os.chdir(str(pathlib.Path(lk.__file__).parent))
-sys.exit(lk.pytest(args=["--runslow", "--color=yes"]))
+sys.exit(lk.pytest(args=["--runslow", "--color=yes", "-Werror"]))

--- a/lumicks/pylake/nb_widgets/image_editing.py
+++ b/lumicks/pylake/nb_widgets/image_editing.py
@@ -9,10 +9,15 @@ from ..detail.image import make_image_title
 
 
 def add_selector(axes, callback, button=None, interactive=True, **kwargs):
+    from inspect import signature
+
+    # Remove once matplotlib >= 3.5.0
+    props = "props" if "props" in signature(RectangleSelector).parameters else "rectprops"
+
     kwargs = {
         "button": button,
         "interactive": interactive,
-        "rectprops": {
+        props: {
             "facecolor": "none",
             "edgecolor": "w",
             "fill": False,


### PR DESCRIPTION
**Why this PR?**
We've been getting a warning from `mpl` for a while. Since it only involves a simple parameter rename, I figured it's fine to support both for a while. I added a comment so that we don't forget to remove it once we upgrade to `>= 3.5.0`.

I also took the liberty of adding `Werror` to our `pytest` script, so that warnings are treated as errors from now on. Hopefully this'll make us a bit more proactive about clearing these out.