### PR TITLE
ci: add pylake to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lumicks/python_review
+* @lumicks/python_review @lumicks/pylake


### PR DESCRIPTION
**Why this PR?**
It's convenient to make sure that we always get at least one internal Pylake reviewer.