### PR TITLE
kymotracker: ensure threshold default is never 0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
 * `lk.track_greedy` now returns an empty `KymoTrackGroup` instead of an empty list when no coordinates exceed the threshold.
 * Functions that use `KymoTrackGroup` now gracefully handle the cases where no tracks are available. The refinement functions `refine_tracks_centroid` and `refine_tracks_gaussian` return an empty list, while `KymoTrackGroup.fit_binding_times()` and `KymoTrackGroup.plot_binding_histogram()` raise an exception.
 * `lk.track_greedy` now returns an empty `KymoTrackGroup` instead of an error when an ROI is selected that results in no lines tracked.
+* Fixed a bug where the `pixel_threshold` could be set to zero for an empty image. Now the minimum `pixel_threshold` is one.
 
 ### Other changes
 

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -735,8 +735,8 @@ def _get_default_parameters(kymo, channel):
             "Threshold",
             "Set the pixel threshold.",
             "int",
-            np.percentile(data.flatten(), 98),
-            *(1, np.max(data)),
+            max(1, int(np.percentile(data.flatten(), 98))),
+            *(1, max(2, np.max(data))),
             True,
         ),
         "track_width": KymotrackerParameter(


### PR DESCRIPTION
**Why this PR?**
With an empty image, the threshold could be set to zero. It should at a minimum be `1`.

I noticed that the properties that depend on the `Kymo` were untested, so I added tests for these as well.