### PR TITLE
Add `Kymo.duration` property

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
   * `CorrelatedStack`: See deprecation changelog entry.
 * `Kymo.plot()` now returns a handle of the plotted image
 * `PointScan.plot()` now returns a list of handles of the plotted lines
+* Added the `Kymo.duration` property.
 
 #### Other changes
 

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -67,6 +67,8 @@ There are also several properties available for convenient access to the kymogra
   between successive lines
 * :attr:`kymo.pixel_time_seconds <lumicks.pylake.kymo.Kymo.pixel_time_seconds>` provides the pixel
   dwell time.
+* :attr:`kymo.duration <lumicks.pylake.kymo.Kymo.duration>` provides the full duration of the kymograph
+  in seconds. This is equivalent to the number of scan lines times `line_time_seconds`.
 
 
 Cropping and slicing

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -269,6 +269,14 @@ class Kymo(ConfocalImage):
         return self._line_time_factory(self)
 
     @property
+    def duration(self):
+        """Duration of the kymograph in seconds. This value is equivalent to the number of scan
+        lines times the line time in seconds. It does not take into account incomplete scan
+        lines or mirror fly-in/out time.
+        """
+        return self.line_time_seconds * self.shape[1]
+
+    @property
     def pixelsize(self):
         """Returns a `List` of axes dimensions in calibrated units. The length of the
         list corresponds to the number of scan axes."""
@@ -314,17 +322,17 @@ class Kymo(ConfocalImage):
         image = self._get_plot_data(channel, adjustment)
 
         size_calibrated = self._calibration.value * self._num_pixels[0]
-        duration = self.line_time_seconds * image.shape[1]
+
         default_kwargs = dict(
             # With origin set to upper (default) bounds should be given as (0, n, n, 0)
             # pixel center aligned with mean time per line
             extent=[
                 -0.5 * self.line_time_seconds,
-                duration - 0.5 * self.line_time_seconds,
+                self.duration - 0.5 * self.line_time_seconds,
                 size_calibrated - 0.5 * self.pixelsize[0],
                 -0.5 * self.pixelsize[0],
             ],
-            aspect=(image.shape[0] / image.shape[1]) * (duration / size_calibrated),
+            aspect=(image.shape[0] / image.shape[1]) * (self.duration / size_calibrated),
             cmap=linear_colormaps[channel],
         )
 
@@ -694,6 +702,10 @@ class EmptyKymo(Kymo):
 
     def get_image(self, channel="rgb"):
         return self._image(channel)
+
+    @property
+    def duration(self):
+        return 0
 
     @property
     @deprecated(

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -36,6 +36,7 @@ def test_kymo_properties(test_kymos):
     assert kymo.fast_axis == "X"
     np.testing.assert_allclose(kymo.pixelsize_um, 10/1000)
     np.testing.assert_allclose(kymo.line_time_seconds, 1.03125)
+    np.testing.assert_allclose(kymo.duration, 1.03125 * 4)
     np.testing.assert_allclose(kymo.center_point_um["x"], 58.075877109272604)
     np.testing.assert_allclose(kymo.center_point_um["y"], 31.978375270573267)
     np.testing.assert_allclose(kymo.center_point_um["z"], 0)
@@ -50,6 +51,25 @@ def test_kymo_properties(test_kymos):
         assert kymo.blue_image.shape == (5, 4)
     with pytest.deprecated_call():
         assert kymo.green_image.shape == (5, 4)
+
+
+def test_empty_kymo_properties(test_kymos):
+    kymo = test_kymos["Kymo1"]
+    empty_kymo = kymo["3s":"2s"]
+
+    assert empty_kymo.fast_axis == "X"
+    np.testing.assert_allclose(empty_kymo.pixelsize_um, 10/1000)
+    np.testing.assert_equal(empty_kymo.duration, 0)
+    np.testing.assert_allclose(empty_kymo.center_point_um["x"], 58.075877109272604)
+    np.testing.assert_allclose(empty_kymo.center_point_um["y"], 31.978375270573267)
+    np.testing.assert_allclose(empty_kymo.center_point_um["z"], 0)
+    np.testing.assert_allclose(empty_kymo.size_um, [0.050])
+
+    with pytest.raises(RuntimeError, match="Can't get pixel timestamps if there are no pixels"):
+        empty_kymo.line_time_seconds
+
+    with pytest.raises(RuntimeError, match="Can't get pixel timestamps if there are no pixels"):
+        empty_kymo.pixel_time_seconds
 
 
 def test_kymo_slicing(test_kymos):


### PR DESCRIPTION
**Why this PR?**
It's nice to know how long your kymograph is. This functionality was already nested inside `Kymo.plot()`, just pulled it out as a separate property. Also facilitates calculating average binding events per second after tracking: `len(tracks) / kymo.duration`