### PR TITLE
Provide default values for parameter arguments of functions

### DIFF
--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -101,3 +101,19 @@ def could_sum_overflow(a, axis=None):
     A `False` result is definitive. The sum will definitely not overflow.
     """
     return np.any(will_mul_overflow(np.max(a, axis), a.size if axis is None else a.shape[axis]))
+
+
+def hide_parameter(name):
+    """
+    A decorator for functions to remove a parameter from their call signature.
+    """
+    from inspect import signature
+
+    def hide_parameter_name(f):
+        # Remove parameter from signature and set cached signature attribute
+        sig = signature(f)
+        sig = sig.replace(parameters=(par for par in sig.parameters.values() if par.name != name))
+        f.__signature__ = sig
+        return f
+
+    return hide_parameter_name

--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -101,19 +101,3 @@ def could_sum_overflow(a, axis=None):
     A `False` result is definitive. The sum will definitely not overflow.
     """
     return np.any(will_mul_overflow(np.max(a, axis), a.size if axis is None else a.shape[axis]))
-
-
-def hide_parameter(name):
-    """
-    A decorator for functions to remove a parameter from their call signature.
-    """
-    from inspect import signature
-
-    def hide_parameter_name(f):
-        # Remove parameter from signature and set cached signature attribute
-        sig = signature(f)
-        sig = sig.replace(parameters=(par for par in sig.parameters.values() if par.name != name))
-        f.__signature__ = sig
-        return f
-
-    return hide_parameter_name

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -1,6 +1,9 @@
-from .detail.trace_line_2d import detect_lines, points_to_line_segments
-from .detail.scoring_functions import kymo_score
-from .kymotrack import KymoTrack, KymoTrackGroup
+import warnings
+
+import numpy as np
+from deprecated.sphinx import deprecated
+
+from ..detail.utilities import hide_parameter
 from .detail.gaussian_mle import gaussian_mle_1d, overlapping_pixels
 from .detail.peakfinding import (
     peak_estimate,
@@ -8,10 +11,9 @@ from .detail.peakfinding import (
     merge_close_peaks,
     KymoPeaks,
 )
-from .detail.localization_models import GaussianLocalizationModel
-import numpy as np
-import warnings
-from deprecated.sphinx import deprecated
+from .detail.scoring_functions import kymo_score
+from .detail.trace_line_2d import detect_lines, points_to_line_segments
+from .kymotrack import KymoTrack, KymoTrackGroup
 
 __all__ = [
     "track_greedy",


### PR DESCRIPTION
**Why?**
As a developer I want to be able to get the default values for parameters

**Requirements**
* A user should be able to retrieve default arguments of a function with parameters initially set to `None`
* Pylake users should not be bothered (docstrings from Pylake should not be altered)

Please, see second proposal section further down.

**Implementation details**
~I decided to add the special optional parameter `get_arg_defaults` in the function that should return the default values of the parameters initialliy set to `None`. To hide this parameter from the user, I created a decorator who reads the signature of the function, removes the parameter from the signature and sets the cached signature attribute `__signature__` to the modified signature.
With `get_arg_defaults` set to `False` the functionality of the function does not change at all. With `get_arg_defaults` set to `True`, the function returns a `dict` with two entries `dependent` and `independent`. The `independent` entry contains a dict of parameters with their default values, independent of the arguments supplied during the function call.  The `dependent` entry contains a dict of parameters with their values considering arguments supplied. The `dependent` parameter values could be used to dynamically adjust sliders to available ranges the user could select from.~

~As an example I chose to implement the `get_arg_defaults` functionality for `track_greedy`. The [docs](https://lumicks-pylake.readthedocs.io/en/provide_default_values/_api/lumicks.pylake.track_greedy.html) are not altered and the call of `track_greedy` with the special parameter returns:~

```python3
lk.track_greedy(kymo, "green", track_width=None, pixel_threshold=35, window=6, rect=None, get_arg_defaults=True)
```
```
({'dependent': {'track_width': 0.35,
   'pixel_threshold': 35,
   'sigma': 0.175,
   'rect': ((249.593856, 19.958527131776336),
    (249.7238528, 20.008527131776336))},
  'independent': {'track_width': 0.35,
   'pixel_threshold': 7.0,
   'sigma': 0.175,
   'rect': ((0.0, 0.0), (285.6029696, 31.200000000000003))}},)
```

**Short discussion and question**
~What I like about this solution is that the default values are defined/created in the same spot were the default values are returned. Also, adding this functionality to other functions should be straight forward. What I dislike is the extra clutter in the function body. What I also do not like is that some parameters (like `rect` in this example of `track_greedy`)  need extra computation, to be properly determined. Before we proceed adding the `get_arg_defaults` functionality to other functions, we should probably clearly define what is needed exactly.~

~However, this draft PR demonstrates a working solution to the problem. What do you think about this solution in general? Do we need the dependent and indepent variables or do the independent variables suffice (this would also avoid extra computations).~

**Second proposal details**
The first proposal was a _suboptimal_ solution. Therefore, I implemented another one based on the suggestion with parameter annotation directly in the function signature. However, I purposefully selected a more complicated _example_ with parameters of the function `track_greedy()` whose default values are `None` and are computed in the function body. The outcome of this computation is determined by other parameters supplied to the `track_greedy` function, meaning, these are no simple parameters whose values are known a priori. Therefore, to be able to get valid default values, I introduced the function `_track_greedy_args()`. It returns the dataclass object `TrackGreedyArgs`, which holds the calculated default values. Each default value is annotated with its corresponding constraints. The default values and constraints can be retrieved as follows:

```Python3
track_greedy_args = lk.kymotracker.kymotracker._track_greedy_args(kymo, "red")
for key, value in asdict(track_greedy_args).items():
    datatype, constraints = get_args(get_type_hints(track_greedy_args, include_extras=True)[key])
    print(key, value, datatype, asdict(constraints))
```
The parameters are returned along with their default value, their type and a `Constraints` object:
```
track_width 0.35 <class 'float'> {'min': 0.0, 'max': None, 'step': None, 'min_inclusive': False, 'max_inclusive': False, 'description': 'Track width in physical units'}
pixel_threshold 4.0 <class 'float'> {'min': 0.0, 'max': None, 'step': None, 'min_inclusive': False, 'max_inclusive': False, 'description': 'Intensity threshold for the pixels'}
sigma 0.175 <class 'float'> {'min': None, 'max': None, 'step': None, 'min_inclusive': False, 'max_inclusive': False, 'description': 'Uncertainty in the particle position'}
```

**Positive consequences**
* The publicly visible signature of `track_greedy()` does not change. The annotation is not made public which allows us to iterate and hopefully settle on the specific format.
* Any end user who needs to know proper default values and constraints of `track_width`, `pixel_threshold` and `sigma` can call the function `_track_greedy_args()` . Computation is minimal.
* The function `_track_greedy_args()` is also used by the `track_greedy()` function. There is one central place were the default values and their constraints are calculated/defined. Code duplication is avoided.
* If this solution turns out to be viable and we have settled on a format for the the annotation, we could (possibly) make the annotation public by directly moving it into the `track_greedy()` function.

**Negative consequences**
* extra code
* let me know ...

What do you think about this proposal?