### PR TITLE
Unify `export_tiff` for `Scan`, `Kymo` and `CorrelatedStack` and export metadata in all cases

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Fixed and reintroduced lazy loading for `TimeSeries` data.
 * You can now add two `KymoTrackGroups` tracked on the same kymo together with the `+` operator.
+* TIFFs exported from `Scan` and `Kymo` now contain metadata. The `DateTime` tag indicated the start/stop timestamp of each frame. The `ImageDescription` tag contains additional information about the confocal acquisition parameters. 
 
 #### Other changes
 

--- a/lumicks/pylake/conftest.py
+++ b/lumicks/pylake/conftest.py
@@ -88,3 +88,25 @@ def configure_mpl():
             yield
     finally:
         plt.close("all")
+
+
+@pytest.fixture
+def grab_tiff_tags():
+    def grab_tags(file):
+        import tifffile
+        from ast import literal_eval
+
+        tiff_tags = []
+        with tifffile.TiffFile(file) as tif:
+            for page in tif.pages:
+                page_tags = {}
+                for tag in page.tags.values():
+                    name, value = tag.name, tag.value
+                    try:
+                        page_tags[name] = literal_eval(value)
+                    except (ValueError, SyntaxError):
+                        page_tags[name] = value
+                tiff_tags.append(page_tags)
+        return tiff_tags
+
+    return grab_tags

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -1,9 +1,101 @@
+import json
+import numpy as np
+import numpy.typing as npt
+import tifffile
+from typing import Iterator, Union
+
 from ..adjustments import ColorAdjustment
 from .timeindex import to_timestamp
-import numpy as np
-from typing import Union
 
 _FIRST_TIMESTAMP = 1388534400
+
+
+class TiffExport:
+    def export_tiff(self, filename, *, dtype=None, clip=False):
+        """Export frames to a TIFF image
+
+        Parameters
+        ----------
+        filename : str
+            The name of the TIFF file where the image will be saved.
+        dtype : np.dtype
+            The data type of a single color channel in the resulting image.
+        clip : bool
+            If enabled, the image data will be clipped to fit into the desired `dtype`. This option
+            is disabled by default: an error will be raise if the data does not fit.
+        """
+        # If the exported tiff should be cast to `dtype`, get the full image stack to later safely
+        # cast it. Otherwise, try to get an iterator, to save memory.
+        frames = self._tiff_frames(iterator=dtype is None)
+        timestamp_ranges = self._tiff_timestamp_ranges()
+
+        # Check length of timestamp ranges, as this is easier than checking the number of frames,
+        # which could be an iterator or an np.ndarray.
+        if len(timestamp_ranges) == 0:
+            raise RuntimeError("Can't export TIFF if there are no images.")
+
+        # Cast frames if a specific dtype is requested.
+        def cast_image(image, dtype=np.float32, clip=False):
+            # Check if requested dtype can fit image values without an overflow
+            info = np.finfo(dtype) if np.dtype(dtype).kind == "f" else np.iinfo(dtype)
+            if not clip and (np.min(image) < info.min or np.max(image) > info.max):
+                raise RuntimeError(
+                    f"Can't safely export image with `dtype={dtype.__name__}` channels."
+                    f" Switch to a larger `dtype` in order to safely store everything"
+                    f" or pass `force=True` to clip the data."
+                )
+
+            return image.astype(dtype)
+
+        frames = cast_image(frames, dtype=dtype, clip=clip) if dtype else frames
+
+        def extratags(timestamp_range):
+            """Create the extratags tuple used for the `TiffWriter.write()` method
+
+            Notes
+            -----
+            See TIFF specification for the definition of tags (or fields)
+            """
+            # DateTime, str, len, start:stop
+            datetime = f"{timestamp_range[0]}:{timestamp_range[1]}"
+            datetime = (306, "s", len(datetime), datetime)
+            return (datetime,)
+
+        # Save the tiff file page by page
+        with tifffile.TiffWriter(filename) as tif:
+            for frame, timestamp_range in zip(frames, timestamp_ranges):
+                tif.write(
+                    frame,
+                    contiguous=False,  # write tags on each page
+                    extratags=extratags(timestamp_range),
+                    metadata=None,  # suppress tifffile default ImageDescription tag
+                    description=json.dumps(self._tiff_image_metadata(), indent=4),
+                    **self._tiff_writer_kwargs(),
+                )
+
+    def _tiff_frames(self, iterator=False) -> Union[npt.ArrayLike, Iterator]:
+        """Create frames of TIFFs used by `export_tiff()`."""
+        raise NotImplementedError(
+            f"`{self.__module__}.{self.__class__.__name__}` does not implement `_tiff_frames()`."
+        )
+
+    def _tiff_image_metadata(self) -> dict:
+        """Create metadata stored in the ImageDescription field of TIFFs used by `export_tiff()`."""
+        raise NotImplementedError(
+            f"`{self.__module__}.{self.__class__.__name__}` does not implement `_tiff_image_metadata()`."
+        )
+
+    def _tiff_timestamp_ranges(self) -> Union[list, Iterator]:
+        """Create Timestamp ranges for DateTime field of TIFFs used by `export_tiff()`."""
+        raise NotImplementedError(
+            f"`{self.__module__}.{self.__class__.__name__}` does not implement `_tiff_timestamp_ranges()`."
+        )
+
+    def _tiff_writer_kwargs(self) -> dict:
+        """Create keyword arguments used for `TiffWriter.write()` in `self.export_tiff()`."""
+        raise NotImplementedError(
+            f"`{self.__module__}.{self.__class__.__name__}` does not implement `_tiff_writer_kwargs()`."
+        )
 
 
 class VideoExport:

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -365,7 +365,7 @@ class ImageDescription:
         if self._alignment.do_alignment:
             for j in range(3):
                 out[f"Applied channel {j} alignment"] = out.pop(f"Channel {j} alignment")
