### PR TITLE
Rename fdfit functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,17 @@
 ### Other changes
 
 * Updated benchmark to not use deprecated functions and arguments. Prior to this change, running the benchmark would produce deprecation warnings.
+* Renamed force distance fitting functions. They are deprecated now and will be removed in the future:
+    *  `inverted_marko_siggia_simplified` -> `wlc_marko_siggia_distance`
+    *  `marko_siggia_simplified` -> `wlc_marko_siggia_force`
+    *  `marko_siggia_ewlc_distance` -> `ewlc_marko_siggia_distance`
+    *  `marko_siggia_ewlc_force` -> `ewlc_marko_siggia_force`
+    *  `odijk` -> `ewlc_odijk_distance`
+    *  `inverted_odijk` -> `ewlc_odijk_force`
+    *  `freely_jointed_chain` -> `efjc_distance`
+    *  `inverted_freely_jointed_chain` -> `efjc_force`
+    *  `twistable_wlc` -> `twlc_distance`
+    *  `inverted_twistable_wlc` -> `twlc_force`
 
 ## v0.13.1 | 2022-09-08
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -62,16 +62,16 @@ FD Fitting
 
     force_offset
     distance_offset
-    marko_siggia_ewlc_force
-    marko_siggia_ewlc_distance
-    marko_siggia_simplified
-    inverted_marko_siggia_simplified
-    odijk
-    inverted_odijk
-    freely_jointed_chain
-    inverted_freely_jointed_chain
-    twistable_wlc
-    inverted_twistable_wlc
+    wlc_marko_siggia_force
+    wlc_marko_siggia_distance
+    ewlc_marko_siggia_force
+    ewlc_marko_siggia_distance
+    ewlc_odijk_force
+    ewlc_odijk_distance
+    twlc_force
+    twlc_distance
+    efjc_force
+    efjc_distance
 
 
 Kymotracking

--- a/docs/examples/reca_fitting/reca_fitting.rst
+++ b/docs/examples/reca_fitting/reca_fitting.rst
@@ -47,7 +47,7 @@ Set up the model
 
 For this we want to use an inverted worm-like chain model. We also include an estimated distance and force offset::
 
-    model = lk.inverted_odijk("DNA").subtract_independent_offset() + lk.force_offset("DNA")
+    model = lk.ewlc_odijk_force("DNA").subtract_independent_offset() + lk.force_offset("DNA")
 
 We would like to fit this model to some data. So let's make a `FdFit`::
 
@@ -175,7 +175,7 @@ Try another model
 There are more models in pylake. We can also try the Marko Siggia model for instance and see if it fits this data any
 differently::
 
-    ms_model = lk.marko_siggia_ewlc_force("DNA").subtract_independent_offset() + lk.force_offset("DNA")
+    ms_model = lk.ewlc_marko_siggia_force("DNA").subtract_independent_offset() + lk.force_offset("DNA")
     ms_fit = lk.FdFit(ms_model)
     ms_fit.add_data("Control", force_control, distance_control)
     ms_fit.add_data("RecA", force_reca, distance_reca,

--- a/docs/examples/twlc_fitting/twlc_fitting.rst
+++ b/docs/examples/twlc_fitting/twlc_fitting.rst
@@ -40,7 +40,7 @@ slightly from experiment to experiment, or the force may have experienced some d
 both distance and force to compensate for small offsets that may exist in the data. Let's set up the Odijk worm-like
 chain model and create the fit::
 
-    m_odijk = lk.inverted_odijk("DNA").subtract_independent_offset() + lk.force_offset("DNA")
+    m_odijk = lk.ewlc_odijk_force("DNA").subtract_independent_offset() + lk.force_offset("DNA")
     fit_odijk = lk.FdFit(m_odijk)
 
 Considering that this model only describes the force-extension behaviour at low forces (0.1 - 30 pN), we have to extract
@@ -87,12 +87,12 @@ And fit the model::
 Set up the twistable worm like chain model
 ------------------------------------------
 
-By default, the `twistable_wlc` model provided with pylake outputs the distance as a function of force. However, we
+By default, the `twlc_distance` model provided with pylake outputs the distance as a function of force. However, we
 typically want to fit force as a function of distance. To achieve this, we can invert the model using its `invert`
 function at the cost of slowing down the fit. Alternatively, we have a faster way of achieving this in pylake, by
-using the dedicated `inverted_twistable_wlc` model::
+using the dedicated `twlc_force` model::
 
-    m_dna = lk.inverted_twistable_wlc("DNA").subtract_independent_offset() + lk.force_offset("DNA")
+    m_dna = lk.twlc_force("DNA").subtract_independent_offset() + lk.force_offset("DNA")
     fit_twlc = lk.FdFit(m_dna)
 
 Load the full data into the model

--- a/docs/tutorial/fdfitting.rst
+++ b/docs/tutorial/fdfitting.rst
@@ -16,11 +16,11 @@ Models
 ------
 
 When fitting data, everything revolves around models. One of these models is the so-called extensible worm-like-chain
-model by Odijk et al. Let's have a look at it. We can construct this model using the supplied function `lk.odijk()`.
+model by Odijk et al. Let's have a look at it. We can construct this model using the supplied function `lk.ewlc_odijk_distance()`.
 
 Note that we also have to give it a name. This name will be prefixed to model specific parameters in this model::
 
-    >>> model = lk.odijk("DNA")
+    >>> model = lk.ewlc_odijk_distance("DNA")
 
 Entering model prints the model equation and its default parameters::
 
@@ -58,7 +58,7 @@ Simulating the model
 
 We can simulate the model by passing a dictionary with parameters values::
 
-    dna = lk.odijk("DNA")
+    dna = lk.ewlc_odijk_distance("DNA")
     force = np.arange(0.1, 14, 0.1)
     dna(force, {"DNA/Lp": 50.0, "DNA/Lc": 16.0, "DNA/St": 1500.0, "kT": 4.11})
 
@@ -70,7 +70,7 @@ Model composition and inversion
 In practice, we would typically want to fit force as a function of distance however. For this we have the inverted
 Odijk model::
 
-    model = lk.inverted_odijk("DNA")
+    model = lk.ewlc_odijk_force("DNA")
 
 We can have a quick look at what this model looks like and which parameters are in there::
 
@@ -94,7 +94,7 @@ we notice that the template matching wasn't completely optimal. In addition, we 
 forgetting to reset the force back to zero. In this case, we can incorporate offsets in our model. We can introduce an
 offset in the independent parameter, by calling `.subtract_independent_offset()` on our model::
 
-    >>> model = lk.inverted_odijk("DNA").subtract_independent_offset()
+    >>> model = lk.ewlc_odijk_force("DNA").subtract_independent_offset()
     >>> model
 
     Model: DNA(x-d)
@@ -115,7 +115,7 @@ offset in the independent parameter, by calling `.subtract_independent_offset()`
 
 If we also expect an offset in the dependent parameter, we can simply add an offset model to our model::
 
-    >>> model = lk.inverted_odijk("DNA").subtract_independent_offset() + lk.force_offset("DNA")
+    >>> model = lk.ewlc_odijk_force("DNA").subtract_independent_offset() + lk.force_offset("DNA")
     >>> model
 
     Model: DNA(x-d)_with_DNA
@@ -139,7 +139,7 @@ From the above example, you can see how easy it is to composite models. Sometime
 instance, we may have two worm like chain models that we wish to add, and then invert. For the Odijk model, this can be
 done as follows::
 
-    model = lk.odijk("DNA") + lk.odijk("protein") + lk.distance_offset("offset")
+    model = lk.ewlc_odijk_distance("DNA") + lk.ewlc_odijk_distance("protein") + lk.distance_offset("offset")
     model = model.invert()
 
 Note how we added three models and then inverted the composition of those models. Models inverted via `invert()` will
@@ -245,7 +245,7 @@ Incremental fitting
 
 Fits can also be done incrementally::
 
-    >>> model = lk.inverted_odijk("DNA")
+    >>> model = lk.ewlc_odijk_force("DNA")
     >>> fit = lk.FdFit(model)
     >>> print(fit.params)
     No parameters
@@ -290,7 +290,7 @@ point basis). This can be used to obtain dynamic contour lengths for instance. I
 be performed. We first set up a model and fit it to some data. This is all analogous to what we've learned before::
 
     # Define the model to be fitted
-    model = lk.inverted_odijk("model") + lk.force_offset("model")
+    model = lk.ewlc_odijk_force("model") + lk.force_offset("model")
 
     # Fit the overall model first
     fit = lk.FdFit(model)
@@ -335,7 +335,7 @@ Global fits versus single fits
 The `FdFit` object manages a fit. To illustrate its use, and how a global fit differs from a local fit, consider the
 following two examples::
 
-    model = lk.inverted_odijk("DNA")
+    model = lk.ewlc_odijk_force("DNA")
     fit = lk.FdFit(model)
     for i, (distance, force) in enumerate(zip(distances, forces)):
         fit.add_data(f"RecA {i}", f=force, d=distance)
@@ -345,7 +345,7 @@ following two examples::
 and::
 
     for i, (distance, force) in enumerate(zip(distances, forces)):
-        model = lk.inverted_odijk("DNA")
+        model = lk.ewlc_odijk_force("DNA")
         fit = lk.FdFit(model)
         fit.add_data(f"RecA {i}", f=force, d=distance)
         fit.fit()
@@ -362,7 +362,7 @@ parameters shared between different conditions. It's usually a good idea to thin
 be different between different experiments and only allow these parameters to be different in the fit. For example,
 if the only expected difference between the experiments is the contour length, then this can be achieved using::
 
-    model = lk.inverted_odijk("DNA")
+    model = lk.ewlc_odijk_force("DNA")
     fit = lk.FdFit(model)
     for i, (distance, force) in enumerate(zip(distances, forces)):
         fit.add_data(f"RecA {i}", force, distance, {"DNA/Lc": f"DNA/Lc_{i}"})
@@ -377,8 +377,8 @@ Multiple models
 When working with multiple models, things can get a little more complicated. Let's say we have two models, `model1` and
 `model2` and we want to fit both in a global fit. Constructing the `FdFit` is easy::
 
-    model1 = lk.inverted_odijk("DNA")
-    model2 = (lk.odijk("DNA") + lk.odijk("protein")).invert()
+    model1 = lk.ewlc_odijk_force("DNA")
+    model2 = (lk.ewlc_odijk_distance("DNA") + lk.ewlc_odijk_distance("protein")).invert()
     fit = lk.FdFit(model1, model2)
 
 But then the question arises, how do we add data to each model? Well, the trick is in the assignments to `model1` and

--- a/lumicks/pylake/benchmark.py
+++ b/lumicks/pylake/benchmark.py
@@ -129,11 +129,11 @@ class _FdFit(_Benchmark):
         # The interpolated method is a lot faster, so we can do more points in that case
         force = np.arange(0.1, 20.0, 0.95 * (0.07 if self.interpolated else 1))
         true = {"m/Lp": 50.0, "m/Lc": 1024 * 0.34, "m/St": 1200.0, "kT": 4.11}
-        distance = lk.odijk("m")(force, true) + 0.02
+        distance = lk.ewlc_odijk_distance("m")(force, true) + 0.02
 
         def bench():
             # Deliberately use the manually inverted form (slower)
