### PR TITLE
diffusion: implement the covariance based estimator for diffusion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,8 @@
 
 * Fixed and reintroduced lazy loading for `TimeSeries` data.
 * You can now add two `KymoTrackGroups` tracked on the same kymo together with the `+` operator.
-* TIFFs exported from `Scan` and `Kymo` now contain metadata. The `DateTime` tag indicated the start/stop timestamp of each frame. The `ImageDescription` tag contains additional information about the confocal acquisition parameters. 
+* TIFFs exported from `Scan` and `Kymo` now contain metadata. The `DateTime` tag indicated the start/stop timestamp of each frame. The `ImageDescription` tag contains additional information about the confocal acquisition parameters.
+* Added covariance-based estimator (cve) option to `KymoTrack.estimate_diffusion`. See [kymotracker documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#studying-diffusion-processes) for more details.
 
 #### Other changes
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -10,6 +10,18 @@
 }
 
 
+@article{vestergaard2016optimizing,
+  title={Optimizing experimental parameters for tracking of diffusing particles},
+  author={Vestergaard, Christian L},
+  journal={Physical Review E},
+  volume={94},
+  number={2},
+  pages={022401},
+  year={2016},
+  publisher={APS}
+}
+
+
 @article{huber2009new,
   title={New international formulation for the viscosity of H 2 O},
   author={Huber, Marcia L and Perkins, Richard A and Laesecke, Arno and Friend, Daniel G and Sengers, Jan V and Assael, Marc J and Metaxa, Ifigenia N and Vogel, Eckhard and Mare{\v{s}}, R and Miyagawa, Kiyoshi},

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,3 +1,15 @@
+@article{vestergaard2014optimal,
+  title={Optimal estimation of diffusion coefficients from single-particle trajectories},
+  author={Vestergaard, Christian L and Blainey, Paul C and Flyvbjerg, Henrik},
+  journal={Physical Review E},
+  volume={89},
+  number={2},
+  pages={022726},
+  year={2014},
+  publisher={APS}
+}
+
+
 @article{huber2009new,
   title={New international formulation for the viscosity of H 2 O},
   author={Huber, Marcia L and Perkins, Richard A and Laesecke, Arno and Friend, Daniel G and Sengers, Jan V and Assael, Marc J and Metaxa, Ifigenia N and Vogel, Eckhard and Mare{\v{s}}, R and Miyagawa, Kiyoshi},

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -446,7 +446,8 @@ We can also directly determine them for an entire group by just invoking::
     DiffusionEstimate(value=4.9236019911012745, std_err=1.7399505893645122, num_lags=3, num_points=80, method='ols', unit='um^2 / s')]
 
 We can see that there is considerable variation in the estimates, which is unfortunately typical for diffusion coefficient estimates.
-By default, :func:`~lumicks.pylake.kymotracker.kymotrack.KymoTrack.estimate_diffusion` will use the optimal number of lags as specified in :cite:`michalet2012optimal`. You can however, override this optimal number of lags, by specifying a `max_lag` parameter::
+By default, :func:`~lumicks.pylake.kymotracker.kymotrack.KymoTrack.estimate_diffusion` will use the optimal number of lags as specified in :cite:`michalet2012optimal`.
+You can however, override this optimal number of lags, by specifying a `max_lag` parameter::
 
     >>> tracks.estimate_diffusion(method="ols", max_lag=30)
     [DiffusionEstimate(value=11.949917925662831, std_err=10.394298104056345, num_lags=30, num_points=80, method='ols', unit='um^2 / s'),
@@ -476,6 +477,17 @@ This method is slower, since it has to solve some implicit equations, but it doe
      DiffusionEstimate(value=4.432955288469379, std_err=1.565056974828146, num_lags=30, num_points=80, method='gls', unit='um^2 / s'),
      DiffusionEstimate(value=5.378609478528924, std_err=1.7771064499907185, num_lags=30, num_points=80, method='gls', unit='um^2 / s')]
 
+A third more performant and unbiased method for computing the free diffusion is the covariance-based estimator (CVE) :cite:`vestergaard2014optimal`.
+The CVE does not rely on computing mean squared displacements and avoids the complications that arise from their use.
+The performance of this estimator can be characterized by its signal to noise ratio (SNR).
+This SNR is defined by:
+
+.. math::
+
+    SNR = \frac{\sqrt{D \Delta t}}{{\sigma}}
+
+Here :math:`D` is the diffusion constant, :math:`Delta t` the time step and :math:`\sigma` the localization uncertainty.
+Use of the CVE is indicated when the SNR is bigger than 1. For smaller values for the SNR, we recommend using OLS or GLS instead.
 
 Dwelltime analysis
 ------------------

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -477,7 +477,7 @@ This method is slower, since it has to solve some implicit equations, but it doe
      DiffusionEstimate(value=4.432955288469379, std_err=1.565056974828146, num_lags=30, num_points=80, method='gls', unit='um^2 / s'),
      DiffusionEstimate(value=5.378609478528924, std_err=1.7771064499907185, num_lags=30, num_points=80, method='gls', unit='um^2 / s')]
 