-        return json.dumps(out, indent=4)
+        return out
 
 
 class AlignmentStatus(enum.Enum):

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -188,6 +188,21 @@ class Kymo(ConfocalImage):
 
         return self._line_timestamp_ranges_factory(self, not include)
 
+    def _tiff_image_metadata(self) -> dict:
+        """Create metadata for the ImageDescription field of TIFFs used by `export_tiff()`."""
+        metadata = super()._tiff_image_metadata()
+        metadata["Line time (s)"] = self.line_time_seconds
+        # Cast numpy.int64 into Python int to make it compatible to json
+        metadata["Start pixel timestamp (ns)"] = int(self.line_timestamp_ranges()[0][0])
+        metadata["Stop pixel timestamp (ns)"] = int(self.line_timestamp_ranges()[-1][1])
+        return metadata
+
+    def _tiff_timestamp_ranges(self) -> list:
+        """Create Timestamp ranges for the DateTime field of TIFFs used by `export_tiff`."""
+        # As `Kymo` has only one frame, return a list with one timestamp range
+        ts_ranges = np.array(self.line_timestamp_ranges())
+        return [(np.min(ts_ranges), np.max(ts_ranges))]
+
     @cachetools.cachedmethod(lambda self: self._cache)
     def _line_start_timestamps(self):
         """Compute starting timestamp of each line (first DAQ sample corresponding to that line),

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -221,6 +221,16 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             )
         return self._metadata.num_frames
 
+    def _tiff_image_metadata(self) -> dict:
+        """Create metadata for the ImageDescription field of TIFFs used by `export_tiff()`."""
+        metadata = super()._tiff_image_metadata()
+        metadata["Number of frames"] = self.num_frames
+        return metadata
+
+    def _tiff_timestamp_ranges(self) -> list:
+        """Create Timestamp ranges for the DateTime field of TIFFs used by `export_tiff()`."""
+        return self.frame_timestamp_ranges()
+
     def frame_timestamp_ranges(self, exclude=None, *, include_dead_time=None):
         """Get start and stop timestamp of each frame in the scan.
 

