### PR TITLE
Validate the lengths of tracks analyzed in `KymoTrackGroup.estimate_diffusion()`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,11 +7,13 @@
 * Fixed and reintroduced lazy loading for `TimeSeries` data.
 * You can now add two `KymoTrackGroups` tracked on the same kymo together with the `+` operator.
 * TIFFs exported from `Scan` and `Kymo` now contain metadata. The `DateTime` tag indicated the start/stop timestamp of each frame. The `ImageDescription` tag contains additional information about the confocal acquisition parameters.
-* Added covariance-based estimator (cve) option to `KymoTrack.estimate_diffusion`. See [kymotracker documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#studying-diffusion-processes) for more details.
+* Added covariance-based estimator (cve) option to `KymoTrack.estimate_diffusion()`. See [kymotracker documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html#studying-diffusion-processes) for more details.
+* Added the optional `min_length` parameter to `KymoTrackGroup.estimate_diffusion()` to discard tracks shorter than a specified length from the analysis.
 
 #### Other changes
 
 * All `KymoTrack` intances must have the same source `Kymo` and color channel in order to be in the same `KymoTrackGroup` instance. While this behavior was required previously for some downstream analyses on the tracks, it is now explicitly enforced upon `KymoTrackGroup` construction.
+* When calling `KymoTrackGroup.estimate_diffusion()` without specifying the `min_length` parameter, tracks which are shorter than the required length for the specified method will be discarded from analysis and a warning emitted. Previously, if any tracks were shorter than required, an error would be raised.
 
 #### Deprecations
 


### PR DESCRIPTION
**Why this PR?**
When using `KymoTrackGroup.estimate_diffusion()`, if any tracks are shorter than the required length (3 for `"cve"` or 5 for the others), an error would be thrown. Instead we want to gracefully handle this and discard tracks that do not meet the requirement and issue a warning to the user.

Here I add a `min_length` argument where the user can specify a length, or defaults to `None` in which the appropriate min is used based on the specified method. I also changed up the docstring to reference `KymoTrack.estimate_diffusion()` in order to properly document the updated call signature without duplicating (most of it).

Relevant docs changes are [here](https://lumicks-pylake.readthedocs.io/en/msd_checker/_api/lumicks.pylake.kymotracker.kymotrack.KymoTrackGroup.html#lumicks.pylake.kymotracker.kymotrack.KymoTrackGroup)

I also checked that there is a simple way to catch the emitted warning. You can do this with the `warnings` package and the following context manager:

```
# collect emitted warnings in a list `w`
with warnings.catch_warnings(record=True) as w:
    # turn on all warnings
    warnings.simplefilter("always")

    # warning is emitted here
    tracks.estimate_diffusion("ols")]

    # access relevant warning information for validation
    warning_type = w[0].category, RuntimeWarning)
    warning_msg = str(w[0].message))
```