### PR TITLE
channel: fixed `TimeSeries.from_dataset()` not lazy loading data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 * Added possibility to access property `sample_rate` for `TimeSeries` data with constant sample rate.
 * Added shape property to `Scan` and `Kymo`.
 * Added a warning to the Kymotracker widget if the threshold parameter is set too low, which may result in slow tracking and the widget hanging.
+* Pylake now depends on `h5py>=3.4, <4`. This change is required to still support `len()` with the lazy loading fix for `TimeSeries`.
 
 #### Bug fixes
 
@@ -30,6 +31,7 @@
 * Force distance models now have a non-zero lower bound for the contour length (`Lc`), persistence length (`Lp`), stretch modulus (`St`) and boltzmann constant times temperature (`kT`) instead of a lower bound of zero.
 * Force distance fits now raise a `RuntimeError` if any of the returned simulation values are NaN.
 * Fixed bug that resulted in profile likelihood automatically failing when an attempted step exceeded the bounds where the model could be simulated.
+* Fixed method `TimeSeries.from_dataset()` reading all data from datasets upon creation of a `TimeSeries` instance instead of lazy loading 
 
 #### Breaking changes
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -559,7 +559,7 @@ class TimeSeries:
         self._cached_timestamps = None
 
     def __len__(self):
-        return len(self.data)
+        return len(self._src_data)
 
     def _with_data(self, data):
         return self.__class__(data, self.timestamps)
@@ -572,7 +572,7 @@ class TimeSeries:
     @staticmethod
     def from_dataset(dset, y_label="y", calibration=None):
         return Slice(
-            TimeSeries(dset["Value"], dset["Timestamp"]),
+            TimeSeries(dset.fields("Value"), dset.fields("Timestamp")),
             labels={"title": dset.name.strip("/"), "y": y_label},
             calibration=calibration,
         )

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "pytest>=3.5",
-        "h5py>=3.0, <4",
+        "h5py>=3.4, <4",
         "numpy>=1.20, <2",
         "scipy>=1.1, <2",
         "matplotlib>=2.2",


### PR DESCRIPTION
The method `TimeSeries.from_dataset()` automatically loaded the data and timestamps from an HDF5 file upon creation of a `TimeSeries` instance. This is now avoided by creating the `TimeSeries` instance using the `h5py.Dataset.fields()` method of data and timestamps.

Just to add more information, how I realized this:

```
from lumicks import pylake as lk

filepath = "./data/Lakeview Showcase Data-20220616T152657Z-001/FD Curve_forw_DNA.h5"
file = lk.File(filepath)

a = file.h5["Distance"]["Distance 1"]["Value"]
b = file.h5["Distance"]["Distance 1"].fields("Value")

type(a), type(b)
```

The output of this is `(numpy.ndarray, h5py._hl.dataset.FieldsWrapper)`, so `a` is a numpy array directly loaded into memory, whereas `b` is a `FieldsWrapper`, enabling the lazy loading.