### PR TITLE
"line" to "track" - part 2 / 3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,7 @@
 
 #### Other changes
 
+* Added default values for the `track_greedy()` arguments `line_width` and `pixel_threshold`.
 * Renamed classes/methods/functions dealing with tracked particles. This change was made to avoid ambiguity with regard to the term *"line"*. Now, a *"line"* refers to a single scan pass of the confocal mirror during imaging. A *"track"* refers to the coordinates of tracked particles from a kymograph. Note: the relevant classes are considered internal API and should not be constructed manually. Any breaking changes or deprecations are noted above. The specific name changes are as follows:
     * `KymoLine` was renamed to `KymoTrack`
     * `KymoLineGroup` was renamed to `KymoTrackGroup`

--- a/changelog.md
+++ b/changelog.md
@@ -54,11 +54,14 @@
 * In the functions `Scan.frame_timestamp_ranges()` and `Kymo.line_timestamp_ranges()`, the parameter `exclude` was deprecated in favor of `include_dead_time` for clarity.
 * Deprecated `KymoTrackGroup.remove_lines_in_rect()`; use `KymoTrackGroup.remove_tracks_in_rect()` instead (see below).
 * Deprecated the `line_width` argument of `track_greedy()`; use `track_width` instead.
+* Deprecated `filter_lines()`; use `filter_tracks()` instead.
+* Deprecated `refine_lines_centroid()`; use `refine_tracks_centroid()` instead. *Note: the `track_width` argument of `refine_tracks_centroid()` expects values in physical units whereas the previous `refine_lines_centroid()` expected the `line_width` argument in pixel units.*
+* Deprecated `refine_lines_gaussian()`; use `refine_tracks_gaussian()` instead.
 
 #### Other changes
 
 * Added default values for the `track_greedy()` arguments `track_width` and `pixel_threshold`.
-* Renamed classes/methods/functions dealing with tracked particles. This change was made to avoid ambiguity with regard to the term *"line"*. Now, a *"line"* refers to a single scan pass of the confocal mirror during imaging. A *"track"* refers to the coordinates of tracked particles from a kymograph. Note: the relevant classes are considered internal API and should not be constructed manually. Any breaking changes or deprecations are noted above. The specific name changes are as follows:
+* Renamed classes/methods/functions dealing with tracked particles. This change was made to avoid ambiguity with regard to the term *"line"*. Now, a *"line"* refers to a single scan pass of the confocal mirror during imaging. A *"track"* refers to the coordinates of tracked particles from a kymograph. *Note: Any breaking changes or deprecations to the public API are noted above. The renamed classes/functions below are considered internal API and subject to change without notice; these classes should not be constructed manually:*
     * `KymoLine` was renamed to `KymoTrack`
     * `KymoLineGroup` was renamed to `KymoTrackGroup`
     * `export_kymolinegroup_to_csv()` was renamed to `export_kymotrackgroup_to_csv()`

