### PR TITLE
docs: fixing docs build warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,8 @@ autosummary_generate = True
 # types are used
 autodoc_type_aliases = {"npt.ArrayLike": "numpy.typing.ArrayLike"}
 
+napoleon_custom_sections = ["Actions"]
+
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://docs.scipy.org/doc/numpy/", None),

--- a/lumicks/pylake/adjustments.py
+++ b/lumicks/pylake/adjustments.py
@@ -3,55 +3,54 @@ import matplotlib as mpl
 
 
 class ColorAdjustment:
-    """Color adjustment for plotting"""
+    """Utility class to adjust the min/max values of image colormaps.
+
+    Values can be supplied as a single number or 1-component list, in which case the value is
+    applied to all color channels, or a 3-component list specifying the values for red, green,
+    and blue channels.
+
+    Parameters
+    ----------
+    minimum : array_like
+        1 or 3-component list of lower limits for the color mapping
+    maximum : array_like
+        1 or 3-component list of upper limits for the color mapping
+    mode : str
+        - "percentile" : color limits are given as percentiles of the image in question.
+          Percentiles are calculated for each color channel separately
+        - "absolute" : color limits are given as absolute values.
+
+        Note: When providing bounds in percentiles, limits will change depending on which image
+        you are looking at. When scrolling through a stack of images, the limits will not remain
+        constant.
+    gamma : float
+        1 or 3-component list of gamma adjustments.
+
+        Applies a power law to the data according to: `((data - vmin) / (vmax - vmin)) ** gamma`
+
+    Examples
+    --------
+    ::
+
+        from lumicks import pylake
+        file = pylake.File("example.h5")
+
+        # Plot scan with red color mapped from 5th to 95th percentile.
+        adjustment = lk.ColorAdjustment(5, 95, mode="percentile")
+        file.scans["scan"].plot(channel="red", adjustment=adjustment)
+
+        # Plot scan with RGB colors mapped from 5th to 95th percentile.
+        adjustment = lk.ColorAdjustment([5, 5, 5], [95, 95, 95], mode="percentile")
+        file.scans["scan"].plot(adjustment=adjustment)
+
+        stack = lk.CorrelatedStack("camera_recording.tiff")
+        # Plot force 1x with this stack and adjust the contrast by specifying an absolute upper
+        # and lower bound for the intensities.
+        absolute_adjustment = lk.ColorAdjustment([50, 30, 20], [1000, 195, 95])
+        stack.plot_correlated(file.force1x, channel="rgb", adjustment=absolute_adjustment)
+    """
 
     def __init__(self, minimum, maximum, mode="absolute", gamma=1):
-        """Utility class to adjust the min/max values of image colormaps.
-
-        Values can be supplied as a single number or 1-component list, in which case the value is
-        applied to all color channels, or a 3-component list specifying the values for red, green,
-        and blue channels.
-
-        Parameters
-        ----------
-        minimum : array_like
-            1 or 3-component list of lower limits for the color mapping
-        maximum : array_like
-            1 or 3-component list of upper limits for the color mapping
-        mode : str
-            - "percentile" : color limits are given as percentiles of the image in question.
-              Percentiles are calculated for each color channel separately
-            - "absolute" : color limits are given as absolute values.
-
-            Note: When providing bounds in percentiles, limits will change depending on which image
-            you are looking at. When scrolling through a stack of images, the limits will not remain
-            constant.
-        gamma : float
-            1 or 3-component list of gamma adjustments.
-
-            Applies a power law to the data according to: `((data - vmin) / (vmax - vmin)) ** gamma`
-
-        Examples
-        --------
-        ::
-
-            from lumicks import pylake
-            file = pylake.File("example.h5")
-
-            # Plot scan with red color mapped from 5th to 95th percentile.
-            adjustment = lk.ColorAdjustment(5, 95, mode="percentile")
-            file.scans["scan"].plot(channel="red", adjustment=adjustment)
-
-            # Plot scan with RGB colors mapped from 5th to 95th percentile.
-            adjustment = lk.ColorAdjustment([5, 5, 5], [95, 95, 95], mode="percentile")
-            file.scans["scan"].plot(adjustment=adjustment)
-
-            stack = lk.CorrelatedStack("camera_recording.tiff")
-            # Plot force 1x with this stack and adjust the contrast by specifying an absolute upper
-            # and lower bound for the intensities.
-            absolute_adjustment = lk.ColorAdjustment([50, 30, 20], [1000, 195, 95])
-            stack.plot_correlated(file.force1x, channel="rgb", adjustment=absolute_adjustment)
-        """
         minimum, maximum, gamma = (np.atleast_1d(x) for x in (minimum, maximum, gamma))
         self.mode = None if mode == "nothing" else mode
         if not self.mode:

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -20,7 +20,7 @@ class Slice:
     Parameters
     ----------
     data_source : Any
-        A slice data source. Can be `Continuous`, `TimeSeries`, 'TimeTags',
+        A slice data source. Can be `Continuous`, `TimeSeries`, `TimeTags`,
         or any other source which conforms to the same interface.
     labels : Dict[str, str]
         Plot labels: "x", "y", "title".
@@ -195,10 +195,15 @@ class Slice:
 
     @property
     def calibration(self) -> list:
-        """Calibration data slicing is deferred until calibration is requested to avoid
-        slicing values that may be needed."""
+        """List of force calibration items
+
+        The first element represents the calibration item that was active when this slice was
+        made.
+        """
         if self._calibration:
             try:
+                # Calibration data slicing is deferred until calibration is requested to avoid
+                # slicing values that may be needed.
                 return self._calibration.filter_calibration(self._src.start, self._src.stop)
             except IndexError:
                 return []
@@ -225,9 +230,9 @@ class Slice:
             )
 
     def downsampled_over(self, range_list, reduce=np.mean, where="center"):
-        """Downsample channel data based on timestamp ranges. The downsampling function (e.g. np.mean) is evaluated for
-        the time between a start and end time of each block. A list is returned that contains the data corresponding to
-        each block.
+        """Downsample channel data based on timestamp ranges. The downsampling function (e.g.
+        np.mean) is evaluated for the time between a start and end time of each block. A list is
+        returned that contains the data corresponding to each block.
 
         Parameters
         ----------
@@ -240,9 +245,11 @@ class Slice:
             cases, e.g. photon counts.
         where : str
             Where to put the final time point.
-            'center' time point is put at (timestamps_subset[0] + timestamps_subset[-1]) / 2, where timestamps_subset
-            are the timestamps corresponding to the samples being downsampled over.
-            'left' time point is put at start
+
+            - "center" : The new time points are set to
+              `(timestamps_subset[0] + timestamps_subset[-1]) / 2`, where `timestamps_subset` are
+              the timestamps corresponding to the samples being downsampled over.
+            - "left" : Time points are set to the starting timestamp of the downsampled data.
 
         Examples
         --------
@@ -298,18 +305,23 @@ class Slice:
             cases, e.g. photon counts.
         where : str
             Where to put the final time point.
-            'center' time point is put at (timestamps_subset[0] + timestamps_subset[-1]) / 2, where timestamps_subset
-            are the timestamps corresponding to the samples being downsampled over.
-            'left' time point is put at start
-        method : str
-            How to handle target sample times that are not exact multiples of the current sample time.
 
