### PR TITLE
ci: test docs build

### DIFF
--- a/.github/workflows/pylake_docs_test.yml
+++ b/.github/workflows/pylake_docs_test.yml
@@ -1,0 +1,23 @@
+name: docs build
+
+on: [push]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v2
+          with:
+            lfs: true
+        - name: Set up Python
+          uses: actions/setup-python@v2
+          with:
+              python-version: '3.7'
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install .
+            pip install -r docs/requirements.txt
+        - name: Build the docs
+          run: |
+            python -m sphinx -W -b html docs build/html


### PR DESCRIPTION
**Why this PR?**
After the work that went into cleaning up the docs and making sure that everything works, it'd be nice to maintain them in good working order. Therefore I propose this CI test to make sure we don't end up with weird oddities on our API docs again. If it turns out to be too brittle we can remove it again, but I think we should give it a shot.

Example of what a CI run will look like if it fails (here I had deliberately broken a docstring):
![image](https://user-images.githubusercontent.com/19836026/187876855-38677a2a-632a-4e7c-9242-168dc8b7d8e6.png)

Note that this PR depends on all the PRs that clear out the warnings we have now before it can be merged and turned into an active test.