--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,7 @@
 * Removed public attributes `CorrelatedStack.start_idx` and `CorrelatedStack.stop_idx` and made them protected.
 * The property `sample_rate` of `Continuous` data now returns a `float` instead of an `int``
 * Removed deprecated argument `roi` from `CorrelatedStack.export_tiff`. Use `CorrelatedStack.crop_by_pixels()` to select the ROI before exporting.
+* `KymoWidgetGreedy` now enforces using keywords for all arguments after the first two (`kymo` and `channel`).
 
 #### Deprecations
 

--- a/changelog.md
+++ b/changelog.md
@@ -52,10 +52,11 @@
 * `Scan.save_tiff()` and `Kymo.save_tiff()` were deprecated and replaced with `Scan.export_tiff()` and `Kymo.export_tiff()` to more clearly communicate that the data is exported to a different format.
 * In the functions `Scan.frame_timestamp_ranges()` and `Kymo.line_timestamp_ranges()`, the parameter `exclude` was deprecated in favor of `include_dead_time` for clarity.
 * Deprecated `KymoTrackGroup.remove_lines_in_rect()`; use `KymoTrackGroup.remove_tracks_in_rect()` instead (see below).
+* Deprecated the `line_width` argument of `track_greedy()`; use `track_width` instead.
 
 #### Other changes
 
-* Added default values for the `track_greedy()` arguments `line_width` and `pixel_threshold`.
+* Added default values for the `track_greedy()` arguments `track_width` and `pixel_threshold`.
 * Renamed classes/methods/functions dealing with tracked particles. This change was made to avoid ambiguity with regard to the term *"line"*. Now, a *"line"* refers to a single scan pass of the confocal mirror during imaging. A *"track"* refers to the coordinates of tracked particles from a kymograph. Note: the relevant classes are considered internal API and should not be constructed manually. Any breaking changes or deprecations are noted above. The specific name changes are as follows:
     * `KymoLine` was renamed to `KymoTrack`
     * `KymoLineGroup` was renamed to `KymoTrackGroup`

--- a/docs/examples/cas9_kymotracking/cas9_kymotracking.rst
+++ b/docs/examples/cas9_kymotracking/cas9_kymotracking.rst
@@ -102,7 +102,7 @@ view of our data.
 
 We will be using the greedy algorithm. The `threshold` should typically be chosen somewhere between the expected
 baseline photon count and the photon count of a true track (note that you can see the local photon count between square
-brackets while hovering over the kymograph). The `line width` should roughly be set to the expected line width (in the spatial dimension) of a
+brackets while hovering over the kymograph). The `track width` should roughly be set to the expected spot size (in the spatial dimension) of a
 track. The `window` should be chosen such that small gaps in a track can be overcome, but not so large that spurious
 points may be strung together as a track. `Sigma` controls how much the location can fluctuate from one time point to the
 next, while the `min length` determines how many peak points should be in a track for it to be considered a valid track.

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -118,7 +118,7 @@ def track_greedy(
         to omit the peaks that fall outside of the rect. Coordinates should be given as:
         ((min_time, min_coord), (max_time, max_coord)).
     line_width : float
-        **Deprecated** Forwarded to track_width.
+        **Deprecated** Forwarded to `track_width`.
 
     References
     ----------

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from lumicks.pylake.kymotracker.kymotrack import KymoTrack, KymoTrackGroup
+from lumicks.pylake.kymo import _kymo_from_array
 from lumicks.pylake.tests.data.mock_confocal import generate_kymo
 from .data.generate_gaussian_data import read_dataset as read_dataset_gaussian
 
@@ -28,6 +29,27 @@ def kymo_integration_test_data():
         samples_per_pixel=3,
         line_padding=5,
     )
+
+
+@pytest.fixture
+def kymo_pixel_calibrations():
+    image = raw_test_data()
+    background = np.random.uniform(1, 10, size=image.size).reshape(image.shape)
+
+    kymo_um = generate_kymo(
+        "test",
+        image + background,
+        pixel_size_nm=50,
+        start=int(4e9),
+        dt=int(5e9 / 100),
+        samples_per_pixel=3,
+        line_padding=5,
+    )
+
+    kymo_kbp = kymo_um.calibrate_to_kbp(kymo_um.pixelsize_um[0] * kymo_um.pixels_per_line / 0.34)
+    kymo_px = _kymo_from_array(image + background, "r", kymo_um.line_time_seconds)
+
+    return kymo_um, kymo_kbp, kymo_px
 
 
 @pytest.fixture

--- a/lumicks/pylake/kymotracker/tests/test_algorithm_scaling.py
+++ b/lumicks/pylake/kymotracker/tests/test_algorithm_scaling.py
@@ -30,18 +30,18 @@ def generate_gaussian_line(vel, dt, dx, sigma=0.3, area=10, samples_per_pixel=10
 def test_kymotracker_positional_scaling(vel, dt, dx):
     """Integration test to make sure position and velocity parameters are correctly scaled"""
     kymo = generate_gaussian_line(vel=vel, dt=dt, dx=dx)
-    traces = track_greedy(kymo, "red", pixel_threshold=3, line_width=1, sigma=0.01, vel=vel)
+    traces = track_greedy(kymo, "red", pixel_threshold=3, track_width=1, sigma=0.01, vel=vel)
     ref_seconds = np.arange(0.0, 2.0, dt)
     ref_positions = 1 + vel * ref_seconds
     np.testing.assert_allclose(traces[0].seconds, ref_seconds)
     np.testing.assert_allclose(traces[0].position, ref_positions, rtol=1e-2)
 
     # Check whether a wrong velocity also fails to track the line
-    traces = track_greedy(kymo, "red", pixel_threshold=3, line_width=1, sigma=0.01, vel=2 * vel)
+    traces = track_greedy(kymo, "red", pixel_threshold=3, track_width=1, sigma=0.01, vel=2 * vel)
     np.testing.assert_equal(len(traces[0].seconds), 1)
     np.testing.assert_equal(len(traces[0].position), 1)
 
     # When sigma is large, we expect the line to be strung together despite the velocity being zero
-    traces = track_greedy(kymo, "red", pixel_threshold=3, line_width=1, sigma=0.5 * vel * dx, vel=0)
+    traces = track_greedy(kymo, "red", pixel_threshold=3, track_width=1, sigma=0.5 * vel * dx, vel=0)
     np.testing.assert_allclose(traces[0].seconds, ref_seconds)
     np.testing.assert_allclose(traces[0].position, ref_positions, rtol=1e-2)

--- a/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
@@ -28,14 +28,14 @@ def test_kymotracker_test_bias_rect():
 
 def test_kymotracker_subset_test_greedy(kymo_integration_test_data):
     """If this test fires, it likely means that either the coordinates are not coordinates w.r.t.
-    the original image, or that the reference to the image held by KymoLine is a reference to a
+    the original image, or that the reference to the image held by KymoTrack is a reference to a
     subset of the image, while the coordinates are still in the global coordinate system."""
     line_time = kymo_integration_test_data.line_time_seconds
     pixel_size = kymo_integration_test_data.pixelsize_um[0]
     rect = [[0.0 * line_time, 15.0 * pixel_size], [30 * line_time, 30.0 * pixel_size]]
 
-    lines = track_greedy(kymo_integration_test_data, "red", 3 * pixel_size, 4, rect=rect)
-    np.testing.assert_allclose(lines[0].sample_from_image(1), [40] * np.ones(10))
+    tracks = track_greedy(kymo_integration_test_data, "red", 3 * pixel_size, 4, rect=rect)
+    np.testing.assert_allclose(tracks[0].sample_from_image(1), [40] * np.ones(10))
 
 
 def test_kymotracker_greedy_algorithm_integration_tests(kymo_integration_test_data):
@@ -43,30 +43,30 @@ def test_kymotracker_greedy_algorithm_integration_tests(kymo_integration_test_da
     line_time = test_data.line_time_seconds
     pixel_size = test_data.pixelsize_um[0]
 
-    lines = track_greedy(test_data, "red", 3 * pixel_size, 4)
-    np.testing.assert_allclose(lines[0].coordinate_idx, [11] * np.ones(10))
-    np.testing.assert_allclose(lines[1].coordinate_idx, [21] * np.ones(10))
-    np.testing.assert_allclose(lines[0].position, [11 * pixel_size] * np.ones(10))
-    np.testing.assert_allclose(lines[1].position, [21 * pixel_size] * np.ones(10))
-    np.testing.assert_allclose(lines[0].time_idx, np.arange(10, 20))
-    np.testing.assert_allclose(lines[1].time_idx, np.arange(15, 25))
-    np.testing.assert_allclose(lines[0].seconds, np.arange(10, 20) * line_time)
-    np.testing.assert_allclose(lines[1].seconds, np.arange(15, 25) * line_time)
-    np.testing.assert_allclose(lines[0].sample_from_image(1), [50] * np.ones(10))
-    np.testing.assert_allclose(lines[1].sample_from_image(1), [40] * np.ones(10))
+    tracks = track_greedy(test_data, "red", 3 * pixel_size, 4)
+    np.testing.assert_allclose(tracks[0].coordinate_idx, [11] * np.ones(10))
+    np.testing.assert_allclose(tracks[1].coordinate_idx, [21] * np.ones(10))
+    np.testing.assert_allclose(tracks[0].position, [11 * pixel_size] * np.ones(10))
+    np.testing.assert_allclose(tracks[1].position, [21 * pixel_size] * np.ones(10))
+    np.testing.assert_allclose(tracks[0].time_idx, np.arange(10, 20))
+    np.testing.assert_allclose(tracks[1].time_idx, np.arange(15, 25))
+    np.testing.assert_allclose(tracks[0].seconds, np.arange(10, 20) * line_time)
+    np.testing.assert_allclose(tracks[1].seconds, np.arange(15, 25) * line_time)
+    np.testing.assert_allclose(tracks[0].sample_from_image(1), [50] * np.ones(10))
+    np.testing.assert_allclose(tracks[1].sample_from_image(1), [40] * np.ones(10))
 
     rect = [[0.0 * line_time, 15.0 * pixel_size], [30 * line_time, 30.0 * pixel_size]]
-    lines = track_greedy(test_data, "red", 3 * pixel_size, 4, rect=rect)
-    np.testing.assert_allclose(lines[0].coordinate_idx, [21] * np.ones(10))
-    np.testing.assert_allclose(lines[0].time_idx, np.arange(15, 25))
+    tracks = track_greedy(test_data, "red", 3 * pixel_size, 4, rect=rect)
+    np.testing.assert_allclose(tracks[0].coordinate_idx, [21] * np.ones(10))
+    np.testing.assert_allclose(tracks[0].time_idx, np.arange(15, 25))
 
 
 def test_greedy_algorithm_input_validation(kymo_integration_test_data):
     test_data = kymo_integration_test_data
 
-    for line_width in (-1, 0):
+    for track_width in (-1, 0):
         with pytest.raises(ValueError, match="should be larger than zero"):
-            track_greedy(test_data, "red", track_width=line_width, pixel_threshold=10)
+            track_greedy(test_data, "red", track_width=track_width, pixel_threshold=10)
 
     # Any positive value will do
     track_greedy(test_data, "red", track_width=0.00001, pixel_threshold=10)

--- a/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
@@ -18,7 +18,7 @@ def test_kymotracker_test_bias_rect():
 
     # We grab a subset of the image right beyond the bright pixel. If there's a bias induced
     # by the rectangle crop, we'll see it!
-    tracking_settings = {"line_width": 3, "pixel_threshold": 4, "sigma": 5, "window": 9}
+    tracking_settings = {"track_width": 3, "pixel_threshold": 4, "sigma": 5, "window": 9}
     traces_rect = track_greedy(kymo, "red", **tracking_settings, rect=[[0, 2], [1000, 12]])
     traces_full = track_greedy(kymo, "red", **tracking_settings)
 
@@ -66,17 +66,17 @@ def test_greedy_algorithm_input_validation(kymo_integration_test_data):
 
     for line_width in (-1, 0):
         with pytest.raises(ValueError, match="should be larger than zero"):
-            track_greedy(test_data, "red", line_width=line_width, pixel_threshold=10)
+            track_greedy(test_data, "red", track_width=line_width, pixel_threshold=10)
 
     # Any positive value will do
-    track_greedy(test_data, "red", line_width=0.00001, pixel_threshold=10)
+    track_greedy(test_data, "red", track_width=0.00001, pixel_threshold=10)
 
     with pytest.raises(ValueError, match="should be positive"):
-        track_greedy(test_data, "red", line_width=10, diffusion=-1, pixel_threshold=10)
+        track_greedy(test_data, "red", track_width=10, diffusion=-1, pixel_threshold=10)
 
     for pixel_threshold in (-1, 0):
         with pytest.raises(ValueError, match="should be larger than zero"):
-            track_greedy(test_data, "red", line_width=10, pixel_threshold=pixel_threshold)
+            track_greedy(test_data, "red", track_width=10, pixel_threshold=pixel_threshold)
 
 
 def test_default_parameters(kymo_pixel_calibrations):

--- a/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from lumicks.pylake.kymotracker.kymotracker import track_greedy
+from lumicks.pylake.kymotracker.kymotracker import track_greedy, _default_track_widths
 from lumicks.pylake.tests.data.mock_confocal import generate_kymo
 
 
@@ -77,3 +77,46 @@ def test_greedy_algorithm_input_validation(kymo_integration_test_data):
     for pixel_threshold in (-1, 0):
         with pytest.raises(ValueError, match="should be larger than zero"):
             track_greedy(test_data, "red", line_width=10, pixel_threshold=pixel_threshold)
+
+
+def test_default_parameters(kymo_pixel_calibrations):
+    # calibrated in microns, kilobase pairs, pixels
+    for kymo, default_width in zip(kymo_pixel_calibrations, [0.35, 0.35 / 0.34, 4]):
+
+        # test that default values are used when `None` is supplied
+        default_threshold = np.percentile(kymo.get_image("red"), 98)
+        ref_tracks = track_greedy(kymo, "red", default_width, default_threshold)
+
+        tracks = track_greedy(kymo, "red", track_width=None, pixel_threshold=default_threshold)
+        for ref, track in zip(ref_tracks, tracks):
+            np.testing.assert_allclose(ref.position, track.position)
+
+        tracks = track_greedy(kymo, "red", track_width=default_width, pixel_threshold=None)
+        for ref, track in zip(ref_tracks, tracks):
+            np.testing.assert_allclose(ref.position, track.position)
+
+        tracks = track_greedy(kymo, "red", track_width=None, pixel_threshold=None)
+        for ref, track in zip(ref_tracks, tracks):
+            np.testing.assert_allclose(ref.position, track.position)
+
+        # test non-default args fails when compared to tracking with defaults
+        ref_tracks = track_greedy(kymo, "red", None, None)
+        tracks = track_greedy(
+            kymo, "red", track_width=None, pixel_threshold=default_threshold * 0.7
+        )
+        with pytest.raises(AssertionError):
+            for ref, track in zip(ref_tracks, tracks):
+                np.testing.assert_allclose(ref.position, track.position)
+
+        tracks = track_greedy(kymo, "red", track_width=default_width * 1.2, pixel_threshold=None)
+        with pytest.raises(AssertionError):
+            for ref, track in zip(ref_tracks, tracks):
+                np.testing.assert_allclose(ref.position, track.position)
+
+
+def test_deprecated_args(kymo_integration_test_data):
+    with pytest.warns(
+        DeprecationWarning,
+        match="The argument `line_width` is deprecated; use `track_width` instead.",
+    ):
+        track_greedy(kymo_integration_test_data, "red", line_width=5)

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -6,7 +6,7 @@ from copy import copy
 import warnings
 from matplotlib.widgets import RectangleSelector
 from lumicks.pylake.kymotracker.kymotracker import track_greedy
-from lumicks.pylake import filter_lines, refine_lines_centroid
+from lumicks.pylake import filter_tracks, refine_tracks_centroid
 from lumicks.pylake.nb_widgets.detail.mouse import MouseDragCallback
 from lumicks.pylake.kymotracker.kymotrack import KymoTrackGroup, import_kymotrackgroup_from_csv
 from lumicks.pylake.nb_widgets.detail.undostack import UndoStack
@@ -296,7 +296,9 @@ class KymoWidget:
 
     def refine(self):
         if self.lines:
-            self.lines = refine_lines_centroid(self.lines, self._line_width_pixels)
+            self.lines = refine_tracks_centroid(
+                self.lines, self._algorithm_parameters["track_width"].value
+            )
             self.update_lines()
         else:
             self._set_label(
@@ -552,7 +554,7 @@ class KymoWidgetGreedy(KymoWidget):
         """
 
         def wrapped_track_greedy(kymo, channel, min_length, **kwargs):
-            return filter_lines(
+            return filter_tracks(
                 track_greedy(kymo, channel, **kwargs),
                 min_length,
             )

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -3,6 +3,7 @@ import inspect
 import numpy as np
 import matplotlib.pyplot as plt
 from copy import copy
+import warnings
 from matplotlib.widgets import RectangleSelector
 from lumicks.pylake.kymotracker.kymotracker import track_greedy
 from lumicks.pylake import filter_lines, refine_lines_centroid
@@ -16,6 +17,7 @@ class KymoWidget:
         self,
         kymo,
         channel,
+        *,
         axis_aspect_ratio,
         use_widgets,
         output_filename,
@@ -87,7 +89,7 @@ class KymoWidget:
 
     @property
     def _line_width_pixels(self):
-        return np.ceil(self._algorithm_parameters["line_width"].value / self._kymo.pixelsize[0])
+        return np.ceil(self._algorithm_parameters["track_width"].value / self._kymo.pixelsize[0])
 
     def track_kymo(self, click, release):
         """Handle mouse release event.
@@ -482,7 +484,9 @@ class KymoWidgetGreedy(KymoWidget):
         self,
         kymo,
         channel,
+        *,
         axis_aspect_ratio=None,
+        track_width=None,
         line_width=None,
         pixel_threshold=None,
         window=None,
@@ -508,8 +512,10 @@ class KymoWidgetGreedy(KymoWidget):
             Desired aspect ratio of the viewport. Sometimes kymographs can be very long and thin.
             This helps you visualize them. The aspect ratio is defined in physical spatial and
             temporal units (rather than pixels).
-        line_width : float, optional
+        track_width : float, optional
             Expected width of the particles in physical units. Defaults to 4 * pixel size.
+        line_width : float, optional
+            **Deprecated** Forwarded to `track_width`.
         pixel_threshold : float, optional
             Intensity threshold for the pixels. Local maxima above this intensity level will be designated as a line
             origin. Defaults to 98th percentile of the pixel intensities.
@@ -541,7 +547,7 @@ class KymoWidgetGreedy(KymoWidget):
         slider_ranges : dict of list, optional
             Dictionary with custom ranges for selected parameter sliders. Ranges should be in the
             following format: (lower bound, upper bound).
-            Valid options are: "window", "pixel_threshold", "line_width", "sigma", "min_length" and
+            Valid options are: "window", "pixel_threshold", "track_width", "sigma", "min_length" and
             "vel".
         """
 
@@ -553,6 +559,17 @@ class KymoWidgetGreedy(KymoWidget):
 
         algorithm = wrapped_track_greedy
         algorithm_parameters = _get_default_parameters(kymo, channel)
+
+        # TODO: remove line_width argument deprecation path
+        if "line_width" in slider_ranges.keys():
+            warnings.warn(
+                DeprecationWarning(
+                    "The argument `slider_ranges['line_width']` is deprecated; use `'track_width'` instead."
+                ),
+                stacklevel=2,
+            )
+            slider_ranges["track_width"] = slider_ranges["line_width"]
+            slider_ranges.pop("line_width")
 
         # check slider_ranges entries are valid
         keys = tuple(algorithm_parameters.keys())
@@ -577,6 +594,17 @@ class KymoWidgetGreedy(KymoWidget):
         # update defaults to user-supplied parameters
         arg_names, _, _, values = inspect.getargvalues(inspect.currentframe())
         parameters = {name: values[name] for name in arg_names if name != "self"}
+
+        # TODO: remove line_width argument deprecation path
+        if line_width is not None:
+            warnings.warn(
+                DeprecationWarning(
+                    "The argument `line_width` is deprecated; use `track_width` instead."
+                ),
+                stacklevel=2,
+            )
+            parameters["track_width"] = line_width
+
         for key in keys:
             if parameters[key] is not None:
                 algorithm_parameters[key].value = parameters[key]
@@ -587,11 +615,11 @@ class KymoWidgetGreedy(KymoWidget):
         super().__init__(
             kymo,
             channel,
-            axis_aspect_ratio,
-            use_widgets,
-            output_filename,
-            algorithm,
-            algorithm_parameters,
+            axis_aspect_ratio=axis_aspect_ratio,
+            use_widgets=use_widgets,
+            output_filename=output_filename,
+            algorithm=algorithm,
+            algorithm_parameters=algorithm_parameters,
             **kwargs,
         )
 
@@ -665,8 +693,8 @@ def _get_default_parameters(kymo, channel):
             *(1, np.max(data)),
             True,
         ),
-        "line_width": KymotrackerParameter(
-            "Line width",
+        "track_width": KymotrackerParameter(
+            "Track width",
             "Estimated spot width.",
             "float",
             4 * position_scale,

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -15,14 +15,14 @@ def calibrate_to_kymo(kymo):
 
 @cleanup
 def test_widget_open(kymograph):
-    KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
+    KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
 
 
 @cleanup
 def test_parameters_kymo(kymograph):
     """Test whether the parameter setting is passed correctly to the algorithm. By setting the threshold to different
     values we can check which lines are detected and use that to verify that the parameter is used."""
-    kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
+    kymo_widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     kymo_widget._algorithm_parameters["pixel_threshold"].value = 30
     kymo_widget.track_all()
     assert len(kymo_widget.lines) == 0
@@ -38,7 +38,7 @@ def test_parameters_kymo(kymograph):
 
 @cleanup
 def test_invalid_algorithm_parameter(kymograph):
-    kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
+    kymo_widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     with pytest.raises(KeyError):
         kymo_widget._algorithm_parameters["bob"].value = 5
         kymo_widget.track_all()
@@ -72,7 +72,7 @@ def test_aspect_ratio(kymograph, region_select):
 
 @cleanup
 def test_track_kymo(kymograph, region_select):
-    kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
+    kymo_widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     assert len(kymo_widget.lines) == 0
 
     in_um, in_s = calibrate_to_kymo(kymograph)
@@ -105,7 +105,7 @@ def test_save_load_from_ui(kymograph, tmpdir_factory):
     """Check if a round trip through the UI saving function works."""
     testfile = f"{tmpdir_factory.mktemp('pylake')}/kymo.csv"
 
-    kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
+    kymo_widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     kymo_widget._algorithm_parameters["pixel_threshold"].value = 4
     kymo_widget.track_all()
     kymo_widget.output_filename = testfile
@@ -113,7 +113,7 @@ def test_save_load_from_ui(kymograph, tmpdir_factory):
 
     lines = kymo_widget.lines
 
-    kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
+    kymo_widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     assert len(kymo_widget.lines) == 0
 
     kymo_widget.output_filename = testfile
@@ -125,7 +125,7 @@ def test_save_load_from_ui(kymograph, tmpdir_factory):
 
 
 def test_refine_from_widget(kymograph, region_select):
-    kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
+    kymo_widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     in_um, in_s = calibrate_to_kymo(kymograph)
 
     # Test whether error is handled when refining before tracking / loading
@@ -154,7 +154,7 @@ def test_refine_from_widget(kymograph, region_select):
 
 
 def test_stitch(kymograph, mockevent):
-    kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
+    kymo_widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
 
     k1 = KymoTrack(
         np.array([1, 2, 3]),
@@ -200,7 +200,7 @@ def test_stitch(kymograph, mockevent):
     "start,stop,same_line", [(2, 7, False), (3, 7, False), (2, 6, False), (2, 5, True)]
 )
 def test_stitch_anywhere(start, stop, same_line, kymograph, mockevent):
-    kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
+    kymo_widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
 
     k1 = KymoTrack(
         np.array([1, 2, 3, 4, 5]),
@@ -240,15 +240,17 @@ def test_stitch_anywhere(start, stop, same_line, kymograph, mockevent):
     assert len(kymo_widget.lines) == 2 if same_line else 1
 
 
-def test_refine_line_width_units(kymograph, region_select):
-    kymo_widget = KymoWidgetGreedy(kymograph, "red", 1, line_width=2, use_widgets=False)
+def test_refine_track_width_units(kymograph, region_select):
+    kymo_widget = KymoWidgetGreedy(
+        kymograph, "red", axis_aspect_ratio=1, track_width=2, use_widgets=False
+    )
     in_um, in_s = calibrate_to_kymo(kymograph)
 
     kymo_widget._algorithm_parameters["pixel_threshold"].value = 4
     kymo_widget.track_kymo(*region_select(in_s(5), in_um(12), in_s(20), in_um(13)))
     kymo_widget.refine()
 
-    # With this line_width we'll include the two dim pixels in the test data
+    # With this track_width we'll include the two dim pixels in the test data
     true_coordinate = [12.176471] * 15
     true_coordinate[2] = 12
     true_coordinate[3] = 12
@@ -257,31 +259,33 @@ def test_refine_line_width_units(kymograph, region_select):
 
 @cleanup
 def test_widget_with_calibration(kymograph):
-    widget = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
+    widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     np.testing.assert_allclose(
-        widget._algorithm_parameters["line_width"].value, kymograph.pixelsize[0] * 4
+        widget._algorithm_parameters["track_width"].value, kymograph.pixelsize[0] * 4
     )
-    np.testing.assert_allclose(widget._algorithm_parameters["line_width"].value, 1.6)
+    np.testing.assert_allclose(widget._algorithm_parameters["track_width"].value, 1.6)
     assert widget._axes.get_ylabel() == r"position ($\mu$m)"
 
     kymo_bp = kymograph.calibrate_to_kbp(10.000)
-    widget = KymoWidgetGreedy(kymo_bp, "red", 1, use_widgets=False)
+    widget = KymoWidgetGreedy(kymo_bp, "red", axis_aspect_ratio=1, use_widgets=False)
     np.testing.assert_allclose(
-        widget._algorithm_parameters["line_width"].value, kymo_bp.pixelsize[0] * 4
+        widget._algorithm_parameters["track_width"].value, kymo_bp.pixelsize[0] * 4
     )
-    np.testing.assert_allclose(widget._algorithm_parameters["line_width"].value, 2.0)
+    np.testing.assert_allclose(widget._algorithm_parameters["track_width"].value, 2.0)
     assert widget._axes.get_ylabel() == "position (kbp)"
 
 
 @cleanup
 def test_invalid_range_overrides(kymograph):
     with pytest.raises(KeyError, match="Slider range provided for parameter that does not exist"):
-        KymoWidgetGreedy(kymograph, "red", 1, slider_ranges={"wrong_par": (1, 5)})
+        KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, slider_ranges={"wrong_par": (1, 5)})
     with pytest.raises(
         ValueError,
         match="Lower bound should be lower than upper bound for " "parameter pixel_threshold",
     ):
-        KymoWidgetGreedy(kymograph, "red", 1, slider_ranges={"pixel_threshold": (5, 1)})
+        KymoWidgetGreedy(
+            kymograph, "red", axis_aspect_ratio=1, slider_ranges={"pixel_threshold": (5, 1)}
+        )
     with pytest.raises(
         ValueError,
         match=re.escape(
@@ -289,25 +293,35 @@ def test_invalid_range_overrides(kymograph):
             "(lower bound, upper bound)."
         ),
     ):
-        KymoWidgetGreedy(kymograph, "red", 1, slider_ranges={"pixel_threshold": (1, 5, 6)})
+        KymoWidgetGreedy(
+            kymograph, "red", axis_aspect_ratio=1, slider_ranges={"pixel_threshold": (1, 5, 6)}
+        )
 
 
 @cleanup
 def test_valid_override(kymograph):
     """Tests whether the correct ranges make it into the widget data. Unfortunately we cannot test
     the full widget as we cannot spin up the UI."""
-    kw = KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)
+    kw = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     assert kw._algorithm_parameters["pixel_threshold"].lower_bound == 1
     assert kw._algorithm_parameters["pixel_threshold"].upper_bound == 10
 
     kw = KymoWidgetGreedy(
-        kymograph, "red", 1, use_widgets=False, slider_ranges={"pixel_threshold": (5, 10)}
+        kymograph,
+        "red",
+        axis_aspect_ratio=1,
+        use_widgets=False,
+        slider_ranges={"pixel_threshold": (5, 10)},
     )
     assert kw._algorithm_parameters["pixel_threshold"].lower_bound == 5
     assert kw._algorithm_parameters["pixel_threshold"].upper_bound == 10
 
     kw = KymoWidgetGreedy(
-        kymograph, "red", 1, use_widgets=False, slider_ranges={"min_length": (5, 10)}
+        kymograph,
+        "red",
+        axis_aspect_ratio=1,
+        use_widgets=False,
+        slider_ranges={"min_length": (5, 10)},
     )
     assert kw._algorithm_parameters["min_length"].lower_bound == 5
     assert kw._algorithm_parameters["min_length"].upper_bound == 10
@@ -320,3 +334,10 @@ def test_valid_default_parameters():
             match="Lower and upper bounds must be supplied for widget to be set as visible.",
         ):
             KymotrackerParameter("p", "d", "int", 5, *rng, True)
+
+
+@cleanup
+def test_keyword_args(kymograph):
+    """Test that only 2 positional arguments can be used."""
+    with pytest.raises(TypeError):
+        KymoWidgetGreedy(kymograph, "red", 1, use_widgets=False)


### PR DESCRIPTION
**Why this PR?**
Continuing with the terminology refactor. This PR tackles functions in `kymotracker.py` and some things in the widget to ensure the tests pass. There are some additional breaking changes that I've included since we're on one of those releases anyway and it cut down on some ugliness wrt argument order in the function signatures
- added defaults to the pixel threshold and track width args for `track_greedy`; this allowed for an aliasing/deprecation pathway for the former `line_width` argument
- `KymoWidget` and `KymoWidgetGreedy` now enforce keyworded arguments for everything beyond the first 2 (`kymo` and `channel`). Without this change, I would have had to put the new `track_width` parameter at the end of the constructor signature and would end up separated from the rest of the algorithm parameters
- the new `refine_tracks_centroid()` accepts `track_width` in physical units whereas the deprecated `refine_lines_centroid()` expects `line_width` to be in pixel units. This change was made so that `track_greedy`, `refine_tracks_centroid` and the widget all use physical units

I tried to keep the commits organized and fairly well separated. Again, most can be squashed before merging

Next and final PR will tackle the remaining terminology changes necessary in the widget