-            'safe'  new sample time must be an exact multiple of the current sample time,
-                    else an exception is raised.
-            'ceil'  rounds the sample rate up to the nearest frequency which fulfills this condition
-            'force' downsample data with the target input frequency; this will result in variable
-                    sample times and a variable number of sampling contributing to each target sample,
-                    but must be used for variable-frequency data
+            - "center" : The new time points are set to
+              `(timestamps_subset[0] + timestamps_subset[-1]) / 2`, where `timestamps_subset` are
+              the timestamps corresponding to the samples being downsampled over.
+            - "left" : Time points are set to the starting timestamp of the downsampled data.
+
+        method : str
+            How to handle target sample times that are not exact multiples of the current sample
+            time.
+
+            - "safe" : New sample time must be an exact multiple of the current sample time, else
+              an exception is raised.
+            - 'ceil' : Rounds the sample rate up to the nearest frequency which fulfills this
+              condition.
+            - 'force' : Downsample data with the target input frequency; this will result in
+              variable sample times and a variable number of sampling contributing to each target
+              sample but must be used for variable-frequency data.
         """
         if method not in ("safe", "ceil", "force"):
             raise ValueError(f"method '{method}' is not recognized")

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -298,7 +298,8 @@ class CorrelatedStack(VideoExport):
     def crop_and_rotate(self, frame=0, channel="rgb", show_title=True, **kwargs):
         """Open a widget to interactively edit the image stack.
 
-        Actions include:
+        Actions
+        -------
 
             * scrolling through frames using the mouse wheel
             * left-click to define the location of the tether

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -1,7 +1,6 @@
 import numpy as np
 import os
 import tifffile
-import warnings
 from deprecated.sphinx import deprecated
 from .detail.imaging_mixins import VideoExport
 from .adjustments import ColorAdjustment
@@ -282,7 +281,7 @@ class CorrelatedStack(VideoExport):
         axes : mpl.axes.Axes or None
             If supplied, the axes instance in which to plot.
         **kwargs
-            Forwarded to :fun:`matplotlib.pyplot.plot`.
+            Forwarded to :func:`matplotlib.pyplot.plot`.
         """
         import matplotlib.pyplot as plt
 
@@ -300,6 +299,7 @@ class CorrelatedStack(VideoExport):
         """Open a widget to interactively edit the image stack.
 
         Actions include:
+
             * scrolling through frames using the mouse wheel
             * left-click to define the location of the tether
 
@@ -319,19 +319,19 @@ class CorrelatedStack(VideoExport):
         --------
         ::
 
-        from lumicks import pylake
-        import matplotlib.pyplot as plt
+            from lumicks import pylake
+            import matplotlib.pyplot as plt
 
-        # Loading a stack.
-        stack = pylake.CorrelatedStack("example.tiff")
-        widget = stack.crop_and_rotate()
-        plt.show()
+            # Loading a stack.
+            stack = pylake.CorrelatedStack("example.tiff")
+            widget = stack.crop_and_rotate()
+            plt.show()
 
-        # Select cropping ROI by right-click drag
-        # Select tether ends by left-click
+            # Select cropping ROI by right-click drag
+            # Select tether ends by left-click
 
-        # Grab the updated image stack
-        new_stack = widget.image
+            # Grab the updated image stack
+            new_stack = widget.image
         """
         from .nb_widgets.image_editing import ImageEditorWidget
 
@@ -351,9 +351,9 @@ class CorrelatedStack(VideoExport):
         figure_scale=0.75,
         adjustment=ColorAdjustment.nothing(),
     ):
-        """Downsample channel on a frame by frame basis and plot the results. The downsampling function (e.g. np.mean)
-        is evaluated for the time between a start and end time of a frame. Note: In environments which support
-        interactive figures (e.g. jupyter notebook with ipywidgets or interactive python) this plot will be interactive.
+        """Downsample channel on a frame by frame basis and plot the results. The downsampling
+        function (e.g. `np.mean`) is evaluated for the time between a start and end time of a
+        frame.
 
         Parameters
         ----------
@@ -374,6 +374,10 @@ class CorrelatedStack(VideoExport):
         adjustment : lk.ColorAdjustment
             Color adjustments to apply to the output image.
 
+        Note
+        ----
+        In environments which support interactive figures (e.g. `jupyter notebook` with
+        `ipywidgets` or interactive python) this plot will be interactive.
 
         Examples
         --------
@@ -501,6 +505,7 @@ class CorrelatedStack(VideoExport):
         version="0.11.1",
     )
     def timestamps(self):
+        """Get start and stop timestamp of each frame in the stack."""
         return self.frame_timestamp_ranges()
 
     def frame_timestamp_ranges(self, *, include_dead_time=False):

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -264,63 +264,39 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
         raise NotImplementedError
 
     @deprecated(
-        reason="`plot_red()` is deprecated. Use `plot(channel='red') instead.",
+        reason=("`plot_red()` is deprecated. Use `plot(channel='red')` instead."),
         version="0.11.1",
         action="always",
     )
     def plot_red(self, **kwargs):
-        """Plot an image of the red photon channel
-
-        Parameters
-        ----------
-        **kwargs
-            Forwarded to :func:`matplotlib.pyplot.imshow`.
-        """
+        """Plot an image of the red photon channel"""
         return self.plot(channel="red", **kwargs)
 
     @deprecated(
-        reason="`plot_green()` is deprecated. Use `plot(channel='green') instead.",
+        reason="`plot_green()` is deprecated. Use `plot(channel='green')` instead.",
         version="0.11.1",
         action="always",
     )
     def plot_green(self, **kwargs):
-        """Plot an image of the green photon channel
-
-        Parameters
-        ----------
-        **kwargs
-            Forwarded to :func:`matplotlib.pyplot.imshow`.
-        """
+        """Plot an image of the green photon channel"""
         return self.plot(channel="green", **kwargs)
 
     @deprecated(
-        reason="`plot_blue()` is deprecated. Use `plot(channel='blue') instead.",
+        reason="`plot_blue()` is deprecated. Use `plot(channel='blue')` instead.",
         version="0.11.1",
         action="always",
     )
     def plot_blue(self, **kwargs):
-        """Plot an image of the blue photon channel
-
-        Parameters
-        ----------
-        **kwargs
-            Forwarded to :func:`matplotlib.pyplot.imshow`.
-        """
+        """Plot an image of the blue photon channel"""
         return self.plot(channel="blue", **kwargs)
 
     @deprecated(
-        reason="`plot_rgb()` is deprecated. Use `plot(channel='rgb') instead.",
+        reason="`plot_rgb()` is deprecated. Use `plot(channel='rgb')` instead.",
         version="0.11.1",
         action="always",
     )
     def plot_rgb(self, **kwargs):
-        """Plot an image of all color channels.
-
-        Parameters
-        ----------
-        **kwargs
-            Forwarded to :func:`matplotlib.pyplot.imshow`.
-        """
+        """Plot an image of all color channels."""
         return self.plot(channel="rgb", **kwargs)
 
     def _get_plot_data(self, channel):
@@ -459,9 +435,10 @@ class ConfocalImage(BaseScan):
 
     @property
     def timestamps(self) -> np.ndarray:
-        """Timestamps for image pixels, not for samples
+        """Timestamps for each image pixel.
 
-        The returned array has the same shape as the `*_image` arrays.
+        The returned array has the same shape as the `{color}_image` arrays. Timestamps are defined
+        at the mean of the timestamps.
         """
         return self._timestamps("timestamps")
 