--- a/lumicks/pylake/tests/test_imaging_mixins.py
+++ b/lumicks/pylake/tests/test_imaging_mixins.py
@@ -1,0 +1,199 @@
+import pytest
+import numpy as np
+
+from lumicks.pylake.detail.imaging_mixins import TiffExport
+
+
+def tiffexport_factory(
+    images,
+    frames=True,
+    image_metadata=True,
+    timestamp_ranges=True,
+    writer_kwargs=True,
+    start_time=0,
+    exposure_time=5,
+    frame_time=10,
+):
+    def tiff_frames_factory(frames):
+        return lambda iterator: (frame for frame in frames) if iterator else frames
+
+    def tiff_image_metadata():
+        return {"Writing": "tests is awesome!"}
+
+    def tiff_timestamp_ranges_factory(number_of_frames):
+        def tiff_timestamp_ranges():
+            return [
+                np.array([i, i + exposure_time])
+                for i in range(
+                    start_time, start_time + frame_time * number_of_frames, start_time + frame_time
+                )
+            ]
+
+        return tiff_timestamp_ranges
+
+    def tiff_writer_kwargs():
+        return {"software": "Pylake Test", "photometric": "rgb"}
+
+    export = TiffExport()
+    if frames:
+        export._tiff_frames = tiff_frames_factory(images)
+    if image_metadata:
+        export._tiff_image_metadata = tiff_image_metadata
+    if timestamp_ranges:
+        export._tiff_timestamp_ranges = tiff_timestamp_ranges_factory(len(images))
+    if writer_kwargs:
+        export._tiff_writer_kwargs = tiff_writer_kwargs
+    return export
+
+
+def test_export_tiff_insufficient_implementation(tmp_path):
+    images = np.ones(shape=(2, 10, 10, 3))  # (n, h, w, c)
+
+    export_bare = TiffExport()
+    export_missing_frames = tiffexport_factory(images, frames=False)
+    export_missing_meta = tiffexport_factory(images, image_metadata=False)
+    export_missing_time = tiffexport_factory(images, timestamp_ranges=False)
+    export_missing_kwargs = tiffexport_factory(images, writer_kwargs=False)
+    filename = tmp_path / "insufficient.tiff"
+
+    classmodule = TiffExport.__module__
+    classname = TiffExport.__name__
+    message_frames = f"`{classmodule}.{classname}` does not implement `_tiff_frames\\(\\)`."
+    message_meta = f"`{classmodule}.{classname}` does not implement `_tiff_image_metadata\\(\\)`."
+    message_time = f"`{classmodule}.{classname}` does not implement `_tiff_timestamp_ranges\\(\\)`."
+    message_kwargs = f"`{classmodule}.{classname}` does not implement `_tiff_writer_kwargs\\(\\)`."
+
+    # Test existence of interface methods and throwing of `NotImplementedError`
+    with pytest.raises(NotImplementedError, match=message_frames):
+        export_bare._tiff_frames()
+    with pytest.raises(NotImplementedError, match=message_meta):
+        export_bare._tiff_image_metadata()
+    with pytest.raises(NotImplementedError, match=message_time):
+        export_bare._tiff_timestamp_ranges()
+    with pytest.raises(NotImplementedError, match=message_kwargs):
+        export_bare._tiff_writer_kwargs()
+    # Test if `export_tiff()` requires all `_tiff_*()` methods
+    with pytest.raises(NotImplementedError, match=message_frames):
+        export_missing_frames.export_tiff(filename)
+    with pytest.raises(NotImplementedError, match=message_meta):
+        export_missing_meta.export_tiff(filename)
+    with pytest.raises(NotImplementedError, match=message_time):
+        export_missing_time.export_tiff(filename)
+    with pytest.raises(NotImplementedError, match=message_kwargs):
+        export_missing_kwargs.export_tiff(filename)
+
+
+def test_export_tiff_empty(tmp_path):
+    export_empty = tiffexport_factory(np.array([]))
+    filename = tmp_path / "empty.tiff"
+
+    # Test empty `export_tiff` array
+    with pytest.raises(RuntimeError, match="Can't export TIFF if there are no images."):
+        export_empty.export_tiff(filename)
+
+    # Test empty `export_tiff` iterator
+    with pytest.raises(RuntimeError, match="Can't export TIFF if there are no images."):
+        export_empty.export_tiff(filename, dtype=np.float32)
+
+
+def test_export_tiff_int(tmp_path):
+    images = np.ones(shape=(2, 10, 10, 3))  # (n, h, w, c)
+    export_image16 = tiffexport_factory(images * np.iinfo(np.uint16).max)
+
+    # Sufficient bit-depth or forced clipping
+    export_image16.export_tiff(tmp_path / "uint16", dtype=np.uint16)
+    export_image16.export_tiff(tmp_path / "float32", dtype=np.float32)
+    export_image16.export_tiff(tmp_path / "clipped", dtype=np.uint8, clip=True)
+
+    # Raise because unsafe
+    with pytest.raises(RuntimeError, match="Can't safely export image with `dtype=uint8` channels"):
+        export_image16.export_tiff(tmp_path / "uint8", dtype=np.uint8)
+
+    with pytest.raises(
+        RuntimeError, match="Can't safely export image with `dtype=float16` channels"
+    ):
+        export_image16.export_tiff(tmp_path / "float16", dtype=np.float16)
+
+
+def test_export_tiff_float(tmp_path):
+    images = np.ones(shape=(2, 10, 10, 3))  # (n, h, w, c)
+    export_image32 = tiffexport_factory(images * np.finfo(np.float32).max)
+
+    # Sufficient bit-depth or forced clipping
+    export_image32.export_tiff(tmp_path / "float32", dtype=np.float32)
+    export_image32.export_tiff(tmp_path / "clipped", dtype=np.float16, clip=True)
+
+    # Raise because unsafe
+    with pytest.raises(
+        RuntimeError, match="Can't safely export image with `dtype=float16` channels"
+    ):
+        export_image32.export_tiff(tmp_path / "float16", dtype=np.float16)
+
+    with pytest.raises(
+        RuntimeError, match="Can't safely export image with `dtype=uint16` channels"
+    ):
+        export_image32.export_tiff(tmp_path / "uint16", dtype=np.uint16)
+
+
+@pytest.mark.parametrize(
+    "output_dtype, number_of_bits, sampleformat",
+    [
+        (None, 64, 3),
+        (np.uint16, 16, None),
+        (np.float32, 32, 3),
+    ],
+)
+def test_export_tiff_tags(tmp_path, output_dtype, number_of_bits, sampleformat):
+    """Test proper export of tiff data format and tags
+
+    Parameters
+    ----------
+    sampleformat : int or None
+        From the TIFF specification:
+        1 = unsigned integer data, (default, if not defined)
+        2 = two’s complement signed integer data
+        3 = IEEE floating point data [IEEE]
+        4 = undefined data format
+    """
+
+    def grab_tags(file):
+        import tifffile
+        from ast import literal_eval
+
+        tiff_tags = []
+        with tifffile.TiffFile(file) as tif:
+            for page in tif.pages:
+                page_tags = {}
+                for tag in page.tags.values():
+                    name, value = tag.name, tag.value
+                    try:
+                        page_tags[name] = literal_eval(value)
+                    except (ValueError, SyntaxError):
+                        page_tags[name] = value
+                tiff_tags.append(page_tags)
+        return tiff_tags
+
+    # Create tifffile with 2 frames
+    images = np.ones(shape=(2, 5, 10, 3))  # (n, h, w, c)
+    exposure_time = 5
+    frame_time = 10
+    export_images = tiffexport_factory(images, exposure_time=exposure_time, frame_time=frame_time)
+    filename = tmp_path / "testimages"
+    export_images.export_tiff(filename, dtype=output_dtype)
+
+    # Check if tags were properly stored for both frames, i.e. test functionality of
+    # `_tiff_image_metadata()`, `_tiff_timestamp_ranges()` and `_tiff_writer_kwargs()` (see
+    # `tiffexport_factory()`)
+    tiff_tags = grab_tags(filename)
+    assert len(tiff_tags) == len(images)
+    for frame_idx, tags in enumerate(tiff_tags):
+        assert tags["ImageDescription"]["Writing"] == "tests is awesome!"
+        assert (
+            tags["DateTime"] == f"{frame_idx * frame_time}:{frame_idx * frame_time + exposure_time}"
+        )
+        assert tags["Software"] == "Pylake Test"
+        assert tags["ImageWidth"] == 10
+        assert tags["ImageLength"] == 5
+        assert tags["BitsPerSample"] == (number_of_bits,) * 3
+        if sampleformat:
+            assert tags["SampleFormat"] == (sampleformat,) * 3


