### PR TITLE
Fixup API docs

### DIFF
--- a/docs/_templates/class.rst
+++ b/docs/_templates/class.rst
@@ -1,0 +1,10 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :special-members:
+   :inherited-members:
+
+

--- a/docs/_templates/function.rst
+++ b/docs/_templates/function.rst
@@ -1,0 +1,5 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autofunction:: {{ objname }}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,6 +7,7 @@ If you are just looking to get started, read the :doc:`/tutorial/index` first.
 .. currentmodule:: lumicks.pylake
 
 .. autosummary::
+    :template: class.rst
     :toctree: _api
 
     File
@@ -24,12 +25,16 @@ Force calibration
 
 .. autosummary::
     :toctree: _api
+    :template: class.rst
+
+    PassiveCalibrationModel
+    ActiveCalibrationModel
+
+    :template: function.rst
 
     calibrate_force
     calculate_power_spectrum
     fit_power_spectrum
-    PassiveCalibrationModel
-    ActiveCalibrationModel
     force_calibration.power_spectrum.PowerSpectrum
     force_calibration.power_spectrum_calibration.CalibrationResults
     viscosity_of_water
@@ -40,9 +45,12 @@ FD Fitting
 
 .. autosummary::
     :toctree: _api
+    :template: class.rst
 
     fitting.model.Model
     FdFit
+
+    :template: function.rst
     parameter_trace
 
 .. _fd_models:
@@ -50,6 +58,7 @@ FD Fitting
 
 .. autosummary::
     :toctree: _api
+    :template: function.rst
 
     force_offset
     distance_offset
@@ -70,9 +79,12 @@ Kymotracking
 
 .. autosummary::
     :toctree: _api
+    :template: class.rst
 
     kymotracker.kymotrack.KymoTrack
-    kymotracker.kymotrack.KymoTrack.estimate_diffusion
+
+    :template: function.rst
+
     track_greedy
     track_lines
     filter_lines
@@ -84,6 +96,7 @@ Notebook widgets
 
 .. autosummary::
     :toctree: _api
+    :template: class.rst
 
     FdRangeSelector
     FdDistanceRangeSelector
@@ -93,6 +106,7 @@ Population Dynamics
 
 .. autosummary::
     :toctree: _api
+    :template: class.rst
 
     GaussianMixtureModel
     DwelltimeModel
@@ -103,6 +117,7 @@ Piezo tracking
 
 .. autosummary::
     :toctree: _api
+    :template: class.rst
 
     DistanceCalibration
     ForceBaseLine

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,9 +47,8 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
-    "sphinx.ext.mathjax",
     "sphinxcontrib.bibtex",
-    "numpydoc",
+    "sphinx.ext.napoleon",
     "matplotlib.sphinxext.plot_directive",
     "nbexport",
     "sphinx_lfs_content",
@@ -67,9 +66,6 @@ intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
     "matplotlib": ("http://matplotlib.org/", None),
 }
-
-numpydoc_class_members_toctree = False
-numpydoc_show_class_members = False
 
 plot_include_source = True
 plot_html_show_source_link = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,12 @@ autodoc_default_flags = ["members", "special-members", "inherited-members"]
 autodoc_allowed_special_members = ["__call__", "__getitem__"]
 autosummary_generate = True
 
+# custom type aliases to prevent rendering an unreadable list of all types
+# defined by generic types
+# requires `from __future__ import annotations` in files where the aliased
+# types are used
+autodoc_type_aliases = {"npt.ArrayLike": "numpy.typing.ArrayLike"}
+
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://docs.scipy.org/doc/numpy/", None),

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,6 @@ matplotlib
 nbconvert
 nbformat
 numpy
-numpydoc
 scipy
 sphinx==4.5.0
 sphinx_rtd_theme==1.0.0

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import numpy.typing as npt
 import numbers


### PR DESCRIPTION
**Why this PR?**
There are a number of problems with how our API docs stubs are currently built. 
- Regardless of the `autodoc` settings to hide private methods, these still show up. This seems to be because we use `autosummary` to build the TOC
- The methods section for each page is just a table with the method name and first line of the docstring; the actual docstrings including parameters aren't shown anywhere. 
- Linking to specific methods of a documented class requires adding a separate entry in the TOC so that a specific stub will be built for that method (you can't link to a row in the methods table).

The only solution I could find was to write custom templates which directly use `autodoc` directives; the settings from `conf.py` then get applied correctly. I also had to switch from `numpydoc` to the `napolean` extension to get formatting with the `deprecated` directive to display properly (although, see note below). This extension is also the preferred way to convert from numpy docstrings to rst according to the Sphinx documentation; it comes bundled with Sphinx already.

With the proposed change, each page for the class lists the full docstring for each method (including examples) and private API is not displayed (except for certain special methods which we turn on in the config). Linking to specific methods of a class also works properly now. A before and after example is below and full [docs are here](https://lumicks-pylake.readthedocs.io/en/docs_api/api.html).

**Before**
![image](https://user-images.githubusercontent.com/61475504/186888176-7e740b8e-c0d7-4d8b-b3d2-93607250df26.png)

**After**
![image](https://user-images.githubusercontent.com/61475504/186888222-a09241d5-aca5-4c1d-b093-2e3121cfd85c.png)

There are still a couple things that are less than optimal
- The formatting for the the parameter list for deprecated methods is slightly off (see [Kymo.plot_rgb()](https://lumicks-pylake.readthedocs.io/en/docs_api/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.plot_rgb) for example, compare with the method below it). This also leads to warnings being emitted; it seems to be that with the inserted `.. deprecated` directive, the `Parameters` section title isn't recognized. I tried to figure out exactly what is going on but with no luck. For me, the benefits here far outweigh this minor formatting error and a couple warnings being emitted; especially for things that will be removed after a short time.
- The constructor signature is displayed even though most classes we don't want users constructing instances manually. This is actually true for what we have now. My idea is to use the `.. Attention:: ` directive in these docstrings to add a note explicitly mentioning that objects shouldn't be constructed by users but obtained in other ways (eg. `get a Kymo from File.kymos`). I didn't piggyback this here though. 
- With the proper display of all docstrings, there's a lot of apparent formatting mistakes on our part. I also didn't piggy back these needed changes here.
- Again, now that docstrings are displayed properly, there can be some less than ideal formatting for type annotations. For example see [Slice.data](https://lumicks-pylake.readthedocs.io/en/docs_api/_api/lumicks.pylake.channel.Slice.html#lumicks.pylake.channel.Slice.data) which is annotated with `npt.ArrayLike`

Again, even with all of these downsides, I still think the benefits of proper API documentation are worthwhile
