### PR TITLE
Make attribute `src` private

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 * Fixed and reintroduced lazy loading for `TimeSeries` data. 
 
+#### Deprecations
+
+* Deprecated property `CorrelatedStack.src`.
+
 ### Other changes
 
 * Updated benchmark to not use deprecated functions and arguments. Prior to this change, running the benchmark would produce deprecation warnings.

--- a/lumicks/pylake/benchmark.py
+++ b/lumicks/pylake/benchmark.py
@@ -160,7 +160,7 @@ class _ReadTIFF(_Benchmark):
             def read_correlated_stack():
                 stack = lk.CorrelatedStack(filename)
                 stack.get_image()
-                stack.src.close()  # Explicitly close, otherwise cleanup will fail
+                stack._src.close()  # Explicitly close, otherwise cleanup will fail
 
             yield read_correlated_stack
 
@@ -175,7 +175,7 @@ class _ProcessTIFF(_Benchmark):
             _generate_test_stack(tiff_fn, pixel_size=0.23)
             stack = lk.CorrelatedStack(tiff_fn)
             yield lambda: stack.define_tether((10, 10), (50, 50)).get_image()
-            stack.src.close()  # Explicitly close, otherwise cleanup will fail
+            stack._src.close()  # Explicitly close, otherwise cleanup will fail
 
 
 def benchmark(repeat=5):

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -819,9 +819,9 @@ def _kymo_from_correlated_stack(
     start = ts_ranges[0, 0]
 
     # Ensure correlated stack has proper tether
-    if not corrstack.src._tether:
+    if not corrstack._src._tether:
         raise ValueError("The correlated stack does not have a tether.")
-    (x1, y1), (x2, y2) = corrstack.src._tether.ends
+    (x1, y1), (x2, y2) = corrstack._src._tether.ends
     if np.floor(y1) != np.floor(y2):
         raise ValueError("The correlated stack is not aligned along the tether axis.")
 

--- a/lumicks/pylake/nb_widgets/image_editing.py
+++ b/lumicks/pylake/nb_widgets/image_editing.py
@@ -158,7 +158,7 @@ class ImageEditorAxes(ImageStackAxes):
 
         if len(self.current_points) == 2:
             self._current_image = self._current_image.define_tether(*self.current_points)
-            temp_tether = np.vstack(self._current_image[0].src._tether.ends)
+            temp_tether = np.vstack(self._current_image[0]._src._tether.ends)
             self.current_points = []
         else:
             temp_tether = np.atleast_2d(np.vstack(self.current_points))

--- a/lumicks/pylake/nb_widgets/tests/test_image_editing.py
+++ b/lumicks/pylake/nb_widgets/tests/test_image_editing.py
@@ -102,7 +102,7 @@ def test_cropping_clicks(region_select):
     events = region_select(50, 25, 150, 75)
     ax.handle_crop(*events)
     np.testing.assert_equal(ax.roi_limits, (50, 150, 25, 75))
-    np.testing.assert_equal(w.image.src._shape, (50, 100))
+    np.testing.assert_equal(w.image._src._shape, (50, 100))
 
 
 def test_kymo_cropping_clicks(kymograph, region_select):

--- a/lumicks/pylake/tests/test_imaging_camera/test_export.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_export.py
@@ -12,7 +12,7 @@ def test_export(rgb_tiff_file, rgb_tiff_file_multi, gray_tiff_file, gray_tiff_fi
         savename = str(filename.new(purebasename=f"out_{filename.purebasename}"))
         stack = CorrelatedStack(str(filename), align=align)
         stack.export_tiff(savename)
-        stack.src.close()
+        stack._src.close()
         assert stat(savename).st_size > 0
 
         with tifffile.TiffFile(str(filename)) as tif0, tifffile.TiffFile(savename) as tif:
@@ -44,7 +44,7 @@ def test_export_roi(rgb_tiff_file, rgb_tiff_file_multi, gray_tiff_file, gray_tif
             assert tif.pages[0].tags["ImageWidth"].value == 180
             assert tif.pages[0].tags["ImageLength"].value == 60
 
-        stack.src.close()
+        stack._src.close()
 
 
 def test_stack_movie_export(
@@ -63,4 +63,4 @@ def test_stack_movie_export(
         with pytest.raises(ValueError, match="Channel should be red, green, blue or rgb"):
             stack.export_video("gray", "dummy.gif")  # Gray is not a color!
 
-        stack.src.close()
+        stack._src.close()


### PR DESCRIPTION
**Why this PR?**
~As a developer I want `file` and `src` attributes of `Scan` and `CorrelatedStack` to be private, to protect them from users.
I renamed `.src` to `._src` and `._file` to `.__file`. I left the property `file` but renamed it to `_file`, as some of the code relies on the `ValueError` the property throws when there is no file stored in `.__file`.~

After reconsidering based on Joeps comment, the incentive changed:

As a developer I want `CorrelatedStack.src` to be private to protect it from the users.

I deprecated `CorrelatedStack.src`.