### PR TITLE
Make function mentions in the documentation link to pages with the docstring

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,7 @@
+/* Set color of python role cross references to same as color for links */
+code.xref.py {
+  color: #2980b9 !important;
+}
+code.xref.any.py {
+  color: #2980b9 !important;
+}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,14 +29,14 @@ Force calibration
 
     PassiveCalibrationModel
     ActiveCalibrationModel
+    force_calibration.power_spectrum.PowerSpectrum
+    force_calibration.power_spectrum_calibration.CalibrationResults
 
     :template: function.rst
 
     calibrate_force
     calculate_power_spectrum
     fit_power_spectrum
-    force_calibration.power_spectrum.PowerSpectrum
-    force_calibration.power_spectrum_calibration.CalibrationResults
     viscosity_of_water
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,8 +169,10 @@ html_favicon = "fav.ico"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ["_static"]
 # html_context = {'extra_css_files': ['_static/extra.css']}
+
+html_css_files = ["custom.css"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/examples/cas9_kymotracking/cas9_kymotracking.rst
+++ b/docs/examples/cas9_kymotracking/cas9_kymotracking.rst
@@ -156,7 +156,7 @@ This sums the photon counts from `pixel_position - sampling_width` to (and inclu
 Analyzing the results
 ---------------------
 
-The tracks are available in `kymowidget.tracks`, which returns a `KymoTrackGroup` object. The group is a customized list of `KymoTrack` objects
+The tracks are available in `kymowidget.tracks`, which returns a `KymoTrackGroup` object. The group is a customized list of :class:`~lumicks.pylake.kymotracker.kymotrack.KymoTrack` objects
 which contain lists of position and time coordinates for each tracked particle. These can be accessed with the `KymoTrack.position` and
 `KymoTrack.seconds` properties, respectively. Let's grab the longest track we found, and have a look at its position over time::
 

--- a/docs/examples/reca_fitting/reca_fitting.rst
+++ b/docs/examples/reca_fitting/reca_fitting.rst
@@ -49,7 +49,7 @@ For this we want to use an inverted worm-like chain model. We also include an es
 
     model = lk.ewlc_odijk_force("DNA").subtract_independent_offset() + lk.force_offset("DNA")
 
-We would like to fit this model to some data. So let's make a `FdFit`::
+We would like to fit this model to some data. So let's make a :class:`~lumicks.pylake.FdFit`::
 
     fit = lk.FdFit(model)
 
@@ -66,9 +66,9 @@ We have to be careful when loading the data, as the Odijk worm-like chain model 
 (0 - 30 pN). That means we'll have to crop out the section of the data that's outside this range. We can do this by
 creating a logical mask which is true for the data we wish to include and false for the data we wish to exclude.
 
-The data in an `FdCurve` can be referenced by invoking the f and d attribute for force and distance respectively. This
-returns `Slice` objects, from which we can extract the data by calling `.data`. Since we have to do this twice, let's
-make a little function that extracts the data from the `FdCurve` and filters it::
+The data in an :class:`~lumicks.pylake.fdcurve.FdCurve` can be referenced by invoking the f and d attribute for force and distance respectively. This
+returns :class:`~lumicks.pylake.channel.Slice` objects, from which we can extract the data by calling `.data`. Since we have to do this twice, let's
+make a little function that extracts the data from the :class:`~lumicks.pylake.fdcurve.FdCurve` and filters it::
 
     def extract_data(fdcurve, f_min, f_max):
         f = fdcurve.f.data
@@ -79,7 +79,7 @@ make a little function that extracts the data from the `FdCurve` and filters it:
     force_control, distance_control = extract_data(control_curve, 0, 30)
     force_reca, distance_reca = extract_data(reca_curve, 0, 30)
 
-We can load data into the `FdFit` by using the function `add_data`::
+We can load data into the :class:`~lumicks.pylake.FdFit` by using the function `add_data`::
 
     fit.add_data("Control", force_control, distance_control)
 
@@ -141,7 +141,7 @@ Everything is set up now and we can proceed to fit the model::
 Plot the fit
 ------------
 
-Calling the plot function on the `FdFit` (i.e. `fit.plot()`) plots the fit alongside the data::
+Calling the plot function on the :class:`~lumicks.pylake.FdFit` (i.e. `fit.plot()`) plots the fit alongside the data::
 
     fit.plot()
     plt.ylabel("Force [pN]")
@@ -297,7 +297,7 @@ A contour length per point
 --------------------------
 
 Now comes the more challenging part. Inverting the model for contour length. Luckily, this procedure has already been
-implemented in Pylake. The function `parameter_trace` inverts the model for a particular model parameter. Let's have
+implemented in Pylake. The function :func:`~lumicks.pylake.parameter_trace()` inverts the model for a particular model parameter. Let's have
 a look at the parameters it needs. We can look this up in the documentation for :func:`~lumicks.pylake.parameter_trace`
 or invoke help::
 

--- a/docs/examples/twlc_fitting/twlc_fitting.rst
+++ b/docs/examples/twlc_fitting/twlc_fitting.rst
@@ -87,10 +87,10 @@ And fit the model::
 Set up the twistable worm like chain model
 ------------------------------------------
 
-By default, the `twlc_distance` model provided with pylake outputs the distance as a function of force. However, we
+By default, the :func:`~lumicks.pylake.twlc_distance()` model provided with pylake outputs the distance as a function of force. However, we
 typically want to fit force as a function of distance. To achieve this, we can invert the model using its `invert`
 function at the cost of slowing down the fit. Alternatively, we have a faster way of achieving this in pylake, by
-using the dedicated `twlc_force` model::
+using the dedicated :func:`~lumicks.pylake.twlc_force()` model::
 
     m_dna = lk.twlc_force("DNA").subtract_independent_offset() + lk.force_offset("DNA")
     fit_twlc = lk.FdFit(m_dna)

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -6,7 +6,7 @@ Correlated stacks
     :nbexport:`Download this page as a Jupyter notebook <self>`
 
 Bluelake has the ability to export videos from the camera's.
-These videos can be opened and sliced using `CorrelatedStack`::
+These videos can be opened and sliced using :class:`~lumicks.pylake.correlated_stack.CorrelatedStack`::
 
     stack = lk.CorrelatedStack("wf.tiff")  # Loading a stack.
     stack_slice = stack[2:10]  # Grab frame 2 to 9
@@ -19,7 +19,8 @@ You can easily load multiple TIFF files by simply listing them consecutively::
 
     stack = lk.CorrelatedStack("wf.tiff", "wf2.tiff")  # Loading two tiff files in a single stack.
 
-You can quickly plot an individual frame using the `plot()` method::
+You can quickly plot an individual frame using the
+:meth:`~lumicks.pylake.correlated_stack.CorrelatedStack.plot()` method::
 
     stack.plot(frame=0, channel="rgb")
 
@@ -42,7 +43,7 @@ For example, a gamma adjustment of `2` to the red channel can be applied as foll
     stack.plot(channel="red", adjustment=lk.ColorAdjustment([5, 5, 5], [95, 95, 95], mode="percentile", gamma=[2, 1, 1]))
 
 To define the location of the tether between beads, supply the `(x, y)` pixel coordinates of the end points
-to the `define_tether()` method::
+to the :func:`~lumicks.pylake.correlated_stack.CorrelatedStack.define_tether()` method::
 
     stack = stack.define_tether((126, 193), (341, 200))
     stack.plot()
@@ -50,9 +51,11 @@ to the `define_tether()` method::
 
 .. image:: correlatedstack_tether.png
 
-Note, after defining a tether location the image is rotated such that the tether is horizontal in the field of view.
-You can also plot the overlay of the tether location using `plot_tether(**kwargs)`, which also accepts keyword
-arguments that are passed to `plt.plot()`.
+Note, after defining a tether location the image is rotated such that the tether is horizontal in
+the field of view. You can also plot the overlay of the tether location using
+:func:`plot_tether(**kwargs) <lumicks.pylake.correlated_stack.CorrelatedStack.plot_tether()>`,
+which also accepts keyword arguments that are passed to :func:`plt.plot()
+<matplotlib.pyplot.plot()>`.
 
 You can also spatially crop to select a smaller region of interest::
 
@@ -65,14 +68,16 @@ Alternatively, you can crop directly by slicing the stack::
 
     stack_roi = stack[:, 150:245, 45:420]
 
-Here the first index can be used to select a subset of frames and the second and third indices perform a cropping operation.
-Note how the axes are switched when compared to `crop_by_pixels` to follow the numpy convention (rows and then columns).
+Here the first index can be used to select a subset of frames and the second and third indices
+perform a cropping operation. Note how the axes are switched when compared to
+:meth:`~lumicks.pylake.correlated_stack.CorrelatedStack.crop_by_pixels()` to follow the numpy
+convention (rows and then columns).
 
 Cropping can be useful, for instance, after applying color alignment to RGB images as the edges
 can become corrupted due to interpolation artifacts.
 
-You can also plot only a single color channel. Note that here we pass some additional formatting arguments, which are
-forwarded to `plt.imshow()`::
+You can also plot only a single color channel. Note that here we pass some additional formatting
+arguments, which are forwarded to :func:`plt.imshow() <matplotlib.pyplot.imshow()>`::
 
     stack_roi.plot(channel="red", cmap="magma", adjustment=lk.ColorAdjustment(550, 800))
 
@@ -87,7 +92,8 @@ from Bluelake if available. This functionality can be turned off with the option
 
 .. image:: correlatedstack_raw.png
 
-You can obtain the image stack data as a `numpy` array using the `get_image()` method::
+You can obtain the image stack data as a :class:`numpy <numpy.ndarray>` array using the
+:meth:`~lumicks.pylake.correlated_stack.CorrelatedStack.get_image()` method::
 
     red_data = stack.get_image(channel="red") # shape = [n_frames, y_pixels, x_pixels]
     rgb_data = stack.get_image(channel="rgb") # shape = [n_frames, y_pixels, x_pixels, 3 channels]
@@ -105,7 +111,7 @@ Correlating force with the image stack
 --------------------------------------
 
 Quite often, it is interesting to correlate events on the camera's to `channel` data.
-To quickly explore the correlation between images in a `CorrelatedStack` and channel data
+To quickly explore the correlation between images in a :class:`~lumicks.pylake.correlated_stack.CorrelatedStack` and channel data
 you can use the following function::
 
     # Making a plot where force is correlated to images in the stack.
@@ -119,7 +125,7 @@ on the left graph to select a particular force. The corresponding video frame wi
 
 In some cases, additional processing may be needed, and we wish to have the data
 downsampled over the video frames. This can be done using the function `Slice.downsampled_over`
-using timestamps obtained from the `CorrelatedStack`::
+using timestamps obtained from the :class:`~lumicks.pylake.correlated_stack.CorrelatedStack`::
 
     # Determine the force trace averaged over frame 2...9.
     file.force1x.downsampled_over(stack[2:10].frame_timestamp_ranges())

--- a/docs/tutorial/fdcurves.rst
+++ b/docs/tutorial/fdcurves.rst
@@ -12,14 +12,15 @@ The following code loads an HDF5 file and lists all of the FD curves inside of i
     file = lk.File("example.h5")
     list(file.fdcurves)  # e.g. shows: "['baseline', '1', '2']"
 
-To visualizes an FD curve, you can use the built-in `.plot_scatter()` function::
+To visualizes an FD curve, you can use the built-in :meth:`.plot_scatter()
+<lumicks.pylake.fdcurve.FdCurve.plot_scatter()>` method::
 
     # Pick a single FD curve
     fd = file.fdcurves["baseline"]
     fd.plot_scatter()
 
-Here, `.fdcurves` is a standard Python dictionary, so we can do standard `dict` thing with it.
-For example, we can iterate over all the FD curve in a file and plot them::
+Here, :attr:`.fdcurves <lumicks.pylake.File.fdcurves>` is a standard Python dictionary, so we can
+do standard `dict` thing with it. For example, we can iterate over all the FD curve in a file and plot them::
 
     for name, fd in file.fdcurves.items():
         fd.plot_scatter()

--- a/docs/tutorial/fdfitting.rst
+++ b/docs/tutorial/fdfitting.rst
@@ -15,8 +15,10 @@ introduction to these fitting capabilities.
 Models
 ------
 
-When fitting data, everything revolves around models. One of these models is the so-called extensible worm-like-chain
-model by Odijk et al. Let's have a look at it. We can construct this model using the supplied function `lk.ewlc_odijk_distance()`.
+When fitting data, everything revolves around models. One of these models is the so-called
+extensible worm-like-chain model by Odijk et al. Let's have a look at it. We can construct this
+model using the supplied function :func:`lk.ewlc_odijk_distance()
+<lumicks.pylake.ewlc_odijk_distance()>`.
 
 Note that we also have to give it a name. This name will be prefixed to model specific parameters in this model::
 
@@ -152,9 +154,10 @@ or see :ref:`fd_models`.
 Fitting data
 ------------
 
-To fit Fd models, we have to create an `FdFit`. This object will collect all the parameters involved in the models and
-data, and will allow you to interact with the model parameters and fit them. We construct it using `lk.FdFit` and
-pass it one or more models. In return, we get an object we can interact with, which in this case we store in `fit`::
+To fit Fd models, we have to create an :class:`~lumicks.pylake.FdFit`. This object will collect all
+the parameters involved in the models and data, and will allow you to interact with the model
+parameters and fit them. We construct it using `lk.FdFit` and pass it one or more models. In
+return, we get an object we can interact with, which in this case we store in `fit`::
 
     fit = lk.FdFit(model)
 
@@ -177,16 +180,17 @@ More specifically, we renamed the parameter `DNA/Lc` to `DNA/Lc_RecA`.
 Setting parameter bounds
 ************************
 
-The parameters of the model can be accessed directly from `FdFit`. Note that by default, parameters tend to have
+The parameters of the model can be accessed directly from :class:`~lumicks.pylake.FdFit`. Note that by default, parameters tend to have
 reasonable initial guesses and bounds in pylake, but we can set our own as follows::
 
     fit["DNA/Lp"].value = 50
     fit["DNA/Lp"].lower_bound = 39
     fit["DNA/Lp"].upper_bound = 80
 
-After this, the model is ready to be fitted. We can fit the model to the data by calling the function `.fit()`. This
-estimates the model parameters by minimizing the least squares differences between the model's dependent variable and
-the data in the fit::
+After this, the model is ready to be fitted. We can fit the model to the data by calling the
+function :meth:`.fit() <lumicks.pylake.FdFit.fit()>`. This estimates the model parameters by
+minimizing the least squares differences between the model's dependent variable and the data in the
+fit::
 
     fit.fit()
 
@@ -298,7 +302,7 @@ be performed. We first set up a model and fit it to some data. This is all analo
     fit.fit()
 
 Now, we wish to allow the contour length to vary on a per data point basis. For this, we use the function
-`parameter_trace`. Here we see a few things happening. The first argument specifies the model to use for the inversion.
+:func:`~lumicks.pylake.parameter_trace()`. Here we see a few things happening. The first argument specifies the model to use for the inversion.
 
 The second argument should contain the parameters to be used in this method. Note how we select them from the parameters
 in the `fit` using the same syntax as before (i.e. `fit[data_name]`). Next, we specify which parameter has to be fitted
@@ -332,7 +336,7 @@ how this works, read up on Python fantastic f-Strings.
 Global fits versus single fits
 ******************************
 
-The `FdFit` object manages a fit. To illustrate its use, and how a global fit differs from a local fit, consider the
+The :class:`~lumicks.pylake.FdFit` object manages a fit. To illustrate its use, and how a global fit differs from a local fit, consider the
 following two examples::
 
     model = lk.ewlc_odijk_force("DNA")
@@ -351,10 +355,12 @@ and::
         fit.fit()
         print(fit["DNA/Lc"])
 
-The first example is what we refer to as a global fit whereas the second example is an example of a local fit. The
-difference between these two is that the former sets up one model that has to fit all the data whereas the latter fits
-all the data sets independently. The former has one parameter set, whereas the latter has a parameter set per data set.
-Also note how in the second example a new `Model` and `FdFit` is created at every cycle of the for loop.
+The first example is what we refer to as a global fit whereas the second example is an example of a
+local fit. The difference between these two is that the former sets up one model that has to fit
+all the data whereas the latter fits all the data sets independently. The former has one parameter
+set, whereas the latter has a parameter set per data set. Also note how in the second example a new
+:class:`~lumicks.pylake.fitting.model.Model` and :class:`~lumicks.pylake.FdFit` is created at every
+cycle of the for loop.
 
 Statistically, it is typically more optimal to fit data using global fitting (meaning you use one model to fit all the
 data, as opposed to recreating the model for each new set of data), as more information goes into estimates of
@@ -375,7 +381,7 @@ Multiple models
 ***************
 
 When working with multiple models, things can get a little more complicated. Let's say we have two models, `model1` and
-`model2` and we want to fit both in a global fit. Constructing the `FdFit` is easy::
+`model2` and we want to fit both in a global fit. Constructing the :class:`~lumicks.pylake.FdFit` is easy::
 
     model1 = lk.ewlc_odijk_force("DNA")
     model2 = (lk.ewlc_odijk_distance("DNA") + lk.ewlc_odijk_distance("protein")).invert()
@@ -387,7 +393,7 @@ But then the question arises, how do we add data to each model? Well, the trick 
     fit[model1].add_data("data for model 1", forces_1, distances_1)
     fit[model2].add_data("data for model 2", forces_2, distances_2)
 
-See how we used the model handles? They are used to let the `FdFit` know to which model each data set should be added.
+See how we used the model handles? They are used to let the :class:`~lumicks.pylake.FdFit` know to which model each data set should be added.
 You can add as many data sets as you want to both models and fit it all at once.
 
 Plotting is straightforward in this setting. We can plot the data sets corresponding to model 1 and 2 as follows::

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -299,7 +299,7 @@ Note that you can slice channel data directly using markers (or any other item t
 Exporting h5 files
 ------------------
 
-We can save the Bluelake HDF5 file to a different filename by using :meth:`~lumicks.pylake.File.save_as`. When
+We can save the Bluelake HDF5 file to a different filename by using :meth:`~lumicks.pylake.File.save_as()`. When
 transferring data, it can be beneficial to omit some channels from the h5 file, or use a higher compression ratio. In
 particular, high frequency channels tend to take up a lot of space, and aren't always necessary for every analysis::
 

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -329,7 +329,7 @@ How to do active calibration in Pylake
 
 Using `pylake`, the procedure to use active calibration is not very different from passive calibration.
 However, it does require some additional data channels as inputs.
-Instead of using the :class:`~.PassiveCalibrationModel` presented in the previous section, we now use the :class:`ActiveCalibrationModel`.
+Instead of using the :class:`~.PassiveCalibrationModel` presented in the previous section, we now use the :class:`~lumicks.pylake.ActiveCalibrationModel`.
 
 In this tutorial, we're going to assume the nanostage was used as driving input::
 

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -6,15 +6,17 @@ Confocal images
     :nbexport:`Download this page as a Jupyter notebook <self>`
 
 The following code uses scans as an example.
-Kymographs work the same way -- just substitute `file.scans` with `file.kymos`.
-To load an HDF5 file and lists all of the scans inside of it, run::
+Kymographs work the same way -- just substitute :attr:`file.scans <lumicks.pylake.File.scans>` with
+:attr:`file.kymos <lumicks.pylake.File.kymos>`. To load an HDF5 file and list all of the scans
+inside of it, run::
 
     import lumicks.pylake as lk
 
     file = lk.File("example.h5")
     list(file.scans)  # e.g. shows: "['reference', 'bleach', 'imaging']"
 
-Once again, `.scans` is a regular Python dictionary so we can easily iterate over it::
+Once again, :attr:`.scans <lumicks.pylake.File.scans>` is a regular Python dictionary so we can
+easily iterate over it::
 
     # Plot all scans in a file
     for name, scan in file.scans.items():
@@ -29,7 +31,7 @@ Or just pick a single one::
 Scan data and details
 ---------------------
 
-You can access the raw image data directly. For a `Scan` with only a single frame::
+You can access the raw image data directly. For a :class:`~lumicks.pylake.scan.Scan` with only a single frame::
 
     rgb = scan.get_image("rgb")  # matrix with `shape == (h, w, 3)`
     blue = scan.get_image("blue")  # single color so `shape == (h, w)`
@@ -51,7 +53,7 @@ We can also slice out a subset of frames from an image stack::
 
     sliced_scan = multiframe_scan[5:10]
 
-This will return a new `Scan` containing data equivalent to::
+This will return a new :class:`~lumicks.pylake.scan.Scan` containing data equivalent to::
 
     multiframe_scan.get_image("rgb")[5:10, :, :, :]
 
@@ -73,20 +75,30 @@ For an even lower-level look at data, the raw photon count samples can be access
 
 There are also several properties available for convenient access to the scan metadata:
 
-* `scan.center_point_um` provides a dictionary of the central x, y, and z coordinates of the scan in micrometers relative to the brightfield field of view
-* `scan.size_um` provides a list of scan sizes in micrometers along the axes of the scan
-* `scan.pixelsize_um` provides the pixel size in micrometers
-* `scan.lines_per_frame` provides the number scanned lines in each frame (number of rows in the raw data array)
-* `scan.pixels_per_line` provides the number of pixels in each line of the scan (number of columns in the raw data array)
-* `scan.fast_axis` provides the fastest axis that was scanned (x or y)
-* `scan.num_frames` provides the number of frames available
-* `kymo.pixel_time_seconds` provides the pixel dwell time.
+* :attr:`scan.center_point_um <lumicks.pylake.scan.Scan.center_point_um>` provides a dictionary of
+  the central x, y, and z coordinates of the scan in micrometers relative to the brightfield field
+  of view
+* :attr:`scan.size_um <lumicks.pylake.scan.Scan.size_um>` provides a list of scan sizes in
+  micrometers along the axes of the scan
+* :attr:`scan.pixelsize_um <lumicks.pylake.scan.Scan.pixelsize_um>` provides the pixel size in
+  micrometers
+* :attr:`scan.lines_per_frame <lumicks.pylake.scan.Scan.lines_per_frame>` provides the number
+  scanned lines in each frame (number of rows in the raw data array)
+* :attr:`scan.pixels_per_line <lumicks.pylake.scan.Scan.pixels_per_line>` provides the number of
+  pixels in each line of the scan (number of columns in the raw data array)
+* :attr:`scan.fast_axis <lumicks.pylake.scan.Scan.fast_axis>` provides the fastest axis that was
+  scanned (x or y)
+* :attr:`scan.num_frames <lumicks.pylake.scan.Scan.num_frames>` provides the number of frames
+  available
+* :attr:`kymo.pixel_time_seconds <lumicks.pylake.scan.Scan.pixel_time_seconds>` provides the pixel
+  dwell time.
 
 
 Plotting and Exporting
 ----------------------
 
-As shown above, there are convenience functions for plotting either the full RGB image or a single color channel.
+As shown above, there are convenience functions for plotting either the full RGB image or a single
+color channel::
 
     scan.plot(channel="red")
 

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -12,7 +12,8 @@ To load an HDF5 file and lists all of the kymographs inside of it, run::
     file = lk.File("example.h5")
     list(file.kymos)  # e.g. shows: "['cas9', 'reference']"
 
-Once again, `.kymos` is a regular Python dictionary so we can easily iterate over it::
+Once again, :attr:`.kymos <lumicks.pylake.File.kymos>` is a regular Python dictionary so we can
+easily iterate over it::
 
     # Plot all kymos in a file
     >>> for name, kymo in file.kymos.items():
@@ -27,9 +28,10 @@ Or just pick a single one::
 
 .. image:: figures/kymographs/kymo_intro.png
 
-Here we see the `plot()` convenience function. The `channel` argument accepts the strings "red", "green",
-"blue", or "rgb". This function accepts keyword arguments that are passed to `plt.imshow()` internally.
-Note also, the axes are labeled with the appropriate time and position units.
+Here we see the :meth:`~lumicks.pylake.kymo.Kymo.plot()` convenience function. The `channel`
+argument accepts the strings "red", "green", "blue", or "rgb". This function accepts keyword
+arguments that are passed to :func:`plt.imshow() <matplotlib.pyplot.imshow()>` internally. Note
+also, the axes are labeled with the appropriate time and position units.
 
 The kymograph can also be exported to TIFF format::
 
@@ -50,20 +52,29 @@ We can access the raw image data as `numpy` arrays::
 
 There are also several properties available for convenient access to the kymograph metadata:
 
-* `kymo.center_point_um` provides a dictionary of the central x, y, and z coordinates of the scan in micrometers relative to the brightfield field of view
-* `kymo.size_um` provides a list of scan sizes in micrometers along the axes of the scan
-* `kymo.pixelsize_um` provides the pixel size in micrometers
-* `kymo.pixels_per_line` provides the number of pixels in each line of the kymograph
-* `kymo.fast_axis` provides the axis that was scanned (x or y)
-* `kymo.line_time_seconds` provides the time between successive lines
-* `kymo.pixel_time_seconds` provides the pixel dwell time.
+* :attr:`kymo.center_point_um <lumicks.pylake.kymo.Kymo.center_point_um>` provides a dictionary of
+  the central x, y, and z coordinates of the scan in micrometers relative to the brightfield field
+  of view
+* :attr:`kymo.size_um <lumicks.pylake.kymo.Kymo.size_um>` provides a list of scan sizes in
+  micrometers along the axes of the scan
+* :attr:`kymo.pixelsize_um <lumicks.pylake.kymo.Kymo.pixelsize_um>` provides the pixel size in
+  micrometers
+* :attr:`kymo.pixels_per_line <lumicks.pylake.kymo.Kymo.pixels_per_line>` provides the number of
+  pixels in each line of the kymograph
+* :attr:`kymo.fast_axis <lumicks.pylake.kymo.Kymo.fast_axis>` provides the axis that was scanned (x
+  or y)
+* :attr:`kymo.line_time_seconds <lumicks.pylake.kymo.Kymo.line_time_seconds>` provides the time
+  between successive lines
+* :attr:`kymo.pixel_time_seconds <lumicks.pylake.kymo.Kymo.pixel_time_seconds>` provides the pixel
+  dwell time.
 
 
 Cropping and slicing
 --------------------
 
-It is possible to crop a kymograph to a specific coordinate range, by using the function `Kymo.crop_by_distance`
-For example, we can crop the region from `6` micron to `24` micron using the following command::
+It is possible to crop a kymograph to a specific coordinate range, by using the function
+:func:`Kymo.crop_by_distance() <lumicks.pylake.kymo.Kymo.crop_by_distance>`. For example, we can
+crop the region from `6` micron to `24` micron using the following command::
 
     kymo.crop_by_distance(6, 24).plot("green)
 
@@ -123,7 +134,8 @@ If the optional `tether_length_kbp` argument is supplied, the kymograph is autom
 length in kilobase pairs. If this argument is missing (the default value `None`) the edited kymograph is only
 sliced and cropped.
 
-Note that you can also flip a kymograph along its positional axis using `kymo.flip()`. This returns a new (but flipped) `Kymo`.
+Note that you can also flip a kymograph along its positional axis using :meth:`kymo.flip()
+<lumicks.pylake.kymo.Kymo.flip()>`. This returns a new (but flipped) :class:`~lumicks.pylake.kymo.Kymo`.
 
 Downsampling
 ------------
@@ -171,7 +183,8 @@ The images can also be exported in the TIFF format::
 Correlating with force
 ----------------------
 
-We can downsample channel data according to the lines in a kymo. We can use :func:`~lumicks.pylake.scan.Kymo.line_timestamp_ranges()` for this::
+We can downsample channel data according to the lines in a kymo. We can use
+:func:`~lumicks.pylake.kymo.Kymo.line_timestamp_ranges()` for this::
 
     line_timestamp_ranges = kymo.line_timestamp_ranges()
 

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -49,7 +49,7 @@ use the region from 7 to 22 micrometer. Let's have a look at what that looks lik
     >>> plt.ylim([22, 7])
 
 If we zoom in a bit, we can see that our tracks in this image are about 0.3 microns wide, so let's set this as our
-`track_width`. Note that we invoked `plt.colorbar()` to add a little color legend here.
+`track_width`. Note that we invoked :func:`plt.colorbar() <matplotlib.pyplot.colorbar()>` to add a little color legend here.
 
 .. image:: kymo_zoom.png
 
@@ -121,7 +121,7 @@ an acceptable result.
 Maximum Likelihood Estimation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The function `refine_tracks_gaussian()` instead uses an MLE optimization of a Poisson likelihood with a Gaussian expectation
+The function :func:`~lumicks.pylake.refine_tracks_gaussian()` instead uses an MLE optimization of a Poisson likelihood with a Gaussian expectation
 to characterize both the expected peak shape and photonic noise of the observed signal, adapted from :cite:`mortensen2010gauloc`.
 For each frame in the kymograph, we fit a small region around the tracked peak to the data by maximizing the following likelihood function:
 
@@ -179,7 +179,8 @@ Computing the appropriate photons/pixel background considering a Poissonian nois
 
     offset = np.mean(kymo_cropped.green_image)
 
-The independently determined offset (in photons per pixel) can then be provided directly to `lk.refine_tracks_gaussian`::
+The independently determined offset (in photons per pixel) can then be provided directly to
+:func:`lk.refine_tracks_gaussian <lumicks.pylake.refine_tracks_gaussian()>`::
 
     refined = lk.refine_tracks_gaussian(tracks, window=3, refine_missing_frames=True, overlap_strategy="skip", fixed_background=offset)
 
@@ -256,27 +257,31 @@ We can easily plot some histograms of the binding events located with the kymotr
 
 .. image:: kymo_bind_histogram_1.png
 
-Here, the `kind="binding"` argument indicates that we only wish to analyze the initial binding events (the first
-position of each track). We can optionally supply a `bins` argument, which is forwarded to `np.histogram()`.
-For instance, we can increase the number of bins from 10 (the default) to 50::
+Here, the `kind="binding"` argument indicates that we only wish to analyze the initial binding
+events (the first position of each track). We can optionally supply a `bins` argument, which is
+forwarded to :func:`np.histogram() <numpy.histogram()>`. For instance, we can increase the number
+of bins from 10 (the default) to 50::
 
     plt.figure()
     tracks.plot_binding_histogram("binding", bins=50)
 
 .. image:: kymo_bind_histogram_2.png
 
-When an integer is supplied to the `bins` argument, the full position range is used to calculate the bin edges (this is
-equivalent to using `np.histogram(data, bins=n, range=(0, max_position))`). This facilitates comparison of histograms calculated
-from different kymographs, as the absolute x-scale is dependent on the kymograph acquisition options, rather than the positions
-of the tracks. Alternatively, it is possible to supply a custom array of bin edges, as demonstrated below::
+When an integer is supplied to the `bins` argument, the full position range is used to calculate
+the bin edges (this is equivalent to using :func:`np.histogram(data, bins=n, range=(0,
+max_position)) <numpy.histogram()>`). This facilitates comparison of histograms calculated from
+different kymographs, as the absolute x-scale is dependent on the kymograph acquisition options,
+rather than the positions of the tracks. Alternatively, it is possible to supply a custom array of
+bin edges, as demonstrated below::
 
     plt.figure()
     tracks.plot_binding_histogram("kind=all", bins=np.linspace(12, 18, 75), fc="#dcdcdc", ec="tab:blue")
 
 .. image:: kymo_bind_histogram_3.png
 
-Notice that here we use `kind="all"` to include all of the bound positions for each track. This snippet also demonstrates
-how we can pass keyword arguments (forwarded to `plt.bar()`) to format the histogram.
+Notice that here we use `kind="all"` to include all of the bound positions for each track. This
+snippet also demonstrates how we can pass keyword arguments (forwarded to :func:`plt.bar()
+<matplotlib.pyplot.bar()>`) to format the histogram.
 
 
 Exporting kymograph tracks
@@ -488,7 +493,7 @@ To fit the bound dwelltime distribution to a single exponential (the simplest ca
 
     dwell = traces.fit_binding_times(n_components=1)
 
-This returns a `DwelltimeModel` object which contains information about the optimized model, such as the lifetime of the state in seconds::
+This returns a :class:`~lumicks.pylake.DwelltimeModel` object which contains information about the optimized model, such as the lifetime of the state in seconds::
 
     print(dwell.lifetimes)
 
@@ -501,6 +506,6 @@ We can also try a double exponential fit::
 For a detailed description of the optimization method and available attributes/methods see the Dwelltime Analysis section
 in :doc:`Population Dynamics </tutorial/population_dynamics>`.
 
-Note: the `min_observation_time` and `max_observation_time` arguments to the underlying `DwelltimeModel` are set automatically by this method.
+Note: the `min_observation_time` and `max_observation_time` arguments to the underlying :class:`~lumicks.pylake.DwelltimeModel` are set automatically by this method.
 The minimum length of the tracks depends not only on the pixel dwell time but also the specific input parameters used for the tracking algorithm.
 Therefore, in order to estimate these bounds, the method uses the shortest track time and the length of the experiment, respectively.

--- a/docs/tutorial/nbwidgets.rst
+++ b/docs/tutorial/nbwidgets.rst
@@ -22,9 +22,10 @@ regions using a widget. Let's load the file and run the widget::
 
 .. image:: slice_widget.png
 
-You can use the left mouse button to select time ranges (by clicking the left and then the right boundary of the region
-you wish to select). The right mouse button can be used to remove previous selections. We can access the selected
-timestamps of the ranges we selected by invoking `selector.ranges`::
+You can use the left mouse button to select time ranges (by clicking the left and then the right
+boundary of the region you wish to select). The right mouse button can be used to remove previous
+selections. We can access the selected timestamps of the ranges we selected by invoking
+:attr:`selector.ranges <lumicks.pylake.FdRangeSelector.ranges>`::
 
     >>> selector.ranges
     [array([1572279165841737600, 1572279191523516800], dtype=int64),
@@ -71,8 +72,9 @@ These timestamps can directly be used to extract the relevant data::
 
 .. image:: fd_widget2.png
 
-This produces a separate plot for each selection. There's also a more direct way to get these plots, namely through
-`FdRangeSelector.fdcurves`. This gives you an `FdCurve` for each section you selected::
+This produces a separate plot for each selection. There's also a more direct way to get these
+plots, namely through :attr:`FdRangeSelector.fdcurves <lumicks.pylake.FdRangeSelector.fdcurves>`.
+This gives you an :class:`~lumicks.pylake.fdcurve.FdCurve` for each section you selected::
 
     for fdcurve in selector.fdcurves["Fd pull #6"]:
         plt.figure()
@@ -117,7 +119,7 @@ It is also possible to select a portion of an F,d curve based on distance::
 
 .. image:: fd_dist_widget.png
 
-Again, we can retrieve the selected data just as with `FdRangeSelector`::
+Again, we can retrieve the selected data just as with :class:`~lumicks.pylake.FdRangeSelector`::
 
     original = fdcurves["Fd pull #6"]
     sliced = selector.fdcurves["Fd pull #6"][0]
@@ -142,7 +144,7 @@ trace falling slightly outside of the thresholds, as illustrated below:
 .. image:: fd_dist_widget3a.png
 
 To avoid premature truncation caused by this noise, there is an additional `max_gap` keyword argument
-to `FdDistanceRangeSelector` that can be used to adjust the acceptable length of noise gaps. The default values
+to :class:`~lumicks.pylake.FdDistanceRangeSelector` that can be used to adjust the acceptable length of noise gaps. The default values
 is zero, such that all data points are guaranteed to fall within the selected distance range. The effect of this
 argument is shown below for an F,d curve sliced with the same distance thresholds:
 
@@ -161,7 +163,7 @@ The selector widgets can also be easily accessed from single F,d curve instances
 Cropping and Rotating Image Stacks
 ----------------------------------
 
-You can interactively define the location of a tether for a `CorrelatedStack` by using::
+You can interactively define the location of a tether for a :class:`~lumicks.pylake.correlated_stack.CorrelatedStack` by using::
 
     stack = lk.CorrelatedStack("cas9_wf.tiff")
     editor = stack.crop_and_rotate()
@@ -185,9 +187,12 @@ you can edit the shape by right-clicking and dragging the various handles.
 
 You can also use the mouse wheel to scroll through the individual frames (if using Jupyter Lab, hold `Shift` while scrolling).
 
-*Note that* `CorrelatedStack.crop_and_rotate()` *accepts all of the arguments that can be used for* `CorrelatedStack.plot()`.
+*Note that* :meth:`CorrelatedStack.crop_and_rotate()
+<lumicks.pylake.correlated_stack.CorrelatedStack.crop_and_rotate()>` *accepts all of the arguments
+that can be used for* :meth:`CorrelatedStack.plot()
+<lumicks.pylake.correlated_stack.CorrelatedStack.plot()>`.
 
-To obtain a copy of the edited `CorrelatedStack` object, use::
+To obtain a copy of the edited :class:`~lumicks.pylake.correlated_stack.CorrelatedStack` object, use::
 
     new_stack = editor.image
     new_stack.plot()

--- a/docs/tutorial/population_dynamics.rst
+++ b/docs/tutorial/population_dynamics.rst
@@ -83,7 +83,7 @@ in order to ensure robust results, it may be advisable to carry out the analysis
 Dwelltime analysis
 ------------------
 
-The lifetimes of bound states can be estimated by fitting to an Exponential distribution. The `DwelltimeModel` class can be used
+The lifetimes of bound states can be estimated by fitting to an Exponential distribution. The :class:`~lumicks.pylake.DwelltimeModel` class can be used
 to optimize the model parameters for an array of determined dwelltimes::
 
     dwell_1 = lk.DwelltimeModel(dwelltimes_seconds, n_components=1)

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -13,9 +13,9 @@ from .nb_widgets.range_selector import SliceRangeSelectorWidget
 class Slice:
     """A lazily evaluated slice of a timeline/HDF5 channel
 
-    Users will only ever get these as a result of slicing a timeline/HDF5
-    channel or slicing another slice (via this class' `__getitem__`), i.e.
-    the `__init__` method will never be invoked by users.
+    Users will only ever get this as a result of slicing a timeline/HDF5 channel or slicing another
+    slice (via this class's :meth:`__getitem__()`), i.e. the `__init__()` method should never be
+    directly invoked by users.
 
     Parameters
     ----------
@@ -240,9 +240,9 @@ class Slice:
             A list of (start, stop) tuples indicating over which ranges to apply the function.
             Start and stop have to be specified in nanoseconds.
         reduce : callable
-            The `numpy` function which is going to reduce multiple samples into one.
-            The default is `np.mean`, but `np.sum` could also be appropriate for some
-            cases, e.g. photon counts.
+            The :mod:`numpy` function which is going to reduce multiple samples into one. The
+            default is :func:`np.mean <numpy.mean>`, but :func:`np.sum <numpy.sum>` could also be
+            appropriate for some cases, e.g. photon counts.
         where : str
             Where to put the final time point.
 
@@ -300,9 +300,9 @@ class Slice:
         frequency : int
             The desired downsampled frequency downsampled (Hz)
         reduce : callable
-            The `numpy` function which is going to reduce multiple samples into one.
-            The default is `np.mean`, but `np.sum` could also be appropriate for some
-            cases, e.g. photon counts.
+            The :mod:`numpy` function which is going to reduce multiple samples into one. The
+            default is :func:`np.mean <numpy.mean>`, but :func:`np.sum <numpy.sum>` could also be
+            appropriate for some cases, e.g. photon counts.
         where : str
             Where to put the final time point.
 
@@ -377,9 +377,9 @@ class Slice:
         factor : int
             The size and sample rate of the data will be divided by this factor.
         reduce : callable
-            The `numpy` function which is going to reduce multiple samples into one.
-            The default is `np.mean`, but `np.sum` could also be appropriate for some
-            cases, e.g. photon counts.
+            The :mod:`numpy` function which is going to reduce multiple samples into one. The
+            default is :func:`np.mean <numpy.mean>`, but :func:`np.sum <numpy.sum>` could also be
+            appropriate for some cases, e.g. photon counts.
         """
         return self._with_data_source(self._src.downsampled_by(factor, reduce))
 
@@ -389,18 +389,18 @@ class Slice:
         Note: some data required to reconstruct the first low frequency time point can actually occur before the starting
         timestamp of the marker and is therefore missing from the exported `.h5` file. Therefore, it is not always possible
         to downsample to all of the data points in the low frequency `other_slice`. This function returns both the
-        requested downsampled channel data *and* a copy of the input channel cropped such that both returned `Slice` objects
+        requested downsampled channel data *and* a copy of the input channel cropped such that both returned :class:`~lumicks.pylake.channel.Slice` objects
         have the same time points.
 
         Parameters
         ----------
         other_slice : Slice
-            Timeline channel to downsample like. This should be a low frequency channel that provides the timestamps
-            to downsample to.
+            Timeline channel to downsample like. This should be a low frequency channel that
+            provides the timestamps to downsample to.
         reduce : callable
-            The `numpy` function which is going to reduce multiple samples into one.
-            The default is `np.mean`, but `np.sum` could also be appropriate for some
-            cases, e.g. photon counts.
+            The :mod:`numpy` function which is going to reduce multiple samples into one. The
+            default is :func:`np.mean <numpy.mean>`, but :func:`np.sum <numpy.sum>` could also be
+            appropriate for some cases, e.g. photon counts.
 
         Returns
         -------

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -138,7 +138,10 @@ class CorrelatedStack(VideoExport, FrameIndex):
 
     @classmethod
     @deprecated(
-        reason=("Renamed to `from_dataset()` for consistency with `Kymo` and `Scan`."),
+        reason=(
+            "Renamed to :func:`from_dataset` for consistency with "
+            ":class:`~lumicks.pylake.kymo.Kymo` and :class:`~lumicks.pylake.scan.Scan`."
+        ),
         action="always",
         version="0.10.1",
     )
@@ -249,7 +252,7 @@ class CorrelatedStack(VideoExport, FrameIndex):
             Controls display of auto-generated plot title
         axes : mpl.axes.Axes or None
             If supplied, the axes instance in which to plot.
-        image_handle : `matplotlib.image.AxesImage` or None
+        image_handle : matplotlib.image.AxesImage or None
             Optional image handle which is used to update plots with new data rather than
             reconstruct them (better for performance).
         **kwargs
@@ -372,8 +375,8 @@ class CorrelatedStack(VideoExport, FrameIndex):
             Frame to show.
         reduce : callable
             The function which is going to reduce multiple samples into one. The default is
-            :func:`numpy.mean`, but :func:`numpy.sum` could also be appropriate for some cases
-            e.g. photon counts.
+            :func:`np.mean <numpy.mean>`, but :func:`np.sum <numpy.sum>` could also be appropriate
+            for some cases e.g. photon counts.
         channel : 'rgb', 'red', 'green', 'blue', None; optional
             Channel to plot for RGB images (None defaults to 'rgb')
             Not used for grayscale images
@@ -480,9 +483,10 @@ class CorrelatedStack(VideoExport, FrameIndex):
     @property
     @deprecated(
         reason=(
-            "Access to raw frame instances will be removed in a future release. "
-            "All operations on these objects should be handled through the `CorrelatedStack` public API. "
-            "For example, to retrieve the image data as an `np.ndarray` please use `CorrelatedStack.get_image()`."
+            "Access to raw frame instances will be removed in a future release. All operations on "
+            "these objects should be handled through the :class:`CorrelatedStack` public API. For "
+            "example, to retrieve the image data as an :class:`numpy.ndarray` please use "
+            ":func:`get_image`."
         ),
         action="always",
         version="0.10.1",
@@ -508,7 +512,7 @@ class CorrelatedStack(VideoExport, FrameIndex):
     @deprecated(
         reason=(
             "For camera based images only the integration start/stop timestamps are defined. "
-            "Use `CorrelatedStack.frame_timestamp_ranges()` instead."
+            "Use :func:`frame_timestamp_ranges` instead."
         ),
         action="always",
         version="0.11.1",

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -264,7 +264,10 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
         raise NotImplementedError
 
     @deprecated(
-        reason=("`plot_red()` is deprecated. Use `plot(channel='red')` instead."),
+        reason=(
+            "This method will be removed in a future release. Use :meth:`plot(channel='red') "
+            "<plot()>` instead."
+        ),
         version="0.11.1",
         action="always",
     )
@@ -273,7 +276,10 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
         return self.plot(channel="red", **kwargs)
 
     @deprecated(
-        reason="`plot_green()` is deprecated. Use `plot(channel='green')` instead.",
+        reason=(
+            "This method will be removed in a future release. Use :meth:`plot(channel='green') "
+            "<plot()>` instead."
+        ),
         version="0.11.1",
         action="always",
     )
@@ -282,7 +288,10 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
         return self.plot(channel="green", **kwargs)
 
     @deprecated(
-        reason="`plot_blue()` is deprecated. Use `plot(channel='blue')` instead.",
+        reason=(
+            "This method will be removed in a future release. Use :meth:`plot(channel='blue') "
+            "<plot()>` instead."
+        ),
         version="0.11.1",
         action="always",
     )
@@ -291,7 +300,10 @@ class BaseScan(PhotonCounts, ExcitationLaserPower):
         return self.plot(channel="blue", **kwargs)
 
     @deprecated(
-        reason="`plot_rgb()` is deprecated. Use `plot(channel='rgb')` instead.",
+        reason=(
+            "This method will be removed in a future release. Use :meth:`plot(channel='rgb') "
+            "<plot()>` instead."
+        ),
         version="0.11.1",
         action="always",
     )
@@ -400,8 +412,8 @@ class ConfocalImage(BaseScan):
 
     @deprecated(
         reason=(
-            "This method has been renamed to `export_tiff` to more accurately reflect that it is "
-            "exporting to a different format."
+            "This method has been renamed to :meth:`export_tiff()` to more accurately reflect that "
+            "it is exporting to a different format."
         ),
         action="always",
         version="0.13.0",
@@ -423,6 +435,7 @@ class ConfocalImage(BaseScan):
 
     @property
     def pixels_per_line(self):
+        """Number of pixels in each line"""
         return self._num_pixels[self._metadata.scan_order[0]]
 
     @property
@@ -431,6 +444,7 @@ class ConfocalImage(BaseScan):
 
     @property
     def fast_axis(self):
+        """The axis that was scanned (x or y)"""
         return self._metadata.fast_axis
 
     @property
@@ -463,7 +477,8 @@ class ConfocalImage(BaseScan):
     @property
     @deprecated(
         reason=(
-            "This property will be removed in a future release. Use `get_image('red')` instead."
+            "This property will be removed in a future release. Use :meth:`get_image('red') "
+            " <get_image()>` instead."
         ),
         action="always",
         version="0.12.0",
@@ -475,7 +490,8 @@ class ConfocalImage(BaseScan):
     @property
     @deprecated(
         reason=(
-            "This property will be removed in a future release. Use `get_image('green')` instead."
+            "This property will be removed in a future release. Use :meth:`get_image('green') "
+            " <get_image()>` instead."
         ),
         action="always",
         version="0.12.0",
@@ -487,7 +503,8 @@ class ConfocalImage(BaseScan):
     @property
     @deprecated(
         reason=(
-            "This property will be removed in a future release. Use `get_image('blue')` instead."
+            "This property will be removed in a future release. Use :meth:`get_image('blue') "
+            " <get_image()>` instead."
         ),
         action="always",
         version="0.12.0",
@@ -499,7 +516,8 @@ class ConfocalImage(BaseScan):
     @property
     @deprecated(
         reason=(
-            "This property will be removed in a future release. Use `get_image('rgb')` instead."
+            "This property will be removed in a future release. Use :meth:`get_image('rgb') "
+            " <get_image()>` instead."
         ),
         action="always",
         version="0.12.0",
@@ -509,7 +527,7 @@ class ConfocalImage(BaseScan):
         return self.get_image("rgb")
 
     def get_image(self, channel="rgb") -> np.ndarray:
-        """Get image data for the full stack as an `np.ndarray`.
+        """Get image data for the full stack as an :class:`~numpy.ndarray`.
 
         Parameters
         ----------

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -157,8 +157,8 @@ def reconstruct_image(data, infowave, shape, reduce=np.sum):
     shape: array_like
         The shape of the image ([optional: pixels on slow axis], pixels on fast axis)
     reduce : callable
-        A function which reduces multiple sample into a pixel. Usually `np.sum`
-        for photon counts and `np.mean` for force samples.
+        A function which reduces multiple sample into a pixel. Usually :func:`np.sum <numpy.sum>`
+        for photon counts and :func:`np.mean <numpy.mean>` for force samples.
 
     Returns
     -------

--- a/lumicks/pylake/fdcurve.py
+++ b/lumicks/pylake/fdcurve.py
@@ -15,7 +15,7 @@ class FdCurve(DownsampledFD):
     """An FD curve exported from Bluelake
 
     By default, the primary force and distance channels are `downsampled_force2`
-    and `distance1`. Alternatives can be selected using `FdCurve.with_channels()`.
+    and `distance1`. Alternatives can be selected using :func:`FdCurve.with_channels()`.
     Note that it does not modify the FD curve in place but returns a copy.
 
     Attributes
@@ -218,7 +218,7 @@ class FdCurve(DownsampledFD):
         Parameters
         ----------
         **kwargs
-            Forwarded to `~matplotlib.pyplot.scatter`.
+            Forwarded to :func:`matplotlib.pyplot.scatter`.
         """
         import matplotlib.pyplot as plt
 

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -66,7 +66,7 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
 
     @classmethod
     def from_h5py(cls, h5py_file):
-        """Directly load an existing `h5py.File`"""
+        """Directly load an existing `h5py.File <https://docs.h5py.org/en/latest/high/file.html>`_"""
         new_file = cls.__new__(cls)
         new_file.h5 = h5py_file
         new_file._check_file_format()
@@ -267,22 +267,27 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
 
     @property
     def kymos(self) -> Dict[str, Kymo]:
+        """Kymos stored in the file"""
         return self._get_object_dictionary("Kymograph", Kymo)
 
     @property
     def point_scans(self) -> Dict[str, Scan]:
+        """Point Scans stored in the file"""
         return self._get_object_dictionary("Point Scan", PointScan)
 
     @property
     def scans(self) -> Dict[str, Scan]:
+        """Confocal Scans stored in the file"""
         return self._get_object_dictionary("Scan", Scan)
 
     @property
     def fdcurves(self) -> Dict[str, FdCurve]:
+        """FdCurves stored in the file"""
         return self._get_object_dictionary("FD Curve", FdCurve)
 
     @property
     def markers(self) -> Dict[str, Marker]:
+        """Markers stored in the file"""
         return self._get_object_dictionary("Marker", Marker)
 
     def save_as(self, filename, compression_level=5, omit_data={}):

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -118,7 +118,7 @@ class Fit:
 
     @property
     def params(self):
-        """Fit parameters. See also `pylake.fitting.Params`"""
+        """Fit parameters. See also `pylake.fitting.parameters.Params`"""
         self._rebuild()
         return self._params
 
@@ -132,8 +132,8 @@ class Fit:
         return dirty
 
     def _rebuild(self):
-        """Checks whether the model state is up to date. Any user facing methods should ideally check whether the model
-        needs to be rebuilt."""
+        """Checks whether the model state is up to date. Any user facing methods should ideally
+        check whether the model needs to be rebuilt."""
         if self.dirty:
             self._build_fit()
 
@@ -141,8 +141,8 @@ class Fit:
         self._built = False
 
     def _build_fit(self):
-        """This function generates the global parameter list from the parameters of the individual sub models.
-        It also generates unique conditions from the data specification."""
+        """This function generates the global parameter list from the parameters of the individual
+        sub models. It also generates unique conditions from the data specification."""
         all_parameter_names = [
             p for data_set in self.datasets.values() for p in data_set._transformed_params
         ]
@@ -443,7 +443,7 @@ class Fit:
             Show data.
         overrides : dict
             Parameter / value pairs which override parameter values in the current fit. Should be
-            a dict of `{str: float}` that provides values for parameters which should be set to
+            a dict of ``{str: float}`` that provides values for parameters which should be set to
             particular values in the plot.
         ``**kwargs``
             Forwarded to :func:`matplotlib.pyplot.plot`.

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -42,28 +42,29 @@ class Model:
         """
         Model constructor. A Model must be named, and this name will appear in the model parameters.
 
-        Ideally a jacobian and derivative w.r.t. the independent variable are provided with every model. This will
-        allow much higher performance when fitting. Jacobians and derivatives are automatically propagated to composite
-        models, inversions of models etc. provided that all participating models have jacobians and derivatives
-        specified.
+        Ideally a jacobian and derivative w.r.t. the independent variable are provided with every
+        model. This will allow much higher performance when fitting. Jacobians and derivatives are
+        automatically propagated to composite models, inversions of models etc. provided that all
+        participating models have jacobians and derivatives specified.
 
         Parameters
         ----------
         name : str
             Name for the model. This name will be prefixed to the model parameter names.
         model_function : callable
-            Function containing the model function. Must return the model prediction given values for the independent
-            variable and parameters.
+            Function containing the model function. Must return the model prediction given values
+            for the independent variable and parameters.
         dependent : str (optional)
             Name of the dependent variable
         independent : str (optional)
             Name of the independent variable
         jacobian : callable (optional)
-            Function which computes the first order derivatives with respect to the parameters for this model.
-            When supplied, this function is used to speed up the optimization considerably.
+            Function which computes the first order derivatives with respect to the parameters for
+            this model. When supplied, this function is used to speed up the optimization
+            considerably.
         derivative : callable (optional)
-            Function which computes the first order derivative with respect to the independent parameter. When supplied
-            this speeds up model inversions considerably.
+            Function which computes the first order derivative with respect to the independent
+            parameter. When supplied this speeds up model inversions considerably.
         eqn : str (optional)
             Equation that this model is specified by.
         eqn_tex : str (optional)
@@ -138,7 +139,7 @@ class Model:
         Parameters
         ----------
         independent : array_like
-        params : ``pylake.fitting.Params``
+        params : lumicks.pylake.fitting.parameters.Params
         """
         independent = np.asarray(independent, dtype=np.float64)
         missing_parameters = set(self.parameter_names) - set(params.keys())
@@ -226,11 +227,11 @@ class Model:
         This operation swaps the dependent and independent parameter and should be avoided if a
         faster alternative (such as an analytically inverted model) exists.
 
-        By default, this function returns an inverted version of the model, where the function
-        is inverted for each point using a least squares optimizer. Alternatively, one can use
-        an interpolation method to perform the inversion (here the relation is interpolated using
-        a spline and the result is looked up). Note that for the interpolation method, the range
-        used for the independent variable must be known a-priori.
+        By default, this function returns an inverted version of the model, where the function is
+        inverted for each point using a least squares optimizer. Alternatively, one can use an
+        interpolation method to perform the inversion (here the relation is interpolated using a
+        spline and the result is looked up). Note that for the interpolation method, the range used
+        for the independent variable must be known a-priori.
 
         Parameters
         ----------
@@ -345,8 +346,8 @@ class Model:
 
     def verify_jacobian(self, independent, params, plot=False, verbose=True, dx=1e-6, **kwargs):
         """
-        Verify this model's Jacobian with respect to the independent variable by comparing it to the Jacobian
-        obtained with finite differencing.
+        Verify this model's Jacobian with respect to the independent variable by comparing it to the
+        Jacobian obtained with finite differencing.
 
         Parameters
         ----------
@@ -361,7 +362,7 @@ class Model:
         dx : float
             Finite difference excursion.
         **kwargs :
-            Forwarded to `~matplotlib.pyplot.plot`.
+            Forwarded to :func:`matplotlib.pyplot.plot()`.
         """
         if len(params) != len(self._params):
             raise ValueError(
@@ -399,8 +400,8 @@ class Model:
 
     def verify_derivative(self, independent, params, dx=1e-6, **kwargs):
         """
-        Verify this model's derivative with respect to the independent variable by comparing it to the derivative
-        obtained with finite differencing.
+        Verify this model's derivative with respect to the independent variable by comparing it to
+        the derivative obtained with finite differencing.
 
         Parameters
         ----------
@@ -433,9 +434,9 @@ class Model:
         independent : array_like
             Array of values for the independent variable.
         fmt : str (optional)
-            Plot formatting string (see `matplotlib.pyplot.plot` documentation).
+            Plot formatting string (see :func:`matplotlib.pyplot.plot()` documentation).
         **kwargs :
-            Forwarded to `~matplotlib.pyplot.plot`.
+            Forwarded to :func:`matplotlib.pyplot.plot()`.
 
         Examples
         --------

--- a/lumicks/pylake/fitting/models.py
+++ b/lumicks/pylake/fitting/models.py
@@ -361,8 +361,8 @@ def ewlc_odijk_force(name):
     """Odijk's Extensible Worm-Like Chain model with force as dependent variable
 
     Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_. Note that
-    this implementation was analytically solved and is significantly faster than fitting the
-    model obtained with `lk.ewlc_odijk_distance("name").invert()`.
+    this implementation was analytically solved and is significantly faster than fitting the model
+    obtained with `lumicks.pylake.ewlc_odijk_distance("name").invert()`.
 
     Parameters
     ----------

--- a/lumicks/pylake/force_calibration/detail/power_models.py
+++ b/lumicks/pylake/force_calibration/detail/power_models.py
@@ -24,7 +24,7 @@ def fit_analytical_lorentzian(ps):
         - `fc` : corner frequency [Hz]
         - `D`: diffusion constant [V^2/s]
         - `sigma_fc`, `sigma_D`: 1-sigma confidence intervals for `fc` and `D`
-        - `ps_fit`: `PowerSpectrum` object with model fit
+        - `ps_fit`: :class:`~lumicks.pylake.force_calibration.power_spectrum.PowerSpectrum` object with model fit
 
         Note: returns None if the fit fails.
     """

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -51,11 +51,11 @@ class CalibrationResults:
 
     Attributes
     ----------
-    model : `lumicks.pylake.force_calibration.CalibrationModel`
+    model : lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationModel
         Model used for calibration.
-    ps_model : `lumicks.pylake.PowerSpectrum`
+    ps_model : PowerSpectrum
         Power spectrum of the fitted model.
-    ps_data : `lumicks.pylake.PowerSpectrum`
+    ps_data : PowerSpectrum
         Power spectrum of the data that the model was fitted to.
     params : dict
         Dictionary of input parameters.
@@ -137,7 +137,8 @@ class CalibrationResults:
 def calculate_power_spectrum(
     data, sample_rate, fit_range=(1e2, 23e3), num_points_per_block=2000, excluded_ranges=None
 ):
-    """Compute power spectrum and returns it as a :class:`~.PowerSpectrum`.
+    """Compute power spectrum and return it as a
+    :class:`~lumicks.pylake.force_calibration.power_spectrum.PowerSpectrum`.
 
     Parameters
     ----------
@@ -156,7 +157,7 @@ def calculate_power_spectrum(
 
     Returns
     -------
-    :class:`~.PowerSpectrum`
+    PowerSpectrum
         Estimated power spectrum based.
     """
     if not isinstance(data, np.ndarray) or (data.ndim != 1):
@@ -203,7 +204,7 @@ def fit_power_spectrum(
 
     Returns
     -------
-    :class:`~.CalibrationResults`
+    CalibrationResults
         Parameters obtained from the calibration procedure.
 
     References

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -216,7 +216,7 @@ class Kymo(ConfocalImage):
 
     @property
     def shape(self):
-        """Shape of the reconstructed `Kymo` image"""
+        """Shape of the reconstructed :class:`~lumicks.pylake.kymo.Kymo` image"""
         # For a kymo the only way to find the shape is to perform the reconstruction. While one
         # could traverse the info-wave for this purpose, we may as well just reconstruct the image
         # since that still has the potential to be useful in the future (since it is cached).
@@ -300,14 +300,14 @@ class Kymo(ConfocalImage):
         aspect_ratio: float
             aspect ratio of the axes (i.e. ratio of y-unit to x-unit)
         reduce : callable
-            The `numpy` function which is going to reduce multiple samples into one.
-            Forwarded to :func:`Slice.downsampled_over`
+            The :mod:`numpy` function which is going to reduce multiple samples into one. Forwarded
+            to :meth:`Slice.downsampled_over() <lumicks.pylake.channel.Slice.downsampled_over()>`
         kymo_args : dict
-            Forwarded to :func:`matplotlib.pyplot.imshow`
+            Forwarded to :func:`matplotlib.pyplot.imshow()`
         adjustment : lk.ColorAdjustment
             Color adjustments to apply to the output image.
         **kwargs
-            Forwarded to :func:`Slice.plot`.
+            Forwarded to :meth:`Slice.plot() <lumicks.pylake.channel.Slice.plot()>`.
         """
 
         def set_aspect_ratio(axis, ar):
@@ -492,8 +492,8 @@ class Kymo(ConfocalImage):
         position_factor : int
             The number of pixels that will be averaged in space (default: 1).
         reduce : callable
-            The `numpy` function which is going to reduce multiple pixels into one.
-            The default is `np.sum`.
+            The :mod:`numpy` function which is going to reduce multiple pixels into one. The default
+            is :func:`np.sum <numpy.sum()>`.
         """
         result = copy(self)
 
@@ -542,6 +542,7 @@ class Kymo(ConfocalImage):
         return result
 
     def flip(self):
+        """Flip the kymograph along the positional axis"""
         result = copy(self)
 
         def image_factory(_, channel):
@@ -590,7 +591,7 @@ class Kymo(ConfocalImage):
             If provided, the kymo returned from the `image` property will be automatically
             calibrated to this tether length.
         **kwargs
-            Forwarded to :func:`Kymo.plot()`.
+            Forwarded to :meth:`Kymo.plot()`.
 
         Examples
         --------
@@ -632,7 +633,8 @@ class EmptyKymo(Kymo):
     @property
     @deprecated(
         reason=(
-            "This property will be removed in a future release. Use `get_image('red')` instead."
+            "This property will be removed in a future release. Use :meth:`get_image('red') "
+            "<get_image()>` instead."
         ),
         action="always",
         version="0.12.0",
@@ -643,7 +645,8 @@ class EmptyKymo(Kymo):
     @property
     @deprecated(
         reason=(
-            "This property will be removed in a future release. Use `get_image('green')` instead."
+            "This property will be removed in a future release. Use :meth:`get_image('green') "
+            "<get_image()>` instead."
         ),
         action="always",
         version="0.12.0",
@@ -654,7 +657,8 @@ class EmptyKymo(Kymo):
     @property
     @deprecated(
         reason=(
-            "This property will be removed in a future release. Use `get_image('blue')` instead."
+            "This property will be removed in a future release. Use :meth:`get_image('blue') "
+            "<get_image()>` instead."
         ),
         action="always",
         version="0.12.0",
@@ -686,7 +690,7 @@ def _kymo_from_array(
     pixel_size_um=None,
     name="",
 ):
-    """Generate a `Kymo` instance from an image array.
+    """Generate a :class:`~lumicks.pylake.kymo.Kymo` instance from an image array.
 
     Parameters
     ----------
@@ -775,7 +779,7 @@ def _kymo_from_array(
 def _kymo_from_correlated_stack(
     corrstack, adjacent_lines=0, pixel_size_um=None, name="", reduce=np.mean
 ) -> Kymo:
-    """Generate a `Kymo` instance from a correlated stack.
+    """Generate a :class:`~lumicks.pylake.kymo.Kymo` instance from a correlated stack.
 
     Parameters
     ----------
@@ -793,7 +797,8 @@ def _kymo_from_correlated_stack(
         Kymo name.
     reduce : callable
         The function which is going to reduce multiple pixels into one. The default is
-        :func:`numpy.mean`, but :func:`numpy.max` could also be appropriate for some cases.
+        :func:`np.mean <numpy.mean()>, but :func:`np.max <numpy.max()>` could also be appropriate
+        for some cases.
     """
     # Ensure constant frame rate of the whole stack
     ts_ranges = np.array(corrstack.frame_timestamp_ranges())

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -98,13 +98,13 @@ class KymoTrack:
 
     Parameters
     ----------
-    time_idx : array-like
+    time_idx : array_like
         Frame time indices.
-    localization : LocalizationModel or array-like
+    localization : LocalizationModel or array_like
         LocalizationModel instance containing localization parameters
         or list of (sub)pixel coordinates to be converted to spatial
         position via calibration with pixel size.
-    kymo : lk.kymo.Kymo
+    kymo : Kymo
         Kymograph instance.
     channel : {"red", "green", "blue"}
         Color channel to analyze
@@ -314,7 +314,7 @@ class KymoTrack:
 
         Parameters
         ----------
-        max_lag : int (optional)
+        max_lag : int, optional
             Maximum lag to include. When omitted, an optimal number of lags is chosen [2]_.
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.plot`.
@@ -412,7 +412,8 @@ class KymoTrack:
 
     @deprecated(
         reason=(
-            'This method is replaced by `KymoTrack.estimate_diffusion(method="ols")` to allow more '
+            'This method is replaced by :meth:`KymoTrack.estimate_diffusion(method="ols") '
+            "<lumicks.pylake.kymotracker.KymoTrack.estimate_diffusion()>` to allow more "
             "flexibility in the choice of algorithms and provide additional metadata."
         ),
         action="always",

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -85,7 +85,7 @@ def track_greedy(
 
     Parameters
     ----------
-    kymograph : lumicks.pylake.Kymo
+    kymograph : Kymo
         The kymograph to track.
     channel : {'red', 'green', 'blue'}
         Color channel to track.
@@ -245,7 +245,7 @@ def track_lines(
 
     Parameters
     ----------
-    kymograph : lumicks.pylake.Kymo
+    kymograph : Kymo
         Kymograph.
     channel : str
         Kymograph channel.
@@ -295,7 +295,7 @@ def track_lines(
 
 
 @deprecated(
-    reason=("`filter_lines()` has been renamed to `filter_tracks()`."),
+    reason=("`filter_lines()` has been renamed to :func:`~lumicks.pylake.filter_tracks()`."),
     action="always",
     version="0.13.0",
 )
@@ -316,7 +316,7 @@ def filter_tracks(tracks, minimum_length):
 
     Parameters
     ----------
-    tracks : List[pylake.KymoTrack]
+    tracks : List[KymoTrack]
         Detected tracks on a kymograph.
     minimum_length : int
         Minimum length for the track to be accepted.
@@ -325,7 +325,9 @@ def filter_tracks(tracks, minimum_length):
 
 
 @deprecated(
-    reason=("`refine_lines_centroid()` has been renamed to `refine_tracks_centroid()`."),
+    reason=(
+        "`refine_lines_centroid()` has been renamed to :func:`~lumicks.pylake.refine_tracks_centroid()`."
+    ),
     action="always",
     version="0.13.0",
 )
@@ -358,7 +360,7 @@ def refine_tracks_centroid(tracks, track_width=None):
 
     Parameters
     ----------
-    tracks : List[pylake.KymoTrack]
+    tracks : List[KymoTrack]
         Detected tracks on a kymograph
     track_width : float
         Expected (spatial) spot size in physical units. Must be larger than zero.
@@ -401,7 +403,9 @@ def refine_tracks_centroid(tracks, track_width=None):
 
 
 @deprecated(
-    reason=("`refine_lines_gaussian()` has been renamed to `refine_tracks_gaussian()`."),
+    reason=(
+        "`refine_lines_gaussian()` has been renamed to :func:`~lumicks.pylake.refine_tracks_gaussian()`."
+    ),
     action="always",
     version="0.13.0",
 )
@@ -436,7 +440,7 @@ def refine_tracks_gaussian(
 
     Parameters
     ----------
-    tracks : List[pylake.KymoTrack] or pylake.KymoTrackGroup
+    tracks : List[KymoTrack] or KymoTrackGroup
         Detected tracks on a kymograph.
     window : int
         Number of pixels on either side of the estimated track to include in the optimization data.
@@ -445,11 +449,12 @@ def refine_tracks_gaussian(
     refine_missing_frames : bool
         Whether to estimate location for frames which were missed in initial peak finding.
     overlap_strategy : {'multiple', 'ignore', 'skip'}
-        How to deal with frames in which the fitting window of two `KymoTrack`'s overlap.
+        How to deal with frames in which the fitting window of two
+        :class:`~lumicks.pylake.kymotracker.kymotrack.KymoTrack`'s overlap.
 
         - 'multiple' : fit the peaks simultaneously.
         - 'ignore' : do nothing, fit the frame as-is (ignoring overlaps).
-        - 'skip' : skip optimization of the frame; remove from returned `KymoTrack`.
+        - 'skip' : skip optimization of the frame; remove from returned :class:`~lumicks.pylake.kymotracker.kymotrack.KymoTrack`.
     initial_sigma : float
         Initial guess for the `sigma` parameter.
     fixed_background : float

--- a/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
@@ -7,7 +7,7 @@ from lumicks.pylake.tests.data.mock_confocal import generate_kymo
 def test_kymotracker_test_bias_rect():
     """Computing the kymograph of a subset of the image should not affect the results of the
     tracking. If this test fires, it means that kymotracking on a subset of the image does not
-    produce the same result as on the full thing for `track_greedy()`.
+    produce the same result as on the full thing for :func:`~lumicks.pylake.track_greedy()`.
     """
 
     # Generate a checkerboard pattern with a single line that we wish to track. The line is on the

--- a/lumicks/pylake/kymotracker/tests/test_lines_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_lines_algorithm.py
@@ -84,7 +84,7 @@ def test_uni_directional():
 def test_kymotracker_test_bias_rect_lines():
     """Computing the kymograph of a subset of the image should not affect the results of the
     tracking. If this test fires, it means that kymotracking on a subset of the image does not
-    produce the same result as on the full thing for `track_lines()`.
+    produce the same result as on the full thing for :func:`~lumicks.pylake.track_lines()`.
     """
 
     img_data = np.array(

--- a/lumicks/pylake/nb_widgets/range_selector.py
+++ b/lumicks/pylake/nb_widgets/range_selector.py
@@ -143,7 +143,7 @@ class SliceRangeSelectorWidget(BaseRangeSelectorWidget):
 
     @property
     def slices(self):
-        """Return list of selected slices of data as `lumicks.pylake.Slice`"""
+        """Return list of selected slices of data as :class:`~lumicks.pylake.channel.Slice`"""
         return [self.slice[start:stop] for start, stop in self._ranges]
 
 
@@ -154,7 +154,7 @@ class FdTimeRangeSelectorWidget(SliceRangeSelectorWidget):
 
     @property
     def fdcurves(self):
-        """Return list of selected fdcurves of data as `lumicks.pylake.FdCurve`"""
+        """Return list of selected fdcurves of data as :class:`~lumicks.pylake.fdcurve.FdCurve`"""
         return [self.fd_curve[start:stop] for start, stop in self._ranges]
 
 
@@ -173,7 +173,7 @@ class FdDistanceRangeSelectorWidget(BaseRangeSelectorWidget):
 
     @property
     def fdcurves(self):
-        """Return list of selected fdcurves of data as `lumicks.pylake.FdCurve`"""
+        """Return list of selected fdcurves of data as :class:`~lumicks.pylake.fdcurve.FdCurve`"""
         return [
             self.fd_curve._sliced_by_distance(min_dist, max_dist, self._max_gap)
             for min_dist, max_dist in self._ranges
@@ -187,7 +187,7 @@ class BaseRangeSelector:
         Parameters
         ----------
         fd_curves : dict
-            Dictionary of `lumicks.pylake.FdCurve`
+            Dictionary of :class:`~lumicks.pylake.fdcurve.FdCurve`
         """
         import ipywidgets
 
@@ -234,7 +234,7 @@ class BaseRangeSelector:
 
     @property
     def fdcurves(self):
-        """Return list of selected fdcurves of data as `lumicks.pylake.FdCurve`"""
+        """Return list of selected fdcurves of data as :class:`~lumicks.pylake.fdcurve.FdCurve`"""
         return {key: selector.fdcurves for key, selector in self.selectors.items()}
 
 

--- a/lumicks/pylake/piezo_tracking/baseline.py
+++ b/lumicks/pylake/piezo_tracking/baseline.py
@@ -16,9 +16,9 @@ class ForceBaseLine:
         ----------
         model : callable
             Model which returns the baseline at specified points.
-        trap_data : lumicks.pylake.Slice
+        trap_data : Slice
             Trap mirror position data
-        force : lumicks.pylake.Slice
+        force : Slice
             Force data
         """
         self._model = model
@@ -38,9 +38,9 @@ class ForceBaseLine:
 
         Parameters
         ----------
-        force : lumicks.pylake.Slice
+        force : Slice
             Force data.
-        trap_position : lumicks.pylake.Slice
+        trap_position : Slice
             Trap position data (needs to be the same time range as the force data).
         """
 
@@ -66,7 +66,7 @@ class ForceBaseLine:
         Parameters
         ----------
         **kwargs
-            Forwarded to :func:`matplotlib.pyplot.scatter`.
+            Forwarded to :func:`matplotlib.pyplot.scatter()`.
         """
         plt.scatter(self._trap_data.data, self._force.data, s=2, **kwargs)
         plt.plot(self._trap_data.data, self._model(self._trap_data.data), "k")
@@ -98,9 +98,9 @@ class ForceBaseLine:
 
         Parameters
         ----------
-        trap_position : lumicks.pylake.Slice
+        trap_position : Slice
             Trap mirror position data
-        force : lumicks.pylake.Slice
+        force : Slice
             Force data
         degree : int
             Polynomial degree

--- a/lumicks/pylake/piezo_tracking/piezo_tracking.py
+++ b/lumicks/pylake/piezo_tracking/piezo_tracking.py
@@ -16,9 +16,9 @@ class DistanceCalibration:
 
         Parameters
         ----------
-        trap_position : lumicks.pylake.Slice
+        trap_position : Slice
             Trap position.
-        camera_distance : lumicks.pylake.Slice
+        camera_distance : Slice
             Camera distance as determined by Bluelake.
             NOTE: The distance data should already have the bead diameter subtracted by Bluelake.
         degree : int
@@ -80,7 +80,7 @@ class DistanceCalibration:
 
         Parameters
         ----------
-        calibration_file : pylake.File
+        calibration_file : lumicks.pylake.File
         degree : int
             Polynomial order.
         """
@@ -99,7 +99,7 @@ class PiezoTrackingCalibration:
     ):
         """Set up piezo tracking calibration
 
-        trap_calibration : pylake.DistanceCalibration
+        trap_calibration : DistanceCalibration
             Calibration from trap position to trap to trap distance.
         signs : tuple(float, float)
             Sign convention for forces (e.g. (1, -1) indicates that force2 is negative).
@@ -121,11 +121,11 @@ class PiezoTrackingCalibration:
 
         Parameters
         ----------
-        trap_position : pylake.channel.Slice
+        trap_position : Slice
             Trap position.
-        force1 : pylake.channel.Slice
+        force1 : Slice
             First force channel to use for piezo tracking.
-        force2 : pylake.channel.Slice
+        force2 : Slice
             Second force channel to use for piezo tracking.
         downsampling_factor : Optional[int]
             Downsampling factor.
@@ -158,11 +158,11 @@ class PiezoForceDistance:
     ):
         """Set up piezo force distance data
 
-        trap_calibration : pylake.DistanceCalibration
+        trap_calibration : DistanceCalibration
             Calibration from trap position to trap to trap distance.
-        baseline_force1 : pylake.ForceBaseline
+        baseline_force1 : ForceBaseline
             Baseline for force1 (optional)
-        baseline_force2 : pylake.ForceBaseline
+        baseline_force2 : ForceBaseline
             Baseline for force2 (optional)
         signs : tuple(float, float)
             Sign convention for forces (e.g. (1, -1) indicates that force2 is negative).
@@ -198,11 +198,11 @@ class PiezoForceDistance:
 
         Parameters
         ----------
-        trap_position : pylake.channel.Slice
+        trap_position : Slice
             Trap position.
-        force1 : pylake.channel.Slice
+        force1 : Slice
             First force channel to use for piezo tracking.
-        force2 : pylake.channel.Slice
+        force2 : Slice
             Second force channel to use for piezo tracking.
         trim : bool
             Trim regions outside the calibration range.

--- a/lumicks/pylake/point_scan.py
+++ b/lumicks/pylake/point_scan.py
@@ -19,7 +19,7 @@ class PointScan(BaseScan):
     """
 
     def _get_plot_data(self, channel):
-        """Get photon count `Slice` for requested channel."""
+        """Get photon count :class:`~lumicks.pylake.channel.Slice` for requested channel."""
         return getattr(self, f"{channel}_photon_count")
 
     def _plot(self, channel, axes, **kwargs):

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -152,7 +152,7 @@ class DwelltimeModel:
 
     Parameters
     ----------
-    dwelltimes : np.ndarray
+    dwelltimes : numpy.ndarray
         observations on which the model was trained. *Note: the units of the optimized lifetime
         will be in the units of the dwelltime data. If the dwelltimes are calculated as the number
         of frames, these then need to be multiplied by the frame time in order to obtain the
@@ -164,11 +164,11 @@ class DwelltimeModel:
     max_observation_time : float
         maximum experimental observation time.
     tol : float
-        The tolerance for optimization convergence. This parameter is forwarded as the `ftol` argument
-        to `scipy.minimize(method="SLSQP")`.
+        The tolerance for optimization convergence. This parameter is forwarded as the `ftol`
+        argument to :func:`scipy.optimize.minimize(method="SLSQP") <scipy.optimize.minimize()>`.
     max_iter : int
-        The maximum number of iterations to perform. This parameter is forwarded as the `maxiter` argument
-        to `scipy.minimize(method="SLSQP")`.
+        The maximum number of iterations to perform. This parameter is forwarded as the `maxiter`
+        argument to :func:`scipy.optimize.minimize(method="SLSQP") <scipy.optimize.minimize()>`.
     """
 
     def __init__(
@@ -246,8 +246,8 @@ class DwelltimeModel:
 
     @deprecated(
         reason=(
-            "This method has been renamed to more closely match its behavior. "
-            "Use `DwelltimeModel.hist()` instead."
+            "This method has been renamed to more closely match its behavior. Use "
+            ":meth:`DwelltimeModel.hist()` instead."
         ),
         action="always",
         version="0.12.0",

--- a/lumicks/pylake/population/mixture.py
+++ b/lumicks/pylake/population/mixture.py
@@ -26,7 +26,7 @@ class GaussianMixtureModel:
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Data object used for model training.
     n_states : int
         The number of Gaussian components in the model.

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -212,6 +212,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
 
     @property
     def num_frames(self):
+        """Number of available frames"""
         if self._metadata.num_frames == 0:
             self._metadata = self._metadata.with_num_frames(
                 reconstruct_num_frames(
@@ -354,6 +355,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
 
     @property
     def lines_per_frame(self):
+        """Number of scanned lines in each frame"""
         return self._num_pixels[self._metadata.scan_order[1]]
 
     @property
@@ -364,7 +366,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
 
     @property
     def shape(self):
-        """Shape of the reconstructed `Scan` image"""
+        """Shape of the reconstructed :class:`~lumicks.pylake.scan.Scan` image"""
         shape = reversed(self._num_pixels)
         return (self.num_frames, *shape, 3) if self.num_frames > 1 else (*shape, 3)
 

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -373,8 +373,11 @@ def test_save_tiff(tmpdir_factory, test_kymos):
     kymo = test_kymos["Kymo1"]
     kymo.export_tiff(f"{tmpdir}/kymo1.tiff")
     assert stat(f"{tmpdir}/kymo1.tiff").st_size > 0
-
-    with pytest.warns(DeprecationWarning, match="This method has been renamed to `export_tiff`"):
+    match = (
+        r"This method has been renamed to `export_tiff\(\)` to more accurately reflect that it is "
+        r"exporting to a different format."
+    )
+    with pytest.warns(DeprecationWarning, match=match):
         kymo.save_tiff(f"{tmpdir}/kymo2.tiff")
         assert stat(f"{tmpdir}/kymo2.tiff").st_size > 0
 

--- a/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
@@ -258,7 +258,11 @@ def test_export_tiff(tmpdir_factory, test_scans):
     assert stat(f"{tmpdir}/multi_frame.tiff").st_size > 0
 
     scan = test_scans["fast Y slow X"]
-    with pytest.warns(DeprecationWarning, match="This method has been renamed to `export_tiff`"):
+    match=(
+        r"This method has been renamed to `export_tiff\(\)` to more accurately reflect that it is "
+        r"exporting to a different format."
+    )
+    with pytest.warns(DeprecationWarning, match=match):
         scan.save_tiff(f"{tmpdir}/single_frame_dep.tiff")
         assert stat(f"{tmpdir}/single_frame_dep.tiff").st_size > 0
 


### PR DESCRIPTION
**Why this PR?**
As a user, I would like function mentions in the documentation to actually link to pages with the docstrings for those functions

To link python objects -mentioned in the documentation- to their corresponding documentation in the api section, I (tried to) replace(d) all default code blocks `PYTHON_OBJECT` with corresponding python roles (https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#python-roles). Additionally, I ensured to use the correct path and name of the python objects. The result is working links.

Additionally, I used a custom css file, to change the default color of the links from "black" to the same color of the sample code blocks (compare `KymoTrack` in the following images), as I find the colored links in the text easier to identify as clickable links:
![Black](https://user-images.githubusercontent.com/28353120/192230902-6cefad4a-be4b-415a-820a-5426089fa6ed.PNG)
![Colored](https://user-images.githubusercontent.com/28353120/192230893-446c8539-f186-4801-905e-e5ed9e8bb894.PNG)

However, this has the side effect, that also the links on the API overview page are "orange". What do you think?

Please, find the compiled version of the docs there: https://lumicks-pylake.readthedocs.io/en/sphinx_links/