### PR TITLE
diffusion: add option to compute ensemble cve

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### New features
 
 * Added `KymoTrack.plot()` and `KymoTrackGroup.plot()` methods to conveniently plot the coordinates of tracked lines. See the [kymotracking documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more details.
+* Added `KymoTrackGroup.ensemble_diffusion()` for estimating an average diffusion for a collection of tracks.
 
 ## v0.13.2 | 2022-11-15
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -1,8 +1,6 @@
 from copy import copy
-import warnings
 from deprecated.sphinx import deprecated
 from sklearn.neighbors import KernelDensity
-from ..detail.utilities import use_docstring_from
 from .detail.msd_estimation import *
 from .detail.localization_models import LocalizationModel
 from .. import __version__
@@ -928,6 +926,33 @@ class KymoTrackGroup:
             )
 
         return [k.estimate_diffusion(method, *args, **kwargs) for k in filtered_tracks]
+
+    def ensemble_diffusion(self, method):
+        """Determine ensemble based diffusion estimates.
+
+        Determines ensemble based diffusion estimates for the entire group of KymoTracks. This
+        method assumes that all tracks experience the same diffusion and computes an averaged
+        diffusion estimate.
+
+        Parameters
+        ----------
+        method : {"cve"}
+            - "cve" : Covariance based estimator. Optimal if SNR > 1. Ensemble average is
+              determined by determining the weighted average of the individual track estimates. The
+              standard error is computed by determining the weighted average of the associated
+              standard errors for each estimate (Equation 57 and 58 from Vestergaard [7]_). See
+              :meth:`KymoTrack.estimate_diffusion` for more detailed information and references.
+
+        References
+        ----------
+        .. [7] Vestergaard, C. L., Blainey, P. C., & Flyvbjerg, H. (2014). Optimal estimation of
+               diffusion coefficients from single-particle trajectories. Physical Review E, 89(2),
+               022726.
+        """
+        if method == "cve":
+            return ensemble_cve(self)
+        else:
+            raise ValueError(f'Invalid method ({method}) selected. Method must be "cve".')
 
     def ensemble_msd(self, max_lag=None, min_count=2) -> EnsembleMSD:
         r"""This method returns the weighted average of the Mean Squared Displacement (MSD) for all

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -425,10 +425,10 @@ class KymoTrack:
         Parameters
         ----------
         method : {"cve", "ols", "gls"}
-            - "cve" : Covariance based estimator [5]_. Optimal if SNR > 1. Can only be used when
-              track is equidistantly sampled.
+            - "cve" : Covariance based estimator [5]_. Optimal if SNR > 1.
             - "ols" : Ordinary least squares [3]_. Determines optimal number of lags.
             - "gls" : Generalized least squares [4]_. Takes into account covariance matrix (slower).
+              Can only be used when track is equidistantly sampled.
         max_lag : int (optional)
             Number of lags to include when using an MSD-based estimator. When omitted, the method
             will choose an appropriate number of lags to use. For the cve estimator this argument
@@ -900,10 +900,10 @@ class KymoTrackGroup:
         Parameters
         ----------
         method : {"cve", "ols", "gls"}
-            - "cve" : Covariance based estimator. Optimal if SNR > 1. Can only be used when
-              track is equidistantly sampled.
+            - "cve" : Covariance based estimator. Optimal if SNR > 1.
             - "ols" : Ordinary least squares. Determines optimal number of lags.
-            - "gls" : Generalized least squares. Takes into account covariance matrix (slower).
+            - "gls" : Generalized least squares. Takes into account covariance matrix (slower). Can
+              only be used when track is equidistantly sampled.
         max_lag : int (optional)
             Number of lags to include when using an MSD-based estimator. When omitted, the method
             will choose an appropriate number of lags to use. For the cve estimator this argument


### PR DESCRIPTION
**Why this PR?**
This functionality is provided so that we have a tried and tested method of computing a correctly weighted average diffusion.

If we don't, I fear people might just average the constants they get from `estimate_diffusion()` which can lead to suboptimal results.

To test the method, I've done some bootstrapping. Below are the results. The diffusion constant was set to a range of values (according to `(snr * noise)**2 / dt)` to simulate various levels of SNR. The noise level was kept fixed to `0.1`. I then simulate `M` "datasets" of `R` tracks. On every set of tracks I apply the methods. At the end, the ensemble method gives me an estimate and an estimate for the standard error. I aggregate these standard errors for realisations to see if there's a bias in them. I do this by squaring them, adding them and then taking the square root.

The shaded area indicate the `mean` +- `stdev` of the bootstrap. So on the individual results obtained with the method. The lines indicate the `aggregated mean` +- `aggregated stdev` returned by the method. Ideally, the lines should extent exactly to the shaded area. If they don't, then the estimate is bad.

![CVE_250reps_equal](https://user-images.githubusercontent.com/19836026/201106097-f7d788d4-1c85-4a59-bb1a-226cfbc2ebb5.PNG)
*Figure 1: 250 replications with all tracks (`R=12`) of equal length (`N=40` points). Weighting doesn't do anything here, but it's just to show the reduced variance that can be obtained.*

![CVE_1500reps](https://user-images.githubusercontent.com/19836026/201107586-cc7b65ee-cbb7-4fab-ace2-0ad02fccfd1f.png)
*Figure 2: `1500` replicates of a set of tracks where `3` tracks have full length (`N=40`) and `9` tracks are much shorter (`N=5`). Here we would expect weighting of the results to kick in, giving more weight to the long tracks.*

![image](https://user-images.githubusercontent.com/19836026/201120462-17d5116b-882e-4fa1-bf84-2124690915f8.png)
*Figure 3: `1500` replicates of a set of tracks where `2` tracks have full length (`N=40`) and `8 tracks are much shorter (`N=6`). Here we would expect weighting of the results to really kick in, giving more weight to the long tracks. Here we can see naive averaging compared to optimal averaging. You can see that naive averaging leads to barely any variance reduction since the estimates are dominated by the short tracks. What you can also see is that there is some bias in the variance estimate for cases where the variance is large. This seems to only occur when there is a large difference between the track lengths.*

![image](https://user-images.githubusercontent.com/19836026/201121323-8877bd21-44a8-428a-ade8-94343aed3f49.png)
*Figure 4: Close up of the most relevant area*

**Why are there no docs?**
Documentation is pending. I plan to rewrite the diffusion part of the documentation, and it will include some plots like the one above.

Small note:
I know that in the function `ensemble_diffusion` I have a function argument with literally one option, but I don't want to omit it in case we release before the `ols` variant makes it in. Users should make the decision of which method to use explicitly, and therefore I think it should not be defaulted (otherwise we'd immediately introduce a breaking change).