### PR TITLE
Customize the docs theme with colors from Pylake logo

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,7 +1,136 @@
-/* Set color of python role cross references to same as color for links */
-code.xref.py {
-  color: #2980b9 !important;
+/* pylake logo colors */
+:root {
+  --gray: #404041;
+  --mediumgray: #666667;
+  --dimgray: #afafaf;
+  --lightgray: #d9d9d9;
+  --lightestgray: #f0f0f0;
+  --pink: #f08d97;
+  --green: #84c175;
+  --blue: #1dabe3;
+  --orange: #f8ae4b;
+  --darkpink: #E74555;
+  --darkgreen: #599F47;
+  --darkblue: #1686B2;
+  --darkorange: #E58508;
+  --lightpink: #F9CED2;
+  --lightgreen: #A5D19A;
+  --mediumblue:  #92D7F2;
+  --lightblue: #C4E9F8;
+  --lightorange: #FCD4A0;
 }
+
+
+div.api-sub-header.docutils.container p {
+  color: var(--dimgray);
+  font-size: 0.85em;
+  margin-top: -2em;
+  font-family: monospace;
+}
+
+/* Links */
+a {
+  color: var(--blue);
+}
+
+a:visited {
+  color: var(--darkblue);
+}
+
+.wy-menu a {
+  color: var(--lightgray);
+}
+
+/* docs build indicator */
+.rst-versions .rst-current-version {
+  color: var(--pink);
+}
+
+/* Cross references to same as color for links */
+code.xref.py {
+  color: var(--blue) !important;
+}
+
 code.xref.any.py {
-  color: #2980b9 !important;
+  color: var(--blue) !important;
+}
+
+/* Navigation side bar */
+.wy-side-nav-search {
+  background-color: var(--blue);
+}
+
+.wy-side-nav-search input[type=text] {
+  border-color: var(--darkblue);
+  border-width: 1.5px;
+}
+
+.wy-menu-vertical header, .wy-menu-vertical p.caption {
+  color: var(--blue);
+}
+
+/* Navigation side bar - version label */
+.wy-side-nav-search>div.version {
+  color: rgba(255,255,255,0.6);
+}
+
+/* API docs, blocks */
+.rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple)>dt {
+  border-top: solid 5px var(--darkblue) !important;
+  background-color: var(--lightblue) !important;
+  width: 100%;
+  border-radius: 3px;
+}
+
+.rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl:not(.field-list)>dt {
+  border-left: solid 3px var(--lightgray) !important;
+  border-top: 0px !important;
+  background-color: var(--lightestgray) !important;
+  padding-right: 25px;
+}
+
+/* inline code */
+.rst-content code.literal {
+  color: var(--gray);
+  border-color: var(--lightgray);
+  background-color: #edf0f2;
+  border-radius: 3px;
+}
+
+.rst-content code.download {
+  color: var(--blue);
+  background-color: rgba(0, 0, 0, 0);
+}
+
+/* code block, outer wrapper */
+.rst-content pre.literal-block, .rst-content div[class^='highlight'] {
+  border-radius: 3px;
+}
+
+/* note box */
+.rst-content .note .admonition-title {
+  border-top-right-radius: 3px;
+  border-top-left-radius: 3px;
+  background-color: var(--blue);
+}
+
+.rst-content .note {
+  border-radius: 3px;
+  background-color: var(--mediumblue);
+}
+
+/* warning box */
+.rst-content .warning .admonition-title {
+  border-top-right-radius: 3px;
+  border-top-left-radius: 3px;
+  background-color: var(--darkpink);
+}
+
+.rst-content .warning {
+  border-radius: 3px;
+  background-color: var(--lightpink);
+}
+
+.rst-content .warning a {
+  color: var(--darkpink);
 }

