### PR TITLE
ci: don't use `cleanup` from the mpl testing decorators

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 * Fixed and reintroduced lazy loading for `TimeSeries` data. 
 
+### Other changes
+
+* Updated benchmark to not use deprecated functions and arguments. Prior to this change, running the benchmark would produce deprecation warnings.
+
 ## v0.13.1 | 2022-09-08
 
 #### Bug fixes

--- a/lumicks/pylake/benchmark.py
+++ b/lumicks/pylake/benchmark.py
@@ -103,7 +103,7 @@ class _Tracking(_Benchmark):
 
     def context(self):
         kymo = _generate_kymo_for_tracking(12, 11)
-        yield lambda: lk.track_greedy(kymo, "red", line_width=1, pixel_threshold=20)
+        yield lambda: lk.track_greedy(kymo, "red", track_width=1, pixel_threshold=20)
 
 
 class _Refinement(_Benchmark):
@@ -112,8 +112,8 @@ class _Refinement(_Benchmark):
 
     def context(self):
         kymo_tracking = _generate_kymo_for_tracking(1, 4)
-        lines = lk.track_greedy(kymo_tracking, "red", line_width=1, pixel_threshold=20)
-        yield lambda: lk.refine_lines_gaussian(
+        lines = lk.track_greedy(kymo_tracking, "red", track_width=1, pixel_threshold=20)
+        yield lambda: lk.refine_tracks_gaussian(
             lines, 10000, refine_missing_frames=True, overlap_strategy="multiple"
         )
 

--- a/lumicks/pylake/fitting/tests/test_fit.py
+++ b/lumicks/pylake/fitting/tests/test_fit.py
@@ -2,11 +2,11 @@ from lumicks.pylake.fitting.models import odijk, inverted_odijk
 from lumicks.pylake.fitting.model import Model
 from lumicks.pylake.fitting.fit import Fit, FdFit, Params, Datasets
 from lumicks.pylake.fitting.parameters import Parameter
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 import pytest
 import numpy as np
 import matplotlib.pyplot as plt
 from collections import OrderedDict
-from matplotlib.testing.decorators import cleanup
 
 
 def test_model_defaults():
@@ -548,7 +548,7 @@ def test_fd_variable_order():
     np.testing.assert_allclose(fit[m].data["test2"].y, [3, 4, 5])
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plotting():
     m = odijk("DNA")
     m2 = odijk("protein")
@@ -596,6 +596,7 @@ def test_plotting():
     with pytest.raises(KeyError):
         fit[m].plot(overrides={"DNA/c": 12})
 
+    plt.close('all')
     independent = np.arange(0.15, 2, 0.25)
     params = [38.18281266, 0.37704827, 278.50103452, 4.11]
     odijk("WLC").verify_jacobian(independent, params, plot=1)
@@ -664,7 +665,7 @@ def test_fit_reprs():
     )
 
 
-@cleanup
+@mpl_test_cleanup
 def test_custom_legend_labels():
     """Test whether users can provide a custom label for plotting"""
     def test_labels(labels):

--- a/lumicks/pylake/fitting/tests/test_profiles.py
+++ b/lumicks/pylake/fitting/tests/test_profiles.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 from lumicks.pylake.fitting.fit import Fit
 from lumicks.pylake.fitting.model import Model
 from lumicks.pylake.fitting.parameters import Parameter
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 
 
 def linear(x, a=1, b=1):
