### PR TITLE
Add `pylake` custom colormaps for single color images

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Added `KymoTrack.plot()` and `KymoTrackGroup.plot()` methods to conveniently plot the coordinates of tracked lines. See the [kymotracking documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more details.
 * Added `KymoTrackGroup.ensemble_diffusion()` for estimating an average diffusion for a collection of tracks.
 * Added the `lk.GaussianMixtureModel.extract_dwell_times()` method to calculate dwell-times for all states from channel data.
+* Added `lk.colormaps` with custom colormaps for plotting single-channel images. Note: this is a `namedtuple` so you can access the attributes using the dot notation (for example `kymo.plot("blue", cmap=lk.colormaps.cyan)`). The available attributes are `red`, `green`, `blue`, `magenta`, `yellow`, `cyan`.
 
 ## v0.13.2 | 2022-11-15
 

--- a/docs/_templates/instance.rst
+++ b/docs/_templates/instance.rst
@@ -1,0 +1,10 @@
+{{ objname | escape | underline}}
+
+.. container:: api_sub_header
+
+   {{ fullname }}
+
+.. currentmodule:: {{ module }}
+
+.. autodata:: {{ objname }}
+  :annotation:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,8 +7,8 @@ If you are just looking to get started, read the :doc:`/tutorial/index` first.
 .. currentmodule:: lumicks.pylake
 
 .. autosummary::
-    :template: class.rst
     :toctree: _api
+    :template: class.rst
 
     File
     channel.Slice
@@ -18,6 +18,10 @@ If you are just looking to get started, read the :doc:`/tutorial/index` first.
     point_scan.PointScan
     correlated_stack.CorrelatedStack
     ColorAdjustment
+
+    :template: instance.rst
+
+    colormaps
 
 
 Force calibration

--- a/docs/tutorial/correlatedstacks.rst
+++ b/docs/tutorial/correlatedstacks.rst
@@ -33,6 +33,11 @@ This can be accomplished by providing a :class:`~lumicks.pylake.ColorAdjustment`
     stack.plot(channel="red", adjustment=lk.ColorAdjustment([50, 50, 50], [100, 250, 196]))
 
 
+There are also a number of custom colormaps for plotting single channel images. These are available from :data:`~lumicks.pylake.colormaps`; the available colormaps are:
+`.red`, `.green`, `.blue`, `.magenta`, `.yellow`, and `.cyan`. For example, we can plot the blue channel image with the cyan colormap::
+
+    stack.plot(channel="blue", cmap=lk.colormaps.cyan)
+
 By default the limits should be provided in absolute values, although percentiles can be used instead for convenience::
 
     stack.plot(channel="red", adjustment=lk.ColorAdjustment([5, 5, 5], [95, 95, 95], mode="percentile"))

--- a/docs/tutorial/images.rst
+++ b/docs/tutorial/images.rst
@@ -27,6 +27,8 @@ Or just pick a single one by providing the name of the scan as ``scan=file.scans
     scan = file.scans["41"]
     scan.plot("red")
 
+.. _confocal_plotting:
+
 Plotting and Exporting
 ----------------------
 
@@ -53,6 +55,11 @@ When this is the case, it may be beneficial to manually set the color limits for
 This can be accomplished by providing a :class:`~lumicks.pylake.ColorAdjustment` to plotting or export functions::
 
     scan.plot(channel="rgb", adjustment=lk.ColorAdjustment([0, 0, 0], [4, 4, 4]))
+
+There are also a number of custom colormaps for plotting single channel images. These are available from :data:`~lumicks.pylake.colormaps`; the available colormaps are:
+`.red`, `.green`, `.blue`, `.magenta`, `.yellow`, and `.cyan`. For example, we can plot the blue channel image with the cyan colormap::
+
+    scan.plot(channel="blue", cmap=lk.colormaps.cyan)
 
 Here the first array gives the minimal values for the color scale of red, green and blue respectively (here `[0, 0, 0]`) and the second array gives the maximum values for the color scales.
 The color scale is linear by default, but `Gamma correction <https://en.wikipedia.org/wiki/Gamma_correction>`_ can be applied in addition to the bounds by supplying an extra argument named `gamma`.

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -33,6 +33,10 @@ argument accepts the strings "red", "green", "blue", or "rgb". This function acc
 arguments that are passed to :func:`plt.imshow() <matplotlib.pyplot.imshow()>` internally. Note
 also, the axes are labeled with the appropriate time and position units.
 
+.. note::
+
+    The same plotting options available for :ref:`confocal scans <confocal_plotting>` are also available for kymographs.
+
 The kymograph can also be exported to TIFF format::
 
     kymo.export_tiff("image.tiff")

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -12,7 +12,7 @@ from .__about__ import (
 
 from .file_download import *
 from .benchmark import benchmark
-from .adjustments import ColorAdjustment
+from .adjustments import ColorAdjustment, colormaps
 from .correlated_stack import CorrelatedStack
 from .piezo_tracking.piezo_tracking import *
 from .piezo_tracking.baseline import *

--- a/lumicks/pylake/adjustments.py
+++ b/lumicks/pylake/adjustments.py
@@ -1,5 +1,7 @@
 import numpy as np
 import matplotlib as mpl
+from matplotlib.colors import LinearSegmentedColormap
+from dataclasses import make_dataclass
 
 
 class ColorAdjustment:
@@ -121,3 +123,55 @@ class ColorAdjustment:
 
 
 no_adjustment = ColorAdjustment.nothing()
+
+
+def _make_cmap(name, color):
+    LinearSegmentedColormap.from_list(name, colors=[(0, 0, 0), color])
+
+
+_available_colormaps = {
+    "red": _make_cmap("red", (1, 0, 0)),
+    "green": _make_cmap("green", (0, 1, 0)),
+    "blue": _make_cmap("blue", (0, 0, 1)),
+    "magenta": _make_cmap("magenta", (1, 0, 1)),
+    "yellow": _make_cmap("yellow", (1, 1, 0)),
+    "cyan": _make_cmap("cyan", (0, 1, 1)),
+}
+
+
+class _ColorMaps(
+    make_dataclass(
+        "ColorMaps",
+        [(key, LinearSegmentedColormap) for key in _available_colormaps.keys()],
+        frozen=True,
+    )
+):
+    """Pylake custom colormaps.
+
+    Attributes
+    ----------
+    red
+    green
+    blue
+    magenta
+    yellow
+    cyan
+
+    Examples
+    --------
+    ::
+
+        # plot the blue image from a kymograph with cyan colormap
+        kymo.plot(channel="blue", cmap=lk.colormaps.cyan)
+
+    """
+
+    def __str__(self):
+        return f"Pylake custom colormaps; available colormaps:\n\t{', '.join(_available_colormaps.keys())}"
+
+    @property
+    def rgb(self):
+        return None
+
+
+colormaps = _ColorMaps(**_available_colormaps)

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -6,7 +6,6 @@ from typing import List
 import cachetools
 import numpy as np
 from deprecated.sphinx import deprecated
-from matplotlib.colors import LinearSegmentedColormap
 from numpy import typing as npt
 
 from ..adjustments import no_adjustment
@@ -14,13 +13,6 @@ from .image import reconstruct_image, reconstruct_image_sum
 from .imaging_mixins import TiffExport
 from .mixin import ExcitationLaserPower, PhotonCounts
 from .utilities import could_sum_overflow
-
-linear_colormaps = {
-    "red": LinearSegmentedColormap.from_list("red", colors=[(0, 0, 0), (1, 0, 0)]),
-    "green": LinearSegmentedColormap.from_list("green", colors=[(0, 0, 0), (0, 1, 0)]),
-    "blue": LinearSegmentedColormap.from_list("blue", colors=[(0, 0, 0), (0, 0, 1)]),
-    "rgb": None,
-}
 
 
 def _int_mean(a, total_size, axis):

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -6,13 +6,13 @@ import numpy as np
 from deprecated.sphinx import deprecated
 from skimage.measure import block_reduce
 
+from . import colormaps
 from .adjustments import no_adjustment
 from .detail.confocal import (
     ConfocalImage,
     ScanAxis,
     ScanMetaData,
     _deprecate_basescan_plot_args,
-    linear_colormaps,
 )
 from .detail.image import histogram_rows, round_down, seek_timestamp_next_line
 from .detail.plotting import get_axes, show_image
@@ -333,7 +333,7 @@ class Kymo(ConfocalImage):
                 -0.5 * self.pixelsize[0],
             ],
             aspect=(image.shape[0] / image.shape[1]) * (self.duration / size_calibrated),
-            cmap=linear_colormaps[channel],
+            cmap=getattr(colormaps, channel),
         )
 
         image_handle = show_image(

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -5,8 +5,9 @@ from itertools import zip_longest
 import numpy as np
 from deprecated import deprecated
 
+from . import colormaps
 from .adjustments import no_adjustment
-from .detail.confocal import ConfocalImage, _deprecate_basescan_plot_args, linear_colormaps
+from .detail.confocal import ConfocalImage, _deprecate_basescan_plot_args
 from .detail.image import make_image_title, reconstruct_num_frames
 from .detail.imaging_mixins import FrameIndex, VideoExport
 from .detail.plotting import get_axes, show_image
@@ -339,7 +340,6 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             scan.plot_correlated(file.force1x, channel="red")
         """
         from lumicks.pylake.nb_widgets.correlated_plot import plot_correlated
-        from .detail.confocal import linear_colormaps
 
         def plot_channel(frame):
             if channel in ("red", "green", "blue", "rgb"):
@@ -362,7 +362,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             title_factory,
             frame,
             reduce,
-            colormap=linear_colormaps[channel],
+            colormap=getattr(colormaps, channel),
             figure_scale=figure_scale,
             post_update=post_update,
         )
@@ -459,7 +459,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             # With origin set to upper (default) bounds should be given as (0, n, n, 0)
             extent=[0, x_um, y_um, 0],
             aspect=(image.shape[0] / image.shape[1]) * (x_um / y_um),
-            cmap=linear_colormaps[channel],
+            cmap=getattr(colormaps, channel),
         )
 
         image_handle = show_image(


### PR DESCRIPTION
**Why this PR?**
Our current default `blue` colormap is basically unreadable (pure blue on black). Here we define `cyan`, `yellow`, and `magenta` colormaps and expose the dictionary through the `lk.colormaps` dictionary. You can use them like:
```
kymo.plot(channel="blue", cmap=lk.colormaps.cyan)
```
![image](https://user-images.githubusercontent.com/61475504/202705450-5b9ecc44-ef24-4624-a5d9-eb2809bf42dd.png)

While a simple feature there are a couple of things I'm unsure about and would like some input:
- what do we think about the simple name `colormaps`
- ~~do we want this to be immutable? right now it's a normal `dict` so users can mess with it, but making it immutable would require something custom. Not sure if it's worth the effort~~
- forgot about `namedtuple`. overall I like this because it's immutable and personally I enjoy the dot notation better than `dict` keys. The one thing I'm not super happy about is you can't document a variable (can't generate a reasonable API stub for it, unless we link to the `namedtuple` definition rather than the instance, which is weird). For now, I added some explanation to the changelog and will put more in the tutorials, but any ideas about this are welcome
- don't really like exposing something from `./detail/...` from the main namespace. Other option is to move the definition directly into `__init__.py`

For now, I went with the _true_ colors (ie, `cyan = #00FFFF`) even though they're not the most beautiful. Two reasons for this: the naming is more correct, and probably needed for the future if we decide to support combining LUTs for multicolor plotting. We can always add "prettier" ones like `light_blue` if we want at a later point.