### PR TITLE
Common plot method call signature for `CorrelatedStack`, `Kymo`, `Scan` and `PointScan`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,13 @@
 * TIFFs exported from `Scan` and `Kymo` now contain metadata. The `DateTime` tag indicated the start/stop timestamp of each frame. The `ImageDescription` tag contains additional information about the confocal acquisition parameters.
 * Added covariance-based estimator (cve) option to `KymoTrack.estimate_diffusion()`. See [kymotracker documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#studying-diffusion-processes) for more details.
 * Added the optional `min_length` parameter to `KymoTrackGroup.estimate_diffusion()` to discard tracks shorter than a specified length from the analysis.
+* Harmonized method `plot()` call signature for `Scan`, `Kymo`, `PointScan` and `CorrelatedStack`:
+  * `Scan`, `Kymo` and `PointScan`: Made argument `channel` optional
+  * `Scan` and `PointScan`: Added argument `show_title`
+  * `Kymo`: Added arguments `image_handle` and `show_title`.
+  * `CorrelatedStack`: See deprecation changelog entry.
+* `Kymo.plot()` now returns a handle of the plotted image
+* `PointScan.plot()` now returns a list of handles of the plotted lines
 
 #### Other changes
 
@@ -18,6 +25,8 @@
 #### Deprecations
 
 * Deprecated property `CorrelatedStack.src`.
+* Reordered the keyword arguments of the method `CorrelatedStack.plot()` and enforced all parameters after `channel` to be keyword arguments. For details see the [docstring](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.correlated_stack.CorrelatedStack.html#lumicks.pylake.correlated_stack.CorrelatedStack.plot).
+* Enforced the argument `axes` of the method `plot()` for `Scan`, `Kymo` and `PointScan` to be a keyword argument.
 
 #### Bugfixes
 
@@ -32,6 +41,7 @@
 * Fixed a bug where the `pixel_threshold` could be set to zero for an empty image. Now the minimum `pixel_threshold` is one.
 * Fixed a bug where single pixel detections in a `KymoTrackGroup` would contribute values with a dwell time of zero. These are now dropped, the correct minimally observable time is set appropriately and a warning is issued.
 * Fixed slicing of a `Kymo` where slicing from a time point inside the last line to the end (e.g. `kymo["5s":]`) resulted in a `Kymo` which returned errors upon trying to access its contents. 
+
 ### Other changes
 
 * Updated benchmark to not use deprecated functions and arguments. Prior to this change, running the benchmark would produce deprecation warnings.

--- a/lumicks/pylake/detail/plotting.py
+++ b/lumicks/pylake/detail/plotting.py
@@ -1,0 +1,38 @@
+from matplotlib import pyplot as plt
+
+from ..adjustments import ColorAdjustment
+
+
+def get_axes(axes=None, image_handle=None):
+    """Return `axes` or the axes of the provided `image_handle` or ensure both axes are the same. If
+    neither `axes` nor `image_handle` are provided, fallback to the current `matplotlib` axes"""
+    if axes is None:
+        axes = plt.gca() if image_handle is None else image_handle.axes
+    if image_handle:
+        assert (
+            axes == image_handle.axes
+        ), "Supplied image_handle with a different axes than the provided axes"
+    return axes
+
+
+def show_image(
+    image,
+    adjustment=ColorAdjustment.nothing(),
+    channel="rgb",
+    image_handle=None,
+    axes=None,
+    **kwargs,
+):
+    """Plot image on an image handle or fall back to plot on a provided or the current axes"""
+    axes = get_axes(axes=axes, image_handle=image_handle)
+
+    if image_handle:
+        # Increase plotting speed by updating the image data in an already existing plot
+        image_handle.set_data(image)
+    else:
+        # Fall back to slower re-plotting with `imshow`.
+        image_handle = axes.imshow(image, **kwargs)
+
+    adjustment._update_limits(image_handle, image, channel)
+
+    return image_handle

--- a/lumicks/pylake/detail/tests/test_plotting.py
+++ b/lumicks/pylake/detail/tests/test_plotting.py
@@ -1,0 +1,151 @@
+from inspect import Parameter, signature
+
+import numpy as np
+import pytest
+from matplotlib import pyplot as plt
+
+from lumicks.pylake.adjustments import ColorAdjustment
+from lumicks.pylake.detail.plotting import get_axes, show_image
+
+
+def test_get_axes():
+    fig, (ax1, ax2) = plt.subplots(2)
+    ih1 = ax1.imshow(np.empty(shape=(2, 2)))
+    ih2 = ax2.imshow(np.empty(shape=(2, 2)))
+
+    ax = get_axes(axes=ax1)
+    assert ax is ax1
+    ax = get_axes()
+    assert ax is ax2
+    ax = get_axes(image_handle=ih1)
+    assert ax is ax1
+    ax = get_axes(image_handle=ih2)
+    assert ax is ax2
+    ax = get_axes(axes=ax1, image_handle=ih1)
+    assert ax is ax1
+    with pytest.raises(
+        AssertionError, match="Supplied image_handle with a different axes than the provided axes"
+    ):
+        ax = get_axes(axes=ax1, image_handle=ih2)
+
+    plt.close(fig)
+
+
+def test_show_image():
+    im1 = np.empty(shape=(2, 2))
+    im2 = np.empty(shape=(3, 3))
+
+    fig, (ax1, ax2) = plt.subplots(2)
+    ih1 = ax1.imshow(im1)
+
+    with pytest.raises(
+        AssertionError, match="Supplied image_handle with a different axes than the provided axes"
+    ):
+        show_image(im1, image_handle=ih1, axes=ax2)
+
+    # Test if image handle is used for plotting
+    ih = show_image(im2, image_handle=ih1)
+    assert ih is ih1
+    np.testing.assert_equal(ih.get_array(), im2)
+
+    # Test if image handle is used for plotting and axes is ignored (no kwargs forwarded to imshow)
+    ih = show_image(im1, image_handle=ih1, axes=ax1, url="NOT_FORWARED_KWARG")
+    assert ih is ih1
+    np.testing.assert_equal(ih.get_array(), im1)
+    assert ih.get_url() is None
+
+    # Test if axes is used for plotting (i.e. new image handle is created)
+    ih = show_image(im2, axes=ax1)
+    assert ih.axes is ax1
+    assert ih is not ih1
+    np.testing.assert_equal(ih.get_array(), im2)
+
+    # Test if current axes is used for plotting
+    ih = show_image(im1)
+    assert ih.axes is ax2
+    np.testing.assert_equal(ih.get_array(), im1)
+
+    # Test if kwargs are forwarded to plt.imshow()
+    ih = show_image(im1, axes=ax1, url="FORWARDED_KWARG")
+    assert ih.get_url() == "FORWARDED_KWARG"
+
+    # Test if ColorAdjustment is applied to image_handle
+    ih = show_image(im2, axes=ax1, adjustment=ColorAdjustment(1.5, 2, mode="absolute"))
+    assert ih.norm.vmin == 1.5
+    assert ih.norm.vmax == 2
+
+    plt.close(fig)
+
+
+def _plot_interface_parameters(image=False, stack=False):
+    """Get a list of parameters the signature of a plot function is supposed to have
+
+    Parameters
+    ----------
+    image : bool
+        The plot function is supposed to support plotting of images
+    stack : bool
+        The plot function is supposed to support selecting frames from image stacks
+
+    Returns
+    -------
+    List[Tuple]
+        A list of (name, kind) of expected parameters
+    """
+    supported_interfaces = ["general"]
+    if image:
+        supported_interfaces.append("image")
+    if stack:
+        supported_interfaces.append("stack")
+
+    arguments = [
+        # interface type, (name, parameter kind)
+        ["general", ("channel", Parameter.POSITIONAL_OR_KEYWORD)],
+        ["stack", ("frame", Parameter.KEYWORD_ONLY)],
+        ["image", ("adjustment", Parameter.KEYWORD_ONLY)],
+        ["general", ("axes", Parameter.KEYWORD_ONLY)],
+        ["image", ("image_handle", Parameter.KEYWORD_ONLY)],
+        ["general", ("show_title", Parameter.KEYWORD_ONLY)],
+        ["general", ("kwargs", Parameter.VAR_KEYWORD)],
+    ]
+
+    return [arg[1] for arg in arguments if arg[0] in supported_interfaces]
+
+
+def _plot_signature_parameters(cls):
+    """Get a list of parameters of the signature of the plot method of a class
+
+    Parameters
+    ----------
+    cls : class
+        The class whose plot method's signature parameters should be retrieved
+
+    Notes
+    -----
+    The first parameter (i.e. `self`) will be excluded from the returned result
+
+    Returns
+    -------
+    List[Tuple]
+        A list of (name, kind) of signature parameters
+    """
+    s = signature(cls.plot)
+    return [(value.name, value.kind) for value in list(s.parameters.values())[1:]]
+
+
+def implements_plot_interface(cls, image=False, stack=False):
+    """Check if plot method signature implements the expected interface"""
+    return _plot_interface_parameters(image=image, stack=stack) == _plot_signature_parameters(cls)
+
+
+def test_plot_interface_implementations():
+    from lumicks.pylake.correlated_stack import CorrelatedStack
+    from lumicks.pylake.kymo import Kymo
+    from lumicks.pylake.point_scan import PointScan
+    from lumicks.pylake.scan import Scan
+
+    # Check if classes properly implement the "plotting" interface
+    assert implements_plot_interface(CorrelatedStack, image=True, stack=True)
+    assert implements_plot_interface(Scan, image=True, stack=True)
+    assert implements_plot_interface(Kymo, image=True, stack=False)
+    assert implements_plot_interface(PointScan, image=False, stack=False)

--- a/lumicks/pylake/point_scan.py
+++ b/lumicks/pylake/point_scan.py
@@ -1,4 +1,5 @@
-from .detail.confocal import BaseScan
+from .detail.confocal import BaseScan, _deprecate_basescan_plot_args
+from .detail.plotting import get_axes
 
 
 class PointScan(BaseScan):
@@ -22,23 +23,36 @@ class PointScan(BaseScan):
         """Get photon count :class:`~lumicks.pylake.channel.Slice` for requested channel."""
         return getattr(self, f"{channel}_photon_count")
 
-    def _plot(self, channel, axes, **kwargs):
+    @_deprecate_basescan_plot_args
+    def plot(self, channel="rgb", *, axes=None, show_title=True, **kwargs):
         """Plot photon counts for the selected channel(s).
 
         Parameters
         ----------
-        channe : {'red', 'green', 'blue', 'rgb'}
-            Color channel to plot
-        axes : mpl.axes.Axes or None
+        channel : {"red", "green", "blue", "rgb"}, optional
+            Color channel to plot.
+        axes : matplotlib.axes.Axes, optional
             If supplied, the axes instance in which to plot.
+        show_title : bool, optional
+            Controls display of auto-generated plot title
         **kwargs
-            Forwarded to :func:`matplotlib.pyplot.imshow`
+            Forwarded to :func:`matplotlib.pyplot.plot`
+
+        Returns
+        -------
+        List[matplotlib.lines.Line2D]
+            A list of lines representing the plotted data.
         """
         channels = ["red", "green", "blue"] if channel == "rgb" else [channel]
+        axes = get_axes(axes=axes)
         for channel in channels:
             count = self._get_plot_data(channel)
             time = (count.timestamps - count.timestamps[0]) * 1e-9
             axes.plot(time, count.data, **{"color": channel, "label": channel, **kwargs})
-            axes.set_xlabel("time (s)")
-            axes.set_ylabel(r"photon count")
+
+        axes.set_xlabel("time (s)")
+        axes.set_ylabel(r"photon count")
+        if show_title:
             axes.set_title(self.name)
+
+        return axes.get_lines()

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -118,8 +118,11 @@ def test_kymo_slicing(test_kymos):
     with pytest.raises(RuntimeError):
         empty_kymograph.export_tiff("test")
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError), pytest.warns(DeprecationWarning):
         empty_kymograph.plot_rgb()
+
+    with pytest.raises(RuntimeError):
+        empty_kymograph.plot()
 
     assert empty_kymograph.get_image("red").shape == (5, 0)
     assert empty_kymograph.infowave.data.size == 0
@@ -178,6 +181,20 @@ def test_deprecated_plotting(test_kymos):
         kymo.plot_blue()
     with pytest.deprecated_call():
         kymo.plot_rgb()
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"The call signature of `plot\(\)` has changed: Please, provide `axes` as a "
+        "keyword argument."
+    ):
+        ih = kymo.plot("red", None)
+        np.testing.assert_allclose(ih.get_array(), kymo.get_image("red"))
+        plt.close()
+    # Test rejection of deprecated call with positional `axes` and double keyword assignment
+    with pytest.raises(
+        TypeError,
+        match=r"`Kymo.plot\(\)` got multiple values for argument `axes`"
+    ):
+        kymo.plot("rgb", None, axes=None)
 
 
 def test_line_timestamp_ranges(test_kymos):

