### PR TITLE
Make tests in `test_imaging_confocal` less brittle: `kymo_from_array`, `kymo_from_corrstack` and `point_scan`

### DIFF
--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
@@ -1,0 +1,178 @@
+import pytest
+import numpy as np
+import itertools
+import matplotlib.pyplot as plt
+from lumicks.pylake.kymo import _kymo_from_array
+
+
+timestamp_err_msg = (
+    "Per-pixel timestamps are not implemented. "
+    "Line timestamps are still available, however. See: `Kymo.line_time_seconds`."
+)
+
+colors = ("red", "green", "blue")
+
+
+def make_kymo_from_array(kymo, image, color_format, no_pxsize=False):
+    start = kymo._timestamps("timestamps", np.min)[0, 0]
+    exposure_time_sec = np.diff(kymo.line_timestamp_ranges(include_dead_time=False)[0])[0] * 1e-9
+
+    return _kymo_from_array(
+        image,
+        color_format,
+        kymo.line_time_seconds,
+        start=start,
+        exposure_time_seconds=exposure_time_sec,
+        name="reconstructed",
+        pixel_size_um=None if no_pxsize else kymo.pixelsize_um[0],
+    )
+
+
+def test_from_array(test_kymos):
+    kymo = test_kymos["noise"]
+    arr_kymo = make_kymo_from_array(kymo, kymo.get_image("rgb"), "rgb")
+
+    np.testing.assert_equal(kymo.get_image("rgb"), arr_kymo.get_image("rgb"))
+    np.testing.assert_equal(kymo._reconstruction_shape, arr_kymo._reconstruction_shape)
+
+    with pytest.raises(NotImplementedError, match=timestamp_err_msg):
+        arr_kymo.pixel_time_seconds
+
+    np.testing.assert_equal(kymo.line_time_seconds, arr_kymo.line_time_seconds)
+    np.testing.assert_equal(
+        kymo.line_timestamp_ranges(include_dead_time=False),
+        arr_kymo.line_timestamp_ranges(include_dead_time=False)
+    )
+    np.testing.assert_equal(
+        kymo.line_timestamp_ranges(include_dead_time=True),
+        arr_kymo.line_timestamp_ranges(include_dead_time=True)
+    )
+
+    np.testing.assert_equal(kymo.pixelsize_um, arr_kymo.pixelsize_um)
+    np.testing.assert_equal(kymo.pixelsize, arr_kymo.pixelsize)
+
+    assert arr_kymo._metadata.center_point_um == {key: None for key in ("x", "y", "z")}
+    assert arr_kymo._metadata.num_frames == 0
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Slicing is not implemented for kymographs derived from image stacks.",
+    ):
+        arr_kymo["0s":"0.5s"]
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Slicing is not implemented for kymographs derived from image stacks.",
+    ):
+        arr_kymo.crop_and_calibrate("red")
+
+
+def test_save_tiff(tmpdir_factory, test_kymos):
+    from os import stat
+
+    tmpdir = tmpdir_factory.mktemp("pylake")
+
+    kymo = test_kymos["noise"]
+
+    for no_pxsize in (True, False):
+        arr_kymo = make_kymo_from_array(kymo, kymo.get_image("rgb"), "rgb", no_pxsize=no_pxsize)
+
+        with pytest.warns(UserWarning):
+            arr_kymo.export_tiff(f"{tmpdir}/kymo1.tiff")
+            assert stat(f"{tmpdir}/kymo1.tiff").st_size > 0
+
+
+def test_from_array_no_pixelsize(test_kymos):
+    kymo = test_kymos["noise"]
+    arr_kymo = make_kymo_from_array(kymo, kymo.get_image("rgb"), "rgb", no_pxsize=True)
+
+    np.testing.assert_equal(kymo.get_image("rgb"), arr_kymo.get_image("rgb"))
+    np.testing.assert_equal(kymo._reconstruction_shape, arr_kymo._reconstruction_shape)
+
+    with pytest.raises(NotImplementedError, match=timestamp_err_msg):
+        arr_kymo.pixel_time_seconds
+
+    np.testing.assert_equal(kymo.line_time_seconds, arr_kymo.line_time_seconds)
+    np.testing.assert_equal(
+        kymo.line_timestamp_ranges(include_dead_time=False),
+        arr_kymo.line_timestamp_ranges(include_dead_time=False)
+    )
+    np.testing.assert_equal(
+        kymo.line_timestamp_ranges(include_dead_time=True),
+        arr_kymo.line_timestamp_ranges(include_dead_time=True)
+    )
+
+    assert arr_kymo.pixelsize_um == [None]
+    assert arr_kymo.pixelsize == [1.0]
+    assert arr_kymo._calibration.unit == "pixel"
+
+    assert arr_kymo._metadata.center_point_um == {key: None for key in ("x", "y", "z")}
+    assert arr_kymo._metadata.num_frames == 0
+
+
+def test_throw_on_file_access(test_kymos):
+    kymo = test_kymos["noise"]
+    arr_kymo = make_kymo_from_array(kymo, kymo.get_image("rgb"), "rgb")
+
+    attributes = (
+        [f"{color}_power" for color in colors]
+        + [f"{color}_photon_count" for color in colors]
+        + ["infowave", "sted_power"]
+    )
+    for attribute in attributes:
+        with pytest.raises(ValueError, match="There is no .h5 file associated with this Kymo"):
+            getattr(arr_kymo, attribute)
+
+    with pytest.raises(ValueError, match="There is no force data associated with this Kymo"):
+        arr_kymo.plot_with_force("1x", "red")
+
+
+def test_from_array_fewer_channels(test_kymos):
+    kymo = test_kymos["noise"]
+    rgb_image = kymo.get_image("rgb")
+
+    # single-channel data
+    for j, color_channel in enumerate(colors):
+        arr_kymo = make_kymo_from_array(kymo, rgb_image[:, :, j], color_channel[0], no_pxsize=True)
+
+        for channel in colors:
+            if channel == color_channel:
+                np.testing.assert_equal(arr_kymo.get_image(channel), kymo.get_image(channel))
+            else:
+                np.testing.assert_equal(arr_kymo.get_image(channel), 0)
+
+    # two-channel data
+    for channels in itertools.permutations(colors, 2):
+        color_format = "".join([c[0] for c in channels])
+        sub_image = np.stack([rgb_image[:, :, "rgb".index(c)] for c in color_format], axis=2)
+        arr_kymo = make_kymo_from_array(kymo, sub_image, color_format, no_pxsize=True)
+
+        for channel in colors:
+            if channel in channels:
+                np.testing.assert_equal(arr_kymo.get_image(channel), kymo.get_image(channel))
+            else:
+                np.testing.assert_equal(arr_kymo.get_image(channel), 0)
+
+
+def test_color_format(test_kymos):
+    kymo = test_kymos["noise"]
+    image = kymo.get_image("rgb")
+    with pytest.raises(
+        ValueError, match="Invalid color format 'rgp'. Only 'r', 'g', and 'b' are valid components."
+    ):
+        arr_kymo = make_kymo_from_array(kymo, image, "rgp")
+
+    with pytest.raises(
+        ValueError, match="Color format 'r' specifies 1 channel for a 3 channel image."
+    ):
+        arr_kymo = make_kymo_from_array(kymo, image, "r")
+
+    with pytest.raises(
+        ValueError, match="Color format 'rb' specifies 2 channels for a 3 channel image."
+    ):
+        arr_kymo = make_kymo_from_array(kymo, image, "rb")
+
+    with pytest.raises(
+        ValueError, match="Color format 'rgb' specifies 3 channels for a 2 channel image."
+    ):
+        arr_kymo = make_kymo_from_array(kymo, image[:, :, :2], "rgb")

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
@@ -1,9 +1,10 @@
-import pytest
-import numpy as np
 import itertools
