### PR TITLE
Ensure same source data for all tracks in group

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,13 @@
 
 ## v0.13.2 | tbd
 
-### New features
+#### New features
 
-* Fixed and reintroduced lazy loading for `TimeSeries` data. 
+* Fixed and reintroduced lazy loading for `TimeSeries` data.
+
+#### Other changes
+
+* All `KymoTrack` intances must have the same source `Kymo` and color channel in order to be in the same `KymoTrackGroup` instance. While this behavior was required previously for some downstream analyses on the tracks, it is now explicitly enforced upon `KymoTrackGroup` construction.
 
 #### Deprecations
 

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -97,6 +97,10 @@ class Kymo(ConfocalImage):
         kymo_copy._calibration = self._calibration
         return kymo_copy
 
+    @property
+    def _id(self):
+        return id(self)
+
     def _check_is_sliceable(self):
         if self._file is None:
             raise NotImplementedError(

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -343,7 +343,7 @@ def refine_lines_centroid(lines, line_width):
         raise ValueError("line_width may not be smaller than 1")
 
     # convert line_width (pixel units) to physical units expected by refine_tracks_centroid
-    track_width = line_width * lines[0]._kymo.pixelsize[0]
+    track_width = line_width * lines._kymo.pixelsize[0]
     return refine_tracks_centroid(lines, track_width)
 
 
@@ -360,7 +360,7 @@ def refine_tracks_centroid(tracks, track_width=None):
 
     Parameters
     ----------
-    tracks : List[KymoTrack]
+    tracks : List[KymoTrack] or KymoTrackGroup
         Detected tracks on a kymograph
     track_width : float
         Expected (spatial) spot size in physical units. Must be larger than zero.
@@ -368,14 +368,15 @@ def refine_tracks_centroid(tracks, track_width=None):
         for kymographs calibrated in microns. For kymographs calibrated in kilobase pairs the
         corresponding value is calculated using 0.34 nm/bp (from duplex DNA).
     """
+    tracks = KymoTrackGroup(tracks) if isinstance(tracks, (list, tuple)) else tracks
     if track_width is None:
-        track_width = _default_track_widths[tracks[0]._kymo._calibration.unit]
+        track_width = _default_track_widths[tracks._kymo._calibration.unit]
 
     if track_width <= 0:
         # Must be positive otherwise refinement fails
         raise ValueError(f"track_width should be larger than zero")
 
-    track_width_pixels = np.ceil(track_width / tracks[0]._kymo.pixelsize[0])
+    track_width_pixels = np.ceil(track_width / tracks._kymo.pixelsize[0])
 
     interpolated_tracks = [track.interpolate() for track in tracks]
     time_idx = np.round(
@@ -463,10 +464,10 @@ def refine_tracks_gaussian(
     """
     assert overlap_strategy in ("ignore", "skip", "multiple")
     if refine_missing_frames:
-        tracks = [track.interpolate() for track in tracks]
+        tracks = KymoTrackGroup([track.interpolate() for track in tracks])
 
-    kymo = tracks[0]._kymo
-    channel = tracks[0]._channel
+    kymo = tracks._kymo
+    channel = tracks._channel
     image_data = kymo.get_image(channel)
 
     initial_sigma = kymo.pixelsize[0] * 1.1 if initial_sigma is None else initial_sigma

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -385,6 +385,9 @@ def test_kymotrackgroup_source_kymo():
     tracks_b = KymoTrackGroup(green_tracks_b[:2])
     assert len(tracks_b) == 2
 
+    assert id(tracks_a._kymo) == id(kymos[0])
+    assert tracks_a._channel == "green"
+
     # test empty result
     tracks_empty = KymoTrackGroup([])
     assert len(tracks_empty) == 0


### PR DESCRIPTION
**Why this PR?**
Some downstream analyses on kymo tracks require information from the source `Kymo`  (`refine_tracks_centroid` and `refine_tracks_gaussian`). Until now we've assumed that all tracks have the same source instance and just used the first track in the group to get this information. Here we specifically enforce this so our assumptions are always valid.

In addition, I added properties to look up the source `Kymo` and color channel, and made some minor changes to downstream functions that ensure we're working on a `KymoTrackGroup` rather than a raw `list` or `tuple` of `KymoTrack`s