### PR TITLE
diffusion: disallow estimating diffusion after downsampling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
 * `lk.track_greedy` now returns an empty `KymoTrackGroup` instead of an empty list when no coordinates exceed the threshold.
 * Functions that use `KymoTrackGroup` now gracefully handle the cases where no tracks are available. The refinement functions `refine_tracks_centroid` and `refine_tracks_gaussian` return an empty list, while `KymoTrackGroup.fit_binding_times()` and `KymoTrackGroup.plot_binding_histogram()` raise an exception.
 * `lk.track_greedy` now returns an empty `KymoTrackGroup` instead of an error when an ROI is selected that results in no lines tracked.
+* Computing diffusion constants from temporally downsampled kymographs is now explicitly disallowed.
 * Fixed a bug where the `pixel_threshold` could be set to zero for an empty image. Now the minimum `pixel_threshold` is one.
 
 ### Other changes

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -70,6 +70,7 @@ class Kymo(ConfocalImage):
         self._line_time_factory = _default_line_time_factory
         self._line_timestamp_ranges_factory = _default_line_timestamp_ranges_factory
         self._position_offset = position_offset
+        self._contiguous = True
 
         self._calibration = (
             calibration
@@ -80,6 +81,14 @@ class Kymo(ConfocalImage):
                 else PositionCalibration("um", self.pixelsize_um[0], r"$\mu$m")
             )
         )
+
+    @property
+    def contiguous(self):
+        """Are the pixels integrated over a contiguous period of time
+
+        If this flag is false then pixels have been integrated over disjoint sections of time. This
+        can be the case when a kymograph has been downsampled over time."""
+        return self._contiguous
 
     def _has_default_factories(self):
         return (
@@ -558,6 +567,7 @@ class Kymo(ConfocalImage):
         result._pixelsize_factory = pixelsize_factory
         result._pixelcount_factory = pixelcount_factory
         result._calibration = self._calibration.downsample(position_factor)
+        result._contiguous = time_factor == 1 and self.contiguous
         return result
 
     def flip(self):

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -389,6 +389,13 @@ class KymoTrack:
         if method not in ("gls", "ols"):
             raise ValueError('Invalid method selected. Method must be "gls" or "ols"')
 
+        if not self._kymo.contiguous:
+            raise NotImplementedError(
+                "Estimating diffusion constants from data which has been integrated over disjoint "
+                "sections of time is not supported. To estimate diffusion constants, do not "
+                "downsample the kymograph temporally prior to tracking."
+            )
+
         frame_idx, positions = np.array(self.time_idx, dtype=int), np.array(self.position)
         max_lag = (
             max_lag

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -653,3 +653,24 @@ def test_kymotrack_group_diffusion(blank_kymo, method, max_lags):
         np.testing.assert_allclose(float(est), float(diff_result.value))
         for attr in ("value", "std_err", "num_lags", "num_points"):
             np.testing.assert_allclose(getattr(est, attr), getattr(diff_result, attr))
+
+
+def test_disallowed_diffusion_est(blank_kymo):
+    contiguous_diffusion_error = (
+        "Estimating diffusion constants from data which has been integrated over disjoint "
+        "sections of time is not supported. To estimate diffusion constants, do not "
+        "downsample the kymograph temporally prior to tracking."
+    )
+
+    blank_kymo._contiguous = False
+    k = KymoTrack([0, 1, 2, 3, 4, 5], [0.0, 1.0, 1.5, 2.0, 2.5, 3.0], blank_kymo, "red")
+
+    with pytest.raises(NotImplementedError, match=contiguous_diffusion_error):
+        k.estimate_diffusion_ols()
+
+    with pytest.raises(NotImplementedError, match=contiguous_diffusion_error):
+        k.estimate_diffusion(method="ols")
+
+    group = KymoTrackGroup([k])
+    with pytest.raises(NotImplementedError, match=contiguous_diffusion_error):
+        group.estimate_diffusion(method="ols")

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -445,6 +445,7 @@ def test_downsampled_kymo():
     np.testing.assert_allclose(kymo_ds.pixelsize_um, 1 / 1000)
     np.testing.assert_allclose(kymo_ds.pixelsize, 1 / 1000)
     np.testing.assert_allclose(kymo_ds.line_time_seconds, 2 * 7 * (5 * 4 + 2 + 2) / 1e9)
+    assert not kymo_ds.contiguous
 
     with pytest.raises(
             NotImplementedError,
@@ -501,6 +502,7 @@ def test_downsampled_kymo_position():
     np.testing.assert_allclose(kymo_ds.pixelsize_um, 2 / 1000)
     np.testing.assert_allclose(kymo_ds.pixelsize, 2 / 1000)
     np.testing.assert_allclose(kymo_ds.line_time_seconds, kymo.line_time_seconds)
+    assert kymo_ds.contiguous
 
     # We lost one line while downsampling
     np.testing.assert_allclose(kymo_ds.size_um[0], kymo.size_um[0] - kymo.pixelsize_um[0])
@@ -540,6 +542,7 @@ def test_downsampled_kymo_both_axes():
         np.testing.assert_allclose(kymo_ds.pixelsize_um, 2 / 1000)
         np.testing.assert_allclose(kymo_ds.pixelsize, 2 / 1000)
         np.testing.assert_allclose(kymo_ds.line_time_seconds, 2 * 5 * (5 * 5 + 2 + 2) / 1e9)
+        assert not kymo_ds.contiguous
         with pytest.raises(
                 NotImplementedError,
                 match=re.escape("Per-pixel timestamps are no longer available after downsampling"),
@@ -577,6 +580,7 @@ def test_side_no_side_effects_downsampling():
     np.testing.assert_allclose(kymo.pixelsize_um, 1 / 1000)
     np.testing.assert_allclose(kymo.line_time_seconds, 5 * (5 * 5 + 2 + 2) / 1e9)
     np.testing.assert_equal(kymo.timestamps, timestamps)
+    assert kymo.contiguous
 
 
 def test_downsampled_slice():


### PR DESCRIPTION
**Why this PR?**
We currently offer downsampling kymographs, but one can still compute diffusion constants from them. However, the assumptions that go into the method are then not met.

This PRs adds a  boolean property to a `Kymo` which indicates whether the Kymo is the result from downsampling. This boolean is checked before doing diffusion analysis.

*What to look out for?*
1. I chose not to disallow computing MSDs (since technically, they are just defined as they are; the assumptions come in once people start inferring things on them). I am on the fence whether we should issue a warning though.

2. I did not disallow dwelltime analyses because I think these are still valid. The downstream methods there just make use of the actually achieved minimum times, and therefore should be fine.