-import matplotlib.pyplot as plt
+
+import numpy as np
+import pytest
 from lumicks.pylake.kymo import _kymo_from_array
 
+from ..data.mock_confocal import generate_kymo
 
 timestamp_err_msg = (
     "Per-pixel timestamps are not implemented. "
@@ -11,6 +12,14 @@ timestamp_err_msg = (
 )
 
 colors = ("red", "green", "blue")
+
+
+# CAVE: If you want to test a cached property, after having modified parameters that change the
+# value of the property, ensure to clear the `_cache` attribute before and after testing. To achieve
+# both, you can monkeypatch the `_cache` attribute with an empty dict.
+@pytest.fixture(scope="module")
+def test_kymos():
+    return {"noise": generate_kymo("noise", np.random.poisson(5, size=(5, 10, 3)))}
 
 
 def make_kymo_from_array(kymo, image, color_format, no_pxsize=False):
@@ -41,11 +50,11 @@ def test_from_array(test_kymos):
     np.testing.assert_equal(kymo.line_time_seconds, arr_kymo.line_time_seconds)
     np.testing.assert_equal(
         kymo.line_timestamp_ranges(include_dead_time=False),
-        arr_kymo.line_timestamp_ranges(include_dead_time=False)
+        arr_kymo.line_timestamp_ranges(include_dead_time=False),
     )
     np.testing.assert_equal(
         kymo.line_timestamp_ranges(include_dead_time=True),
-        arr_kymo.line_timestamp_ranges(include_dead_time=True)
+        arr_kymo.line_timestamp_ranges(include_dead_time=True),
     )
 
     np.testing.assert_equal(kymo.pixelsize_um, arr_kymo.pixelsize_um)
@@ -95,11 +104,11 @@ def test_from_array_no_pixelsize(test_kymos):
     np.testing.assert_equal(kymo.line_time_seconds, arr_kymo.line_time_seconds)
     np.testing.assert_equal(
         kymo.line_timestamp_ranges(include_dead_time=False),
-        arr_kymo.line_timestamp_ranges(include_dead_time=False)
+        arr_kymo.line_timestamp_ranges(include_dead_time=False),
     )
     np.testing.assert_equal(
         kymo.line_timestamp_ranges(include_dead_time=True),
-        arr_kymo.line_timestamp_ranges(include_dead_time=True)
+        arr_kymo.line_timestamp_ranges(include_dead_time=True),
     )
 
     assert arr_kymo.pixelsize_um == [None]

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_corrstack.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_corrstack.py
@@ -1,0 +1,152 @@
+import pytest
+import numpy as np
+from lumicks.pylake.correlated_stack import CorrelatedStack
+from lumicks.pylake.detail.widefield import TiffStack, Tether
+from lumicks.pylake.tests.data.mock_widefield import MockTiffFile
+from lumicks.pylake.kymo import _kymo_from_correlated_stack
+
+
+def make_frame_times(n_frames, rate=10, step=8, start=10, framerate_jitter=0, step_jitter=0):
+    def noise(jitter, j):
+        if j / rate % 2:
+            return 0
+        else:
+            return jitter
+
+    return [
+        [
+            f"{j + noise(framerate_jitter, j)}",
+            f"{j + step + noise(framerate_jitter, j) + noise(step_jitter, j)}",
+        ]
+        for j in range(start, start + n_frames * rate, rate)
+    ]
+
+
+def create_mock_corrstack(
+    n_frames=1, shape=None, image=None, framerate_jitter=0, step_jitter=0, tether_ends=None
+):
+    image = np.ones(shape) if image is None else image
+    times = make_frame_times(n_frames, framerate_jitter=framerate_jitter, step_jitter=step_jitter)
+    tether = tether_ends if tether_ends is None else Tether((0, 0), tether_ends)
+    fake_tiff = TiffStack(
+        [MockTiffFile(data=[image] * n_frames, times=times)],
+        align_requested=False,
+        tether=tether,
+    )
+    return CorrelatedStack.from_dataset(fake_tiff)
+
+
+def gaussian_2d(shape=(15, 15), limit=(3.0, 3.0), mean=(0.0, 0.0), std=(1.0, 1.0), rho=0.0):
+    """Create a 2D gaussian with two different standard deviations
+
+    Parameters
+    ----------
+    shape : tuple of int
+        The shape of the resulting 2D array for x and y.
+    limit : tuple of float
+        The absolute values of standard deviation up to where the values for the gaussians in x and
+        y are calculated.
+    mean : tuple of float
+        The mean of the guassians in values of standard deviation in x and y. 0.0 corresponds to the
+        image center of the corresponding axis.
+    std : tuple of float
+        The standard deviation of the two gaussians in x and y.
+    rho : float
+        The correlation of the two gaussians. Accepted values are in the open interval ( -1 , 1 ).
+    """
+    from scipy.stats import multivariate_normal
+
+    sx, sy = std
+    cov = np.array([[sx**2, sx * sy * rho], [sx * sy * rho, sy**2]])
+    mesh = np.dstack(np.mgrid[[slice(-dx, dx, n * 1j) for (dx, n) in zip(limit, shape)]])
+    return multivariate_normal(mean=mean, cov=cov).pdf(mesh)
+
+
+# Test conditional errors for insufficient correlated stacks as input
+def test_error_frame_rate_not_constant():
+    corrstack = create_mock_corrstack(3, (3, 3, 3), framerate_jitter=1)
+    with pytest.raises(
+        ValueError, match="The frame rate of the images of the correlated stack is not constant."
+    ):
+        _kymo_from_correlated_stack(corrstack)
+
+
+def test_error_exposure_time_not_constant():
+    corrstack = create_mock_corrstack(3, (3, 3, 3), step_jitter=1)
+    with pytest.raises(
+        ValueError, match="The exposure time of the images of the correlated stack is not constant."
+    ):
+        _kymo_from_correlated_stack(corrstack)
+
+
+def test_error_tether_not_exists():
+    corrstack = create_mock_corrstack(3, (3, 3, 3))
+    with pytest.raises(ValueError, match="The correlated stack does not have a tether."):
+        _kymo_from_correlated_stack(corrstack)
+
+
+def test_error_negative_linewidth():
+    corrstack = create_mock_corrstack(3, (3, 3, 3), tether_ends=((0, 0), (4, 0)))
+    with pytest.raises(
+        ValueError, match="The requested number of `adjacent_lines` must not be negative."
+    ):
+        _kymo_from_correlated_stack(corrstack, adjacent_lines=-1)
+
+
+def test_error_tether_linewidth_exceeds_image():
+    corrstack = create_mock_corrstack(3, (3, 3, 3), tether_ends=((0, 0), (4, 0)))
+    with pytest.raises(
+        ValueError,
+        match="The number of `adjacent_lines` exceed the size of the correlated stack images.",
+    ):
+        _kymo_from_correlated_stack(corrstack, adjacent_lines=3)
+
+    corrstack = create_mock_corrstack(3, (3, 3, 3), tether_ends=((0, 2), (4, 2)))
+    with pytest.raises(
+        ValueError,
+        match="The number of `adjacent_lines` exceed the size of the correlated stack images.",
+    ):
+        _kymo_from_correlated_stack(corrstack, adjacent_lines=3)
+
+
+# Test proper shape of kymo
+def test_shape_of_kymo():
+    # 5 pixels, 4 frames, 3 channels
+    corrstack = create_mock_corrstack(4, (5, 5, 3), tether_ends=((0, 2), (4, 2)))
+    kymo = _kymo_from_correlated_stack(corrstack)
+    assert kymo.get_image().shape == (5, 4, 3)
+
+    # 5 pixels (rounded), 4 frames, 3 channels
+    corrstack = create_mock_corrstack(4, (5, 5, 3), tether_ends=((0.5, 2), (4.5, 2)))
+    kymo = _kymo_from_correlated_stack(corrstack)
+    assert kymo.get_image().shape == (5, 4, 3)
+
+    # 3 pixels, 4 frames, 3 channels
+    corrstack = create_mock_corrstack(4, (5, 5, 3), tether_ends=((1, 2), (3, 2)))
+    kymo = _kymo_from_correlated_stack(corrstack)
+    assert kymo.get_image().shape == (3, 4, 3)
+
+    # 3 pixels, 10 frames, 1 channel
+    corrstack = create_mock_corrstack(10, (5, 5), tether_ends=((1, 2), (3, 2)))
+    kymo = _kymo_from_correlated_stack(corrstack)
+    assert kymo.get_image().shape == (3, 10, 3)
+
+
+@pytest.mark.parametrize("adjacent_lines", [0, 1, 2])
+def test_data_identity_horizonal_tether(adjacent_lines, reduce=np.mean):
+    x = 15
+    y = 25
+    # make image with two gaussians
+    image = np.swapaxes(
+        np.array([gaussian_2d(shape=(x, y), mean=(-1.0, -1.5), std=(1, 0.8))] * 3), 0, 2
+    )
+    image += np.swapaxes(
+        np.array([gaussian_2d(shape=(x, y), mean=(1.0, 1.0), std=(0.75, 1))] * 3), 0, 2
+    )
+    ymin = y // 2 - adjacent_lines
+    ymax = y // 2 + adjacent_lines + 1
+    imageline = reduce(image[ymin:ymax], axis=0)
+    corrstack = create_mock_corrstack(5, image=image, tether_ends=((0, y // 2), (x - 1, y // 2)))
+    kymo = _kymo_from_correlated_stack(corrstack, adjacent_lines=adjacent_lines, reduce=reduce)
+    for frameline in np.swapaxes(kymo.get_image(), 0, 1):
+        assert np.array_equal(frameline, imageline)

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_corrstack.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_corrstack.py
@@ -1,9 +1,10 @@
-import pytest
 import numpy as np
+import pytest
 from lumicks.pylake.correlated_stack import CorrelatedStack
-from lumicks.pylake.detail.widefield import TiffStack, Tether
-from lumicks.pylake.tests.data.mock_widefield import MockTiffFile
+from lumicks.pylake.detail.widefield import Tether, TiffStack
 from lumicks.pylake.kymo import _kymo_from_correlated_stack
+
+from ..data.mock_widefield import MockTiffFile
 
 
 def make_frame_times(n_frames, rate=10, step=8, start=10, framerate_jitter=0, step_jitter=0):

--- a/lumicks/pylake/tests/test_imaging_confocal/test_point_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_point_scan.py
@@ -1,0 +1,62 @@
+import pytest
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def test_point_scans(test_point_scans, reference_timestamps, reference_counts):
+    ps = test_point_scans["PointScan1"]
+    ps_red = ps.red_photon_count
+
+    assert ps_red.data.shape == (64,)
+
+    np.testing.assert_allclose(ps_red.timestamps, reference_timestamps)
+    np.testing.assert_allclose(ps_red.data, reference_counts)
+
+
+def test_plotting(test_point_scans):
+    ps = test_point_scans["PointScan1"]
+
+    for channel in ("red", "green", "blue"):
+        xline, yline = ps.plot(channel=channel)[0].get_xydata().T
+
+        count = getattr(ps, f"{channel}_photon_count")
+        np.testing.assert_allclose(xline, (count.timestamps - count.timestamps[0]) * 1e-9)
+        np.testing.assert_allclose(yline, count.data)
+        plt.close()
+
+    lines = ps.plot(channel="rgb", lw=5)
+    for channel, line in zip(("red", "green", "blue"), lines):
+        xline, yline = line.get_xydata().T
+        count = getattr(ps, f"{channel}_photon_count")
+        np.testing.assert_allclose(xline, (count.timestamps - count.timestamps[0]) * 1e-9)
+        np.testing.assert_allclose(yline, count.data)
+    plt.close()
+
+
+def test_deprecated_plotting(test_point_scans):
+    ps = test_point_scans["PointScan1"]
+    with pytest.deprecated_call():
+        ps.plot_red()
+    with pytest.deprecated_call():
+        ps.plot_green()
+    with pytest.deprecated_call():
+        ps.plot_blue()
+    with pytest.deprecated_call():
+        ps.plot_rgb()
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"The call signature of `plot\(\)` has changed: Please, provide `axes` as a "
+        "keyword argument."
+    ):
+        xline, yline = ps.plot("red", None)[0].get_xydata().T
+
+        count = getattr(ps, "red_photon_count")
+        np.testing.assert_allclose(xline, (count.timestamps - count.timestamps[0]) * 1e-9)
+        np.testing.assert_allclose(yline, count.data)
+        plt.close()
+    # Test rejection of deprecated call with positional `axes` and double keyword assignment
+    with pytest.raises(
+        TypeError,
+        match=r"`PointScan.plot\(\)` got multiple values for argument `axes`"
+    ):
+        ps.plot("rgb", None, axes=None)

--- a/lumicks/pylake/tests/test_imaging_confocal/test_point_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_point_scan.py
@@ -1,13 +1,52 @@
-import pytest
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
+
+from lumicks.pylake.point_scan import PointScan
+from ..data.mock_confocal import MockConfocalFile, generate_image_data
+
+start = np.int64(20e9)
+dt = np.int64(62.5e6)
+reference_image = np.random.poisson(10, (64, 1))
+reference_infowave, counts = generate_image_data(reference_image, 5, 3)
 
 
-def test_point_scans(test_point_scans, reference_timestamps, reference_counts):
+@pytest.fixture(scope="module")
+def reference_counts():
+    return counts[0]
+
+
+@pytest.fixture(scope="module")
+def reference_timestamps():
+    stop = start + len(reference_infowave) * dt
+    return np.arange(start, stop, 6.25e7).astype(np.int64)
+
+
+@pytest.fixture(scope="module")
+def test_point_scans(reference_counts):
+    point_scans = {}
+
+    mock_file, metadata, stop = MockConfocalFile.from_streams(
+        start,
+        dt,
+        [],
+        [],
+        [],
+        infowave=reference_infowave,
+        red_photon_counts=reference_counts,
+        green_photon_counts=reference_counts,
+        blue_photon_counts=reference_counts,
+    )
+    point_scans["PointScan1"] = PointScan("PointScan1", mock_file, start, stop, metadata)
+
+    return point_scans
+
+
+def test_point_scan_attrs(test_point_scans, reference_timestamps, reference_counts):
     ps = test_point_scans["PointScan1"]
     ps_red = ps.red_photon_count
 
-    assert ps_red.data.shape == (64,)
+    assert ps_red.data.shape == (64 * 5 + 2 * 3,)
 
     np.testing.assert_allclose(ps_red.timestamps, reference_timestamps)
     np.testing.assert_allclose(ps_red.data, reference_counts)
@@ -46,7 +85,7 @@ def test_deprecated_plotting(test_point_scans):
     with pytest.warns(
         DeprecationWarning,
         match=r"The call signature of `plot\(\)` has changed: Please, provide `axes` as a "
-        "keyword argument."
+        "keyword argument.",
     ):
         xline, yline = ps.plot("red", None)[0].get_xydata().T
 
@@ -56,7 +95,6 @@ def test_deprecated_plotting(test_point_scans):
         plt.close()
     # Test rejection of deprecated call with positional `axes` and double keyword assignment
     with pytest.raises(
-        TypeError,
-        match=r"`PointScan.plot\(\)` got multiple values for argument `axes`"
+        TypeError, match=r"`PointScan.plot\(\)` got multiple values for argument `axes`"
     ):
         ps.plot("rgb", None, axes=None)


### PR DESCRIPTION
**Why?**
See https://github.com/lumicks/pylake/pull/413

**Details**
This PR implements the `test_imaging_confocal` tests for the modules:
* `test_kymo_from_array`
* `test_kymo_from_corrstack`
* `test_point_scan`

To help reviewing, each module has an initial commit that first copies the old test code from `test_imaging_confocal_old`. Each first commit is followed by a commit implementing the changes to work with the new test infrastructure.