@@ -492,6 +469,7 @@ class ConfocalImage(BaseScan):
         version="0.12.0",
     )
     def red_image(self):
+        """Returns an image representing the red channel"""
         return self.get_image("red")
 
     @property
@@ -503,6 +481,7 @@ class ConfocalImage(BaseScan):
         version="0.12.0",
     )
     def green_image(self):
+        """Returns an image representing the green channel"""
         return self.get_image("green")
 
     @property
@@ -514,6 +493,7 @@ class ConfocalImage(BaseScan):
         version="0.12.0",
     )
     def blue_image(self):
+        """Returns an image representing the blue channel"""
         return self.get_image("blue")
 
     @property
@@ -525,6 +505,7 @@ class ConfocalImage(BaseScan):
         version="0.12.0",
     )
     def rgb_image(self):
+        """Returns an rgb image"""
         return self.get_image("rgb")
 
     def get_image(self, channel="rgb") -> np.ndarray:

--- a/lumicks/pylake/fitting/detail/model_implementation.py
+++ b/lumicks/pylake/fitting/detail/model_implementation.py
@@ -61,11 +61,12 @@ def marko_siggia_simplified_equation_tex(d, Lp, Lc, kT):
 
 
 def marko_siggia_simplified(d, Lp, Lc, kT):
-    """Marko Siggia's Worm-like Chain model based on only entropic contributions. Valid for F < 10 pN).
+    """Marko Siggia's Worm-like Chain model based on only entropic contributions. Valid for
+    F < 10 pN) [1]_.
 