-            manually_inverted = (lk.odijk("m") + lk.distance_offset("m")).invert(
+            manually_inverted = (lk.ewlc_odijk_distance("m") + lk.distance_offset("m")).invert(
                 independent_min=0.0, independent_max=30, interpolate=self.interpolated
             )
 

--- a/lumicks/pylake/fitting/datasets.py
+++ b/lumicks/pylake/fitting/datasets.py
@@ -72,7 +72,7 @@ class Datasets:
         Examples
         --------
         ::
-            dna_model = pylake.inverted_odijk("DNA")  # Use an inverted Odijk eWLC model.
+            dna_model = pylake.ewlc_odijk_force("DNA")  # Use an inverted Odijk eWLC model.
             fit = pylake.FdFit(dna_model)
 
             fit.add_data("Control", f1, d1)  # Load the first dataset like that
@@ -136,7 +136,7 @@ class Datasets:
         ::
             from lumicks import pylake
 
-            model = pylake.inverted_odijk("DNA")
+            model = pylake.ewlc_odijk_force("DNA")
             fit = pylake.FdFit(model)
             fit.add_data("Control", force, distance)
             fit.fit()
@@ -148,8 +148,8 @@ class Datasets:
             fit.plot("Control", overrides={"DNA/St": 5})
 
             # When dealing with multiple models in one fit, one has to select the model first when we want to plot.
-            model1 = pylake.odijk("DNA")
-            model2 = pylake.odijk("DNA") + pylake.odijk("protein")
+            model1 = pylake.ewlc_odijk_distance("DNA")
+            model2 = pylake.ewlc_odijk_distance("DNA") + pylake.ewlc_odijk_distance("protein")
             fit[model1].add_data("Control", force1, distance2)
             fit[model2].add_data("Control", force1, distance2)
             fit.fit()
@@ -223,7 +223,7 @@ class FdDatasets(Datasets):
         --------
         ::
 
-            dna_model = pylake.inverted_odijk("DNA")  # Use an inverted Odijk eWLC model.
+            dna_model = pylake.ewlc_odijk_force("DNA")  # Use an inverted Odijk eWLC model.
             fit = pylake.FdFit(dna_model)
 
             fit.add_data("Data1", force1, distance1)  # Load the first data set like that

--- a/lumicks/pylake/fitting/detail/model_implementation.py
+++ b/lumicks/pylake/fitting/detail/model_implementation.py
@@ -49,18 +49,18 @@ def offset_model_derivative(x, offset):
     return np.zeros(len(x))
 
 
-def marko_siggia_simplified_equation(d, Lp, Lc, kT):
+def wlc_marko_siggia_force_equation(d, Lp, Lc, kT):
     return f"({kT}/{Lp}) * ((1/4) * (1-({d}/{Lc}))**(-2) + ({d}/{Lc}) - (1/4))"
 
 
-def marko_siggia_simplified_equation_tex(d, Lp, Lc, kT):
+def wlc_marko_siggia_force_equation_tex(d, Lp, Lc, kT):
     return (
         f"\\frac{{{kT}}}{{{Lp}}} \\left(\\frac{{1}}{{4}} \\left(1-\\frac{{{d}}}{{{Lc}}}\\right)^{{-2}} + "
         f"\\frac{{{d}}}{{{Lc}}} - \\frac{{1}}{{4}}\\right)"
     )
 
 
-def marko_siggia_simplified(d, Lp, Lc, kT):
+def wlc_marko_siggia_force(d, Lp, Lc, kT):
     """Marko Siggia's Worm-like Chain model based on only entropic contributions. Valid for
     F < 10 pN) [1]_.
 
@@ -81,7 +81,7 @@ def marko_siggia_simplified(d, Lp, Lc, kT):
     return (kT / Lp) * (0.25 * (1.0 - d_div_Lc) ** (-2) + d_div_Lc - 0.25)
 
 
-def marko_siggia_simplified_jac(d, Lp, Lc, kT):
+def wlc_marko_siggia_force_jac(d, Lp, Lc, kT):
     return np.vstack(
         (
             -0.25 * Lc**2 * kT / (Lp**2 * (Lc - d) ** 2)
@@ -93,19 +93,19 @@ def marko_siggia_simplified_jac(d, Lp, Lc, kT):
     )
 
 
-def marko_siggia_simplified_derivative(d, Lp, Lc, kT):
+def wlc_marko_siggia_force_derivative(d, Lp, Lc, kT):
     return 0.5 * Lc**2 * kT / (Lp * (Lc - d) ** 3) + kT / (Lc * Lp)
 
 
-def WLC_equation(f, Lp, Lc, St, kT=4.11):
+def ewlc_odijk_distance_equation(f, Lp, Lc, St, kT=4.11):
     return f"{Lc} * (1 - (1/2)*sqrt({kT}/({f}*{Lp})) + {f}/{St})"
 
 
-def WLC_equation_tex(f, Lp, Lc, St, kT=4.11):
+def ewlc_odijk_distance_equation_tex(f, Lp, Lc, St, kT=4.11):
     return f"{Lc} \\left(1 - \\frac{1}{2}\\sqrt{{\\frac{{{kT}}}{{{f} {Lp}}}}} + \\frac{{{f}}}{{{St}}}\\right)"
 
 
-def WLC(f, Lp, Lc, St, kT=4.11):
+def ewlc_odijk_distance(f, Lp, Lc, St, kT=4.11):
     """Odijk's Extensible Worm-like Chain model [1]_ [2]_.
 
     Parameters
@@ -134,7 +134,7 @@ def WLC(f, Lp, Lc, St, kT=4.11):
     return Lc * (1.0 - 1.0 / 2.0 * np.sqrt(kT / (f * Lp)) + f / St)
 
 
-def WLC_jac(f, Lp, Lc, St, kT=4.11):
+def ewlc_odijk_distance_jac(f, Lp, Lc, St, kT=4.11):
     sqrt_term = np.sqrt(kT / (f * Lp))
     return np.vstack(
         (
@@ -146,7 +146,7 @@ def WLC_jac(f, Lp, Lc, St, kT=4.11):
     )
 
 
-def tWLC_equation(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
+def twlc_distance_equation(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     g = f"({g0} + clip({g1}, {Fc}, inf))"
 
     return (
@@ -154,7 +154,7 @@ def tWLC_equation(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     )
 
 
-def tWLC_equation_tex(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
+def twlc_distance_equation_tex(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     g = f"\\left({g0} + \\max({g1}, {Fc})\\right)"
     sqrt_term = latex_sqrt(latex_frac(kT, f"{f} {Lp}"))
     stiff_term = latex_frac(C, f"-{g}^2 + {St} {C}")
@@ -162,7 +162,7 @@ def tWLC_equation_tex(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     return f"{Lc} \\left(1 - \\frac{{1}}{{2}} {sqrt_term} + {stiff_term}{f}\\right)"
 
 
-def tWLC(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
+def twlc_distance(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     """Twistable Worm-like Chain model [1]_.
 
     Parameters
@@ -202,7 +202,7 @@ def tWLC(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     return Lc * (1.0 - 1.0 / 2.0 * np.sqrt(kT / (f * Lp)) + (C / (-g * g + St * C)) * f)
 
 
-def tWLC_jac(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
+def twlc_distance_jac(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     x0 = 1.0 / Lp
     x1 = np.sqrt(kT * x0 / f)
     x2 = 0.25 * Lc * x1
@@ -248,11 +248,11 @@ def coth(x):
     return sol
 
 
-def FJC_equation(f, Lp, Lc, St, kT=4.11):
+def efjc_distance_equation(f, Lp, Lc, St, kT=4.11):
     return f"{Lc} * (coth(2.0 * {f} * {Lp} / {kT}) - {kT} / (2 * {f} * {Lp})) * (1 + {f}/{St})"
 
 
-def FJC_equation_tex(f, Lp, Lc, St, kT=4.11):
+def efjc_distance_equation_tex(f, Lp, Lc, St, kT=4.11):
     frac1 = latex_frac(f"{f} {Lp}", kT)
     frac2 = latex_frac(kT, f"2 {f} {Lp}")
     frac3 = latex_frac(f, St)
@@ -260,8 +260,8 @@ def FJC_equation_tex(f, Lp, Lc, St, kT=4.11):
     return f"{Lc} \\left(coth\\left(2 {frac1}\\right) - {frac2}\\right) \\left(1 + {frac3}\\right)"
 
 
-def FJC(f, Lp, Lc, St, kT=4.11):
-    """Freely-Jointed Chain [1]_ [2]_.
+def efjc_distance(f, Lp, Lc, St, kT=4.11):
+    """Extensible Freely-Jointed Chain [1]_ [2]_.
 
     Parameters
     ----------
@@ -291,7 +291,7 @@ def FJC(f, Lp, Lc, St, kT=4.11):
     return Lc * (coth(2.0 * f * Lp / kT) - kT / (2.0 * f * Lp)) * (1.0 + f / St)
 
 
-def FJC_jac(f, Lp, Lc, St, kT=4.11):
+def efjc_distance_jac(f, Lp, Lc, St, kT=4.11):
     x0 = 0.5 / f
     x1 = 2.0 * f / kT
     x2 = Lp * x1
@@ -311,7 +311,7 @@ def FJC_jac(f, Lp, Lc, St, kT=4.11):
     )
 
 
-def solve_cubic_wlc(a, b, c, selected_root):
+def calc_cubic_root(a, b, c, selected_root):
     # Convert the equation to a depressed cubic for p and q, which'll allow us to greatly simplify the equations
     p = b - a * a / 3.0
     q = 2 * a * a * a / 27.0 - a * b / 3.0 + c
@@ -357,15 +357,15 @@ def solve_cubic_wlc(a, b, c, selected_root):
     return sol - a / 3.0
 
 
-def invWLC_equation(d, Lp, Lc, St, kT=4.11):
-    return solve_formatter(WLC_equation("f", Lp, Lc, St, kT), "f", d)
+def ewlc_odijk_force_equation(d, Lp, Lc, St, kT=4.11):
+    return solve_formatter(ewlc_odijk_distance_equation("f", Lp, Lc, St, kT), "f", d)
 
 
-def invWLC_equation_tex(d, Lp, Lc, St, kT=4.11):
-    return solve_formatter_tex(WLC_equation_tex("f", Lp, Lc, St, kT), "f", d)
+def ewlc_odijk_force_equation_tex(d, Lp, Lc, St, kT=4.11):
+    return solve_formatter_tex(ewlc_odijk_distance_equation_tex("f", Lp, Lc, St, kT), "f", d)
 
 
-def invWLC(d, Lp, Lc, St, kT=4.11):
+def ewlc_odijk_force(d, Lp, Lc, St, kT=4.11):
     """Inverted Odijk's Worm-like Chain model [1]_ [2]_.
 
     Parameters
@@ -420,10 +420,10 @@ def invWLC(d, Lp, Lc, St, kT=4.11):
     b = (alpha * alpha) * (St * St)
     c = -0.25 * gamma * (St * St)
 
-    return solve_cubic_wlc(a, b, c, 2)
+    return calc_cubic_root(a, b, c, 2)
 
 
-def calc_root1_invwlc(det, p, q, dp_da, dq_da, dq_db):
+def calc_first_root(det, p, q, dp_da, dq_da, dq_db):
     # Calculate the first root for det < 0
     # Note that dp/dc = 0, dp_db = 1, dq_dc = 1
 
@@ -464,7 +464,7 @@ def calc_root1_invwlc(det, p, q, dp_da, dq_da, dq_db):
     return total_dy_da, total_dy_db, total_dy_dc
 
 
-def calc_triple_root_invwlc(p, q, dp_da, dq_da, dq_db, root):
+def calc_triple_root(p, q, dp_da, dq_da, dq_db, root):
     # If we define:
     #   sqmp = sqrt(-p)
     #   F = 3 * sqrt(3) * q / (2 * sqmp**3 )
@@ -505,7 +505,7 @@ def calc_triple_root_invwlc(p, q, dp_da, dq_da, dq_db, root):
     return total_dy_da, total_dy_db, total_dy_dc
 
 
-def invwlc_root_derivatives(a, b, c, selected_root):
+def calc_cubic_root_derivatives(a, b, c, selected_root):
     """Calculate the root derivatives of a cubic polynomial with respect to the polynomial coefficients.
 
     For a polynomial of the form:
@@ -536,19 +536,19 @@ def invwlc_root_derivatives(a, b, c, selected_root):
     total_dy_dc = np.zeros(det.shape)
 
     mask = det > 0
-    total_dy_da[mask], total_dy_db[mask], total_dy_dc[mask] = calc_root1_invwlc(
+    total_dy_da[mask], total_dy_db[mask], total_dy_dc[mask] = calc_first_root(
         det[mask], p[mask], q[mask], dp_da[mask], dq_da[mask], dq_db[mask]
     )
 
     nmask = np.logical_not(mask)
-    total_dy_da[nmask], total_dy_db[nmask], total_dy_dc[nmask] = calc_triple_root_invwlc(
+    (total_dy_da[nmask], total_dy_db[nmask], total_dy_dc[nmask]) = calc_triple_root(
         p[nmask], q[nmask], dp_da[nmask], dq_da[nmask], dq_db[nmask], selected_root
     )
 
     return total_dy_da, total_dy_db, total_dy_dc
 
 
-def invWLC_jac(d, Lp, Lc, St, kT=4.11):
+def ewlc_odijk_force_jac(d, Lp, Lc, St, kT=4.11):
     alpha = (d / Lc) - 1.0
     gamma = kT / Lp
 
@@ -557,7 +557,7 @@ def invWLC_jac(d, Lp, Lc, St, kT=4.11):
     b = (alpha * alpha) * St_squared
     c = -0.25 * gamma * St_squared
 
-    total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 2)
+    total_dy_da, total_dy_db, total_dy_dc = calc_cubic_root_derivatives(a, b, c, 2)
 
     # Map back to our output parameters
     da_dLc = 2.0 * St * d / Lc**2
@@ -577,7 +577,7 @@ def invWLC_jac(d, Lp, Lc, St, kT=4.11):
     return [total_dy_dLp, total_dy_dLc, total_dy_dSt, total_dy_dkT]
 
 
-def invWLC_derivative(d, Lp, Lc, St, kT=4.11):
+def ewlc_odijk_force_derivative(d, Lp, Lc, St, kT=4.11):
     alpha = (d / Lc) - 1.0
     gamma = kT / Lp
 
@@ -586,7 +586,7 @@ def invWLC_derivative(d, Lp, Lc, St, kT=4.11):
     b = (alpha * alpha) * St_squared
     c = -0.25 * gamma * St_squared
 
-    total_dy_da, total_dy_db, _ = invwlc_root_derivatives(a, b, c, 2)
+    total_dy_da, total_dy_db, _ = calc_cubic_root_derivatives(a, b, c, 2)
 
     # Map back to our output parameters
     da_dd = -2.0 * St / Lc
@@ -595,12 +595,12 @@ def invWLC_derivative(d, Lp, Lc, St, kT=4.11):
     return total_dy_da * da_dd + total_dy_db * db_dd
 
 
-def WLC_derivative(f, Lp, Lc, St, kT=4.11):
+def ewlc_odijk_distance_derivative(f, Lp, Lc, St, kT=4.11):
     x0 = 1.0 / f
     return Lc * (0.25 * x0 * np.sqrt(kT * x0 / Lp) + 1.0 / St)
 
 
-def tWLC_derivative(f, Lp, Lc, St, C, g0, g1, Fc, kT):
+def twlc_distance_derivative(f, Lp, Lc, St, C, g0, g1, Fc, kT):
     """Derivative of the tWLC model w.r.t. the independent variable"""
     x0 = 1.0 / f
     x1 = f > Fc
@@ -616,7 +616,7 @@ def tWLC_derivative(f, Lp, Lc, St, C, g0, g1, Fc, kT):
     )
 
 
-def FJC_derivative(f, Lp, Lc, St, kT=4.11):
+def efjc_distance_derivative(f, Lp, Lc, St, kT=4.11):
     """Derivative of the FJC model w.r.t. the independent variable"""
     x0 = 1.0 / St
     x1 = 2.0 * Lp / kT
@@ -630,15 +630,19 @@ def FJC_derivative(f, Lp, Lc, St, kT=4.11):
     return Lc * x0 * (coth(x2) - x3 / f) + Lc * (f * x0 + 1.0) * (-x1 * sinh_term + x3 / f**2)
 
 
-def invtWLC_equation(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
-    return solve_formatter(tWLC_equation_tex("f", Lp, Lc, St, C, g0, g1, Fc, kT=4.11), "f", d)
+def twlc_solve_force_equation(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
+    return solve_formatter(
+        twlc_distance_equation_tex("f", Lp, Lc, St, C, g0, g1, Fc, kT=4.11), "f", d
+    )
 
 
-def invtWLC_equation_tex(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
-    return solve_formatter_tex(tWLC_equation_tex("f", Lp, Lc, St, C, g0, g1, Fc, kT=4.11), "f", d)
+def twlc_solve_force_equation_tex(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
+    return solve_formatter_tex(
+        twlc_distance_equation_tex("f", Lp, Lc, St, C, g0, g1, Fc, kT=4.11), "f", d
+    )
 
 
-def invtWLC(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
+def twlc_solve_force(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     """Inverted Twistable Worm-like Chain model
 
     Inverted form of the Twistable Worm-like Chain model that takes into account untwisting of the
@@ -683,22 +687,22 @@ def invtWLC(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
         1.0,
         f_min,
         f_max,
-        lambda f_trial: tWLC(f_trial, Lp, Lc, St, C, g0, g1, Fc, kT),
-        lambda f_trial: tWLC_derivative(f_trial, Lp, Lc, St, C, g0, g1, Fc, kT),
+        lambda f_trial: twlc_distance(f_trial, Lp, Lc, St, C, g0, g1, Fc, kT),
+        lambda f_trial: twlc_distance_derivative(f_trial, Lp, Lc, St, C, g0, g1, Fc, kT),
     )
 
 
-def invtWLC_jac(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
+def twlc_solve_force_jac(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     return invert_jacobian(
         d,
-        lambda f_trial: invtWLC(f_trial, Lp, Lc, St, C, g0, g1, Fc, kT),
-        lambda f_trial: tWLC_jac(f_trial, Lp, Lc, St, C, g0, g1, Fc, kT),
-        lambda f_trial: tWLC_derivative(f_trial, Lp, Lc, St, C, g0, g1, Fc, kT),
+        lambda f_trial: twlc_solve_force(f_trial, Lp, Lc, St, C, g0, g1, Fc, kT),
+        lambda f_trial: twlc_distance_jac(f_trial, Lp, Lc, St, C, g0, g1, Fc, kT),
+        lambda f_trial: twlc_distance_derivative(f_trial, Lp, Lc, St, C, g0, g1, Fc, kT),
     )
 
 
-def invFJC(d, Lp, Lc, St, kT=4.11):
-    """Inverted Freely-Jointed Chain [1]_ [2]_.
+def efjc_solve_force(d, Lp, Lc, St, kT=4.11):
+    """Inverted Extensible Freely-Jointed Chain [1]_ [2]_.
 
     References
     ----------
@@ -734,12 +738,12 @@ def invFJC(d, Lp, Lc, St, kT=4.11):
         1.0,
         f_min,
         f_max,
-        lambda f_trial: FJC(f_trial, Lp, Lc, St, kT),
-        lambda f_trial: FJC_derivative(f_trial, Lp, Lc, St, kT),
+        lambda f_trial: efjc_distance(f_trial, Lp, Lc, St, kT),
+        lambda f_trial: efjc_distance_derivative(f_trial, Lp, Lc, St, kT),
     )
 
 
-def marko_siggia_ewlc_solve_force_equation(d, Lp, Lc, St, kT=4.11):
+def ewlc_marko_siggia_force_equation(d, Lp, Lc, St, kT=4.11):
     return solve_formatter(
         f"(1/4) * (1 - ({d}/{Lc}) + (f/{St}))**(-2) - (1/4) + ({d}/{Lc}) - (f/{St})",
         "f",
@@ -747,7 +751,7 @@ def marko_siggia_ewlc_solve_force_equation(d, Lp, Lc, St, kT=4.11):
     )
 
 
-def marko_siggia_ewlc_solve_force_equation_tex(d, Lp, Lc, St, kT=4.11):
+def ewlc_marko_siggia_force_equation_tex(d, Lp, Lc, St, kT=4.11):
     dLc = latex_frac(d, Lc)
     FSt = latex_frac("f", St)
     lhs = latex_frac(f"f {Lp}", kT)
@@ -760,7 +764,7 @@ def marko_siggia_ewlc_solve_force_equation_tex(d, Lp, Lc, St, kT=4.11):
     )
 
 
-def marko_siggia_ewlc_solve_force(d, Lp, Lc, St, kT=4.11):
+def ewlc_marko_siggia_force(d, Lp, Lc, St, kT=4.11):
     """Modified Marko Siggia's Worm-like Chain model with distance as dependent parameter.
 
     Modification of Marko-Siggia formula [1] to incorporate enthalpic stretching. Has limitations
@@ -797,10 +801,10 @@ def marko_siggia_ewlc_solve_force(d, Lp, Lc, St, kT=4.11):
         / (Lc * (Lp * St + kT))
     )
 
-    return solve_cubic_wlc(a, b, c, 2)
+    return calc_cubic_root(a, b, c, 2)
 
 
-def marko_siggia_ewlc_solve_force_jac(d, Lp, Lc, St, kT=4.11):
+def ewlc_marko_siggia_force_jac(d, Lp, Lc, St, kT=4.11):
     c = -(St**3) * d * kT * (1.5 * Lc**2 - 2.25 * Lc * d + d**2) / (Lc**3 * (Lp * St + kT))
     b = (
         St**2
@@ -820,7 +824,7 @@ def marko_siggia_ewlc_solve_force_jac(d, Lp, Lc, St, kT=4.11):
         / (Lc * (Lp * St + kT))
     )
 
-    total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 2)
+    total_dy_da, total_dy_db, total_dy_dc = calc_cubic_root_derivatives(a, b, c, 2)
 
     # Map back to our output parameters
     denom1 = Lc**3 * (Lp * St + kT) ** 2
@@ -885,7 +889,7 @@ def marko_siggia_ewlc_solve_force_jac(d, Lp, Lc, St, kT=4.11):
     return [total_dy_dLp, total_dy_dLc, total_dy_dSt, total_dy_dkT]
 
 
-def marko_siggia_ewlc_solve_force_derivative(d, Lp, Lc, St, kT=4.11):
+def ewlc_marko_siggia_force_derivative(d, Lp, Lc, St, kT=4.11):
     c = -(St**3) * d * kT * (1.5 * Lc**2 - 2.25 * Lc * d + d**2) / (Lc**3 * (Lp * St + kT))
     b = (
         St**2
@@ -905,7 +909,7 @@ def marko_siggia_ewlc_solve_force_derivative(d, Lp, Lc, St, kT=4.11):
         / (Lc * (Lp * St + kT))
     )
 
-    total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 2)
+    total_dy_da, total_dy_db, total_dy_dc = calc_cubic_root_derivatives(a, b, c, 2)
 
     # Map back to our output parameters
     denom = Lc * (Lp * St + kT)
@@ -918,7 +922,7 @@ def marko_siggia_ewlc_solve_force_derivative(d, Lp, Lc, St, kT=4.11):
     return total_dy_da * da_dd + total_dy_db * db_dd + total_dy_dc * dc_dd
 
 
-def marko_siggia_ewlc_solve_distance_equation(f, Lp, Lc, St, kT=4.11):
+def ewlc_marko_siggia_distance_equation(f, Lp, Lc, St, kT=4.11):
     return solve_formatter(
         f"(1/4) * (1 - (d/{Lc}) + ({f}/{St}))**(-2) - (1/4) + (d/{Lc}) - ({f}/{St})",
         "d",
@@ -926,7 +930,7 @@ def marko_siggia_ewlc_solve_distance_equation(f, Lp, Lc, St, kT=4.11):
     )
 
 
-def marko_siggia_ewlc_solve_distance_equation_tex(f, Lp, Lc, St, kT=4.11):
+def ewlc_marko_siggia_distance_equation_tex(f, Lp, Lc, St, kT=4.11):
     dLc = latex_frac("d", Lc)
     FSt = latex_frac(f, St)
     lhs = latex_frac(f"{f} {Lp}", kT)
@@ -939,26 +943,26 @@ def marko_siggia_ewlc_solve_distance_equation_tex(f, Lp, Lc, St, kT=4.11):
     )
 
 
-def inverted_marko_siggia_simplified_coefficients(f, Lp, Lc, kT):
+def wlc_marko_siggia_distance_coefficients(f, Lp, Lc, kT):
     a = -Lc * (f * Lp / kT + 2.25)
     b = Lc**2.0 * (2.0 * f * Lp / kT + 1.5)
     c = -f * Lc**3.0 * Lp / kT
     return a, b, c
 
 
-def inverted_marko_siggia_simplified(f, Lp, Lc, kT=4.11):
+def wlc_marko_siggia_distance(f, Lp, Lc, kT=4.11):
     if Lp <= 0 or Lc <= 0 or kT <= 0:
         raise ValueError("Persistence length, contour length and kT must be bigger than 0")
 
-    a, b, c = inverted_marko_siggia_simplified_coefficients(f, Lp, Lc, kT)
+    a, b, c = wlc_marko_siggia_distance_coefficients(f, Lp, Lc, kT)
 
-    return solve_cubic_wlc(a, b, c, 1)
+    return calc_cubic_root(a, b, c, 1)
 
 
-def inverted_marko_siggia_simplified_jac(f, Lp, Lc, kT=4.11):
-    a, b, c = inverted_marko_siggia_simplified_coefficients(f, Lp, Lc, kT)
+def wlc_marko_siggia_distance_jac(f, Lp, Lc, kT=4.11):
+    a, b, c = wlc_marko_siggia_distance_coefficients(f, Lp, Lc, kT)
 
-    total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 1)
+    total_dy_da, total_dy_db, total_dy_dc = calc_cubic_root_derivatives(a, b, c, 1)
 
     dc_dLc = -3.0 * f * Lc**2 * Lp / kT
     dc_dLp = -f * Lc**3 / kT
@@ -978,9 +982,9 @@ def inverted_marko_siggia_simplified_jac(f, Lp, Lc, kT=4.11):
     return [total_dy_dLp, total_dy_dLc, total_dy_dkT]
 
 
-def inverted_marko_siggia_simplified_derivative(f, Lp, Lc, kT=4.11):
-    a, b, c = inverted_marko_siggia_simplified_coefficients(f, Lp, Lc, kT)
-    total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 1)
+def wlc_marko_siggia_distance_derivative(f, Lp, Lc, kT=4.11):
+    a, b, c = wlc_marko_siggia_distance_coefficients(f, Lp, Lc, kT)
+    total_dy_da, total_dy_db, total_dy_dc = calc_cubic_root_derivatives(a, b, c, 1)
 
     da_df = -Lc * Lp / kT
     db_df = 2.0 * Lc**2 * Lp / kT
@@ -989,13 +993,13 @@ def inverted_marko_siggia_simplified_derivative(f, Lp, Lc, kT=4.11):
     return total_dy_da * da_df + total_dy_db * db_df + total_dy_dc * dc_df
 
 
-def inverted_marko_siggia_simplified_equation(f, Lp, Lc, kT=4.11):
+def wlc_marko_siggia_distance_equation(f, Lp, Lc, kT=4.11):
     return solve_formatter(
         f"(1/4) * (1 - (d/{Lc}))**(-2) - (1/4) + (d/{Lc})", "d", f"{f}*{Lp}/{kT}"
     )
 
 
-def inverted_marko_siggia_simplified_equation_tex(f, Lp, Lc, kT=4.11):
+def wlc_marko_siggia_distance_equation_tex(f, Lp, Lc, kT=4.11):
     dLc = latex_frac("d", Lc)
     lhs = latex_frac(f"{f} {Lp}", kT)
 
@@ -1004,7 +1008,7 @@ def inverted_marko_siggia_simplified_equation_tex(f, Lp, Lc, kT=4.11):
     )
 
 
-def marko_siggia_ewlc_solve_distance(f, Lp, Lc, St, kT=4.11):
+def ewlc_marko_siggia_distance(f, Lp, Lc, St, kT=4.11):
     if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
         raise ValueError(
             "Persistence length, contour length, stretch modulus and kT must be bigger than 0"
@@ -1036,10 +1040,10 @@ def marko_siggia_ewlc_solve_distance(f, Lp, Lc, St, kT=4.11):
     )
     a = -f * Lc * Lp / kT - 3 * f * Lc / St - 2.25 * Lc
 
-    return solve_cubic_wlc(a, b, c, 1)
+    return calc_cubic_root(a, b, c, 1)
 
 
-def marko_siggia_ewlc_solve_distance_jac(f, Lp, Lc, St, kT=4.11):
+def ewlc_marko_siggia_distance_jac(f, Lp, Lc, St, kT=4.11):
     c = (
         -f
         * Lc**3
@@ -1066,7 +1070,7 @@ def marko_siggia_ewlc_solve_distance_jac(f, Lp, Lc, St, kT=4.11):
     )
     a = -f * Lc * Lp / kT - 3 * f * Lc / St - 2.25 * Lc
 
-    total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 1)
+    total_dy_da, total_dy_db, total_dy_dc = calc_cubic_root_derivatives(a, b, c, 1)
 
     # Map back to our output parameters
     dc_dLc = (
@@ -1121,7 +1125,7 @@ def marko_siggia_ewlc_solve_distance_jac(f, Lp, Lc, St, kT=4.11):
     return [total_dy_dLp, total_dy_dLc, total_dy_dSt, total_dy_dkT]
 
 
-def marko_siggia_ewlc_solve_distance_derivative(f, Lp, Lc, St, kT=4.11):
+def ewlc_marko_siggia_distance_derivative(f, Lp, Lc, St, kT=4.11):
     fsq = f * f
     c = (
         -f
@@ -1149,7 +1153,7 @@ def marko_siggia_ewlc_solve_distance_derivative(f, Lp, Lc, St, kT=4.11):
     )
     a = -f * Lc * Lp / kT - 3 * f * Lc / St - 2.25 * Lc
 
-    total_dy_da, total_dy_db, total_dy_dc = invwlc_root_derivatives(a, b, c, 1)
+    total_dy_da, total_dy_db, total_dy_dc = calc_cubic_root_derivatives(a, b, c, 1)
 
     # Map back to our output parameters
     dc_df = (

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -30,7 +30,7 @@ class Fit:
 
         from lumicks import pylake
 
-        dna_model = pylake.inverted_odijk("DNA")
+        dna_model = pylake.ewlc_odijk_force("DNA")
         fit = pylake.FdFit(dna_model)
         data = fit.add_data("Dataset 1", force, distance)
 
@@ -454,7 +454,7 @@ class Fit:
 
             from lumicks import pylake
 
-            model = pylake.inverted_odijk("DNA")
+            model = pylake.ewlc_odijk_force("DNA")
             fit = pylake.FdFit(model)
             fit.add_data("Control", force, distance)
             fit.fit()
@@ -467,8 +467,8 @@ class Fit:
 
             # When dealing with multiple models in one fit, one has to select the model first when
             # we want to plot.
-            model1 = pylake.odijk("DNA")
-            model2 = pylake.odijk("DNA") + pylake.odijk("protein")
+            model1 = pylake.ewlc_odijk_distance("DNA")
+            model2 = pylake.ewlc_odijk_distance("DNA") + pylake.ewlc_odijk_distance("protein")
             fit[model1].add_data("Control", force1, distance2)
             fit[model2].add_data("Control", force1, distance2)
             fit.fit()
@@ -717,7 +717,7 @@ class FdFit(Fit):
 
         from lumicks import pylake
 
-        dna_model = pylake.inverted_odijk("DNA")
+        dna_model = pylake.ewlc_odijk_force("DNA")
         fit = pylake.FdFit(dna_model)
         data = fit.add_data("Dataset 1", force, distance)
 
@@ -747,7 +747,7 @@ class FdFit(Fit):
         --------
         ::
 
-            dna_model = pylake.inverted_odijk("DNA")  # Use an inverted Odijk eWLC model.
+            dna_model = pylake.ewlc_odijk_force("DNA")  # Use an inverted Odijk eWLC model.
             fit = pylake.FdFit(dna_model)
 
             fit.add_data("Data1", force1, distance1)  # Load the first data set like that

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -77,7 +77,7 @@ class Model:
 
             from lumicks import pylake
 
-            dna_model = pylake.inverted_odijk("DNA")
+            dna_model = pylake.ewlc_odijk_force("DNA")
             fit = pylake.FdFit(dna_model)
             fit.add_data("my data", force, distance)
 
@@ -167,8 +167,8 @@ class Model:
         Examples
         --------
         ::
-            DNA_model = pylake.inverted_odijk("DNA")
-            protein_model = pylake.inverted_odijk("protein")
+            DNA_model = pylake.ewlc_odijk_force("DNA")
+            protein_model = pylake.ewlc_odijk_force("protein")
             construct_model = DNA_model + protein_model
         """
 
@@ -441,7 +441,7 @@ class Model:
         --------
         ::
 
-            dna_model = pylake.inverted_odijk("DNA")  # Use an inverted Odijk eWLC model.
+            dna_model = pylake.ewlc_odijk_force("DNA")  # Use an inverted Odijk eWLC model.
             fit = pylake.FdFit(dna_model)
             fit.add_data("data1", force1, distance1)
             fit.add_data("data2", force2, distance2, {"DNA/Lc": "DNA/Lc_RecA"})

--- a/lumicks/pylake/fitting/models.py
+++ b/lumicks/pylake/fitting/models.py
@@ -1,3 +1,34 @@
+__all__ = [
+    "force_offset",
+    "distance_offset",
+    "ewlc_marko_siggia_force",
+    "ewlc_marko_siggia_distance",
+    "wlc_marko_siggia_force",
+    "wlc_marko_siggia_distance",
+    "ewlc_odijk_distance",
+    "dsdna_ewlc_odijk_distance",
+    "ewlc_odijk_force",
+    "efjc_distance",
+    "ssdna_efjc_distance",
+    "efjc_force",
+    "twlc_distance",
+    "twlc_force",
+    "marko_siggia_ewlc_force",
+    "marko_siggia_ewlc_distance",
+    "marko_siggia_simplified",
+    "inverted_marko_siggia_simplified",
+    "odijk",
+    "dsdna_odijk",
+    "freely_jointed_chain",
+    "ssdna_fjc",
+    "inverted_freely_jointed_chain",
+    "inverted_odijk",
+    "twistable_wlc",
+    "inverted_twistable_wlc",
+]
+
+from deprecated import deprecated
+
 from .parameters import Parameter
 
 force_model_vars = {
@@ -72,7 +103,7 @@ def distance_offset(name):
     )
 
 
-def marko_siggia_ewlc_force(name):
+def ewlc_marko_siggia_force(name):
     """Marko Siggia's Worm-like Chain model with force as dependent parameter.
 
     Modified Marko Siggia's Worm-like Chain model. Modification of Marko-Siggia formula [1]_
@@ -92,22 +123,22 @@ def marko_siggia_ewlc_force(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        marko_siggia_ewlc_solve_force,
-        marko_siggia_ewlc_solve_force_jac,
-        marko_siggia_ewlc_solve_force_derivative,
-        marko_siggia_ewlc_solve_force_equation,
-        marko_siggia_ewlc_solve_force_equation_tex,
+        ewlc_marko_siggia_force,
+        ewlc_marko_siggia_force_jac,
+        ewlc_marko_siggia_force_derivative,
+        ewlc_marko_siggia_force_equation,
+        ewlc_marko_siggia_force_equation_tex,
         Defaults,
     )
 
     return Model(
         name,
-        marko_siggia_ewlc_solve_force,
+        ewlc_marko_siggia_force,
         **force_model_vars,
-        jacobian=marko_siggia_ewlc_solve_force_jac,
-        derivative=marko_siggia_ewlc_solve_force_derivative,
-        eqn=marko_siggia_ewlc_solve_force_equation,
-        eqn_tex=marko_siggia_ewlc_solve_force_equation_tex,
+        jacobian=ewlc_marko_siggia_force_jac,
+        derivative=ewlc_marko_siggia_force_derivative,
+        eqn=ewlc_marko_siggia_force_equation,
+        eqn_tex=ewlc_marko_siggia_force_equation_tex,
         kT=Defaults.kT,
         Lp=Defaults.Lp,
         Lc=Defaults.Lc,
@@ -115,7 +146,7 @@ def marko_siggia_ewlc_force(name):
     )
 
 
-def marko_siggia_ewlc_distance(name):
+def ewlc_marko_siggia_distance(name):
     """Marko Siggia's Worm-like Chain model with distance as dependent parameter
 
     Modified Marko Siggia's Worm-like Chain model. Modification of Marko-Siggia formula [1]_
@@ -135,22 +166,22 @@ def marko_siggia_ewlc_distance(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        marko_siggia_ewlc_solve_distance,
-        marko_siggia_ewlc_solve_distance_jac,
-        marko_siggia_ewlc_solve_distance_derivative,
-        marko_siggia_ewlc_solve_distance_equation,
-        marko_siggia_ewlc_solve_distance_equation_tex,
+        ewlc_marko_siggia_distance,
+        ewlc_marko_siggia_distance_jac,
+        ewlc_marko_siggia_distance_derivative,
+        ewlc_marko_siggia_distance_equation,
+        ewlc_marko_siggia_distance_equation_tex,
         Defaults,
     )
 
     return Model(
         name,
-        marko_siggia_ewlc_solve_distance,
+        ewlc_marko_siggia_distance,
         **distance_model_vars,
-        jacobian=marko_siggia_ewlc_solve_distance_jac,
-        derivative=marko_siggia_ewlc_solve_distance_derivative,
-        eqn=marko_siggia_ewlc_solve_distance_equation,
-        eqn_tex=marko_siggia_ewlc_solve_distance_equation_tex,
+        jacobian=ewlc_marko_siggia_distance_jac,
+        derivative=ewlc_marko_siggia_distance_derivative,
+        eqn=ewlc_marko_siggia_distance_equation,
+        eqn_tex=ewlc_marko_siggia_distance_equation_tex,
         kT=Defaults.kT,
         Lp=Defaults.Lp,
         Lc=Defaults.Lc,
@@ -158,7 +189,7 @@ def marko_siggia_ewlc_distance(name):
     )
 
 
-def marko_siggia_simplified(name):
+def wlc_marko_siggia_force(name):
     """Marko Siggia's Worm-like Chain model.
 
     This model [1]_ is based on only entropic contributions (valid for F << 10 pN). This model has
@@ -175,29 +206,29 @@ def marko_siggia_simplified(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        marko_siggia_simplified,
-        marko_siggia_simplified_jac,
-        marko_siggia_simplified_derivative,
-        marko_siggia_simplified_equation,
-        marko_siggia_simplified_equation_tex,
+        wlc_marko_siggia_force,
+        wlc_marko_siggia_force_jac,
+        wlc_marko_siggia_force_derivative,
+        wlc_marko_siggia_force_equation,
+        wlc_marko_siggia_force_equation_tex,
         Defaults,
     )
 
     return Model(
         name,
-        marko_siggia_simplified,
+        wlc_marko_siggia_force,
         **force_model_vars,
-        jacobian=marko_siggia_simplified_jac,
-        derivative=marko_siggia_simplified_derivative,
-        eqn=marko_siggia_simplified_equation,
-        eqn_tex=marko_siggia_simplified_equation_tex,
+        jacobian=wlc_marko_siggia_force_jac,
+        derivative=wlc_marko_siggia_force_derivative,
+        eqn=wlc_marko_siggia_force_equation,
+        eqn_tex=wlc_marko_siggia_force_equation_tex,
         kT=Defaults.kT,
         Lp=Defaults.Lp,
         Lc=Defaults.Lc,
     )
 
 
-def inverted_marko_siggia_simplified(name):
+def wlc_marko_siggia_distance(name):
     """Marko Siggia's Worm-like Chain model.
 
     This model is based on only entropic contributions [1]_ (valid for F << 10 pN). This model has
@@ -214,29 +245,29 @@ def inverted_marko_siggia_simplified(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        inverted_marko_siggia_simplified,
-        inverted_marko_siggia_simplified_jac,
-        inverted_marko_siggia_simplified_derivative,
-        inverted_marko_siggia_simplified_equation,
-        inverted_marko_siggia_simplified_equation_tex,
+        wlc_marko_siggia_distance,
+        wlc_marko_siggia_distance_jac,
+        wlc_marko_siggia_distance_derivative,
+        wlc_marko_siggia_distance_equation,
+        wlc_marko_siggia_distance_equation_tex,
         Defaults,
     )
 
     return Model(
         name,
-        inverted_marko_siggia_simplified,
+        wlc_marko_siggia_distance,
         **distance_model_vars,
-        jacobian=inverted_marko_siggia_simplified_jac,
-        derivative=inverted_marko_siggia_simplified_derivative,
-        eqn=inverted_marko_siggia_simplified_equation,
-        eqn_tex=inverted_marko_siggia_simplified_equation_tex,
+        jacobian=wlc_marko_siggia_distance_jac,
+        derivative=wlc_marko_siggia_distance_derivative,
+        eqn=wlc_marko_siggia_distance_equation,
+        eqn_tex=wlc_marko_siggia_distance_equation_tex,
         kT=Defaults.kT,
         Lp=Defaults.Lp,
         Lc=Defaults.Lc,
     )
 
 
-def odijk(name):
+def ewlc_odijk_distance(name):
     """Odijk's Extensible Worm-Like Chain model with distance as dependent variable
 
     Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_.
@@ -254,22 +285,22 @@ def odijk(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        WLC,
-        WLC_jac,
-        WLC_derivative,
-        WLC_equation,
-        WLC_equation_tex,
+        ewlc_odijk_distance,
+        ewlc_odijk_distance_jac,
+        ewlc_odijk_distance_derivative,
+        ewlc_odijk_distance_equation,
+        ewlc_odijk_distance_equation_tex,
         Defaults,
     )
 
     return Model(
         name,
-        WLC,
+        ewlc_odijk_distance,
         **distance_model_vars,
-        jacobian=WLC_jac,
-        derivative=WLC_derivative,
-        eqn=WLC_equation,
-        eqn_tex=WLC_equation_tex,
+        jacobian=ewlc_odijk_distance_jac,
+        derivative=ewlc_odijk_distance_derivative,
+        eqn=ewlc_odijk_distance_equation,
+        eqn_tex=ewlc_odijk_distance_equation_tex,
         kT=Defaults.kT,
         Lp=Defaults.Lp,
         Lc=Defaults.Lc,
@@ -277,7 +308,7 @@ def odijk(name):
     )
 
 
-def dsdna_odijk(name, dna_length_kbp, um_per_kbp=0.34, temperature=24.53608821):
+def dsdna_ewlc_odijk_distance(name, dna_length_kbp, um_per_kbp=0.34, temperature=24.53608821):
     """Model for dsDNA with distance as the dependent variable.
 
     Odijk's Extensible Worm-Like Chain model [1]_ [2]_ with distance as the dependent
@@ -316,7 +347,7 @@ def dsdna_odijk(name, dna_length_kbp, um_per_kbp=0.34, temperature=24.53608821):
     """
     from scipy import constants
 
-    model = odijk(name)
+    model = ewlc_odijk_force(name)
     model.defaults[f"{name}/Lc"].value = dna_length_kbp * um_per_kbp
     model.defaults[f"{name}/Lp"].value = 50.0  # [3]
     model.defaults[f"{name}/St"].value = 1200.0  # [4, 5]
@@ -326,12 +357,12 @@ def dsdna_odijk(name, dna_length_kbp, um_per_kbp=0.34, temperature=24.53608821):
     return model
 
 
-def inverted_odijk(name):
+def ewlc_odijk_force(name):
     """Odijk's Extensible Worm-Like Chain model with force as dependent variable
 
     Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_. Note that
     this implementation was analytically solved and is significantly faster than fitting the
-    model obtained with `lk.odijk("name").invert()`.
+    model obtained with `lk.ewlc_odijk_distance("name").invert()`.
 
     Parameters
     ----------
@@ -346,22 +377,22 @@ def inverted_odijk(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        invWLC,
-        invWLC_jac,
-        invWLC_derivative,
-        invWLC_equation,
-        invWLC_equation_tex,
+        ewlc_odijk_force,
+        ewlc_odijk_force_jac,
+        ewlc_odijk_force_derivative,
+        ewlc_odijk_force_equation,
+        ewlc_odijk_force_equation_tex,
         Defaults,
     )
 
     return Model(
         name,
-        invWLC,
+        ewlc_odijk_force,
         **force_model_vars,
-        jacobian=invWLC_jac,
-        derivative=invWLC_derivative,
-        eqn=invWLC_equation,
-        eqn_tex=invWLC_equation_tex,
+        jacobian=ewlc_odijk_force_jac,
+        derivative=ewlc_odijk_force_derivative,
+        eqn=ewlc_odijk_force_equation,
+        eqn_tex=ewlc_odijk_force_equation_tex,
         kT=Defaults.kT,
         Lp=Defaults.Lp,
         Lc=Defaults.Lc,
@@ -369,8 +400,8 @@ def inverted_odijk(name):
     )
 
 
-def freely_jointed_chain(name):
-    """Freely-Jointed Chain with distance as dependent parameter.
+def efjc_distance(name):
+    """Extensible Freely-Jointed Chain with distance as dependent parameter.
 
     Freely jointed chain model [1]_ [2]_. Useful for modelling single stranded DNA.
 
@@ -389,22 +420,22 @@ def freely_jointed_chain(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        FJC,
-        FJC_jac,
-        FJC_derivative,
-        FJC_equation,
-        FJC_equation_tex,
+        efjc_distance,
+        efjc_distance_jac,
+        efjc_distance_derivative,
+        efjc_distance_equation,
+        efjc_distance_equation_tex,
         Defaults,
     )
 
     return Model(
         name,
-        FJC,
+        efjc_distance,
         **distance_model_vars,
-        jacobian=FJC_jac,
-        eqn=FJC_equation,
-        eqn_tex=FJC_equation_tex,
-        derivative=FJC_derivative,
+        jacobian=efjc_distance_jac,
+        eqn=efjc_distance_equation,
+        eqn_tex=efjc_distance_equation_tex,
+        derivative=efjc_distance_derivative,
         kT=Defaults.kT,
         Lp=Defaults.Lp,
         Lc=Defaults.Lc,
@@ -412,6 +443,414 @@ def freely_jointed_chain(name):
     )
 
 
+def ssdna_efjc_distance(name, dna_length_kb, um_per_kb=0.56, temperature=24.53608821):
+    """Model of ssDNA with distance as the dependent parameter.
+
+    Extensible Freely-Jointed Chain model [1]_ [2]_ with distance as dependent parameter, using
+    user-specified kilobases with default parameters obtained from [3]_.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    dna_length_kb: integer
+        The length of the dna in the sample measured in kilobases
+    um_per_kb: float
+        The number of kilobases evaluating to 1 um. This is used to convert the
+        length in kb to um as applied in the fit function.
+    temperature: float
+        The temperature in celsius. This is used to calculate the
+        Boltzmann's constant * temperature value
+
+    References
+    ----------
+    .. [1] S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The Elastic Response of
+           Individual Double-Stranded and Single-Stranded DNA Molecules, Science 271, 795-799
+           (1996).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
+    .. [3] Bosco, A., Camunas-Soler, J., & Ritort, F. (2014). Elastic properties and secondary
+           structure formation of single-stranded DNA at monovalent and divalent salt conditions.
+           Nucleic acids research, 42(3), 2064-2074.
+    """
+    from scipy import constants
+
+    model = efjc_distance(name)
+    model.defaults[f"{name}/Lc"].value = dna_length_kb * um_per_kb
+    model.defaults[f"{name}/Lp"].value = 0.70  # [3]
+    model.defaults[f"{name}/St"].value = 750.0  # [3]
+    model.defaults["kT"].value = (
+        1e21 * constants.k * constants.convert_temperature(temperature, "C", "K")
+    )
+
+    return model
+
+
+def efjc_force(name):
+    """Extensible Freely-Jointed Chain model with force as the dependent parameter.
+
+    The Freely-Jointed Chain model [1]_ [2]_ is useful for modelling ssDNA.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The Elastic Response of
+           Individual Double-Stranded and Single-Stranded DNA Molecules, Science 271, 795-799
+           (1996).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
+    """
+    from .model import InverseModel
+
+    return InverseModel(efjc_distance(name))
+
+
+def twlc_distance(name):
+    """Twistable Worm-like Chain model with distance as dependent variable.
+
+    Twistable Worm-like Chain model [1]_ [2]_ that takes into account untwisting of the DNA at
+    high forces. Note that it is generally recommended to fit this model with force as the
+    dependent variable [2]_.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] P. Gross et al., Quantifying how DNA stretches, melts and changes twist under tension,
+           Nature Physics 7, 731-736 (2011).
+    .. [2] Broekmans, Onno D., et al. DNA twist stability changes with magnesium (2+) concentration,
+           Physical review letters 116.25, 258102 (2016).
+    """
+    from .model import Model
+    from .detail.model_implementation import (
+        twlc_distance,
+        twlc_distance_jac,
+        twlc_distance_derivative,
+        twlc_distance_equation,
+        twlc_distance_equation_tex,
+        Defaults,
+    )
+
+    return Model(
+        name,
+        twlc_distance,
+        **distance_model_vars,
+        jacobian=twlc_distance_jac,
+        derivative=twlc_distance_derivative,
+        eqn=twlc_distance_equation,
+        eqn_tex=twlc_distance_equation_tex,
+        kT=Defaults.kT,
+        Lp=Defaults.Lp,
+        Lc=Defaults.Lc,
+        St=Defaults.St,
+        Fc=Parameter(value=30.6, lower_bound=0.0, upper_bound=50.0, unit="pN"),
+        C=Parameter(value=440.0, lower_bound=0.0, upper_bound=5000.0, unit="pN*nm**2"),
+        g0=Parameter(value=-637, lower_bound=-5000.0, upper_bound=0.0, unit="pN*nm"),
+        g1=Parameter(value=17.0, lower_bound=-100.0, upper_bound=1000.0, unit="nm"),
+    )
+
+
+def twlc_force(name):
+    """Twistable Worm-like Chain model with force as the dependent variable.
+
+    Twistable Worm-like Chain model [1]_ [2]_ that takes into account untwisting of the DNA at
+    high forces. This model uses a more performant implementation for inverting the model. It
+    inverts the model by interpolating the forward curve and using this interpolant to invert the
+    function.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] P. Gross et al., Quantifying how DNA stretches, melts and changes twist under tension,
+           Nature Physics 7, 731-736 (2011).
+    .. [2] Broekmans, Onno D., et al. DNA twist stability changes with magnesium (2+) concentration,
+           Physical review letters 116.25, 258102 (2016).
+    """
+    from .model import Model
+    from .detail.model_implementation import (
+        twlc_solve_force,
+        twlc_solve_force_jac,
+        twlc_solve_force_equation,
+        twlc_solve_force_equation_tex,
+        Defaults,
+    )
+
+    return Model(
+        name,
+        twlc_solve_force,
+        **force_model_vars,
+        jacobian=twlc_solve_force_jac,
+        eqn=twlc_solve_force_equation,
+        eqn_tex=twlc_solve_force_equation_tex,
+        kT=Defaults.kT,
+        Lp=Defaults.Lp,
+        Lc=Defaults.Lc,
+        St=Defaults.St,
+        Fc=Parameter(value=30.6, lower_bound=0.0, upper_bound=50.0, unit="pN"),
+        C=Parameter(value=440.0, lower_bound=0.0, upper_bound=5000.0, unit="pN*nm**2"),
+        g0=Parameter(value=-637, lower_bound=-5000.0, upper_bound=0.0, unit="pN*nm"),
+        g1=Parameter(value=17.0, lower_bound=0.0, upper_bound=1000.0, unit="nm"),
+    )
+
+
+@deprecated(
+    reason=(
+        "This function will be removed in a future release. Use `ewlc_marko_siggia_force('name')` "
+        "instead."
+    ),
+    action="always",
+    version="0.13.2",
+)
+def marko_siggia_ewlc_force(name):
+    """Marko Siggia's Worm-like Chain model with force as dependent parameter.
+
+    Modified Marko Siggia's Worm-like Chain model. Modification of Marko-Siggia formula [1]_
+    to incorporate enthalpic stretching. Has limitations similar to Marko-Siggia
+    near `F = 0.1 pN` [2]_.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
+    .. [2] Wang, M. D., Yin, H., Landick, R., Gelles, J., & Block, S. M. (1997). Stretching DNA
+           with optical tweezers. Biophysical journal, 72(3), 1335-1346.
+    """
+    return ewlc_marko_siggia_force(name)
+
+
+@deprecated(
+    reason=(
+        "This function will be removed in a future release. Use "
+        "`ewlc_marko_siggia_distance('name')` instead."
+    ),
+    action="always",
+    version="0.13.2",
+)
+def marko_siggia_ewlc_distance(name):
+    """Marko Siggia's Worm-like Chain model with distance as dependent parameter
+
+    Modified Marko Siggia's Worm-like Chain model. Modification of Marko-Siggia formula [1]_
+    to incorporate enthalpic stretching. Has limitations similar to Marko-Siggia
+    near `F = 0.1 pN` [2]_.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
+    .. [2] Wang, M. D., Yin, H., Landick, R., Gelles, J., & Block, S. M. (1997). Stretching DNA
+           with optical tweezers. Biophysical journal, 72(3), 1335-1346.
+    """
+    return ewlc_marko_siggia_distance(name)
+
+
+@deprecated(
+    reason=("This function will be removed in a future release. Use `wlc_force('name')` instead."),
+    action="always",
+    version="0.13.2",
+)
+def marko_siggia_simplified(name):
+    """Marko Siggia's Worm-like Chain model.
+
+    This model [1]_ is based on only entropic contributions (valid for F << 10 pN). This model has
+    force as a dependent variable.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
+    """
+    return wlc_marko_siggia_force(name)
+
+
+@deprecated(
+    reason=(
+        "This function will be removed in a future release. Use `wlc_distance('name')` instead."
+    ),
+    action="always",
+    version="0.13.2",
+)
+def inverted_marko_siggia_simplified(name):
+    """Marko Siggia's Worm-like Chain model.
+
+    This model is based on only entropic contributions [1]_ (valid for F << 10 pN). This model has
+    distance as a dependent variable.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
+    """
+    return wlc_marko_siggia_distance(name)
+
+
+@deprecated(
+    reason=(
+        "This function will be removed in a future release. Use `ewlc_odijk_distance('name')` "
+        "instead."
+    ),
+    action="always",
+    version="0.13.2",
+)
+def odijk(name):
+    """Odijk's Extensible Worm-Like Chain model with distance as dependent variable
+
+    Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules 28, 7016-7018 (1995).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
+    """
+    return ewlc_odijk_distance(name)
+
+
+@deprecated(
+    reason=(
+        "This function will be removed in a future release. Use "
+        "`dsdna_ewlc_odijk_distance('name')` instead."
+    ),
+    action="always",
+    version="0.13.2",
+)
+def dsdna_odijk(name, dna_length_kbp, um_per_kbp=0.34, temperature=24.53608821):
+    """Model for dsDNA with distance as the dependent variable.
+
+    Odijk's Extensible Worm-Like Chain model [1]_ [2]_ with distance as the dependent
+    variable using user-specified kilobase-pairs (useful for 10 pN < F < 30 pN). Default model
+    parameters were obtained from [3]_ [4]_ and [5]_.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+    dna_length_kbp: integer
+        The length of the dna in tether/construct measured in kilobase-pairs
+    um_per_kbp: float
+        The number of kilobase pairs evaluating to 1 um. This is used to convert the length in kbp
+        to um as applied in the fit function [6]_.
+    temperature: float
+        The temperature in celsius. This is used to calculate the boltzmann * temperature (kT) value
+
+    References
+    ----------
+    .. [1] T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules 28, 7016-7018 (1995).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
+    .. [3] Manning, G. S. (2006). The persistence length of DNA is reached from the persistence
+           length of its null isomer through an internal electrostatic stretching force.
+           Biophysical journal, 91(10), 3607-3616.
+    .. [4] Liu, J. H., Xi, K., Zhang, X., Bao, L., Zhang, X., & Tan, Z. J. (2019). Structural
+           flexibility of DNA-RNA hybrid duplex: stretching and twist-stretch coupling. Biophysical
+           journal, 117(1), 74-86.
+    .. [5] Herrero-Galán, E., Fuentes-Perez, M. E., Carrasco, C., Valpuesta, J. M.,
+           Carrascosa, J. L., Moreno-Herrero, F., & Arias-Gonzalez, J. R. (2013). Mechanical
+           identities of RNA and DNA double helices unveiled at the single-molecule level. Journal
+           of the American Chemical Society, 135(1), 122-131.
+    .. [6] Saenger, W. (1984). Principles of Nucleic Acid Structure. Springer. New York, Berlin,
+           Heidelberg.
+    """
+    return dsdna_ewlc_odijk_distance(
+        name, dna_length_kbp, um_per_kbp=um_per_kbp, temperature=temperature
+    )
+
+
+@deprecated(
+    reason=(
+        "This function will be removed in a future release. Use `ewlc_odijk_force('name')` instead."
+    ),
+    action="always",
+    version="0.13.2",
+)
+def inverted_odijk(name):
+    """Odijk's Extensible Worm-Like Chain model with force as dependent variable
+
+    Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_. Note that
+    this implementation was analytically solved and is significantly faster than fitting the
+    model obtained with `lk.ewlc_odijk_distance("name").invert()`.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] T. Odijk, Stiff Chains and Filaments under Tension, Macromolecules 28, 7016-7018 (1995).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
+    """
+    return ewlc_odijk_force(name)
+
+
+@deprecated(
+    reason=(
+        "This function will be removed in a future release. Use `efjc_distance('name')` instead."
+    ),
+    action="always",
+    version="0.13.2",
+)
+def freely_jointed_chain(name):
+    """Freely-Jointed Chain with distance as dependent parameter.
+
+    Freely jointed chain model [1]_ [2]_. Useful for modelling single stranded DNA.
+
+    Parameters
+    ----------
+    name : str
+        Name for the model. This name will be prefixed to the model parameter names.
+
+    References
+    ----------
+    .. [1] S. B. Smith, Y. Cui, C. Bustamante, Overstretching B-DNA: The Elastic Response of
+           Individual Double-Stranded and Single-Stranded DNA Molecules, Science 271, 795-799
+           (1996).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
+    """
+    return efjc_distance(name)
+
+
+@deprecated(
+    reason=(
+        "This function will be removed in a future release. Use `ssdna_efjc_distance('name')` "
+        "instead."
+    ),
+    action="always",
+    version="0.13.2",
+)
 def ssdna_fjc(name, dna_length_kb, um_per_kb=0.56, temperature=24.53608821):
     """Model of ssDNA with distance as the dependent parameter.
 
@@ -442,21 +881,16 @@ def ssdna_fjc(name, dna_length_kb, um_per_kb=0.56, temperature=24.53608821):
            structure formation of single-stranded DNA at monovalent and divalent salt conditions.
            Nucleic acids research, 42(3), 2064-2074.
     """
-    from scipy import constants
-
-    model = freely_jointed_chain(name)
-    model.defaults[f"{name}/Lc"].value = dna_length_kb * um_per_kb
-    model.defaults[f"{name}/Lp"].value = 0.70  # [3]
-    model.defaults[f"{name}/St"].value = 750.0  # [3]
-    model.defaults["kT"].value = (
-        1e21 * constants.k * constants.convert_temperature(temperature, "C", "K")
-    )
-
-    return model
+    return ssdna_efjc_distance(name, dna_length_kb, um_per_kb=um_per_kb, temperature=temperature)
 
 
+@deprecated(
+    reason=("This function will be removed in a future release. Use `efjc_force('name')` instead."),
+    action="always",
+    version="0.13.2",
+)
 def inverted_freely_jointed_chain(name):
-    """Freely-Jointed Chain model with distance as the dependent parameter.
+    """Freely-Jointed Chain model with force as the dependent parameter.
 
     The Freely-Jointed Chain model [1]_ [2]_ is useful for modelling ssDNA.
 
@@ -473,11 +907,16 @@ def inverted_freely_jointed_chain(name):
     .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
            tweezers., Biophysical journal 72, 1335-46 (1997).
     """
-    from .model import InverseModel
-
-    return InverseModel(freely_jointed_chain(name))
+    return efjc_force(name)
 
 
+@deprecated(
+    reason=(
+        "This function will be removed in a future release. Use `twlc_distance('name')` instead."
+    ),
+    action="always",
+    version="0.13.2",
+)
 def twistable_wlc(name):
     """Twistable Worm-like Chain model with distance as dependent variable.
 
@@ -497,35 +936,14 @@ def twistable_wlc(name):
     .. [2] Broekmans, Onno D., et al. DNA twist stability changes with magnesium (2+) concentration,
            Physical review letters 116.25, 258102 (2016).
     """
-    from .model import Model
-    from .detail.model_implementation import (
-        tWLC,
-        tWLC_jac,
-        tWLC_derivative,
-        tWLC_equation,
-        tWLC_equation_tex,
-        Defaults,
-    )
-
-    return Model(
-        name,
-        tWLC,
-        **distance_model_vars,
-        jacobian=tWLC_jac,
-        derivative=tWLC_derivative,
-        eqn=tWLC_equation,
-        eqn_tex=tWLC_equation_tex,
-        kT=Defaults.kT,
-        Lp=Defaults.Lp,
-        Lc=Defaults.Lc,
-        St=Defaults.St,
-        Fc=Parameter(value=30.6, lower_bound=0.0, upper_bound=50.0, unit="pN"),
-        C=Parameter(value=440.0, lower_bound=0.0, upper_bound=5000.0, unit="pN*nm**2"),
-        g0=Parameter(value=-637, lower_bound=-5000.0, upper_bound=0.0, unit="pN*nm"),
-        g1=Parameter(value=17.0, lower_bound=-100.0, upper_bound=1000.0, unit="nm"),
-    )
+    return twlc_distance(name)
 
 
+@deprecated(
+    reason=("This function will be removed in a future release. Use `twlc_force('name')` instead."),
+    action="always",
+    version="0.13.2",
+)
 def inverted_twistable_wlc(name):
     """Twistable Worm-like Chain model with force as the dependent variable.
 
@@ -546,28 +964,4 @@ def inverted_twistable_wlc(name):
     .. [2] Broekmans, Onno D., et al. DNA twist stability changes with magnesium (2+) concentration,
            Physical review letters 116.25, 258102 (2016).
     """
-    from .model import Model
-    from .detail.model_implementation import (
-        invtWLC,
-        invtWLC_jac,
-        invtWLC_equation,
-        invtWLC_equation_tex,
-        Defaults,
-    )
-
-    return Model(
-        name,
-        invtWLC,
-        **force_model_vars,
-        jacobian=invtWLC_jac,
-        eqn=invtWLC_equation,
-        eqn_tex=invtWLC_equation_tex,
-        kT=Defaults.kT,
-        Lp=Defaults.Lp,
-        Lc=Defaults.Lc,
-        St=Defaults.St,
-        Fc=Parameter(value=30.6, lower_bound=0.0, upper_bound=50.0, unit="pN"),
-        C=Parameter(value=440.0, lower_bound=0.0, upper_bound=5000.0, unit="pN*nm**2"),
-        g0=Parameter(value=-637, lower_bound=-5000.0, upper_bound=0.0, unit="pN*nm"),
-        g1=Parameter(value=17.0, lower_bound=0.0, upper_bound=1000.0, unit="nm"),
-    )
+    return twlc_force(name)

--- a/lumicks/pylake/fitting/parameter_trace.py
+++ b/lumicks/pylake/fitting/parameter_trace.py
@@ -27,7 +27,7 @@ def parameter_trace(model, params, inverted_parameter, independent, dependent, *
     ::
 
         # Define the model to be fitted
-        model = pylake.inverted_odijk("model") + pylake.force_offset("model")
+        model = pylake.ewlc_odijk_force("model") + pylake.force_offset("model")
 
         # Fit the overall model first
         model.add_data("dataset1", f=force_data, d=distance_data)

--- a/lumicks/pylake/fitting/parameters.py
+++ b/lumicks/pylake/fitting/parameters.py
@@ -94,7 +94,7 @@ class Params:
     Examples
     --------
     ::
-        fit = pylake.FdFit(pylake.odijk("my_model"))
+        fit = pylake.FdFit(pylake.ewlc_odijk_distance("my_model"))
 
         print(fit.params)  # Prints the model parameters
         fit["test_parameter"].value = 5  # Set parameter test_parameter to 5

--- a/lumicks/pylake/fitting/tests/test_fd_models.py
+++ b/lumicks/pylake/fitting/tests/test_fd_models.py
@@ -5,74 +5,97 @@ import numpy as np
 import pytest
 
 
+def test_deprecated_models():
+    """Check that functions are deprecated and point to the corresponding new ones"""
+    old_new = [
+        (marko_siggia_simplified, wlc_marko_siggia_force),
+        (inverted_marko_siggia_simplified, wlc_marko_siggia_distance),
+        (marko_siggia_ewlc_distance, ewlc_marko_siggia_distance),
+        (marko_siggia_ewlc_force, ewlc_marko_siggia_force),
+        (odijk, ewlc_odijk_distance),
+        (inverted_odijk, ewlc_odijk_force),
+        (twistable_wlc, twlc_distance),
+        (inverted_twistable_wlc, twlc_force),
+        (freely_jointed_chain, efjc_distance),
+        (inverted_freely_jointed_chain, efjc_force),
+    ]
+    for old, new in old_new:
+        with pytest.deprecated_call():
+            old("DEPRECATION_IS_FUN")
+            assert repr(old("RENAMING_IS_EVEN_BETTER")) == repr(new("RENAMING_IS_EVEN_BETTER"))
+
+
 def test_models():
     independent = np.arange(0.15, 2, 0.25)
     params = [38.18281266, 0.37704827, 278.50103452, 4.11]
-    assert odijk("WLC").verify_jacobian(independent, params)
-    assert inverted_odijk("iWLC").verify_jacobian(independent, params, atol=1e-5)
-    assert freely_jointed_chain("FJC").verify_jacobian(independent, params, dx=1e-4, atol=1e-6)
-    assert marko_siggia_simplified("MS").verify_jacobian(independent, [5, 5, 4.11], atol=1e-6)
-    assert inverted_marko_siggia_simplified("iMS").verify_jacobian(
+    assert ewlc_odijk_distance("WLC").verify_jacobian(independent, params)
+    assert ewlc_odijk_force("iWLC").verify_jacobian(independent, params, atol=1e-5)
+    assert efjc_distance("FJC").verify_jacobian(independent, params, dx=1e-4, atol=1e-6)
+    assert wlc_marko_siggia_force("MS").verify_jacobian(independent, [5, 5, 4.11], atol=1e-6)
+    assert wlc_marko_siggia_distance("iMS").verify_jacobian(
         independent, [38.18281266, 0.37704827, 4.11], atol=1e-5
     )
 
-    assert odijk("WLC").verify_derivative(independent, params)
-    assert inverted_odijk("iWLC").verify_derivative(independent, params)
-    assert freely_jointed_chain("FJC").verify_derivative(independent, params, atol=1e-6)
-    assert marko_siggia_simplified("MS").verify_derivative(independent, [5, 5, 4.11], atol=1e-6)
+    assert ewlc_odijk_distance("WLC").verify_derivative(independent, params)
+    assert ewlc_odijk_force("iWLC").verify_derivative(independent, params)
+    assert efjc_distance("FJC").verify_derivative(independent, params, atol=1e-6)
+    assert wlc_marko_siggia_force("MS").verify_derivative(independent, [5, 5, 4.11], atol=1e-6)
 
-    assert marko_siggia_ewlc_force("MSF").verify_jacobian(independent, params, dx=1e-4, rtol=1e-4)
-    assert marko_siggia_ewlc_distance("MSD").verify_jacobian(independent, params, dx=1e-4)
-    assert marko_siggia_ewlc_force("MSF").verify_derivative(independent, params, dx=1e-4)
-    assert marko_siggia_ewlc_distance("MSD").verify_derivative(independent, params, dx=1e-4)
-    assert inverted_marko_siggia_simplified("iMS").verify_derivative(
+    assert ewlc_marko_siggia_force("MSF").verify_jacobian(independent, params, dx=1e-4, rtol=1e-4)
+    assert ewlc_marko_siggia_distance("MSD").verify_jacobian(independent, params, dx=1e-4)
+    assert ewlc_marko_siggia_force("MSF").verify_derivative(independent, params, dx=1e-4)
+    assert ewlc_marko_siggia_distance("MSD").verify_derivative(independent, params, dx=1e-4)
+    assert wlc_marko_siggia_distance("iMS").verify_derivative(
         independent, [38.18281266, 0.37704827, 4.11], atol=1e-5
     )
 
     # The finite differencing version of the FJC performs very poorly numerically, hence the less
     # stringent tolerances and larger dx values.
-    assert inverted_freely_jointed_chain("iFJC").verify_derivative(
+    assert efjc_force("iFJC").verify_derivative(
         independent, params, dx=1e-3, rtol=1e-2, atol=1e-6
     )
-    assert inverted_freely_jointed_chain("iFJC").verify_jacobian(
+    assert efjc_force("iFJC").verify_jacobian(
         independent, params, dx=1e-3, atol=1e-2, rtol=1e-2
     )
 
     # Check the tWLC and inverted tWLC model
     params = [5, 5, 5, 3, 2, 1, 6, 4.11]
-    assert twistable_wlc("tWLC").verify_jacobian(independent, params)
-    assert inverted_twistable_wlc("itWLC").verify_jacobian(independent, params)
+    assert twlc_distance("tWLC").verify_jacobian(independent, params)
+    assert twlc_force("itWLC").verify_jacobian(independent, params)
 
     # Check whether the twistable wlc model manipulates the data order
     np.testing.assert_allclose(
-        twistable_wlc("tWLC")._raw_call(independent, params),
-        np.flip(twistable_wlc("tWLC")._raw_call(np.flip(independent), params)),
+        twlc_distance("tWLC")._raw_call(independent, params),
+        np.flip(twlc_distance("tWLC")._raw_call(np.flip(independent), params)),
     )
 
     # Check whether the inverse twistable wlc model manipulates the data order
     np.testing.assert_allclose(
-        inverted_twistable_wlc("itWLC")._raw_call(independent, params),
-        np.flip(inverted_twistable_wlc("itWLC")._raw_call(np.flip(independent), params)),
+        twlc_force("itWLC")._raw_call(independent, params),
+        np.flip(twlc_force("itWLC")._raw_call(np.flip(independent), params)),
     )
 
     # Check whether the inverted models invert correctly
     d = np.array([3.0, 4.0])
     params = [5.0, 5.0, 5.0]
-    np.testing.assert_allclose(model_impl.WLC(model_impl.invWLC(d, *params), *params), d)
+    np.testing.assert_allclose(
+        model_impl.ewlc_odijk_distance(model_impl.ewlc_odijk_force(d, *params), *params), d
+    )
     params = [5.0, 15.0, 1.0, 4.11]
     np.testing.assert_allclose(
-        model_impl.FJC(model_impl.invFJC(independent, *params), *params), independent
+        model_impl.efjc_distance(model_impl.efjc_solve_force(independent, *params), *params),
+        independent,
     )
     params = [40.0, 16.0, 750.0, 440.0, -637.0, 17.0, 30.6, 4.11]
     np.testing.assert_allclose(
-        model_impl.tWLC(model_impl.invtWLC(independent, *params), *params), independent
+        model_impl.twlc_distance(model_impl.twlc_solve_force(independent, *params), *params), independent
     )
 
     d = np.arange(0.15, 2, 0.5)
     (Lp, Lc, St, kT) = (38.18281266, 0.37704827, 278.50103452, 4.11)
     params = [Lp, Lc, St, kT]
-    m_fwd = marko_siggia_ewlc_force("fwd")
-    m_bwd = marko_siggia_ewlc_distance("bwd")
+    m_fwd = ewlc_marko_siggia_force("fwd")
+    m_bwd = ewlc_marko_siggia_distance("bwd")
     force = m_fwd._raw_call(d, params)
     np.testing.assert_allclose(m_bwd._raw_call(force, params), d)
 
@@ -85,8 +108,8 @@ def test_models():
     d = np.arange(0.15, 0.377, 0.05)
     (Lp, Lc, kT) = (38.18281266, 0.37704827, 4.11)
     params = [Lp, Lc, kT]
-    m_fwd = marko_siggia_simplified("fwd")
-    m_bwd = inverted_marko_siggia_simplified("bwd")
+    m_fwd = wlc_marko_siggia_force("fwd")
+    m_bwd = wlc_marko_siggia_distance("bwd")
     force = m_fwd._raw_call(d, params)
     np.testing.assert_allclose(m_bwd._raw_call(force, params), d)
 
@@ -96,31 +119,41 @@ def test_models():
 
 
 def test_model_reprs():
-    assert odijk("test").__repr__()
-    assert inverted_odijk("test").__repr__()
-    assert freely_jointed_chain("test").__repr__()
-    assert marko_siggia_simplified("test").__repr__()
-    assert marko_siggia_ewlc_force("test").__repr__()
-    assert marko_siggia_ewlc_distance("test").__repr__()
-    assert inverted_freely_jointed_chain("test").__repr__()
-    assert twistable_wlc("test").__repr__()
-    assert inverted_twistable_wlc("test").__repr__()
-    assert (odijk("test") + distance_offset("test")).__repr__()
-    assert (odijk("test") + distance_offset("test")).invert().__repr__()
-    assert (odijk("test") + distance_offset("test")).subtract_independent_offset().__repr__()
+    assert ewlc_odijk_distance("test").__repr__()
+    assert ewlc_odijk_force("test").__repr__()
+    assert efjc_distance("test").__repr__()
+    assert wlc_marko_siggia_force("test").__repr__()
+    assert wlc_marko_siggia_distance("test").__repr__()
+    assert ewlc_marko_siggia_force("test").__repr__()
+    assert ewlc_marko_siggia_distance("test").__repr__()
+    assert efjc_force("test").__repr__()
+    assert twlc_distance("test").__repr__()
+    assert twlc_force("test").__repr__()
+    assert (ewlc_odijk_distance("test") + distance_offset("test")).__repr__()
+    assert (ewlc_odijk_distance("test") + distance_offset("test")).invert().__repr__()
+    assert (
+        (ewlc_odijk_distance("test") + distance_offset("test"))
+        .subtract_independent_offset()
+        .__repr__()
+    )
 
-    assert odijk("test")._repr_html_()
-    assert inverted_odijk("test")._repr_html_()
-    assert freely_jointed_chain("test")._repr_html_()
-    assert marko_siggia_simplified("test")._repr_html_()
-    assert marko_siggia_ewlc_force("test")._repr_html_()
-    assert marko_siggia_ewlc_distance("test")._repr_html_()
-    assert inverted_freely_jointed_chain("test")._repr_html_()
-    assert twistable_wlc("test")._repr_html_()
-    assert inverted_twistable_wlc("test")._repr_html_()
-    assert (odijk("test") + distance_offset("test"))._repr_html_()
-    assert (odijk("test") + distance_offset("test")).invert()._repr_html_()
-    assert (odijk("test") + distance_offset("test")).subtract_independent_offset()._repr_html_()
+    assert ewlc_odijk_distance("test")._repr_html_()
+    assert ewlc_odijk_force("test")._repr_html_()
+    assert efjc_distance("test")._repr_html_()
+    assert wlc_marko_siggia_force("test")._repr_html_()
+    assert wlc_marko_siggia_distance("test")._repr_html_()
+    assert ewlc_marko_siggia_force("test")._repr_html_()
+    assert ewlc_marko_siggia_distance("test")._repr_html_()
+    assert efjc_force("test")._repr_html_()
+    assert twlc_distance("test")._repr_html_()
+    assert twlc_force("test")._repr_html_()
+    assert (ewlc_odijk_distance("test") + distance_offset("test"))._repr_html_()
+    assert (ewlc_odijk_distance("test") + distance_offset("test")).invert()._repr_html_()
+    assert (
+        (ewlc_odijk_distance("test") + distance_offset("test"))
+        .subtract_independent_offset()
+        ._repr_html_()
+    )
     assert (force_offset("a_b_c") + force_offset("b_c_d")).invert()._repr_html_().find(
         "offset_{b\\_c\\_d}"
     ) > 0
@@ -129,15 +162,16 @@ def test_model_reprs():
 @pytest.mark.parametrize(
     "model, test_params",
     [
-        (model_impl.WLC, ["Lp", "Lc", "St", "kT"]),
-        (model_impl.invWLC, ["Lp", "Lc", "St", "kT"]),
-        (model_impl.FJC, ["Lp", "Lc", "St", "kT"]),
-        (model_impl.invFJC, ["Lp", "Lc", "St", "kT"]),
-        (model_impl.marko_siggia_simplified, ["Lp", "Lc", "kT"]),
-        (model_impl.marko_siggia_ewlc_solve_force, ["Lp", "Lc", "St", "kT"]),
-        (model_impl.marko_siggia_ewlc_solve_distance, ["Lp", "Lc", "St", "kT"]),
-        (model_impl.tWLC, ["Lp", "Lc", "St", "kT"]),
-        (model_impl.invtWLC, ["Lp", "Lc", "St", "kT"]),
+        (model_impl.ewlc_odijk_force, ["Lp", "Lc", "St", "kT"]),
+        (model_impl.ewlc_odijk_distance, ["Lp", "Lc", "St", "kT"]),
+        (model_impl.efjc_distance, ["Lp", "Lc", "St", "kT"]),
+        (model_impl.efjc_solve_force, ["Lp", "Lc", "St", "kT"]),
+        (model_impl.wlc_marko_siggia_force, ["Lp", "Lc", "kT"]),
+        (model_impl.wlc_marko_siggia_distance, ["Lp", "Lc", "kT"]),
+        (model_impl.ewlc_marko_siggia_force, ["Lp", "Lc", "St", "kT"]),
+        (model_impl.ewlc_marko_siggia_distance, ["Lp", "Lc", "St", "kT"]),
+        (model_impl.twlc_distance, ["Lp", "Lc", "St", "kT"]),
+        (model_impl.twlc_solve_force, ["Lp", "Lc", "St", "kT"]),
     ],
 )
 def test_invalid_params_models(model, test_params):

--- a/lumicks/pylake/fitting/tests/test_model_sim.py
+++ b/lumicks/pylake/fitting/tests/test_model_sim.py
@@ -1,12 +1,12 @@
 import pytest
 import numpy as np
 from lumicks.pylake.fitting.model import Model
-from lumicks.pylake.fitting.models import odijk
+from lumicks.pylake.fitting.models import ewlc_odijk_distance
 from lumicks.pylake.fitting.parameters import Params, Parameter
 
 
 def test_simulation_api():
-    dna = odijk("DNA")
+    dna = ewlc_odijk_distance("DNA")
     force = [0.1, 0.2, 0.3]
     np.testing.assert_allclose(
         dna(force, {"DNA/Lp": 50.0, "DNA/Lc": 16.0, "DNA/St": 1500.0, "kT": 4.11}),
@@ -30,7 +30,7 @@ def test_simulation_api():
 
 
 def test_simulation_api_wrong_par():
-    dna = odijk("DNA")
+    dna = ewlc_odijk_distance("DNA")
 
     with pytest.raises(KeyError):
         dna([1], {"DNA/Lp": 50.0, "DNA/Lc": 16.0, "DN/St": 1500.0, "kT": 4.11})

--- a/lumicks/pylake/fitting/tests/test_parameters.py
+++ b/lumicks/pylake/fitting/tests/test_parameters.py
@@ -1,4 +1,4 @@
-from lumicks.pylake.fitting.parameters import Params
+from lumicks.pylake.fitting.parameters import Params, Parameter
 from lumicks.pylake.fitting.models import *
 import pytest
 import numpy as np

--- a/lumicks/pylake/fitting/tests/test_pickling.py
+++ b/lumicks/pylake/fitting/tests/test_pickling.py
@@ -1,4 +1,4 @@
-from lumicks.pylake.fitting.models import inverted_odijk
+from lumicks.pylake.fitting.models import ewlc_odijk_force
 from lumicks.pylake.fitting.fit import FdFit
 import numpy as np
 import pickle
@@ -7,7 +7,7 @@ import pickle
 def test_pickle(tmpdir_factory):
     tmpdir = tmpdir_factory.mktemp("pylake")
 
-    model = inverted_odijk("DNA")
+    model = ewlc_odijk_force("DNA")
     fit = FdFit(model)
     x = np.arange(1, 20, 5)
     y = model(np.arange(1, 20, 5), params={"DNA/Lp": 50, "DNA/Lc": 24, "DNA/St": 1000, "kT": 4.12})

--- a/lumicks/pylake/fitting/tests/test_utilities.py
+++ b/lumicks/pylake/fitting/tests/test_utilities.py
@@ -6,8 +6,8 @@ from lumicks.pylake.fitting.detail.utilities import (
     latex_sqrt,
 )
 from lumicks.pylake.fitting.detail.model_implementation import (
-    solve_cubic_wlc,
-    invwlc_root_derivatives,
+    calc_cubic_root,
+    calc_cubic_root_derivatives,
 )
 import numpy as np
 import pytest
@@ -59,26 +59,26 @@ def test_analytic_roots():
         np.sort(
             np.array(
                 [
-                    solve_cubic_wlc(a, b, c, 0)[0],
-                    solve_cubic_wlc(a, b, c, 1)[0],
-                    solve_cubic_wlc(a, b, c, 2)[0],
+                    calc_cubic_root(a, b, c, 0)[0],
+                    calc_cubic_root(a, b, c, 1)[0],
+                    calc_cubic_root(a, b, c, 2)[0],
                 ]
             )
         ),
     )
 
     with pytest.raises(RuntimeError):
-        solve_cubic_wlc(a, b, c, 3)
+        calc_cubic_root(a, b, c, 3)
 
     def test_root_derivatives(root):
         dx = 1e-5
-        ref_root = solve_cubic_wlc(a, b, c, root)
-        da = (solve_cubic_wlc(a + dx, b, c, root) - ref_root) / dx
-        db = (solve_cubic_wlc(a, b + dx, c, root) - ref_root) / dx
-        dc = (solve_cubic_wlc(a, b, c + dx, root) - ref_root) / dx
+        ref_root = calc_cubic_root(a, b, c, root)
+        da = (calc_cubic_root(a + dx, b, c, root) - ref_root) / dx
+        db = (calc_cubic_root(a, b + dx, c, root) - ref_root) / dx
+        dc = (calc_cubic_root(a, b, c + dx, root) - ref_root) / dx
 
         np.testing.assert_allclose(
-            np.array(invwlc_root_derivatives(a, b, c, root)),
+            np.array(calc_cubic_root_derivatives(a, b, c, root)),
             np.array([da, db, dc]),
             atol=1e-5,
             rtol=1e-5,

--- a/lumicks/pylake/piezo_tracking/tests/conftest.py
+++ b/lumicks/pylake/piezo_tracking/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 from lumicks.pylake.channel import Continuous, TimeSeries, Slice
-from lumicks.pylake.fitting.models import inverted_odijk
+from lumicks.pylake.fitting.models import ewlc_odijk_force
 from lumicks.pylake.calibration import ForceCalibration
 
 
@@ -65,7 +65,7 @@ def piezo_tracking_test_data(poly_baseline_data, camera_calibration_data):
     tether_length_um = np.hstack(
         (np.arange(0.65, 0.7, 0.08 / sample_rate), np.arange(0.7, 0.785, 0.02 / sample_rate))
     )
-    wlc_force = inverted_odijk("tether")(
+    wlc_force = ewlc_odijk_force("tether")(
         tether_length_um, {"tether/Lp": 60, "tether/Lc": 0.75, "tether/St": 1400, "kT": 4.11}
     )
 


### PR DESCRIPTION
**Why this PR**
As a user I want to have consistent naming of fitting models.

I renamed the public facing models as follows:

`inverted_marko_siggia_simplified` -> `wlc_marko_siggia_distance`
`marko_siggia_simplified` -> `wlc_marko_siggia_force`
`marko_siggia_ewlc_distance` -> `ewlc_marko_siggia_distance`
`marko_siggia_ewlc_force` -> `ewlc_marko_siggia_force`
`odijk` -> `ewlc_odijk_distance`
`inverted_odijk` -> `ewlc_odijk_force`
`freely_jointed_chain` -> `efjc_distance`
`inverted_freely_jointed_chain` -> `efjc_force`
`twistable_wlc` -> `twlc_distance`
`inverted_twistable_wlc` -> `twlc_force`

I refrained from simplifying `wlc_marko_siggia_*` to `wlc_*`, as I am unsure, if we should simplify the names already at this level and not only when we provide convenience functions to assemble a composition of models.

I also renamed the functions of the model implementations accordingly. ~However, there an `i` indicates that the model was inverted to calculate the `*_idistance` and `*_iforce`.~

~Additionally, I took the opportunity to reorder the functions in `models` and `model_implementation`, bundled into a separate commit, so it can be easily reverted, if you do not agree.~ Postponed for now, probably I will open another PR.