### PR TITLE
ci: use `platformdirs` for jupyter

### DIFF
--- a/.github/workflows/pylake_docs_test.yml
+++ b/.github/workflows/pylake_docs_test.yml
@@ -2,6 +2,9 @@ name: docs build
 
 on: [push]
 
+env:
+  JUPYTER_PLATFORM_DIRS: "1"
+
 jobs:
     build_docs:
         runs-on: ubuntu-latest

--- a/.github/workflows/pylake_release.yml
+++ b/.github/workflows/pylake_release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v*
 
+env:
+  JUPYTER_PLATFORM_DIRS: "1"
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -2,6 +2,10 @@ name: pytest
 
 on: [push]
 
+env:
+  # See: https://github.com/jupyter/jupyter_core/pull/292#issuecomment-1258284246
+  JUPYTER_PLATFORM_DIRS: "1"
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pylake_test_no_notebook.yml
+++ b/.github/workflows/pylake_test_no_notebook.yml
@@ -2,6 +2,9 @@ name: no notebook deps
 
 on: [push]
 
+env:
+  JUPYTER_PLATFORM_DIRS: "1"
+
 jobs:
     build_no_nb:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Adds environment variable to acknowledge that we want to use `platformdirs` to determine which paths to use. Basically they changed how the path lookup is done and added a deprecation warning to notify us about this. See https://github.com/jupyter/jupyter_core/pull/292 for more information.