--- a/docs/_static/pylake_syntax_theme.py
+++ b/docs/_static/pylake_syntax_theme.py
@@ -1,0 +1,77 @@
+from pygments.style import Style
+from pygments.token import (
+    Comment,
+    Error,
+    Generic,
+    Name,
+    Number,
+    Operator,
+    String,
+    Text,
+    Whitespace,
+    Keyword,
+)
+
+colors = {
+    "white": "#ffffff",
+    "gray": "#404041",
+    "mediumgray": "#929294",
+    "lightgray": "#d9d9d9",
+    "lightestgray": "#f0f0f0",
+    "pink": "#d30359",
+    "green": "#569a45",
+    "blue": "#0049a9",
+    "orange": "#e06700",
+    "lightpink": "#f9d1d5",
+    "lightgreen": "#cee6c8",
+    "lightblue": "#a5ddf4",
+    "lightorange": "#fcdfb7",
+}
+
+
+class PylakeStyle(Style):
+    """
+    Syntax highlighting with the pylake logo colors
+    """
+
+    background_color = colors["lightestgray"]
+
+    styles = {
+        Comment: f'italic {colors["mediumgray"]}',
+        Comment.Preproc: "noitalic",
+        Comment.Special: "bold",
+        Error: f'bg:{colors["pink"]} {colors["white"]}',
+        Generic.Deleted: f'border:{colors["pink"]} bg:{colors["lightpink"]}',
+        Generic.Emph: "italic",
+        Generic.Error: colors["pink"],
+        Generic.Heading: f'bold {colors["blue"]}',
+        Generic.Inserted: "border:{} bg:{}".format(colors["green"], colors["lightgreen"]),
+        Generic.Output: colors["gray"],
+        Generic.Prompt: f'bold {colors["blue"]}',
+        Generic.Strong: "bold",
+        Generic.Subheading: f'bold {colors["blue"]}',
+        Generic.Traceback: colors["pink"],
+        Keyword: f'bold {colors["green"]}',
+        Keyword.Pseudo: "nobold",
+        Keyword.Type: colors["pink"],
+        Name.Attribute: f'italic {colors["blue"]}',
+        Name.Builtin: f'bold {colors["green"]}',
+        Name.Class: "underline",
+        Name.Namespace: f'bold {colors["blue"]}',
+        Name.Constant: colors["orange"],
+        Name.Decorator: f'bold {colors["orange"]}',
+        Name.Entity: f'bold {colors["pink"]}',
+        Name.Exception: f'bold {colors["pink"]}',
+        Name.Function: f'bold {colors["orange"]}',
+        Name.Tag: f'bold {colors["blue"]}',
+        Number: f'{colors["orange"]}',
+        Operator: colors["blue"],
+        Operator.Word: f'bold {colors["blue"]}',
+        String: f'{colors["pink"]}',
+        String.Doc: "italic",
+        String.Escape: f'bold {colors["pink"]}',
+        String.Other: colors["orange"],
+        String.Symbol: f'bold {colors["pink"]}',
+        Text: colors["gray"],
+        Whitespace: colors["lightestgray"],
+    }

--- a/docs/_templates/class.rst
+++ b/docs/_templates/class.rst
@@ -1,4 +1,8 @@
-{{ fullname | escape | underline}}
+{{ objname | escape | underline}}
+
+.. container:: api_sub_header
+
+   {{ fullname }}
 
 .. currentmodule:: {{ module }}
 

--- a/docs/_templates/function.rst
+++ b/docs/_templates/function.rst
@@ -1,4 +1,8 @@
-{{ fullname | escape | underline}}
+{{ objname | escape | underline}}
+
+.. container:: api_sub_header
+
+   {{ fullname }}
 
 .. currentmodule:: {{ module }}
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,9 @@ import filecmp
 import sphinx_rtd_theme
 
 sys.path.insert(0, os.path.abspath("./_ext"))
+sys.path.insert(0, os.path.abspath("./_static"))
 sys.path.insert(0, os.path.abspath(".."))
+
 from lumicks import pylake
 
 
@@ -173,6 +175,7 @@ html_static_path = ["_static"]
 # html_context = {'extra_css_files': ['_static/extra.css']}
 
 html_css_files = ["custom.css"]
+pygments_style = "pylake_syntax_theme.PylakeStyle"
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
**Why this PR?**
I thought it would be nice to have a slightly customized theme that reflects the colors from the logo and fixes some other eyesores. Help a colorblind guy out and make as many suggestions as you want, important thing is we know how to do it now

[docs build](https://lumicks-pylake.readthedocs.io/en/pylake_theme/)

Some before & afters:
![g1742](https://user-images.githubusercontent.com/61475504/197227636-d64a378c-e5c9-4597-9b51-5235dd154424.png)
![image1586](https://user-images.githubusercontent.com/61475504/197227457-31d825af-55fa-46b4-8d66-e0ad5f78d520.png)
![image1600](https://user-images.githubusercontent.com/61475504/197227470-a883b674-dab5-4364-aaa4-aa24fd7d1bba.png)
![image1614](https://user-images.githubusercontent.com/61475504/197227480-66fa493a-1315-4b60-880d-fa1cee9758da.png)
