### PR TITLE
KymoTrackGroup: Add `+` operator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### New features
 
 * Fixed and reintroduced lazy loading for `TimeSeries` data.
+* You can now add two `KymoTrackGroups` tracked on the same kymo together with the `+` operator.
 
 #### Other changes
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -459,6 +459,11 @@ class KymoTrackGroup:
     def __copy__(self):
         return KymoTrackGroup(copy(self._src))
 
+    def __add__(self, other):
+        new_group = copy(self)
+        new_group.extend(other)
+        return new_group
+
     @property
     def _kymo(self):
         try:
@@ -518,21 +523,22 @@ class KymoTrackGroup:
         return len(self._src)
 
     def extend(self, other):
-        other = [other] if isinstance(other, KymoTrack) else other
+        if not other:
+            return self
 
+        if not (isinstance(other, KymoTrack) or isinstance(other, self.__class__)):
+            raise TypeError(
+                f"You can only extend a {self.__class__.__name__} with a {self.__class__.__name__} "
+                f"or {KymoTrack.__name__}"
+            )
+
+        other = self.__class__([other]) if isinstance(other, KymoTrack) else other
         other_kymo, other_channel = self._validate_single_source(other)
         if self:
             assert self._kymo._id == other_kymo, "All tracks must have the same source kymograph."
             assert self._channel == other_channel, "All tracks must be from the same color channel."
 
-        if isinstance(other, self.__class__):
-            self._src.extend(other._src)
-        elif isinstance(other, list):
-            self._src.extend(other)
-        else:
-            raise TypeError(
-                f"You can only extend a {self.__class__} with a {self.__class__} or " f"{KymoTrack}"
-            )
+        self._src.extend(other._src)
 
     @deprecated(
         reason=(

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -123,6 +123,34 @@ def test_kymotrackgroup(blank_kymo):
         tracks.extend(5)
 
 
+def test_kymotrackgroup(blank_kymo):
+    def validate_same(kymoline_group, ref_list, source_items, ref_kymo):
+        assert [k for k in kymoline_group] == ref_list
+        assert id(kymoline_group) not in (id(s) for s in source_items)
+        if ref_kymo:
+            assert id(kymoline_group._kymo) == id(ref_kymo)
+
+    k1 = KymoTrack(np.array([1, 2, 3]), np.array([2, 3, 4]), blank_kymo, "red")
+    k2 = KymoTrack(np.array([2, 3, 4]), np.array([3, 4, 5]), blank_kymo, "red")
+    k3 = KymoTrack(np.array([3, 4, 5]), np.array([4, 5, 6]), blank_kymo, "red")
+    k4 = KymoTrack(np.array([4, 5, 6]), np.array([5, 6, 7]), blank_kymo, "red")
+
+    tracks1 = KymoTrackGroup([k1, k2])
+    tracks2 = KymoTrackGroup([k3, k4])
+    empty_tracks = KymoTrackGroup([])
+
+    validate_same(tracks1 + tracks2, [k1, k2, k3, k4], {tracks1, tracks2}, k1._kymo)
+    validate_same(tracks1 + k4, [k1, k2, k4], {tracks1, k4}, k1._kymo)
+    validate_same(tracks1 + empty_tracks, [k1, k2], {tracks1, empty_tracks}, k1._kymo)
+    validate_same(empty_tracks + tracks2, [k3, k4], {empty_tracks, tracks2}, k3._kymo)
+    validate_same(empty_tracks + empty_tracks, [], {empty_tracks}, None)
+
+    with pytest.raises(
+        TypeError, match="You can only extend a KymoTrackGroup with a KymoTrackGroup or KymoTrack"
+    ):
+        tracks1 + 5
+
+
 def test_kymotrack_concat(blank_kymo):
     k1 = KymoTrack(np.array([1, 2, 3]), np.array([1, 1, 1]), blank_kymo, "red")
     k2 = KymoTrack(np.array([6, 7, 8]), np.array([2, 2, 2]), blank_kymo, "red")


### PR DESCRIPTION
**Why this PR?**
I did this PR for a few reasons (found mostly while doing testing on the new msd methods):

- It's very convenient to be able to add `KymoTrackGroups` and to be able to add lines to one and getting a shallow copy of the group. Similarly, being able to add groups together is quite convenient when creating test data (which will come in handy when writing the theory section).
- There were some weird cornercases in `_extend`. Extending with an empty list produced an error because it doesn't have a Kymo and `_validate_single_source` fails.
- Analogously, extending with an incorrect datatype didn't manage to make it to the correct `TypeError` for the same reason.