### PR TITLE
calibration: fix analytic fit failing is `b < 0` and potentially returning `diff < 0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -41,6 +41,7 @@
 * Fixed a bug where the `pixel_threshold` could be set to zero for an empty image. Now the minimum `pixel_threshold` is one.
 * Fixed a bug where single pixel detections in a `KymoTrackGroup` would contribute values with a dwell time of zero. These are now dropped, the correct minimally observable time is set appropriately and a warning is issued.
 * Fixed slicing of a `Kymo` where slicing from a time point inside the last line to the end (e.g. `kymo["5s":]`) resulted in a `Kymo` which returned errors upon trying to access its contents. 
+* Fixed a minor bug in force calibration. In rare cases it was possible that the procedure to generate an initial guess for the power spectral fit failed. This seemed to occur when the spectrum supplied is a mostly flat plateau. After the fix, an alternative method to compute an initial guess is applied in cases where the regular method fails. Note that successful calibrations were not at risk for being incorrect due to this bug since they would have resulted in an exception rather than an invalid result.
 
 ### Other changes
 

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -79,6 +79,14 @@ def test_fit_analytic(
     np.testing.assert_allclose(fit.sigma_D, sigma_diffusion)
 
 
+def test_analytic_corner_case():
+    ps = PowerSpectrum([1, 2, 3], 78125)
+    ps.frequency = np.array([178.63690424, 335.92231409, 493.20772395, 650.4931338, 807.77854365])
+    ps.power = np.array([0.00029835, 0.00027251, 0.00027432, 0.00028302, 0.00029127])
+    fit = fit_analytical_lorentzian(ps)
+    assert fit.D > 0
+
+
 def test_analytic_low_frequency(reference_models):
     # When the corner frequency is below the lower bound of the fit, the analytic fit fails with a
     # non-informative error. The reason for this is that a term which produces the corner frequency


### PR DESCRIPTION
In rare cases, it is possible that during the analytic fit, the diffusion constant returned is negative. This makes no sense as an initial guess and leads to numerical problems down the road. For this reason, an alternative method to guesstimate it is used when this occurs.

In addition, `a > 0` is not a strong enough condition for the fc estimator, because the square root operation can still produce an exception if `b < 0` while `a > 0`.