### PR TITLE
nb_widgets: fix widget layout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -43,6 +43,7 @@
 * Fixed a bug where single pixel detections in a `KymoTrackGroup` would contribute values with a dwell time of zero. These are now dropped, the correct minimally observable time is set appropriately and a warning is issued.
 * Fixed slicing of a `Kymo` where slicing from a time point inside the last line to the end (e.g. `kymo["5s":]`) resulted in a `Kymo` which returned errors upon trying to access its contents. 
 * Fixed a minor bug in force calibration. In rare cases it was possible that the procedure to generate an initial guess for the power spectral fit failed. This seemed to occur when the spectrum supplied is a mostly flat plateau. After the fix, an alternative method to compute an initial guess is applied in cases where the regular method fails. Note that successful calibrations were not at risk for being incorrect due to this bug since they would have resulted in an exception rather than an invalid result.
+* Fixed issue where on Jupyter Lab the kymotracker widget would align the Kymograph and track parameters vertically rather than horizontally.
 
 ### Other changes
 

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 import inspect
 import numpy as np
 import matplotlib.pyplot as plt
@@ -328,8 +329,8 @@ class KymoWidget:
         return ipywidgets.interactive(
             set_value,
             value=slider_types[parameter.type](
-                description=parameter.name,
-                description_tooltip=parameter.description,
+                description=parameter.abridged_name,
+                description_tooltip=parameter.extended_description,
                 min=parameter.lower_bound,
                 max=parameter.upper_bound,
                 step=parameter.step_size,
@@ -723,12 +724,16 @@ class KymotrackerParameter:
     upper_bound: Number
     ui_visible: bool
     extended_description: str
+    abridged_name: Optional[str] = None
 
     def __post_init__(self):
         if self.ui_visible and (self.lower_bound is None or self.upper_bound is None):
             raise ValueError(
                 "Lower and upper bounds must be supplied for widget to be set as visible."
             )
+
+        if not self.abridged_name:
+            self.abridged_name = self.name
 
     @property
     def step_size(self):
@@ -752,6 +757,7 @@ def _get_default_parameters(kymo, channel):
             r"considered part of a track. This parameter should be chosen slightly above the "
             r"background photon count. Higher values reject more noise, but parts of the track may "
             r"be missed.",
+            abridged_name="Min intensity",
         ),
         "sigma": KymotrackerParameter(
             "Positional search range",
@@ -764,6 +770,7 @@ def _get_default_parameters(kymo, channel):
             r"from one time point to the next while still being considered part of the same "
             r"track. Larger values will result in a wider range in which points are added to a "
             r"track.",
+            abridged_name="Search range",
         ),
         "window": KymotrackerParameter(
             "Maximum gap",
@@ -778,6 +785,7 @@ def _get_default_parameters(kymo, channel):
             r"intensity threshold. This value should be chosen such that small gaps in a track "
             r"can be overcome and tracked as one, but not so large that separate tracks are strung "
             r"together.",
+            abridged_name="Max gap",
         ),
         "min_length": KymotrackerParameter(
             "Minimum length",
@@ -790,6 +798,7 @@ def _get_default_parameters(kymo, channel):
             r"it to be considered valid. Reducing this parameter can be effective in reducing "
             r"tracking noise. Note that this length refers to the number of detected points, not "
             r"length in time!",
+            abridged_name="Min length",
         ),
         "track_width": KymotrackerParameter(
             "Expected spot size",
@@ -802,6 +811,7 @@ def _get_default_parameters(kymo, channel):
             r"kymograph for it to be tracked as a single molecule. This parameter should be set to "
             r"roughly the width of the point spread function. Setting it larger rejects more "
             r"noise, but at the cost of potentially merging tracks that are close together.",
+            abridged_name="Spot size",
         ),
         "vel": KymotrackerParameter(
             "Expected velocity",
@@ -814,6 +824,7 @@ def _get_default_parameters(kymo, channel):
             r"to move along the DNA on average. When tracking, the algorithm searches for points "
             r"in future scan lines to connect. Points within a certain distance from the expected "
             r"future position are connected.",
+            abridged_name="Velocity",
         ),
         "diffusion": KymotrackerParameter(
             "Diffusion",

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -439,9 +439,17 @@ class KymoWidget:
         self._mode.observe(self._select_state, "value")
 
         output = ipywidgets.Output()
+
+        with output:
+            self._fig = plt.figure()
+            self._axes = self._fig.add_subplot(111)
+
+            # Without this, HBox fails to align horizontally.
+            self._fig.canvas.show()
+
         ui = ipywidgets.HBox(
             [
-                ipywidgets.VBox([output]),
+                output,
                 ipywidgets.VBox(
                     [
                         all_button,
@@ -461,9 +469,10 @@ class KymoWidget:
 
         display(ui)
 
-        with output:
-            self._fig = plt.figure()
-            self._axes = self._fig.add_subplot(111)
+        if "ipympl" not in plt.get_backend():
+            # Without this, the figure doesn't show up on non ipympl backends
+            with output:
+                display(self._fig)
 
     def _select_state(self, value):
         """Select a different state to operate the widget in. Note that the input argument is value


### PR DESCRIPTION
**Why this PR?**
On our current main, the widget renders vertically in Jupyter lab, while it should render horizontally. This makes it borderline unusable.

![image](https://user-images.githubusercontent.com/19836026/199046804-9291cc6e-3182-4ee4-b730-c23879551448.png)

This PR fixes that by forcing a `show` on the plot before setting up the layout boxes.

A second thing I noticed is that our new labels are too long for the widgets. The most interesting part of the label ends up getting ellipsed out:
![image](https://user-images.githubusercontent.com/19836026/199047063-4697f1b9-d160-4edf-97f5-20c624cdd3b1.png)

As a workaround, I played  bit with the styling, but the problem is that the margin between the slider and the edit part of the box is not configurable, so that leaves you with an annoyingly small slider:
![image](https://user-images.githubusercontent.com/19836026/199047239-69e2cbf0-873d-4d1f-a5d8-ab7461321943.png)

Considering that we are a bit limited in how much screen space we have, I decided to shorten the label names instead.

This is what it looks like with the abridged names:

![image](https://user-images.githubusercontent.com/19836026/199047551-4c503ec0-7c33-487e-bbb3-f5350ba1f5bd.png)

I also switched out the short form tooltip for the long form one, since it's far more informative.