### PR TITLE
Add tests for `KymoTrackGroup._merge_tracks()`

### DIFF
--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -488,6 +488,9 @@ class KymoTrackGroup:
         self._src.remove(ending_track)
 
     def _merge_tracks(self, starting_track, starting_node, ending_track, ending_node):
+        if starting_track not in self._src or ending_track not in self._src:
+            raise RuntimeError("Both tracks need to be part of this group to be merged")
+
         starting_node = int(starting_node) + 1
         ending_node = int(ending_node)
 


### PR DESCRIPTION
**Why this PR?**
While working on the PR for ensuring the same source kymo for a group, I noticed there are not tests for `_merge_tracks()` and it was not explicitly enforced that the two track instances were from the same group. Looking back, this functionality is actually tested in the widget tests, but I thought it would be good to have the smaller unit test here too.