@@ -136,7 +136,7 @@ def test_non_identifiability():
     )
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plotting():
     x = np.arange(10.0) / 100.0
     y = [

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
@@ -1,5 +1,5 @@
 from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 import numpy as np
 import pytest
 
@@ -160,13 +160,13 @@ def test_in_range(frequency, num_data, sample_rate, num_blocks, f_min, f_max):
     np.testing.assert_allclose(power_spectrum.sample_rate, power_subset.sample_rate)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plot():
     ps = PowerSpectrum(np.sin(2.0 * np.pi * 100 / 78125 * np.arange(100)), 78125)
     ps.plot()
 
 
-@cleanup
+@mpl_test_cleanup
 def test_replace_spectrum():
     power_spectrum = PowerSpectrum(np.arange(10), 5)
     replaced = power_spectrum.with_spectrum(np.arange(6))

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -6,7 +6,7 @@ from lumicks.pylake.force_calibration.calibration_models import (
     viscosity_of_water,
     NoFilter,
 )
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 from textwrap import dedent
 import numpy as np
 import scipy as sp
@@ -223,13 +223,13 @@ def test_actual_spectrum(reference_calibration_result):
     np.testing.assert_allclose(ps_calibration.ps_data.num_points_per_block, 100)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_result_plot(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
     ps_calibration.plot()
 
 
-@cleanup
+@mpl_test_cleanup
 def test_result_plot(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
     ps_calibration.plot_spectrum_residual()

--- a/lumicks/pylake/force_calibration/tests/test_touchdown.py
+++ b/lumicks/pylake/force_calibration/tests/test_touchdown.py
@@ -1,7 +1,7 @@
 import pytest
 import warnings
 import numpy as np
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 from lumicks.pylake.force_calibration.touchdown import (
     fit_piecewise_linear,
     fit_damped_sine_with_polynomial,
@@ -99,7 +99,7 @@ def test_touchdown(mack_parameters):
     np.testing.assert_allclose(touchdown_result.focal_shift, 0.9212834464971221)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plot():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "Covariance of the parameters could not be estimated")

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -1,6 +1,6 @@
 import pytest
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 from lumicks.pylake.kymotracker.kymotrack import *
 from lumicks.pylake.kymotracker.detail.localization_models import *
 from lumicks.pylake.tests.data.mock_confocal import generate_kymo
@@ -301,7 +301,7 @@ def test_lag_default(blank_kymo):
         (3, [2, 4, 6], (3 * np.arange(1, 4)) ** 2),
     ],
 )
-@cleanup
+@mpl_test_cleanup
 def test_kymotrack_msd_plot(max_lag, x_data, y_data):
     # See whether the plot spins up
     kymo = generate_kymo(

--- a/lumicks/pylake/nb_widgets/tests/test_correlated_plot.py
+++ b/lumicks/pylake/nb_widgets/tests/test_correlated_plot.py
@@ -3,10 +3,10 @@ from lumicks.pylake.channel import Slice, Continuous
 import pytest
 import numpy as np
 import matplotlib as mpl
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plot_correlated():
     start = 1592916040906356300
     dt = int(1e9)

--- a/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
+++ b/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
@@ -4,7 +4,7 @@ from lumicks.pylake.nb_widgets.range_selector import (FdTimeRangeSelectorWidget,
                                                       BaseRangeSelectorWidget)
 from lumicks.pylake.fdcurve import FdCurve
 from lumicks.pylake.channel import TimeSeries, Slice
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 import pytest
 import numpy as np
 
@@ -19,7 +19,7 @@ def make_mock_fd(force, distance, start=0, dt=600e9):
     return fd
 
 
-@cleanup
+@mpl_test_cleanup
 def test_selector_widget(mockevent):
     start_point = int(2500e9)
     dt = int(600e9)
@@ -98,7 +98,7 @@ def test_selector_widget(mockevent):
     assert selector.fdcurves == []
 
 
-@cleanup
+@mpl_test_cleanup
 def test_distance_selector_widget(mockevent):
     start_point = int(2500e9)
     dt = int(600e9)
@@ -177,7 +177,7 @@ def test_distance_selector_widget(mockevent):
 
 
 @pytest.mark.notebook
-@cleanup
+@mpl_test_cleanup
 def test_multi_selector_widget():
     fd_curve1 = make_mock_fd([0, 1, 2, 3], [0, 1, 2, 3], start=int(2500e9))
     fd_curve2 = make_mock_fd([2, 3, 4, 5], [2, 3, 4, 5], start=int(2500e9))
@@ -190,7 +190,7 @@ def test_multi_selector_widget():
 
 
 @pytest.mark.notebook
-@cleanup
+@mpl_test_cleanup
 def test_multi_distance_selector_widget():
     fd_curve1 = make_mock_fd(np.arange(10), np.arange(10), start=int(2500e9))
     fd_curve2 = make_mock_fd(np.arange(3, 13), np.arange(3, 13), start=int(2500e9))
@@ -202,7 +202,7 @@ def test_multi_distance_selector_widget():
         FdRangeSelector({"fd1": fd_curve1, "fd2": fd_curve2})        
 
 
-@cleanup
+@mpl_test_cleanup
 def test_selector_widgets_open():
     channel = Slice(TimeSeries([1, 2, 3, 4], [100, 200, 300, 400]))
     widget = channel.range_selector()

--- a/lumicks/pylake/nb_widgets/tests/test_image_editing.py
+++ b/lumicks/pylake/nb_widgets/tests/test_image_editing.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 import json
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 
 from lumicks.pylake.tests.data.mock_widefield import make_alignment_image_data, MockTiffFile
 from lumicks.pylake.detail.widefield import TiffStack

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -1,6 +1,6 @@
 from lumicks.pylake.nb_widgets.kymotracker_widgets import KymoWidgetGreedy, KymotrackerParameter
 from lumicks.pylake.kymotracker.kymotrack import KymoTrack, KymoTrackGroup
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 import numpy as np
 import re
 import pytest
@@ -13,19 +13,19 @@ def calibrate_to_kymo(kymo):
     )
 
 
-@cleanup
+@mpl_test_cleanup
 def test_widget_open(kymograph):
     KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_deprecations(kymograph):
     kymo_widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     with pytest.warns(DeprecationWarning):
         kymo_widget.lines
 
 
-@cleanup
+@mpl_test_cleanup
 def test_parameters_kymo(kymograph):
     """Test whether the parameter setting is passed correctly to the algorithm. By setting the threshold to different
     values we can check which tracks are detected and use that to verify that the parameter is used."""
@@ -43,7 +43,7 @@ def test_parameters_kymo(kymograph):
     assert len(kymo_widget.tracks) == 3
 
 
-@cleanup
+@mpl_test_cleanup
 def test_invalid_algorithm_parameter(kymograph):
     kymo_widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     with pytest.raises(KeyError):
@@ -61,7 +61,7 @@ def test_invalid_algorithm_parameter(kymograph):
         kymo_widget.track_all()
 
 
-@cleanup
+@mpl_test_cleanup
 def test_aspect_ratio(kymograph, region_select):
     for requested_aspect in (2, 3, 5):
         kymo_widget = KymoWidgetGreedy(
@@ -77,7 +77,7 @@ def test_aspect_ratio(kymograph, region_select):
         )
 
 
-@cleanup
+@mpl_test_cleanup
 def test_track_kymo(kymograph, region_select):
     kymo_widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     assert len(kymo_widget.tracks) == 0
@@ -265,7 +265,7 @@ def test_refine_track_width_units(kymograph, region_select):
     np.testing.assert_allclose(kymo_widget.tracks[0].coordinate_idx, true_coordinate)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_widget_with_calibration(kymograph):
     widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     np.testing.assert_allclose(
@@ -283,7 +283,7 @@ def test_widget_with_calibration(kymograph):
     assert widget._axes.get_ylabel() == "position (kbp)"
 
 
-@cleanup
+@mpl_test_cleanup
 def test_invalid_range_overrides(kymograph):
     with pytest.raises(KeyError, match="Slider range provided for parameter that does not exist"):
         KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, slider_ranges={"wrong_par": (1, 5)})
@@ -306,7 +306,7 @@ def test_invalid_range_overrides(kymograph):
         )
 
 