-A third more performant and unbiased method for computing the free diffusion is the covariance-based estimator (CVE) :cite:`vestergaard2014optimal`.
+A third more performant and unbiased method for computing the free diffusion is the covariance-based estimator (CVE) :cite:`vestergaard2014optimal,vestergaard2016optimizing`.
 The CVE does not rely on computing mean squared displacements and avoids the complications that arise from their use.
 The performance of this estimator can be characterized by its signal to noise ratio (SNR).
 This SNR is defined by:

--- a/lumicks/pylake/kymotracker/detail/msd_estimation.py
+++ b/lumicks/pylake/kymotracker/detail/msd_estimation.py
@@ -492,12 +492,13 @@ def _var_cve_unknown_var(
            diffusion coefficients from single-particle trajectories. Physical Review E, 89(2),
            022726.
     """
-    epsilon = variance_loc / (diffusion_constant * dt) - 2.0 * blur_constant
-    numerator = 6.0 * avg_frame_steps**2 + 4.0 * epsilon * avg_frame_steps + 2.0 * epsilon**2
+    epsilon = variance_loc / dt - 2.0 * blur_constant * diffusion_constant
+    avg_diff = avg_frame_steps * diffusion_constant
+    numerator = 6.0 * avg_diff**2 + 4.0 * epsilon * avg_diff + 2.0 * epsilon**2
     denominator = num_points * avg_frame_steps**2
     term1 = numerator / denominator
-    term2 = (4.0 * (avg_frame_steps + epsilon) ** 2) / (num_points**2 * avg_frame_steps**2)
-    return (term1 + term2) * diffusion_constant**2
+    term2 = 4.0 * (avg_diff + epsilon) ** 2 / (num_points**2 * avg_frame_steps**2)
+    return term1 + term2
 
 
 def _var_cve_known_var(
@@ -542,11 +543,10 @@ def _var_cve_known_var(
     .. [2] Vestergaard, C. L. (2016). Optimizing experimental parameters for tracking of diffusing
            particles. Physical Review E, 94(2), 022401.
     """
-    epsilon = variance_loc / (diffusion_constant * dt) - 2.0 * blur_constant
+    epsilon = variance_loc / dt - 2.0 * blur_constant * diffusion_constant
     blur_term = (avg_frame_steps - 2.0 * blur_constant) ** 2
-    numerator = diffusion_constant**2 * (
-        2.0 * avg_frame_steps**2 + 4.0 * epsilon * avg_frame_steps + 3.0 * epsilon**2
-    )
+    avg_diff = avg_frame_steps * diffusion_constant
+    numerator = 2.0 * avg_diff**2 + 4.0 * epsilon * avg_diff + 3.0 * epsilon**2
     denominator = num_points * blur_term
     term1 = numerator / denominator
     term2 = variance_variance_loc / (blur_term * dt**2)

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -344,8 +344,11 @@ class KymoTrack:
 
         1. Covariance based estimator (CVE)
 
-        The CVE is unbiased and practically optimal when SNR > 1. Here SNR is defined as follows
-        :math:`\sqrt(D \Delta t) / \sigma`.
+        The covariance-based diffusion estimator provides a simple unbiased estimator of diffusion.
+        This estimator was introduced in the work of Vestergaard et al [5]_. The correction for
+        missing data was introduced in [6]_. The CVE is unbiased and practically optimal when the
+        signal-to-noise ratio (SNR) is bigger than 1. In this context, the SNR is defined
+        as: :math:`\sqrt{D \Delta t} / \sigma`.
 
         2. MSD-based estimators (OLS, GLS)
 
@@ -384,7 +387,7 @@ class KymoTrack:
             Valid options are "cve", "ols" and "gls".
 
             - "cve" : Covariance based estimator [5]_. Optimal if SNR > 1. Can only be used when
-                      track is equidistantly sampled.
+              track is equidistantly sampled.
             - "ols" : Ordinary least squares [3]_. Determines optimal number of lags.
             - "gls" : Generalized least squares [4]_. Takes into account covariance matrix (slower).
         max_lag : int (optional)
@@ -399,11 +402,13 @@ class KymoTrack:
         .. [3] Michalet, X., & Berglund, A. J. (2012). Optimal diffusion coefficient estimation in
                single-particle tracking. Physical Review E, 85(6), 061916.
         .. [4] Bullerjahn, J. T., von Bülow, S., & Hummer, G. (2020). Optimal estimates of
-               self-diffusion coefficients from molecular dynamics simulations. The Journal of Chemical
-               Physics, 153(2), 024116.
+               self-diffusion coefficients from molecular dynamics simulations. The Journal of
+               Chemical Physics, 153(2), 024116.
         .. [5] Vestergaard, C. L., Blainey, P. C., & Flyvbjerg, H. (2014). Optimal estimation of
                diffusion coefficients from single-particle trajectories. Physical Review E, 89(2),
                022726.
+        .. [6] Vestergaard, C. L. (2016). Optimizing experimental parameters for tracking of
+               diffusing particles. Physical Review E, 94(2), 022401.
         """
         if method not in ("cve", "gls", "ols"):
             raise ValueError('Invalid method selected. Method must be "gls" or "ols"')
@@ -423,7 +428,7 @@ class KymoTrack:
 
         if method == "cve":
             return estimate_diffusion_cve(
-                frame_idx, positions, self._line_time_seconds, **unit_labels
+                frame_idx, positions, self._line_time_seconds, **unit_labels, blur_constant=0
             )
 
         max_lag = (

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -427,6 +427,7 @@ class KymoTrack:
         }
 
         if method == "cve":
+            # We hardcode the blur constant for confocal for now (no motion blur)
             return estimate_diffusion_cve(
                 frame_idx, positions, self._line_time_seconds, **unit_labels, blur_constant=0
             )

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -674,3 +674,17 @@ def test_disallowed_diffusion_est(blank_kymo):
     group = KymoTrackGroup([k])
     with pytest.raises(NotImplementedError, match=contiguous_diffusion_error):
         group.estimate_diffusion(method="ols")
+
+
+def test_diffusion_cve(blank_kymo):
+    """Test the API for the covariance based estimator"""
+    k = KymoTrack(np.arange(5), np.arange(5), blank_kymo, "red")
+    cve_est = k.estimate_diffusion("cve")
+
+    np.testing.assert_allclose(cve_est.value, 1.5)
+    np.testing.assert_allclose(cve_est.std_err, 1.3928388277184118)
+    np.testing.assert_allclose(cve_est.num_points, 5)
+    assert cve_est.num_lags is None
+    assert cve_est.method == 'cve'
+    assert cve_est.unit == "um^2 / s"
+    assert cve_est._unit_label == "$\\mu$m$^2$/s"


### PR DESCRIPTION
**Why this PR?**
This is the first part of some of the new diffusion estimation work. This implements the CVE method.

Benefits:
- Provides a really fast unbiased estimator that provides a better alternative to OLS/GLS for cases where the `SNR > 1`.
- Future extension is possible towards methods where we take into account the bias caused by substrate fluctuations (whether this is relevant for us is still T.B.D).
- Future extension to incorporating the static localization uncertainty obtained from Gaussian refinement is possible, this reduces the problem by one parameter and reduces spread of the diffusion estimates.

Below you see a figure where this method was using on a 50 point trace with 20 random points missing. The solid lines with the symbols represent the mean, while the lines indicate `mean +- standard deviation`. You can see that all three methods are unbiased for `SNR > 1`.

![image](https://user-images.githubusercontent.com/19836026/190682892-6f4b181c-30fa-4a4d-b642-542c1cf8c050.png)

Note that if you provide the localization uncertainty, the variance goes down (as expected).

![image](https://user-images.githubusercontent.com/19836026/190993159-02a88bb9-1d55-4d88-b6cf-d0ec1bc7c1dd.png)

One thing to keep in mind when dealing with these estimates is that the distribution of the estimates is not very normal. It is skewed towards positive values. While the `mean` is asymptotically correct and unbiased, the `median` will not be at the true value, and the `mean` can be outlier sensitive.

I have also compared the variance estimators that were provided (and implemented in this PR). In the results below we can see the difference between the theoretical variance estimate (variance estimator with the true parameters filled in) vs the variance actually obtained from running many traces (N=1500). Used here are traces of 50 points with 10 points randomly omitted (meaning 40 points effectively):

Left shows unknown localization uncertainty, right shows with localization uncertainty known (currently not exposed through the API):

![image](https://user-images.githubusercontent.com/19836026/190991441-8e89c385-5d73-484e-95d4-7ba3fe0ed5a5.png)

The relevant papers are: [here](https://backend.orbit.dtu.dk/ws/files/90238574/PhysRevE.89.022726.pdf) and [here](https://arxiv.org/pdf/1504.05462.pdf).

Docs build can be found [here](https://lumicks-pylake.readthedocs.io/en/cve/_api/lumicks.pylake.kymotracker.kymotrack.KymoTrack.html#lumicks.pylake.kymotracker.kymotrack.KymoTrack.estimate_diffusion) and [here](https://lumicks-pylake.readthedocs.io/en/cve/tutorial/kymotracking.html#studying-diffusion-processes). They are usable, but still a bit spartan. Reason for this is that I intend to restructure them when the ensemble MSD PR rolls around. Since that one requires some reworking in how the story is told, I didn't want to add too many docs changes to this PR (to avoid double work).