### PR DESCRIPTION
**Why this PR?**
As a user, I want to have timestamps and metadata in TIFFs exported from Pylake (Confocal like WIT). As a developer I want to have common code in all different classes that handles exporting tiffs.

**Implementation details**
The new mixin class `TiffExport` implements the method `export_tiff()` to export tiff stacks. It uses the method `_tiff_frames()` to get frames to be written to a TIFF file. The method `_tiff_writer_kwargs()` generates the arguments used for the `TiffWriter.write()` method. The method  `_tiff_image_metadata()` generates the metadata to be written to the ImageDescription field of the exported tiff file pages and the method `_tiff_timestamp_ranges()` is used to generate a list of (start, stop) ranges, to set the (non standard) DateTime field for all pages. The `_tiff_*()` methods are meant to be overwritten by child classes to adjust the metadata to be exported. `CorrelatedStack`, `ConfocalImage`, `Scan` and `Kymo` now implement the new `TiffExport` mixin. I did not change the public facing `export_tiff()` method. I also added/updated the tests to separately test the mixin class `TiffExport` and the functionality of the child classes.

As a consequence, I removed the now unused `save_tiff()` function.

**What is still missing**
Checking of the `Camera` field in `CorrelatedStack` to avoid trying to access alignment matrices and a roundtrip test of a `Kymo`/`Scan` stored as a tiff and reloaded as a `CorrelatedStack`. A future PR might add these to ensure that we can guarantee tiffs exported from `Scan` and `Kymo` to be compatible with `CorrelatedStack`.