-@cleanup
+@mpl_test_cleanup
 def test_valid_override(kymograph):
     """Tests whether the correct ranges make it into the widget data. Unfortunately we cannot test
     the full widget as we cannot spin up the UI."""
@@ -344,7 +344,7 @@ def test_valid_default_parameters():
             KymotrackerParameter("p", "d", "int", 5, *rng, True)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_keyword_args(kymograph):
     """Test that only 2 positional arguments can be used."""
     with pytest.raises(TypeError):

--- a/lumicks/pylake/piezo_tracking/tests/test_baseline.py
+++ b/lumicks/pylake/piezo_tracking/tests/test_baseline.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 from copy import deepcopy
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 from lumicks.pylake.piezo_tracking.baseline import ForceBaseLine
 
 
@@ -26,7 +26,7 @@ def test_baseline_downsampled(poly_baseline_data):
     np.testing.assert_allclose(baseline._force, force.downsampled_by(500))
 
 
-@cleanup
+@mpl_test_cleanup
 def test_baseline_plots(poly_baseline_data):
     trap, force = poly_baseline_data
 

--- a/lumicks/pylake/piezo_tracking/tests/test_piezo_tracking.py
+++ b/lumicks/pylake/piezo_tracking/tests/test_piezo_tracking.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 from lumicks.pylake.channel import Slice, Continuous, TimeSeries
 from lumicks.pylake.piezo_tracking.piezo_tracking import (
     DistanceCalibration,
@@ -81,7 +81,7 @@ def test_from_file():
     assert calibrated_slice.labels["y"] == "Distance [um]"
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plots():
     distance_calibration = DistanceCalibration(*trap_pos_camera_distance(), 1)
     distance_calibration.plot()

--- a/lumicks/pylake/population/tests/test_mixture.py
+++ b/lumicks/pylake/population/tests/test_mixture.py
@@ -1,6 +1,6 @@
 from lumicks.pylake import GaussianMixtureModel
 from lumicks.pylake.channel import Slice, Continuous
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 import numpy as np
 import pytest
 import matplotlib.pyplot as plt
@@ -48,7 +48,7 @@ def test_pdf(trace_simple):
     np.testing.assert_allclose(m.pdf(np.array([10, 11])), [[1.857758, 5e-26], [5e-21, 2.222931]], rtol=1e-5, atol=1e-13)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_gmm_plots(trace_simple):
     data, statepath, params = trace_simple
     m = GaussianMixtureModel(data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100)

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -2,7 +2,6 @@ import importlib
 import pytest
 import json
 import warnings
-import matplotlib.pyplot as plt
 from .data.mock_file import MockDataFile_v2
 from .data.mock_fdcurve import generate_fdcurve_with_baseline_offset
 
@@ -33,8 +32,6 @@ def pytest_collection_modifyitems(config, items):
 
 
 def pytest_configure(config):
-    # Use a headless backend for testing
-    plt.switch_backend("agg")
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     config.addinivalue_line(
         "markers", "preflight: mark preflight tests which should only be run manually"

--- a/lumicks/pylake/tests/test_channels/test_channels.py
+++ b/lumicks/pylake/tests/test_channels/test_channels.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from lumicks.pylake import channel
 from lumicks.pylake.calibration import ForceCalibration
 import matplotlib as mpl
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 
 
 def with_offset(t, start_time=1592916040906356300):
@@ -720,7 +720,7 @@ def test_downsampling_like():
     with pytest.raises(AssertionError):
         s.downsampled_like(s)
 
-@cleanup
+@mpl_test_cleanup
 def test_channel_plot():
     def testLine(x, y):
         data = [obj for obj in mpl.pyplot.gca().get_children() if isinstance(obj, mpl.lines.Line2D)]

--- a/lumicks/pylake/tests/test_decorators.py
+++ b/lumicks/pylake/tests/test_decorators.py
@@ -1,0 +1,22 @@
+import functools
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+
+
+def mpl_test_cleanup(func):
+    """Runs tests in a context manager and closes figures after each test"""
+
+    @functools.wraps(func)
+    def wrapped_callable(*args, **kwargs):
+        try:
+            orig_backend = plt.get_backend()
+            with mpl.style.context(["classic", "_classic_test_patch"]):
+                # Use a headless backend for testing, note that passing it as a context parameter
+                # did not work.
+                plt.switch_backend("agg")
+                func(*args, **kwargs)
+        finally:
+            plt.close("all")
+            plt.switch_backend(orig_backend)
+
+    return wrapped_callable

--- a/lumicks/pylake/tests/test_imaging_camera/test_correlated_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_correlated_stack.py
@@ -10,7 +10,7 @@ from lumicks.pylake.detail.widefield import TiffStack
 from lumicks.pylake import channel
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 from ..data.mock_widefield import MockTiffFile, make_alignment_image_data, make_frame_times
 
 
@@ -340,7 +340,7 @@ def test_deprecate_raw():
         stack.raw
 
 
-@cleanup
+@mpl_test_cleanup
 def test_correlated_stack_plotting(rgb_alignment_image_data):
     reference_image, warped_image, description, bit_depth = rgb_alignment_image_data
     fake_tiff = TiffStack(
@@ -390,7 +390,7 @@ def test_correlated_stack_plotting(rgb_alignment_image_data):
         stack.plot(channel="blue", frame=-1)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plot_correlated():
     cc = channel.Slice(
         channel.Continuous(np.arange(10, 80, 2), 10, 2), {"y": "mock", "title": "mock"}
@@ -667,7 +667,7 @@ def test_define_tether():
     check_result(stack, ref_stack, 16)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_correlated_stack_plot_rgb_absolute_color_adjustment(rgb_alignment_image_data):
     """Tests whether we can set an absolute color range for RGB plots."""
     reference_image, warped_image, description, bit_depth = rgb_alignment_image_data
@@ -695,7 +695,7 @@ def test_correlated_stack_plot_rgb_absolute_color_adjustment(rgb_alignment_image
     plt.close(fig)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_correlated_stack_plot_channels_absolute_color_adjustment(rgb_alignment_image_data):
     """Tests whether we can set an absolute color range for separate channel plots."""
     reference_image, warped_image, description, bit_depth = rgb_alignment_image_data
@@ -723,7 +723,7 @@ def test_correlated_stack_plot_channels_absolute_color_adjustment(rgb_alignment_
         plt.close(fig)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_correlated_stack_plot_rgb_percentile_color_adjustment(rgb_alignment_image_data):
     """Tests whether we can set a percentile color range for RGB plots."""
     reference_image, warped_image, description, bit_depth = rgb_alignment_image_data
@@ -756,7 +756,7 @@ def test_correlated_stack_plot_rgb_percentile_color_adjustment(rgb_alignment_ima
     plt.close(fig)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_correlated_stack_plot_single_channel_percentile_color_adjustment(rgb_alignment_image_data):
     """Tests whether we can set a percentile color range for separate channel plots."""
     reference_image, warped_image, description, bit_depth = rgb_alignment_image_data

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -6,7 +6,7 @@ from lumicks.pylake.channel import Slice, TimeSeries, empty_slice
 from lumicks.pylake.kymo import EmptyKymo
 from lumicks.pylake.adjustments import ColorAdjustment
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 from ..data.mock_confocal import generate_kymo
 
 
@@ -140,7 +140,7 @@ def test_damaged_kymo(test_kymos):
     np.testing.assert_allclose(kymo.get_image("red").data, kymo_reference[:, 1:])
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plotting(test_kymos):
     kymo = test_kymos["Kymo1"]
 
@@ -166,7 +166,7 @@ def test_plotting(test_kymos):
     plt.close()
 
 
-@cleanup
+@mpl_test_cleanup
 def test_deprecated_plotting(test_kymos):
     kymo = test_kymos["Kymo1"]
     with pytest.deprecated_call():
@@ -256,7 +256,7 @@ def test_plotting_with_force_downsampling(kymo_h5_file):
     np.testing.assert_allclose(ds.data, [30, 30, 10, 10])
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plotting_with_force(kymo_h5_file):
     f = pylake.File.from_h5py(kymo_h5_file)
     kymo = f.kymos["Kymo1"]
@@ -272,7 +272,7 @@ def test_plotting_with_force(kymo_h5_file):
     np.testing.assert_allclose(np.sort(plt.ylim()), [10, 30])
 
 
-@cleanup
+@mpl_test_cleanup
 def test_downsample_channel_downsampled_kymo(kymo_h5_file):
     f = pylake.File.from_h5py(kymo_h5_file)
     kymo = f.kymos["Kymo1"]
@@ -301,7 +301,7 @@ def test_downsample_channel_downsampled_kymo(kymo_h5_file):
         kymo.downsampled_by(time_factor=2).plot_with_force("1x", "red")
 
 
-@cleanup
+@mpl_test_cleanup
 def test_regression_plot_with_force(kymo_h5_file):
     # Plot_with_force used to fail when the last line of a kymograph was incomplete. The reason for
     # this was that the last few timestamps on the last line had zero as their timestamp. This meant
@@ -325,7 +325,7 @@ def test_regression_plot_with_force(kymo_h5_file):
     np.testing.assert_allclose(ds.data, [30, 30, 10, 10])
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plotting_with_histograms(test_kymos):
     def get_rectangle_data():
         widths = [p.get_width() for p in plt.gca().patches]
@@ -340,6 +340,7 @@ def test_plotting_with_histograms(test_kymos):
     assert np.all(np.equal(w, [3, 1, 1, 1, 3]))
     np.testing.assert_allclose(np.sort(plt.xlim()), [0, 3], atol=0.05)
 
+    plt.close('all')
     kymo.plot_with_time_histogram(color_channel="red", pixels_per_bin=1)
     w, h = get_rectangle_data()
     np.testing.assert_allclose(w, 1.03, atol=0.002)
@@ -347,6 +348,7 @@ def test_plotting_with_histograms(test_kymos):
     np.testing.assert_allclose(np.sort(plt.ylim()), [0, 4], atol=0.05)
 
     with pytest.warns(UserWarning):
+        plt.close('all')
         kymo.plot_with_position_histogram(color_channel="red", pixels_per_bin=3)
         w, h = get_rectangle_data()
         np.testing.assert_allclose(h, [0.03, 0.02])
@@ -354,6 +356,7 @@ def test_plotting_with_histograms(test_kymos):
         np.testing.assert_allclose(np.sort(plt.xlim()), [0, 5], atol=0.05)
 
     with pytest.warns(UserWarning):
+        plt.close('all')
         kymo.plot_with_time_histogram(color_channel="red", pixels_per_bin=3)
         w, h = get_rectangle_data()
         np.testing.assert_allclose(w, [3.09, 1.03], atol=0.02)
@@ -361,9 +364,11 @@ def test_plotting_with_histograms(test_kymos):
         np.testing.assert_allclose(np.sort(plt.ylim()), [0, 6], atol=0.05)
 
     with pytest.raises(ValueError):
+        plt.close('all')
         kymo.plot_with_position_histogram(color_channel="red", pixels_per_bin=6)
 
     with pytest.raises(ValueError):
+        plt.close('all')
         kymo.plot_with_time_histogram(color_channel="red", pixels_per_bin=6)
 
 
@@ -1002,7 +1007,7 @@ def test_partial_pixel_kymo():
     np.testing.assert_equal(kymo.get_image("red")[-2, -1], 0)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plot_with_lf_force():
     dt = int(1e9 / 78125)
     start = 1536582124217030400
@@ -1035,7 +1040,7 @@ def test_plot_with_lf_force():
         kymo.plot_with_force("1x", "red")
 
 
-@cleanup
+@mpl_test_cleanup
 def test_kymo_plot_rgb_absolute_color_adjustment(test_kymos):
     """Tests whether we can set an absolute color range for the RGB plot."""
     kymo = test_kymos["Kymo1"]
@@ -1048,7 +1053,7 @@ def test_kymo_plot_rgb_absolute_color_adjustment(test_kymos):
     plt.close(fig)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_kymo_plot_rgb_percentile_color_adjustment(test_kymos):
     """Tests whether we can set a percentile color range for the RGB plot."""
     kymo = test_kymos["Kymo1"]
@@ -1068,7 +1073,7 @@ def test_kymo_plot_rgb_percentile_color_adjustment(test_kymos):
     plt.close(fig)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_kymo_plot_single_channel_absolute_color_adjustment(test_kymos):
     """Tests whether we can set an absolute color range for a single channel plot."""
     kymo = test_kymos["Kymo1"]

--- a/lumicks/pylake/tests/test_imaging_confocal/test_point_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_point_scan.py
@@ -2,7 +2,7 @@ import pytest
 import matplotlib.pyplot as plt
 import numpy as np
 from lumicks import pylake
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 
 
 def test_point_scans(test_point_scans, reference_timestamps, reference_counts):
@@ -15,7 +15,7 @@ def test_point_scans(test_point_scans, reference_timestamps, reference_counts):
     np.testing.assert_allclose(ps_red.data, reference_counts)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plotting(test_point_scans):
     ps = test_point_scans["PointScan1"]
 
@@ -38,7 +38,7 @@ def test_plotting(test_point_scans):
     plt.close()
 
 
-@cleanup
+@mpl_test_cleanup
 def test_deprecated_plotting(test_point_scans):
     ps = test_point_scans["PointScan1"]
     with pytest.deprecated_call():

--- a/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from lumicks.pylake.detail.imaging_mixins import _FIRST_TIMESTAMP
 from lumicks.pylake.adjustments import ColorAdjustment
-from matplotlib.testing.decorators import cleanup
+from lumicks.pylake.tests.test_decorators import mpl_test_cleanup
 from ..data.mock_confocal import generate_scan
 
 
@@ -200,7 +200,7 @@ def test_damaged_scan(test_scans):
     np.testing.assert_allclose(scan.start, middle)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plotting(test_scans):
     scan = test_scans["fast Y slow X multiframe"]
     scan.plot(channel="blue")
@@ -234,7 +234,7 @@ def test_plotting(test_scans):
         scan.plot(channel="rgb", frame=-1)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_deprecated_plotting(test_scans):
     scan = test_scans["fast Y slow X multiframe"]
     with pytest.deprecated_call():
@@ -388,7 +388,7 @@ def test_multiple_frame_times(dim_x, dim_y, frames, line_padding, start, dt, sam
         scan.frame_timestamp_ranges(False, include_dead_time=True)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_scan_plot_rgb_absolute_color_adjustment(test_scans):
     """Tests whether we can set an absolute color range for an RGB plot."""
     scan = test_scans["fast Y slow X"]
@@ -403,7 +403,7 @@ def test_scan_plot_rgb_absolute_color_adjustment(test_scans):
     plt.close(fig)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_scan_plot_single_channel_absolute_color_adjustment(test_scans):
     """Tests whether we can set an absolute color range for a single channel plot."""
     scan = test_scans["fast Y slow X"]
@@ -431,7 +431,7 @@ def test_scan_plot_single_channel_absolute_color_adjustment(test_scans):
         plt.close(fig)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plot_rgb_percentile_color_adjustment(test_scans):
     """Tests whether we can set a percentile color range for an RGB plot."""
     scan = test_scans["fast Y slow X multiframe"]
@@ -453,7 +453,7 @@ def test_plot_rgb_percentile_color_adjustment(test_scans):
     plt.close(fig)
 
 
-@cleanup
+@mpl_test_cleanup
 def test_plot_single_channel_percentile_color_adjustment(test_scans):
     """Tests whether we can set a percentile color range for separate channel plots."""
     scan = test_scans["fast Y slow X multiframe"]


### PR DESCRIPTION
**Why this PR?**
We've been using the `cleanup` decorator from `matplotlib`, but it's [deprecated](https://github.com/matplotlib/matplotlib/pull/22697) now, so here is our own.

I also took the liberty of getting rid of a few deprecated API calls in the benchmark and adding a few `plt.close('all')` calls in a few of the tests, since auto-removal of overlapping axes is deprecated.

Longer term it might be nice to look into something such as [pytest-mpl](https://github.com/matplotlib/pytest-mpl). Maybe a fun friday afternoon project, but for now this at least gets us back up and running without using deprecated functionality.