### PR TITLE
dwelltime: fix issue with single pixel detections

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 * `lk.track_greedy` now returns an empty `KymoTrackGroup` instead of an error when an ROI is selected that results in no lines tracked.
 * Computing diffusion constants from temporally downsampled kymographs is now explicitly disallowed.
 * Fixed a bug where the `pixel_threshold` could be set to zero for an empty image. Now the minimum `pixel_threshold` is one.
+* Fixed a bug where single pixel detections in a `KymoTrackGroup` would contribute values with a dwell time of zero. These are now dropped, the correct minimally observable time is set appropriately and a warning is issued.
 
 ### Other changes
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -687,14 +687,27 @@ class KymoTrackGroup:
         )
         dwelltimes_sec = np.array([track.seconds[-1] - track.seconds[0] for track in tracks])
 
-        if dwelltimes_sec.size == 0:
+        nonzero_dwelltimes_sec = dwelltimes_sec[dwelltimes_sec > 0]
+        if len(nonzero_dwelltimes_sec) != len(dwelltimes_sec):
+            warnings.warn(
+                RuntimeWarning(
+                    "Some dwell times are zero. A dwell time of zero indicates that some of the "
+                    "tracks were only observed in a single frame. For these samples it is not "
+                    "possible to actually determine a dwell time. Therefore these samples are "
+                    "dropped from the analysis. If you wish to not see this warning, filter the "
+                    "tracks with `lk.filter_tracks` with a minimum length of 2 samples."
+                ),
+                stacklevel=2,
+            )
+
+        if nonzero_dwelltimes_sec.size == 0:
             raise RuntimeError("No tracks available for analysis")
 
-        min_observation_time = np.min(dwelltimes_sec)
+        min_observation_time = np.min(nonzero_dwelltimes_sec)
         max_observation_time = self[0]._image.shape[1] * self[0]._line_time_seconds
 
         return DwelltimeModel(
-            dwelltimes_sec,
+            nonzero_dwelltimes_sec,
             n_components,
             min_observation_time=min_observation_time,
             max_observation_time=max_observation_time,

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -627,6 +627,25 @@ def test_fit_binding_times(blank_kymo):
     np.testing.assert_allclose(dwells.lifetimes, [1.25710457])
 
 
+def test_fit_binding_times_nonzero(blank_kymo):
+    k1 = KymoTrack(np.array([2]), np.zeros(3), blank_kymo, "red")
+    k2 = KymoTrack(np.array([2, 3, 4, 5, 6]), np.zeros(5), blank_kymo, "red")
+    tracks = KymoTrackGroup([k1, k2, k2, k2, k2])
+
+    with pytest.warns(
+        RuntimeWarning,
+        match=r"Some dwell times are zero. A dwell time of zero indicates that some of the tracks "
+              r"were only observed in a single frame. For these samples it is not possible to "
+              r"actually determine a dwell time. Therefore these samples are dropped from the "
+              r"analysis. If you wish to not see this warning, filter the tracks with "
+              r"`lk.filter_tracks` with a minimum length of 2 samples."
+    ):
+        dwelltime_model = tracks.fit_binding_times(1)
+        np.testing.assert_equal(dwelltime_model.dwelltimes, [4, 4, 4, 4])
+        np.testing.assert_equal(dwelltime_model._observation_limits[0], 4)
+        np.testing.assert_allclose(dwelltime_model.lifetimes[0], [0.4])
+
+
 def test_fit_binding_times_empty():
     with pytest.raises(RuntimeError, match="No tracks available for analysis"):
         KymoTrackGroup([]).fit_binding_times(1)

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -403,10 +403,8 @@ def exponential_mixture_log_likelihood(params, t, min_observation_time, max_obse
 
     Parameters
     ----------
-    amplitudes : array_like
-        fractional amplitude parameters for each component
-    lifetimes : array_like
-        lifetime parameters for each component in seconds
+    params : array_like
+        array of model parameters (amplitude and lifetime per component)
     t : array_like
         dwelltime observations in seconds
     min_observation_time : float
@@ -414,9 +412,9 @@ def exponential_mixture_log_likelihood(params, t, min_observation_time, max_obse
     max_observation_time : float
         maximum observation time in seconds
     """
-    params = np.reshape(params, (2, -1))
+    amplitudes, lifetimes = np.reshape(params, (2, -1))
     components = exponential_mixture_log_likelihood_components(
-        params[0], params[1], t, min_observation_time, max_observation_time
+        amplitudes, lifetimes, t, min_observation_time, max_observation_time
     )
     log_likelihood = logsumexp(components, axis=0)
     return -np.sum(log_likelihood)


### PR DESCRIPTION
**Why this PR?**
`KymoTrackGroup.fit_binding_times(#)` did not filter tracks with only a single point. This leads to zero dwelltimes for those tracks and can lead to biased results since the dwell time isn't actually zero, just below the line time. Since the estimation procedure supports a minimum observation time, it is better to filter these.

I also fixed up a small docstring error in this PR.