### PR TITLE
Dwell-times from Gaussian Mixture Models

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Added `KymoTrack.plot()` and `KymoTrackGroup.plot()` methods to conveniently plot the coordinates of tracked lines. See the [kymotracking documentation](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymotracking.html) for more details.
 * Added `KymoTrackGroup.ensemble_diffusion()` for estimating an average diffusion for a collection of tracks.
+* Added the `lk.GaussianMixtureModel.extract_dwell_times()` method to calculate dwell-times for all states from channel data.
 
 ## v0.13.2 | 2022-11-15
 

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -482,7 +482,7 @@ def _exponential_mle_optimize(
     return result.x, -result.fun
 
 
-def _dwellcounts_from_statepath(statepath, exclude_ambiguous_dwells=True):
+def _dwellcounts_from_statepath(statepath, exclude_ambiguous_dwells):
     """Calculate the dwell counts and slicing indices for all states in a state path trajectory.
 
     Note: the counts are the number of frames or time points. To convert to proper
@@ -490,12 +490,12 @@ def _dwellcounts_from_statepath(statepath, exclude_ambiguous_dwells=True):
 
     Parameters
     ----------
-    statepath : numpy.typing.ArrayLike
+    statepath : array_like
         Time-ordered array of state labels
     exclude_ambiguous_dwells : bool
-            Determines whether to exclude dwelltimes which are not exactly determined. If `True`, tracks which
-            start in the first frame or end in the last frame of the kymograph are not used in the analysis,
-            since the exact start/stop times of the binding event are not definitively known.
+        Determines whether to exclude dwelltimes which are not exactly determined. If `True`, the first
+        and last dwells are not used in the analysis, since the exact start/stop times of these events are
+        not definitively known.
 
     Returns
     -------

--- a/lumicks/pylake/population/tests/test_mixture.py
+++ b/lumicks/pylake/population/tests/test_mixture.py
@@ -7,7 +7,9 @@ import matplotlib.pyplot as plt
 
 def test_gmm(trace_lownoise):
     data, statepath, params = trace_lownoise
-    m = GaussianMixtureModel(data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100)
+    m = GaussianMixtureModel(
+        data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
+    )
     weights = np.array([np.sum(statepath == j) for j in np.arange(params["n_states"])])
     weights = weights / weights.sum()
 
@@ -16,6 +18,7 @@ def test_gmm(trace_lownoise):
     np.testing.assert_allclose(m.std, params["st_devs"], atol=0.02)
     np.testing.assert_allclose(m.weights, weights)
 
+
 def test_gmm_from_slice(trace_simple):
     data, statepath, params = trace_simple
     trace = Slice(Continuous(data, 20000, 12800))
@@ -23,9 +26,37 @@ def test_gmm_from_slice(trace_simple):
     np.testing.assert_allclose(m.means, params["means"], atol=0.05)
 
 
+def test_labels(trace_simple):
+    data, statepath, params = trace_simple
+    m = GaussianMixtureModel(
+        data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
+    )
+    labels = m.label(Slice(Continuous(data, 20000, 12800)))
+    np.testing.assert_equal(labels, statepath)
+
+
+def test_dwelltimes(trace_simple):
+    data, statepath, params = trace_simple
+    m = GaussianMixtureModel(
+        data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
+    )
+
+    channel = Slice(Continuous(data, 20000, 12800))
+
+    dwell_times = m.extract_dwell_times(channel, exclude_ambiguous_dwells=False)
+    np.testing.assert_allclose(dwell_times[0], [3.200e-04, 2.432e-04, 5.120e-05])
+    np.testing.assert_allclose(dwell_times[1], [1.664e-04, 3.456e-04, 3.840e-05, 1.152e-04])
+
+    dwell_times = m.extract_dwell_times(channel, exclude_ambiguous_dwells=True)
+    np.testing.assert_allclose(dwell_times[0], [3.200e-04, 2.432e-04, 5.120e-05])
+    np.testing.assert_allclose(dwell_times[1], [3.456e-04, 3.840e-05])
+
+
 def test_information_criteria(trace_simple):
     data, statepath, params = trace_simple
-    m = GaussianMixtureModel(data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100)
+    m = GaussianMixtureModel(
+        data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
+    )
 
     np.testing.assert_allclose(m.bic, -20.04115465)
     np.testing.assert_allclose(m.aic, -33.06700559)
@@ -33,7 +64,9 @@ def test_information_criteria(trace_simple):
 
 def test_exit_flag(trace_simple):
     data, statepath, params = trace_simple
-    m = GaussianMixtureModel(data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100)
+    m = GaussianMixtureModel(
+        data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
+    )
 
     ef = m.exit_flag
     assert ef["converged"] == True
@@ -43,13 +76,19 @@ def test_exit_flag(trace_simple):
 
 def test_pdf(trace_simple):
     data, statepath, params = trace_simple
-    m = GaussianMixtureModel(data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100)
-    np.testing.assert_allclose(m.pdf(np.array([10, 11])), [[1.857758, 5e-26], [5e-21, 2.222931]], rtol=1e-5, atol=1e-13)
+    m = GaussianMixtureModel(
+        data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
+    )
+    np.testing.assert_allclose(
+        m.pdf(np.array([10, 11])), [[1.857758, 5e-26], [5e-21, 2.222931]], rtol=1e-5, atol=1e-13
+    )
 
 
 def test_gmm_plots(trace_simple):
     data, statepath, params = trace_simple
-    m = GaussianMixtureModel(data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100)
+    m = GaussianMixtureModel(
+        data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
+    )
     trace = Slice(Continuous(data, 20000, 12800))
 
     m.hist(trace)


### PR DESCRIPTION
**Why this PR?**
We have two main functionalities currently in the `population` module: Gaussian mixture models and Dwell-time analysis. This feature allows for the results from the first to be used as input to the second. Specifically, channel data can be fit with the GMM and a labeled state-path extracted. This state-path is converted into lists of dwell-times for each state and these can then be fit with the exponential distribution.

While I was working on the tutorial update I noticed the need for this feature. So there are no docs updates here; a second PR with those changes will follow shortly

It might also be useful to have some classmethod on `DwelltimeModel` to read in state-paths directly