-    References:
-        1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
-        8759-8770 (1995).
+    References
+    ----------
+    .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
     """
     if Lp <= 0 or Lc <= 0 or kT <= 0:
         raise ValueError("Persistence length, contour length and kT must be bigger than 0")
@@ -105,13 +106,7 @@ def WLC_equation_tex(f, Lp, Lc, St, kT=4.11):
 
 
 def WLC(f, Lp, Lc, St, kT=4.11):
-    """Odijk's Extensible Worm-like Chain model
-
-    References:
-      1. T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules
-         28, 7016-7018 (1995).
-      2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
-         DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+    """Odijk's Extensible Worm-like Chain model [1]_ [2]_.
 
     Parameters
     ----------
@@ -125,6 +120,12 @@ def WLC(f, Lp, Lc, St, kT=4.11):
         stretching modulus [pN]
     kT : float
         Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
+
+    References
+    ----------
+    .. [1] T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules 28, 7016-7018 (1995).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
     """
     if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
         raise ValueError(
@@ -162,11 +163,7 @@ def tWLC_equation_tex(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
 
 
 def tWLC(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
-    """Twistable Worm-like Chain model
-
-    References:
-       1. P. Gross et al., Quantifying how DNA stretches, melts and changes
-          twist under tension, Nature Physics 7, 731-736 (2011).
+    """Twistable Worm-like Chain model [1]_.
 
     Parameters
     ----------
@@ -188,6 +185,11 @@ def tWLC(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
         critical force for twist stretch coupling [pN]
     kT : float
         Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
+
+    References
+    ----------
+    .. [1] P. Gross et al., Quantifying how DNA stretches, melts and changes twist under tension,
+    Nature Physics 7, 731-736 (2011).
     """
     if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
         raise ValueError(
@@ -259,14 +261,7 @@ def FJC_equation_tex(f, Lp, Lc, St, kT=4.11):
 
 
 def FJC(f, Lp, Lc, St, kT=4.11):
-    """Freely-Jointed Chain
-
-    References:
-       1. S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The
-          Elastic Response of Individual Double-Stranded and Single-Stranded
-          DNA Molecules, Science 271, 795-799 (1996).
-       2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
-          DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+    """Freely-Jointed Chain [1]_ [2]_.
 
     Parameters
     ----------
@@ -280,6 +275,14 @@ def FJC(f, Lp, Lc, St, kT=4.11):
         elastic modulus [pN]
     kT : float
         Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
+
+    References
+    ----------
+    .. [1] S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The Elastic Response of
+           Individual Double-Stranded and Single-Stranded DNA Molecules, Science 271, 795-799
+           (1996).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
     """
     if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
         raise ValueError(
@@ -363,13 +366,7 @@ def invWLC_equation_tex(d, Lp, Lc, St, kT=4.11):
 
 
 def invWLC(d, Lp, Lc, St, kT=4.11):
-    """Inverted Odijk's Worm-like Chain model
-
-    References:
-      1. T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules
-         28, 7016-7018 (1995).
-      2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
-         DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+    """Inverted Odijk's Worm-like Chain model [1]_ [2]_.
 
     Parameters
     ----------
@@ -383,6 +380,12 @@ def invWLC(d, Lp, Lc, St, kT=4.11):
         stretching modulus [pN]
     kT : float
         Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
+
+    References
+    ----------
+    .. [1] T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules 28, 7016-7018 (1995).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
     """
     #
     # In short, this model was analytically solved, since it is basically a cubic equation. There are some issues
@@ -638,9 +641,13 @@ def invtWLC_equation_tex(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
 def invtWLC(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     """Inverted Twistable Worm-like Chain model
 
-    References:
-       1. P. Gross et al., Quantifying how DNA stretches, melts and changes
-          twist under tension, Nature Physics 7, 731-736 (2011).
+    Inverted form of the Twistable Worm-like Chain model that takes into account untwisting of the
+    DNA at high forces.
+
+    References
+    ----------
+    .. [1] P. Gross et al., Quantifying how DNA stretches, melts and changes twist under tension,
+           Nature Physics 7, 731-736 (2011).
 
     Parameters
     ----------
@@ -691,14 +698,15 @@ def invtWLC_jac(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
 
 
 def invFJC(d, Lp, Lc, St, kT=4.11):
-    """Inverted Freely-Jointed Chain
+    """Inverted Freely-Jointed Chain [1]_ [2]_.
 
-    References:
-       1. S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The
-          Elastic Response of Individual Double-Stranded and Single-Stranded
-          DNA Molecules, Science 271, 795-799 (1996).
-       2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
-          DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+    References
+    ----------
+    .. [1] S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The Elastic Response of
+           Individual Double-Stranded and Single-Stranded DNA Molecules, Science 271, 795-799
+           (1996).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
 
     Parameters
     ----------
@@ -753,13 +761,23 @@ def marko_siggia_ewlc_solve_force_equation_tex(d, Lp, Lc, St, kT=4.11):
 
 
 def marko_siggia_ewlc_solve_force(d, Lp, Lc, St, kT=4.11):
-    """Marko-Siggia's Worm-like Chain model with distance as dependent parameter (useful for F < 10 pN).
-    These equations were symbolically derived. The expressions are not pretty, but they work."""
+    """Modified Marko Siggia's Worm-like Chain model with distance as dependent parameter.
+
+    Modification of Marko-Siggia formula [1] to incorporate enthalpic stretching. Has limitations
+    similar to Marko-Siggia near `F = 0.1 pN` [2]_.
+
+    References
+    ----------
+    .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
+    .. [2] Wang, M. D., Yin, H., Landick, R., Gelles, J., & Block, S. M. (1997). Stretching DNA
+           with optical tweezers. Biophysical journal, 72(3), 1335-1346.
+    """
     if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
         raise ValueError(
             "Persistence length, contour length, stretch modulus and kT must be bigger than 0"
         )
 
+    """Margo-Siggia's Worm-like Chain model with distance as dependent parameter."""
     c = -(St**3) * d * kT * (1.5 * Lc**2 - 2.25 * Lc * d + d**2) / (Lc**3 * (Lp * St + kT))
     b = (
         St**2

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -16,8 +16,8 @@ def front(x):
 
 
 class Fit:
-    """Object which is used for fitting. It is a collection of models and their data. Once data is loaded, a fit object
-    contains parameters, which can be fitted by invoking fit.
+    """Object which is used for fitting. It is a collection of models and their data. Once data is
+    loaded, a fit object contains parameters, which can be fitted by invoking fit.
 
     Parameters
     ----------
@@ -275,29 +275,31 @@ class Fit:
         confidence_level=0.95,
         verbose=False,
     ):
-        """Calculate a profile likelihood. This method traces an optimal path through parameter space in order to
-        estimate parameter confidence intervals. It iteratively performs a step for the profiled parameter, then fixes
-        that parameter and re-optimizes all the other parameters.
+        """Calculate a profile likelihood. This method traces an optimal path through parameter
+        space in order to estimate parameter confidence intervals. It iteratively performs a step
+        for the profiled parameter, then fixes that parameter and re-optimizes all the other
+        parameters [4]_ [5]_.
 
         Parameters
         ----------
         parameter_name: str
             Which parameter to evaluate a profile likelihood for.
         min_step: float
-            Minimum step size. This is multiplied by the current parameter value to come to a minimum step size used
-            in the step-size estimation procedure (default: 1e-4).
+            Minimum step size. This is multiplied by the current parameter value to come to a
+            minimum step size used in the step-size estimation procedure.
         max_step: float
-            Maximum step size (default: 1.0).
+            Maximum step size.
         num_steps: integer
-            Number of steps to take (default: 100).
+            Number of steps to take .
         step_factor: float
-            Which factor to change the step-size by when step-size is too large or too small (default: 2).
+            Which factor to change the step-size by when step-size is too large or too small.
         min_chi2_step: float
-            Minimal desired step in terms of chi squared change prior to re-optimization. When the step results in a fit
-            change smaller than this threshold, the step-size will be increased.
+            Minimal desired step in terms of chi squared change prior to re-optimization. When the
+            step results in a fit change smaller than this threshold, the step-size will be
+            increased.
         max_chi2_step: float
-            Minimal desired step in terms of chi squared change prior to re-optimization. When the step results in a fit
-            change bigger than this threshold, the step-size will be reduced.
+            Minimal desired step in terms of chi squared change prior to re-optimization. When the
+            step results in a fit change bigger than this threshold, the step-size will be reduced.
         termination_significance: float
             Significance level for terminating the parameter scan. When the fit quality exceeds the
             termination_significance confidence level, it stops scanning.
@@ -305,6 +307,16 @@ class Fit:
             Significance level for the chi squared test.
         verbose: bool
             Controls the verbosity of the output.
+
+        References
+        ----------
+        .. [4] Raue, A., Kreutz, C., Maiwald, T., Bachmann, J., Schilling, M., Klingmüller, U.,
+               & Timmer, J. (2009). Structural and practical identifiability analysis of partially
+               observed dynamical models by exploiting the profile likelihood. Bioinformatics,
+               25(15), 1923-1929.
+        .. [5] Maiwald, T., Hass, H., Steiert, B., Vanlier, J., Engesser, R., Raue, A., Kipkeew,
+               F., Bock, H.H., Kaschek, D., Kreutz, C. and Timmer, J., 2016. Driving the model to
+               its limit: profile likelihood based model reduction. PloS one, 11(9).
         """
 
         if parameter_name not in self.params:
@@ -426,13 +438,13 @@ class Fit:
         independent : array_like
             Array with values for the independent variable (used when plotting the model).
         legend : bool
-            Show legend (default: True).
+            Show legend.
         plot_data : bool
-            Show data (default: True).
+            Show data.
         overrides : dict
-            Parameter / value pairs which override parameter values in the current fit. Should be a dict of
-            {str: float} that provides values for parameters which should be set to particular values in the plot
-            (default: None);
+            Parameter / value pairs which override parameter values in the current fit. Should be
+            a dict of `{str: float}` that provides values for parameters which should be set to
+            particular values in the plot.
         ``**kwargs``
             Forwarded to :func:`matplotlib.pyplot.plot`.
 
@@ -453,7 +465,8 @@ class Fit:
             # Have a quick look at what a stiffness of 5 would do to the fit.
             fit.plot("Control", overrides={"DNA/St": 5})
 
-            # When dealing with multiple models in one fit, one has to select the model first when we want to plot.
+            # When dealing with multiple models in one fit, one has to select the model first when
+            # we want to plot.
             model1 = pylake.odijk("DNA")
             model2 = pylake.odijk("DNA") + pylake.odijk("protein")
             fit[model1].add_data("Control", force1, distance2)
@@ -532,8 +545,8 @@ class Fit:
     @property
     def sigma(self):
         """Error variance of the data points."""
-        # TO DO: Ideally, this will eventually depend on the exact error model used. For now, we use the a-posteriori
-        # noise standard deviation estimate based on the residual.
+        # TO DO: Ideally, this will eventually depend on the exact error model used. For now,
+        # we use the a-posteriori noise standard deviation estimate based on the residual.
         res = self._calculate_residual()
         est_sd = np.sqrt((res * res).sum() / (len(res) - np.sum(self.params.fitted)))
 
@@ -562,17 +575,19 @@ class Fit:
     def aic(self):
         """Calculates the Akaike Information Criterion:
 
-            AIC = 2 k - 2 ln(L)
+        .. math::
+            AIC = 2 k - 2 \mathrm{ln}(L)
 
-        Where k refers to the number of parameters, n to the number of observations (or data points) and L to the
-        maximized value of the likelihood function
+        Where k refers to the number of parameters, n to the number of observations (or data
+        points) and L to the maximized value of the likelihood function [6]_.
 
-        The emphasis of this criterion is future prediction. It does not lead to consistent model selection and is more
-        prone to over-fitting than the Bayesian Information Criterion.
+        The emphasis of this criterion is future prediction. It does not lead to consistent model
+        selection and is more prone to over-fitting than the Bayesian Information Criterion.
 
-        References:
-            Cavanaugh, J.E., 1997. Unifying the derivations for the Akaike and corrected Akaike information criteria.
-            Statistics & Probability Letters, 33(2), pp.201-208.
+        References
+        ----------
+        .. [6] Cavanaugh, J.E., 1997. Unifying the derivations for the Akaike and corrected Akaike
+               information criteria. Statistics & Probability Letters, 33(2), pp.201-208.
         """
         self._rebuild()
         k = sum(self.params.fitted)
@@ -586,15 +601,17 @@ class Fit:
         .. math::
             AICc = AIC + \\frac{2 k^2 + 2 k}{n - k - 1}
 
-        Where k refers to the number of parameters, n to the number of observations (or data points) and L to the
-        maximized value of the likelihood function
+        Where k refers to the number of parameters, n to the number of observations (or data
+        points) and L to the maximized value of the likelihood function [7]_.
 
-        The emphasis of this criterion is future prediction. Compared to the AIC it should be less prone to overfitting
-        for smaller sample sizes. Analogously to the AIC, it does not lead to a consistent model selection procedure.
+        The emphasis of this criterion is future prediction. Compared to the AIC it should be less
+        prone to overfitting for smaller sample sizes. Analogously to the AIC, it does not lead to
+        a consistent model selection procedure.
 
-        References:
-            Cavanaugh, J.E., 1997. Unifying the derivations for the Akaike and corrected Akaike information criteria.
-            Statistics & Probability Letters, 33(2), pp.201-208.
+        References
+        ----------
+        .. [7] Cavanaugh, J.E., 1997. Unifying the derivations for the Akaike and corrected Akaike
+               information criteria. Statistics & Probability Letters, 33(2), pp.201-208.
         """
 
         aic = self.aic
@@ -605,14 +622,16 @@ class Fit:
     def bic(self):
         """Calculates the Bayesian Information Criterion:
 
-            BIC = k ln(n) - 2 ln(L)
+        .. math::
+            BIC = k \mathrm{ln}(n) - 2 \mathrm{ln}(L)
 
-        Where k refers to the number of parameters, n to the number of observations (or data points) and L to the
-        maximized value of the likelihood function
+        Where k refers to the number of parameters, n to the number of observations (or data points)
+        and L to the maximized value of the likelihood function
 
-        The emphasis of the BIC is put on parsimonious models. As such it is less prone to over-fitting. Selection via
-        BIC leads to a consistent model selection procedure, meaning that as the number of data points tends to
-        infinity, BIC will select the true model assuming the true model is in the set of selected models.
+        The emphasis of the BIC is put on parsimonious models. As such it is less prone to
+        over-fitting. Selection via BIC leads to a consistent model selection procedure, meaning
+        that as the number of data points tends to infinity, BIC will select the true model
+        assuming the true model is in the set of selected models.
         """
 
         k = sum(self.params.fitted)
@@ -620,18 +639,21 @@ class Fit:
 
     @property
     def cov(self):
-        """Returns the inverse of the approximate Hessian. This approximation is valid when the model fits well (small
-        residuals) and there is sufficient data to assume we're in the asymptotic regime.
+        """Returns the inverse of the approximate Hessian. This approximation is valid when the
+        model fits well (small residuals) and there is sufficient data to assume we're in the
+        asymptotic regime.
 
-        It makes use of the Gauss-Newton approximation of the Hessian, which uses only the first order sensitivity
-        information. This is valid for linear problems and problems near the optimum (assuming the model fits).
+        It makes use of the Gauss-Newton approximation of the Hessian, which uses only the first
+        order sensitivity information. This is valid for linear problems and problems near the
+        optimum (assuming the model fits) [8]_ [9]_.
 
-        References:
-            Press, W.H., Teukolsky, S.A., Vetterling, W.T. and Flannery, B.P., 1988. Numerical recipes in C.
-
-            Maiwald, T., Hass, H., Steiert, B., Vanlier, J., Engesser, R., Raue, A., Kipkeew, F., Bock, H.H.,
-            Kaschek, D., Kreutz, C. and Timmer, J., 2016. Driving the model to its limit: profile likelihood
-            based model reduction. PloS one, 11(9).
+        References
+        ----------
+        .. [8] Press, W.H., Teukolsky, S.A., Vetterling, W.T. and Flannery, B.P., 1988. Numerical
+               recipes in C.
+        .. [9] Maiwald, T., Hass, H., Steiert, B., Vanlier, J., Engesser, R., Raue, A., Kipkeew,
+               F., Bock, H.H., Kaschek, D., Kreutz, C. and Timmer, J., 2016. Driving the model to
+               its limit: profile likelihood based model reduction. PloS one, 11(9).
         """
         # Note that this approximation is only valid if the noise on each data set is the same.
         if self.has_jacobian:
@@ -686,8 +708,8 @@ class Fit:
 
 
 class FdFit(Fit):
-    """Object which is used for fitting. It is a collection of models and their data. Once data is loaded, a fit object
-    contains parameters, which can be fitted by invoking fit.
+    """Object which is used for fitting. It is a collection of models and their data. Once data is
+    loaded, a fit object contains parameters, which can be fitted by invoking fit.
 
     Examples
     --------
@@ -717,8 +739,9 @@ class FdFit(Fit):
         d : array_like
             An array_like containing distance data.
         params : dict of {str : str or int}
-            List of parameter transformations. These can be used to convert one parameter in the model, to a new
-            parameter name or constant for this specific data set (for more information, see the examples).
+            List of parameter transformations. These can be used to convert one parameter in the
+            model, to a new parameter name or constant for this specific data set (for more
+            information, see the examples).
 
         Examples
         --------

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -221,8 +221,27 @@ class Model:
         return model_info
 
     def invert(self, independent_min=0.0, independent_max=np.inf, interpolate=False):
-        """
-        Invert this model (swap dependent and independent parameter).
+        """Invert this model.
+
+        This operation swaps the dependent and independent parameter and should be avoided if a
+        faster alternative (such as an analytically inverted model) exists.
+
+        By default, this function returns an inverted version of the model, where the function
+        is inverted for each point using a least squares optimizer. Alternatively, one can use
+        an interpolation method to perform the inversion (here the relation is interpolated using
+        a spline and the result is looked up). Note that for the interpolation method, the range
+        used for the independent variable must be known a-priori.
+
+        Parameters
+        ----------
+        independent_min : float
+            Minimum value for the independent variable over which to interpolate. Only used when
+            `interpolate` is set to `True`.
+        independent_max : float
+            Maximum value for the independent variable over which to interpolate. Only used when
+            `interpolate` is set to `True`.
+        interpolate : bool
+            Use interpolation method rather than numerical inversion.
         """
         return InverseModel(self, independent_min, independent_max, interpolate)
 
@@ -281,13 +300,14 @@ class Model:
 
     @property
     def has_jacobian(self):
-        """Returns true if the model can return an analytically computed Jacobian."""
+        """Returns `True` if the model can return an analytically computed Jacobian."""
         if self._jacobian:
             return True
 
     @property
     def has_derivative(self):
-        """Returns true if the model can return an analytically computed derivative w.r.t. the independent variable."""
+        """Returns `True` if the model can return an analytically computed derivative w.r.t. the
+        independent variable."""
         if self._derivative:
             return True
 

--- a/lumicks/pylake/fitting/models.py
+++ b/lumicks/pylake/fitting/models.py
@@ -75,14 +75,20 @@ def distance_offset(name):
 def marko_siggia_ewlc_force(name):
     """Marko Siggia's Worm-like Chain model with force as dependent parameter.
 
-    References:
-        1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
-        8759-8770 (1995).
+    Modified Marko Siggia's Worm-like Chain model. Modification of Marko-Siggia formula [1]_
+    to incorporate enthalpic stretching. Has limitations similar to Marko-Siggia
+    near `F = 0.1 pN` [2]_.
 
     Parameters
     ----------
     name : str
         Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
+    .. [2] Wang, M. D., Yin, H., Landick, R., Gelles, J., & Block, S. M. (1997). Stretching DNA
+           with optical tweezers. Biophysical journal, 72(3), 1335-1346.
     """
     from .model import Model
     from .detail.model_implementation import (
@@ -110,16 +116,22 @@ def marko_siggia_ewlc_force(name):
 
 
 def marko_siggia_ewlc_distance(name):
-    """Marko Siggia's Worm-like Chain model with distance as dependent parameter.
+    """Marko Siggia's Worm-like Chain model with distance as dependent parameter
 
-    References:
-        1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
-        8759-8770 (1995).
+    Modified Marko Siggia's Worm-like Chain model. Modification of Marko-Siggia formula [1]_
+    to incorporate enthalpic stretching. Has limitations similar to Marko-Siggia
+    near `F = 0.1 pN` [2]_.
 
     Parameters
     ----------
     name : str
         Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
+    .. [2] Wang, M. D., Yin, H., Landick, R., Gelles, J., & Block, S. M. (1997). Stretching DNA
+           with optical tweezers. Biophysical journal, 72(3), 1335-1346.
     """
     from .model import Model
     from .detail.model_implementation import (
@@ -147,17 +159,19 @@ def marko_siggia_ewlc_distance(name):
 
 
 def marko_siggia_simplified(name):
-    """Marko Siggia's Worm-like Chain model based on only entropic contributions (valid for F << 10 pN). This model
-    has force as a dependent variable.
+    """Marko Siggia's Worm-like Chain model.
 
-    References:
-        1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
-        8759-8770 (1995).
+    This model [1]_ is based on only entropic contributions (valid for F << 10 pN). This model has
+    force as a dependent variable.
 
     Parameters
     ----------
     name : str
         Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
     """
     from .model import Model
     from .detail.model_implementation import (
@@ -184,17 +198,19 @@ def marko_siggia_simplified(name):
 
 
 def inverted_marko_siggia_simplified(name):
-    """Marko Siggia's Worm-like Chain model based on only entropic contributions (valid for F << 10 pN). This model
-    has distance as a dependent variable.
+    """Marko Siggia's Worm-like Chain model.
 
-    References:
-        1. J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26,
-        8759-8770 (1995).
+    This model is based on only entropic contributions [1]_ (valid for F << 10 pN). This model has
+    distance as a dependent variable.
 
     Parameters
     ----------
     name : str
         Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
     """
     from .model import Model
     from .detail.model_implementation import (
@@ -221,18 +237,20 @@ def inverted_marko_siggia_simplified(name):
 
 
 def odijk(name):
-    """Odijk's Extensible Worm-Like Chain model with distance as dependent variable (useful for 10 pN < F < 30 pN).
+    """Odijk's Extensible Worm-Like Chain model with distance as dependent variable
 
-    References:
-      1. T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules
-         28, 7016-7018 (1995).
-      2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
-         DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+    Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_.
 
     Parameters
     ----------
     name : str
         Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules 28, 7016-7018 (1995).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
     """
     from .model import Model
     from .detail.model_implementation import (
@@ -260,26 +278,11 @@ def odijk(name):
 
 
 def dsdna_odijk(name, dna_length_kbp, um_per_kbp=0.34, temperature=24.53608821):
-    """Odijk's Extensible Worm-Like Chain model with distance as the dependent variable, using user-specified kilobase-pairs (useful for 10 pN < F < 30 pN).
+    """Model for dsDNA with distance as the dependent variable.
 
-    References:
-      1. T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules
-         28, 7016-7018 (1995).
-      2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
-         DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
-      3. Manning, G. S. (2006). The persistence length of DNA is reached from
-         the persistence length of its null isomer through an internal
-         electrostatic stretching force. Biophysical journal, 91(10),
-         3607-3616.
-      4. Liu, J. H., Xi, K., Zhang, X., Bao, L., Zhang, X., & Tan, Z. J.
-         (2019). Structural flexibility of DNA-RNA hybrid duplex: stretching
-         and twist-stretch coupling. Biophysical journal, 117(1), 74-86.
-      5. Herrero-Galán, E., Fuentes-Perez, M. E., Carrasco, C., Valpuesta,
-         J. M., Carrascosa, J. L., Moreno-Herrero, F., & Arias-Gonzalez, J. R.
-         (2013). Mechanical identities of RNA and DNA double helices unveiled
-         at the single-molecule level. Journal of the American Chemical Society,
-         135(1), 122-131.
-     6.  Saenger, W. (1984). Principles of Nucleic Acid Structure. Springer. New York, Berlin, Heidelberg.
+    Odijk's Extensible Worm-Like Chain model [1]_ [2]_ with distance as the dependent
+    variable using user-specified kilobase-pairs (useful for 10 pN < F < 30 pN). Default model
+    parameters were obtained from [3]_ [4]_ and [5]_.
 
     Parameters
     ----------
@@ -288,9 +291,28 @@ def dsdna_odijk(name, dna_length_kbp, um_per_kbp=0.34, temperature=24.53608821):
     dna_length_kbp: integer
         The length of the dna in tether/construct measured in kilobase-pairs
     um_per_kbp: float
-        The number of kilobase pairs evaluating to 1 um. This is used to convert the length in kbp to um as applied in the fit function [6].
+        The number of kilobase pairs evaluating to 1 um. This is used to convert the length in kbp
+        to um as applied in the fit function [6]_.
     temperature: float
         The temperature in celsius. This is used to calculate the boltzmann * temperature (kT) value
+
+    References
+    ----------
+    .. [1] T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules 28, 7016-7018 (1995).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
+    .. [3] Manning, G. S. (2006). The persistence length of DNA is reached from the persistence
+           length of its null isomer through an internal electrostatic stretching force.
+           Biophysical journal, 91(10), 3607-3616.
+    .. [4] Liu, J. H., Xi, K., Zhang, X., Bao, L., Zhang, X., & Tan, Z. J. (2019). Structural
+           flexibility of DNA-RNA hybrid duplex: stretching and twist-stretch coupling. Biophysical
+           journal, 117(1), 74-86.
+    .. [5] Herrero-Galán, E., Fuentes-Perez, M. E., Carrasco, C., Valpuesta, J. M.,
+           Carrascosa, J. L., Moreno-Herrero, F., & Arias-Gonzalez, J. R. (2013). Mechanical
+           identities of RNA and DNA double helices unveiled at the single-molecule level. Journal
+           of the American Chemical Society, 135(1), 122-131.
+    .. [6] Saenger, W. (1984). Principles of Nucleic Acid Structure. Springer. New York, Berlin,
+           Heidelberg.
     """
     from scipy import constants
 
@@ -305,18 +327,22 @@ def dsdna_odijk(name, dna_length_kbp, um_per_kbp=0.34, temperature=24.53608821):
 
 
 def inverted_odijk(name):
-    """Odijk's Extensible Worm-Like Chain model with force as dependent variable (useful for 10 pN < F < 30 pN).
+    """Odijk's Extensible Worm-Like Chain model with force as dependent variable
 
-    References:
-      1. T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules
-         28, 7016-7018 (1995).
-      2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
-         DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+    Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_. Note that
+    this implementation was analytically solved and is significantly faster than fitting the
+    model obtained with `lk.odijk("name").invert()`.
 
     Parameters
     ----------
     name : str
         Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules 28, 7016-7018 (1995).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
     """
     from .model import Model
     from .detail.model_implementation import (
@@ -346,17 +372,20 @@ def inverted_odijk(name):
 def freely_jointed_chain(name):
     """Freely-Jointed Chain with distance as dependent parameter.
 
-    References:
-        1. S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The
-           Elastic Response of Individual Double-Stranded and Single-Stranded
-           DNA Molecules, Science 271, 795-799 (1996).
-        2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
-           DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+    Freely jointed chain model [1]_ [2]_. Useful for modelling single stranded DNA.
 
     Parameters
     ----------
     name : str
         Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The Elastic Response of
+           Individual Double-Stranded and Single-Stranded DNA Molecules, Science 271, 795-799
+           (1996).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
     """
     from .model import Model
     from .detail.model_implementation import (
@@ -384,18 +413,10 @@ def freely_jointed_chain(name):
 
 
 def ssdna_fjc(name, dna_length_kb, um_per_kb=0.56, temperature=24.53608821):
-    """Freely-Jointed Chain with distance as dependent parameter, using user-specified kilobases.
+    """Model of ssDNA with distance as the dependent parameter.
 
-    References:
-        1. S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The
-           Elastic Response of Individual Double-Stranded and Single-Stranded
-           DNA Molecules, Science 271, 795-799 (1996).
-        2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
-           DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
-        3. Bosco, A., Camunas-Soler, J., & Ritort, F. (2014). Elastic
-           properties and secondary structure formation of single-stranded
-           DNA at monovalent and divalent salt conditions. Nucleic acids
-           research, 42(3), 2064-2074.
+    Freely-Jointed Chain model [1]_ [2]_ with distance as dependent parameter, using
+    user-specified kilobases with default parameters obtained from [3]_.
 
     Parameters
     ----------
@@ -409,6 +430,17 @@ def ssdna_fjc(name, dna_length_kb, um_per_kb=0.56, temperature=24.53608821):
     temperature: float
         The temperature in celsius. This is used to calculate the
         Boltzmann's constant * temperature value
+
+    References
+    ----------
+    .. [1] S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The Elastic Response of
+           Individual Double-Stranded and Single-Stranded DNA Molecules, Science 271, 795-799
+           (1996).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
+    .. [3] Bosco, A., Camunas-Soler, J., & Ritort, F. (2014). Elastic properties and secondary
+           structure formation of single-stranded DNA at monovalent and divalent salt conditions.
+           Nucleic acids research, 42(3), 2064-2074.
     """
     from scipy import constants
 
@@ -424,19 +456,22 @@ def ssdna_fjc(name, dna_length_kb, um_per_kb=0.56, temperature=24.53608821):
 
 
 def inverted_freely_jointed_chain(name):
-    """Inverted Freely-Jointed Chain with force as dependent parameter.
+    """Freely-Jointed Chain model with distance as the dependent parameter.
 
-    References:
-        1. S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The
-           Elastic Response of Individual Double-Stranded and Single-Stranded
-           DNA Molecules, Science 271, 795-799 (1996).
-        2. M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching
-           DNA with optical tweezers., Biophysical journal 72, 1335-46 (1997).
+    The Freely-Jointed Chain model [1]_ [2]_ is useful for modelling ssDNA.
 
     Parameters
     ----------
     name : str
         Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The Elastic Response of
+           Individual Double-Stranded and Single-Stranded DNA Molecules, Science 271, 795-799
+           (1996).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
     """
     from .model import InverseModel
 
@@ -444,19 +479,23 @@ def inverted_freely_jointed_chain(name):
 
 
 def twistable_wlc(name):
-    """Twistable Worm-like Chain model. With distance as dependent variable.
+    """Twistable Worm-like Chain model with distance as dependent variable.
 
-    References:
-       1. P. Gross et al., Quantifying how DNA stretches, melts and changes
-          twist under tension, Nature Physics 7, 731-736 (2011).
-       2. Broekmans, Onno D., et al. DNA twist stability changes with
-          magnesium (2+) concentration, Physical review letters 116.25,
-          258102 (2016).
+    Twistable Worm-like Chain model [1]_ [2]_ that takes into account untwisting of the DNA at
+    high forces. Note that it is generally recommended to fit this model with force as the
+    dependent variable [2]_.
 
     Parameters
     ----------
     name : str
         Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] P. Gross et al., Quantifying how DNA stretches, melts and changes twist under tension,
+           Nature Physics 7, 731-736 (2011).
+    .. [2] Broekmans, Onno D., et al. DNA twist stability changes with magnesium (2+) concentration,
+           Physical review letters 116.25, 258102 (2016).
     """
     from .model import Model
     from .detail.model_implementation import (
@@ -488,21 +527,24 @@ def twistable_wlc(name):
 
 
 def inverted_twistable_wlc(name):
-    """Twistable Worm-like Chain model. With force as dependent variable. This model uses a more performant implementation
-    for inverting the model. It inverts the model by interpolating the forward curve and using this interpolant to
-    invert the function.
+    """Twistable Worm-like Chain model with force as the dependent variable.
 
-    References:
-       1. P. Gross et al., Quantifying how DNA stretches, melts and changes
-          twist under tension, Nature Physics 7, 731-736 (2011).
-       2. Broekmans, Onno D., et al. DNA twist stability changes with
-          magnesium (2+) concentration, Physical review letters 116.25,
-          258102 (2016).
+    Twistable Worm-like Chain model [1]_ [2]_ that takes into account untwisting of the DNA at
+    high forces. This model uses a more performant implementation for inverting the model. It
+    inverts the model by interpolating the forward curve and using this interpolant to invert the
+    function.
 
     Parameters
     ----------
     name : str
         Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] P. Gross et al., Quantifying how DNA stretches, melts and changes twist under tension,
+           Nature Physics 7, 731-736 (2011).
+    .. [2] Broekmans, Onno D., et al. DNA twist stability changes with magnesium (2+) concentration,
+           Physical review letters 116.25, 258102 (2016).
     """
     from .model import Model
     from .detail.model_implementation import (

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -66,11 +66,7 @@ def diode_params_from_voltage(
 def viscosity_of_water(temperature):
     """Computes the viscosity of water in [Pa*s] at a particular temperature.
 
-    These equations come from section 3.7 from [7].
-
-    [7] Huber, M. L., Perkins, R. A., Laesecke, A., Friend, D. G., Sengers, J. V.,
-    Assael, M. J., & Miyagawa, K. (2009). New international formulation for the viscosity of H2O.
-    Journal of Physical and Chemical Reference Data, 38(2), 101-125.
+    These equations come from section 3.7 from [1]_.
 
     Parameters
     ----------
@@ -81,6 +77,13 @@ def viscosity_of_water(temperature):
     -------
     array_like
         Viscosity of water [Pa*s]
+
+    References
+    ----------
+
+    .. [1] Huber, M. L., Perkins, R. A., Laesecke, A., Friend, D. G., Sengers, J. V.,
+           Assael, M. J., & Miyagawa, K. (2009). New international formulation for the viscosity of
+           H2O. Journal of Physical and Chemical Reference Data, 38(2), 101-125.
     """
     temperature = np.asarray(temperature)
     if not np.all(np.logical_and(temperature >= -20, temperature < 110)):
@@ -206,7 +209,7 @@ class PassiveCalibrationModel:
     """Model to fit data acquired during passive calibration.
 
     The power spectrum calibration algorithm implemented here is based on a number of publications
-    by the Flyvbjerg group at DTU [1]_ [2]_ [3]_ [4]_.
+    by the Flyvbjerg group at DTU [1]_ [2]_ [3]_ [4]_ [5]_ [6]_.
 
     References
     ----------
@@ -498,8 +501,8 @@ class PassiveCalibrationModel:
 class ActiveCalibrationModel(PassiveCalibrationModel):
     """Model to fit data acquired during active calibration.
 
-    The power spectrum calibration algorithm implemented here is based on [1]_, [2]_, [3]_, [4]_,
-    [5]_, [6]_.
+    The power spectrum calibration algorithm implemented here is based on [1]_ [2]_ [3]_ [4]_ [5]_
+    [6]_.
 
     References
     ----------

--- a/lumicks/pylake/force_calibration/convenience.py
+++ b/lumicks/pylake/force_calibration/convenience.py
@@ -36,8 +36,8 @@ def calibrate_force(
 ) -> CalibrationResults:
     """Determine force calibration factors.
 
-    The power spectrum calibration algorithm implemented here is based on [1]_, [2]_, [3]_, [4]_,
-    [5]_, [6]_.
+    The power spectrum calibration algorithm implemented here is based on [1]_ [2]_ [3]_ [4]_ [5]_
+    [6]_.
 
     References
     ----------

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -179,6 +179,9 @@ def fit_power_spectrum(
 ):
     """Power Spectrum Calibration
 
+    The power spectrum calibration algorithm implemented here is based on [1]_ [2]_ [3]_ [4]_ [5]_
+    [6]_.
+
     Parameters
     ----------
     power_spectrum : PowerSpectrum

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -575,7 +575,8 @@ class Kymo(ConfocalImage):
     def crop_and_calibrate(self, channel="rgb", tether_length_kbp=None, **kwargs):
         """Open a widget to interactively edit the image stack.
 
-        Actions include:
+        Actions
+        -------
 
             * left-click and drag to define the cropped ROI
 

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -576,6 +576,7 @@ class Kymo(ConfocalImage):
         """Open a widget to interactively edit the image stack.
 
         Actions include:
+
             * left-click and drag to define the cropped ROI
 
         Parameters
@@ -594,19 +595,19 @@ class Kymo(ConfocalImage):
         --------
         ::
 
-        from lumicks import pylake
-        import matplotlib.pyplot as plt
+            from lumicks import pylake
+            import matplotlib.pyplot as plt
 
-        # Loading a stack.
-        h5_file = pylake.File("example.h5")
-        _, kymo = h5_file.kymos.popitem()
-        widget = kymo.crop_and_calibrate("green", 48.502)
-        plt.show()
+            # Loading a stack.
+            h5_file = pylake.File("example.h5")
+            _, kymo = h5_file.kymos.popitem()
+            widget = kymo.crop_and_calibrate("green", 48.502)
+            plt.show()
 
-        # Select cropping ROI by left-click drag
+            # Select cropping ROI by left-click drag
 
-        # Grab the updated image stack
-        new_kymo = widget.kymo
+            # Grab the updated image stack
+            new_kymo = widget.kymo
         """
         from .nb_widgets.image_editing import KymoEditorWidget
 

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -67,10 +67,10 @@ def track_greedy(
     and the API is still subject to change without a prior deprecation notice.
 
     A method based on connecting feature points. Detection of the feature points is done analogously
-    to [1], using a greyscale dilation approach to detect peaks, followed by a local centroid
+    to [1]_, using a greyscale dilation approach to detect peaks, followed by a local centroid
     computation to achieve subpixel accuracy. After peak detection the feature points are linked
-    together using a greedy forward search analogous to [2]. This in contrast with the linking
-    algorithm in [1] which uses a graph based optimization approach.
+    together using a greedy forward search analogous to [2]_. This in contrast with the linking
+    algorithm in [1]_ which uses a graph based optimization approach.
 
     The linking step traverses the kymograph, tracing tracks starting from each frame. It starts with
     the highest intensity track and proceeds to tracks with lower signal intensity. For every point along the
@@ -130,11 +130,12 @@ def track_greedy(
 
     References
     ----------
-    [1] Sbalzarini, I. F., & Koumoutsakos, P. (2005). Feature point tracking and trajectory analysis
-    for video imaging in cell biology. Journal of structural biology, 151(2), 182-195.
-    [2] Mangeol, P., Prevo, B., & Peterman, E. J. (2016). KymographClear and KymographDirect: two
-    tools for the automated quantitative analysis of molecular and cellular dynamics using
-    kymographs. Molecular biology of the cell, 27(12), 1948-1957.
+    .. [1] Sbalzarini, I. F., & Koumoutsakos, P. (2005). Feature point tracking and trajectory
+           analysis for video imaging in cell biology. Journal of structural biology, 151(2),
+           182-195.
+    .. [2] Mangeol, P., Prevo, B., & Peterman, E. J. (2016). KymographClear and KymographDirect: two
+           tools for the automated quantitative analysis of molecular and cellular dynamics using
+           kymographs. Molecular biology of the cell, 27(12), 1948-1957.
     """
 
     # TODO: remove line_width argument deprecation path
@@ -229,7 +230,7 @@ def track_lines(
     This function tracks particles in an image. It takes a pixel image, and traces lines on it.
     These lines can subsequently be refined and/or used to extract intensities or other parameters.
 
-    This method is based on sections 1, 2 and 3 from [1]. This method attempts to find lines purely
+    This method is based on sections 1, 2 and 3 from [1]_. This method attempts to find lines purely
     based on differential geometric considerations. It blurs the image based with a user specified
     line width and then attempts to find curvilinear sections. Based on eigenvalue decomposition of
     the local Hessian it finds the principal direction of the line. It then computes subpixel
@@ -266,8 +267,8 @@ def track_lines(
 
     References
     ----------
-    [1] Steger, C. (1998). An unbiased detector of curvilinear structures. IEEE Transactions on
-    pattern analysis and machine intelligence, 20(2), 113-125.
+    .. [1] Steger, C. (1998). An unbiased detector of curvilinear structures. IEEE Transactions on
+           pattern analysis and machine intelligence, 20(2), 113-125.
     """
     if line_width <= 0:
         raise ValueError("line_width should be larger than zero")


### PR DESCRIPTION
**Why this PR?**
With the API docs becoming visible, so does a bunch of our sins against the format. I noticed that when building the docs on the napoleon branch that many of the docs were throwing warnings, so I took the liberty of fixing a lot of the small issues that were there.

Whenever relevant, I also improved small parts of docstrings to hopefully make them a bit more useful to users.

A few not so nice things to note:
- It seems that our current doc building system does not play nice when we use a deprecation notice on a function that has a list of parameters. For now, I have removed these (in two places), since people should be using the new API anyhow. I am open to suggestions on how to make it play nice however.
- Deprecation notice also don't play nice with functions that don't have docstrings. In this case, I have just provided the function with a docstring.
- Docstring references are a bit of an issue. Having references with the same value end up on the same RST page results in warnings and broken references. I spent a while exploring options here, but didn't find anything particularly good ones.
a. I tried using footnotes, but they are also globally defined.
b. Manually make sure that no duplicates exist for any single class (you'll see this in `KymoTrack` for instance). The ugly downside is that if you ask for the docstring of a method here, the reference counting may start at an (from the user perspective) arbitrary number.
c. I tried hijacking the sphinx post-processor for this. Basically make the docstring just have regular values, but then in the sphinx post-processor rename them with a regular expression replacement. The problem here is that most references are multiple lines and the indent overhangs like so, so if you start replacing those counts with different numeric values, you need to adjust the spacing of the lines below it. The issue then comes with detecting the last line to do this for. It's certainly possible, but feels like it's going to be very brittle (kept finding corner cases and even though they were fixable, don't feel comfortable putting that in this PR).
```
[1] R. Pauszek, J. Vanlier, T. Jachowski, "what a lovely reference
    this is man", Journal of Questionable Sphinx Hacks, 2022.
```

At the time of this writing, the history is warning free on my local build :)

Docs build here: https://lumicks-pylake.readthedocs.io/en/docs_fixups/api.html#