--- a/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_scan.py
@@ -242,7 +242,20 @@ def test_deprecated_plotting(test_scans):
         scan.plot_blue()
     with pytest.deprecated_call():
         scan.plot_rgb()
-
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"The call signature of `plot\(\)` has changed: Please, provide `axes` as a "
+        "keyword argument."
+    ):
+        ih = scan.plot("blue", None)
+        np.testing.assert_allclose(ih.get_array(), scan.get_image("blue")[0])
+        plt.close()
+    # Test rejection of deprecated call with positional `axes` and double keyword assignment
+    with pytest.raises(
+        TypeError,
+        match=r"`Scan.plot\(\)` got multiple values for argument `axes`"
+    ):
+        scan.plot("rgb", None, axes=None)
 
 @pytest.mark.parametrize(
     "scanname, tiffname",


### PR DESCRIPTION
**Why?**
As a user I want a sensible docstring for the `plot()` method of `CorrelatedStack`, `Kymo`, `Scan` and `PointScan`. Additionally, I would like to have a sensible and similar call signature for all `plot()` implementations.

This PR aligns the different plot functions and involves the following changes:
  * A new module `plotting`, which provides common utility functions for plotting
  * `Scan`, `Kymo` and `PointScan`: Made argument `channel` optional.
  * `Scan`: Added argument `show_title`
  * `Kymo`: Added arguments `image_handle` and `show_title`.
  * `CorrelatedStack`: Reordered the keyword arguments and enforced all parameters after `axes` to be keyword arguments.
  * The method call to `CorrelatedStack.plot()` has a decorater, which checks if the method was called with the deprecated order of arguments.
  * Tests for the new `plotting` functions and deprecation of the argument order of `CorrelatedStack.plot()`.

Before merging, I would squash all commits into one: `plotting: common plot method call signature for ...`
