### PR TITLE
kymo: Fix erroneous slicing of kymos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,7 +31,7 @@
 * Computing diffusion constants from temporally downsampled kymographs is now explicitly disallowed.
 * Fixed a bug where the `pixel_threshold` could be set to zero for an empty image. Now the minimum `pixel_threshold` is one.
 * Fixed a bug where single pixel detections in a `KymoTrackGroup` would contribute values with a dwell time of zero. These are now dropped, the correct minimally observable time is set appropriately and a warning is issued.
-
+* Fixed slicing of a `Kymo` where slicing from a time point inside the last line to the end (e.g. `kymo["5s":]`) resulted in a `Kymo` which returned errors upon trying to access its contents. 
 ### Other changes
 
 * Updated benchmark to not use deprecated functions and arguments. Prior to this change, running the benchmark would produce deprecation warnings.

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -51,25 +51,6 @@ def reconstruct_num_frames(infowave, pixels_per_line, lines_per_frame):
     return math.ceil(num_pixels / pixels_per_frames)
 
 
-def line_timestamps_image(time_stamps, infowave, pixels_per_line):
-    """Determine the starting timestamps for lines in the kymograph
-
-    Parameters
-    ----------
-    time_stamps : array_like
-        Timestamps corresponding to the infowave.
-    infowave : array_like
-        The infamous infowave.
-    pixels_per_line : int
-        The number of pixels on the fast axis of the scan.
-    """
-    infowave, valid_idx = discard_zeros(infowave)
-    time_stamps = time_stamps[valid_idx]
-    pixel_start_idx = np.flatnonzero(infowave == InfowaveCode.pixel_boundary)
-    pixel_start_idx = np.concatenate(([0], pixel_start_idx + 1))
-    return time_stamps[pixel_start_idx[0:-1:pixels_per_line]]
-
-
 def seek_timestamp_next_line(infowave):
     """Seeks the timestamp beyond the first line. Used for repairing kymos with truncated start."""
     time = infowave.timestamps

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -5,28 +5,8 @@ from lumicks.pylake.detail.image import (
     reconstruct_image,
     reconstruct_image_sum,
     reconstruct_num_frames,
-    line_timestamps_image,
     histogram_rows,
 )
-
-
-@pytest.mark.parametrize("num_lines, pixels_per_line, pad_size", [(5, 3, 3), (5, 4, 2), (4, 7, 5)])
-def test_timestamps_image(num_lines, pixels_per_line, pad_size):
-    line_info_wave = np.tile(np.array([1, 1, 2], dtype=np.int32), (pixels_per_line,))
-    line_selector = np.zeros(line_info_wave.shape)
-    line_selector[0] = True
-    pad = np.zeros(pad_size, dtype=np.int32)
-    infowave = np.hstack([np.hstack([pad, line_info_wave, pad]) for _ in np.arange(num_lines)])
-    start_indices = np.hstack([np.hstack([pad, line_selector, pad]) for _ in np.arange(num_lines)])
-
-    # Generate list of timestamp data.
-    # It is important to use timestamps that are large enough such that floating point
-    # round-off errors will occur if the data is converted to floating point representation.
-    time = np.arange(len(infowave), dtype=np.int64) * int(700e9) + 1623965975045144000
-
-    line_stamps = line_timestamps_image(time, infowave, pixels_per_line)
-    assert line_stamps.shape == (sum(start_indices),)
-    np.testing.assert_equal(line_stamps, time[start_indices == 1])
 
 
 def test_reconstruct():

--- a/lumicks/pylake/tests/test_imaging_confocal/conftest.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/conftest.py
@@ -101,6 +101,17 @@ def test_kymos(reference_counts):
     )
     kymos["noise"] = Kymo("noise", mock_file, start, stop, metadata)
 
+    mock_file, metadata, stop = MockConfocalFile.from_image(
+        np.ones(shape=(5, 4, 3)),
+        [10.0],
+        start,
+        dt,
+        [0],
+        samples_per_pixel=5,
+        line_padding=3
+    )
+    kymos["slicing_regression"] = Kymo("slicing_regression", mock_file, start, stop, metadata)
+
     return kymos
 
 

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -128,6 +128,10 @@ def test_kymo_slicing(test_kymos):
     assert empty_kymograph.get_image("red").size == 0
     assert empty_kymograph.get_image("rgb").size == 0
 
+    kymo = test_kymos["slicing_regression"]
+    assert isinstance(kymo["23.0s":], EmptyKymo)
+    assert isinstance(kymo["24.2s":], EmptyKymo)
+
 
 def test_damaged_kymo(test_kymos):
     # Assume the user incorrectly exported only a partial Kymo


### PR DESCRIPTION
**Why**
While following and rewriting fixtures to test kymo slicing, I stumbled over a weird corner case when slicing Kymos:

![Kymo_slicing_error](https://user-images.githubusercontent.com/28353120/198114775-177a405c-b4dc-4caa-a61a-ebb09876ee9a.PNG)

**Explanation**
Slicing by providing only the start time with a value greater than the start timestamp of the very last line and less than or equal to the very last timestamp of the infowave created a dysfunctional Kymo. To fix it, the method to calculate the line timestamps in `Kymo.__getitem__()` was replaced with the method `Kymo.line_timestamp_ranges()`. Additionally, a check was introduced to ensure the stop timestamp of the kymo to have a value greater or equal to the stop timestamp of the last Kymo line, if the stop value of the slice item was greater than the start timestamp of the last Kymo line. As a bonus the old functions to calculate line and image timestamps are not needed anymore and were removed.

~**Why still a draft**
While rewriting the test for slicing, probably I found another bug in slicing. Investigating and working on it to be fixed ...~ It was an error in the tests.