### PR TITLE
ci: enable `flake8`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,31 @@
+[flake8]
+max-line-length = 100
+
+exclude =
+    .git,
+    __pycache__,
+    .ipynb_checkpoints,
+    .mypy_cache,
+    .pytest_cache,
+    .venv,
+    examples
+    | tests  # ignore test directories until we have a better solution for test datasets
+
+
+per-file-ignores =
+    # Ignore imported but not used for __init__.py files.
+    __init__.py:F401
+
+ignore =
+    # Don't complain about long docstring lines (yet).
+    W505,
+    # Allow whitespace before colon (black compatibility).
+    E203,
+    # Allow line break before binary operator (black compatibility).
+    W503,
+    # Don't fail over line length. We will clean them up as we go.
+    E501,
+    # Don't complain about star imports.
+    F403,F405,
+
+show-source = True

--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -38,3 +38,7 @@ jobs:
       run: |
         pip install black==22.3.0
         black --check --diff --color .
+    - name: flake8
+      run: |
+        pip install flake8 flake8-bugbear
+        flake8 .

--- a/docs/_ext/nbexport.py
+++ b/docs/_ext/nbexport.py
@@ -238,7 +238,7 @@ def remove_notebooks_from_deps(app, _):
     if not hasattr(env, "nbfiles"):
         return
 
-    for target_docname, ipynb_path in env.nbfiles.items():
+    for ipynb_path in env.nbfiles.values():
         for docname, deps in env.dependencies.items():
             docpath = os.path.dirname(docname)
             relpath = os.path.relpath(ipynb_path, os.path.join(env.srcdir, docpath))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath("./_ext"))
 sys.path.insert(0, os.path.abspath("./_static"))
 sys.path.insert(0, os.path.abspath(".."))
 
-from lumicks import pylake
+from lumicks import pylake  # noqa: E402
 
 
 # -- Project information -----------------------------------------------------

--- a/lumicks/pylake/adjustments.py
+++ b/lumicks/pylake/adjustments.py
@@ -118,3 +118,6 @@ class ColorAdjustment:
     @classmethod
     def nothing(cls):
         return cls(None, None, "nothing")
+
+
+no_adjustment = ColorAdjustment.nothing()

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -464,9 +464,6 @@ class CorrelatedStack(FrameIndex, TiffExport, VideoExport):
         """
         from lumicks.pylake.nb_widgets.correlated_plot import plot_correlated
 
-        title_factory = lambda frame: make_image_title(self, frame, show_name=False)
-        frame_timestamps = self.frame_timestamp_ranges()
-
         def frame_grabber(frame_idx):
             return self._get_frame(frame_idx)._get_plot_data(channel, adjustment=adjustment)
 
@@ -474,12 +471,12 @@ class CorrelatedStack(FrameIndex, TiffExport, VideoExport):
             return adjustment._update_limits(image_handle, image, channel)
 
         plot_correlated(
-            channel_slice,
-            frame_timestamps,
-            frame_grabber,
-            title_factory,
-            frame,
-            reduce,
+            channel_slice=channel_slice,
+            frame_timestamps=self.frame_timestamp_ranges(),
+            get_plot_data=frame_grabber,
+            title_factory=lambda frame: make_image_title(self, frame, show_name=False),
+            frame=frame,
+            reduce=reduce,
             figure_scale=figure_scale,
             post_update=post_update,
         )

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -5,7 +5,7 @@ import numpy as np
 import numpy.typing as npt
 from deprecated.sphinx import deprecated
 
-from .adjustments import ColorAdjustment
+from .adjustments import ColorAdjustment, no_adjustment
 from .detail.image import make_image_title
 from .detail.imaging_mixins import FrameIndex, TiffExport, VideoExport
 from .detail.plotting import get_axes, show_image
@@ -33,7 +33,7 @@ def _deprecate_plot_arguments(plot):
         # We can gracefully convert the old ordered positional arguments into keyword arguments
         if is_old_order(args):
             keys = ["frame", "channel", "show_title", "axes", "adjustment"]
-            defaults = [0, "rgb", True, None, ColorAdjustment.nothing()]
+            defaults = [0, "rgb", True, None, no_adjustment]
             warn_on_keys = []
             for arg, key, default in zip(args, keys, defaults):
                 if key in kwargs:
@@ -298,7 +298,7 @@ class CorrelatedStack(FrameIndex, TiffExport, VideoExport):
         channel="rgb",
         *,
         frame=0,
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
         axes=None,
         image_handle=None,
         show_title=True,
@@ -422,7 +422,7 @@ class CorrelatedStack(FrameIndex, TiffExport, VideoExport):
         reduce=np.mean,
         channel="rgb",
         figure_scale=0.75,
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
     ):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling
         function (e.g. `np.mean`) is evaluated for the time between a start and end time of a

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -9,7 +9,7 @@ from deprecated.sphinx import deprecated
 from matplotlib.colors import LinearSegmentedColormap
 from numpy import typing as npt
 
-from ..adjustments import ColorAdjustment
+from ..adjustments import no_adjustment
 from .image import reconstruct_image, reconstruct_image_sum
 from .imaging_mixins import TiffExport
 from .mixin import ExcitationLaserPower, PhotonCounts
@@ -374,7 +374,7 @@ class ConfocalImage(BaseScan, TiffExport):
         assert channel == "timestamps"
         return self._timestamp_factory(self, reduce)
 
-    def _get_plot_data(self, channel, adjustment=ColorAdjustment.nothing(), frame=None):
+    def _get_plot_data(self, channel, adjustment=no_adjustment, frame=None):
         """Get image data for plotting requested channel.
 
         Parameters

--- a/lumicks/pylake/detail/h5_helper.py
+++ b/lumicks/pylake/detail/h5_helper.py
@@ -2,7 +2,7 @@ import h5py
 from fnmatch import fnmatch
 
 
-def write_h5(h5_file, output_filename, compression_level=5, omit_data={}):
+def write_h5(h5_file, output_filename, compression_level=5, omit_data=None):
     """Write a modified h5 file to disk.
 
     Parameters
@@ -13,14 +13,14 @@ def write_h5(h5_file, output_filename, compression_level=5, omit_data={}):
         Output file name.
     compression_level : int
         Compression level for gzip compression.
-    omit_data : Set[str]
+    omit_data : Optional[Set[str]]
         Which data sets to omit. Should be a set of h5 paths.
     """
 
     with h5py.File(output_filename, "w") as out_file:
 
         def traversal_function(name, node):
-            if any([fnmatch(name, o) for o in omit_data]):
+            if omit_data and any([fnmatch(name, o) for o in omit_data]):
                 print(f"Omitted {name} from export")
                 return
 

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -2,7 +2,6 @@ import enum
 import math
 import numpy as np
 import warnings
-from deprecated import deprecated
 
 
 class InfowaveCode(enum.IntEnum):

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -4,7 +4,7 @@ import numpy.typing as npt
 import tifffile
 from typing import Iterator, Union
 
-from ..adjustments import ColorAdjustment
+from ..adjustments import no_adjustment
 from .timeindex import to_timestamp
 
 _FIRST_TIMESTAMP = 1388534400
@@ -107,7 +107,7 @@ class VideoExport:
         start_frame=None,
         stop_frame=None,
         fps=15,
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
         **kwargs,
     ):
         """Export a video

--- a/lumicks/pylake/detail/plotting.py
+++ b/lumicks/pylake/detail/plotting.py
@@ -1,6 +1,6 @@
 from matplotlib import pyplot as plt
 
-from ..adjustments import ColorAdjustment
+from ..adjustments import no_adjustment
 
 
 def get_axes(axes=None, image_handle=None):
@@ -17,7 +17,7 @@ def get_axes(axes=None, image_handle=None):
 
 def show_image(
     image,
-    adjustment=ColorAdjustment.nothing(),
+    adjustment=no_adjustment,
     channel="rgb",
     image_handle=None,
     axes=None,

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -7,7 +7,7 @@ import warnings
 import enum
 from copy import copy
 from dataclasses import dataclass
-from ..adjustments import ColorAdjustment
+from ..adjustments import no_adjustment
 
 
 def _get_page_timestamps(page):
@@ -78,7 +78,7 @@ class TiffFrame:
     def is_rgb(self):
         return self._description.is_rgb
 
-    def _get_plot_data(self, channel="rgb", adjustment=ColorAdjustment.nothing()):
+    def _get_plot_data(self, channel="rgb", adjustment=no_adjustment):
         """Return data as a numpy array, appropriate for use by `imshow`.
 
         Parameters

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -290,13 +290,14 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
         """Markers stored in the file"""
         return self._get_object_dictionary("Marker", Marker)
 
-    def save_as(self, filename, compression_level=5, omit_data={}):
+    def save_as(self, filename, compression_level=5, omit_data=None):
         """Write a modified h5 file to disk.
 
-        When transferring data, it can be beneficial to omit some channels from the h5 file, or use a higher compression
-        ratio. High frequency channels tend to take up a lot of space and aren't always necessary for every single
-        analysis. It is also worth mentioning that Bluelake exports files at compression level 1 for performance
-        reasons, so this function can help reduce the file size even when no data is omitted.
+        When transferring data, it can be beneficial to omit some channels from the h5 file, or use
+        a higher compression ratio. High frequency channels tend to take up a lot of space and
+        aren't always necessary for every single analysis. It is also worth mentioning that
+        Bluelake exports files at compression level 1 for performance reasons, so this function
+        can help reduce the file size even when no data is omitted.
 
         Parameters
         ----------
@@ -304,9 +305,10 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
             Output file name.
         compression_level : int
             Compression level for gzip compression (default: 5).
-        omit_data : Set[str]
-            Which data sets to omit. Should be a set of h5 paths (e.g. {"Force HF/Force 1y"}). `fnmatch` patterns are
-            used to specify which fields to omit, which means you can use wildcards as well (see examples below).
+        omit_data : Optional[Set[str]]
+            Which data sets to omit. Should be a set of h5 paths (e.g. {"Force HF/Force 1y"}).
+            `fnmatch` patterns are used to specify which fields to omit, which means you can use
+            wildcards as well (see examples below).
 
         Examples
         --------

--- a/lumicks/pylake/fitting/datasets.py
+++ b/lumicks/pylake/fitting/datasets.py
@@ -53,7 +53,7 @@ class Datasets:
 
         return count
 
-    def _add_data(self, name, x, y, params={}):
+    def _add_data(self, name, x, y, params=None):
         """
         Loads a data set.
 
@@ -65,7 +65,7 @@ class Datasets:
             Independent variable. NaNs are silently dropped.
         y : array_like
             Dependent variable. NaNs are silently dropped.
-        params : dict of {str : str or int}
+        params : Optional[dict of {str : str or int}]
             List of parameter transformations. These can be used to convert one parameter in the model, to a new
             parameter name or constant for this specific data set (for more information, see the examples).
 
@@ -203,7 +203,7 @@ class Datasets:
 
 
 class FdDatasets(Datasets):
-    def add_data(self, name, f, d, params={}):
+    def add_data(self, name, f, d, params=None):
         """
         Adds a data set to this fit.
 
@@ -215,7 +215,7 @@ class FdDatasets(Datasets):
             An array_like containing force data.
         d : array_like
             An array_like containing distance data.
-        params : dict of {str : str or int}
+        params : Optional[dict of {str : str or int}]
             List of parameter transformations. These can be used to convert one parameter in the model, to a new
             parameter name or constant for this specific data set (for more information, see the examples).
 

--- a/lumicks/pylake/fitting/detail/utilities.py
+++ b/lumicks/pylake/fitting/detail/utilities.py
@@ -12,8 +12,11 @@ def unique_idx(input_list):
     return unique_list, inverse_list
 
 
-def parse_transformation(params, param_transform={}):
+def parse_transformation(params, param_transform=None):
     transformed = OrderedDict(zip(params, params))
+
+    if not param_transform:
+        return transformed
 
     for key, value in param_transform.items():
         if key in transformed:

--- a/lumicks/pylake/fitting/detail/utilities.py
+++ b/lumicks/pylake/fitting/detail/utilities.py
@@ -4,12 +4,13 @@ import numpy as np
 
 def unique_idx(input_list):
     """
-    Determine unique elements of a list and return indices which reconstruct the original list from the unique elements.
+    Determine unique elements of a list and return indices which reconstruct the original list from
+    the unique elements.
     """
     unique_list = []
     [unique_list.append(x) for x in input_list if x not in unique_list]
-    inverse_list = [unique_list.index(l) for l in input_list]
-    return unique_list, inverse_list
+    inverse_indices = [unique_list.index(x) for x in input_list]
+    return unique_list, inverse_indices
 
 
 def parse_transformation(params, param_transform=None):

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -155,7 +155,7 @@ class Fit:
         for data in self.datasets.values():
             data._link_data(parameter_lookup)
 
-        defaults = [all_defaults[all_parameter_names.index(l)] for l in unique_parameter_names]
+        defaults = [all_defaults[all_parameter_names.index(n)] for n in unique_parameter_names]
         self._params._set_params(unique_parameter_names, defaults)
         self._built = True
 

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -82,7 +82,7 @@ class Fit:
 
         return front(self.datasets.values()).data
 
-    def _add_data(self, name, x, y, params={}):
+    def _add_data(self, name, x, y, params=None):
         if len(self.datasets) > 1:
             raise RuntimeError(
                 "This Fit is comprised of multiple models. Please add data to a particular model by "
@@ -340,7 +340,7 @@ class Fit:
             1,
         )
 
-        def trial(parameters=[]):
+        def trial(parameters=None):
             return -2.0 * self.log_likelihood(parameters, self.sigma)
 
         profile._extend_profile(trial, self._fit, self.params, num_steps, True, verbose)
@@ -350,9 +350,9 @@ class Fit:
 
         return profile
 
-    def _calculate_residual(self, parameter_values=[]):
+    def _calculate_residual(self, parameter_values=None):
         self._rebuild()
-        if len(parameter_values) == 0:
+        if parameter_values is None:
             parameter_values = self.params.values
 
         residual_idx = 0
@@ -367,9 +367,9 @@ class Fit:
 
         return residual
 
-    def _calculate_jacobian(self, parameter_values=[]):
+    def _calculate_jacobian(self, parameter_values=None):
         self._rebuild()
-        if len(parameter_values) == 0:
+        if parameter_values is None:
             parameter_values = self.params.values
 
         residual_idx = 0
@@ -556,7 +556,7 @@ class Fit:
 
         return est_sd * np.ones(len(res))
 
-    def log_likelihood(self, params=[], sigma=None):
+    def log_likelihood(self, params=None, sigma=None):
         """The model residual is given by chi squared = -2 log(L)"""
         self._rebuild()
         res = self._calculate_residual(params)
@@ -727,7 +727,7 @@ class FdFit(Fit):
 
         fit.plot("Dataset 1", "k--")  # Plot the fitted model"""
 
-    def add_data(self, name, f, d, params={}):
+    def add_data(self, name, f, d, params=None):
         """Adds a data set to this fit.
 
         Parameters
@@ -738,7 +738,7 @@ class FdFit(Fit):
             An array_like containing force data.
         d : array_like
             An array_like containing distance data.
-        params : dict of {str : str or int}
+        params : Optional[dict of {str : str or int}]
             List of parameter transformations. These can be used to convert one parameter in the
             model, to a new parameter name or constant for this specific data set (for more
             information, see the examples).

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -381,10 +381,10 @@ class Model:
             n_x, n_y = optimal_plot_layout(len(self._params))
             for i_param, param in enumerate(self._params):
                 plt.subplot(n_x, n_y, i_param + 1)
-                l1 = plt.plot(independent, np.transpose(jacobian[i_param, :]))
-                l2 = plt.plot(independent, np.transpose(jacobian_fd[i_param, :]), "--")
+                plt.plot(independent, np.transpose(jacobian[i_param, :]), label="Analytic")
+                plt.plot(independent, np.transpose(jacobian_fd[i_param, :]), "--", label="FD")
                 plt.title(param)
-                plt.legend({"Analytic", "FD"})
+                plt.legend()
 
         is_close = np.allclose(jacobian, jacobian_fd, **kwargs)
         if not is_close:

--- a/lumicks/pylake/fitting/profile_likelihood.py
+++ b/lumicks/pylake/fitting/profile_likelihood.py
@@ -433,18 +433,18 @@ class ProfileLikelihood1D:
             ]
         )
 
-    def plot_relations(self, params={}, **kwargs):
+    def plot_relations(self, params=None, **kwargs):
         """Plot the relations between the different parameters.
 
         Parameters
         ----------
-        params : Set[str]
+        params : Optional[Set[str]]
             List of parameter names to plot (optional, omission plots all)
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.plot`."""
         parameters = self.parameters
 
-        if len(params) == 0:
+        if not params:
             other = [
                 x
                 for x in range(parameters.shape[1])

--- a/lumicks/pylake/force_calibration/convenience.py
+++ b/lumicks/pylake/force_calibration/convenience.py
@@ -1,4 +1,3 @@
-import numpy as np
 from lumicks.pylake.force_calibration.calibration_models import (
     ActiveCalibrationModel,
     PassiveCalibrationModel,

--- a/lumicks/pylake/force_calibration/convenience.py
+++ b/lumicks/pylake/force_calibration/convenience.py
@@ -18,7 +18,7 @@ def calibrate_force(
     sample_rate,
     viscosity=None,
     active_calibration=False,
-    driving_data=np.asarray([]),
+    driving_data=None,
     driving_frequency_guess=None,
     axial=False,
     hydrodynamically_correct=False,
@@ -28,7 +28,7 @@ def calibrate_force(
     fast_sensor=False,
     num_points_per_block=2000,
     fit_range=(1e2, 23e3),
-    excluded_ranges=[],
+    excluded_ranges=None,
     fixed_diode=None,
     fixed_alpha=None,
     drag=None,
@@ -116,7 +116,7 @@ def calibrate_force(
         raise ValueError("When using fast_sensor=True, there is no diode model to fix.")
 
     if active_calibration:
-        if driving_data.size == 0:
+        if driving_data is None or driving_data.size == 0:
             raise ValueError("Active calibration requires the driving_data to be defined.")
         if not driving_frequency_guess or driving_frequency_guess < 0:
             raise ValueError("Approximate driving frequency must be specified and larger than zero")

--- a/lumicks/pylake/force_calibration/detail/power_models.py
+++ b/lumicks/pylake/force_calibration/detail/power_models.py
@@ -2,7 +2,6 @@ import math
 import numpy as np
 from collections import namedtuple
 from itertools import product
-from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
 
 
 def fit_analytical_lorentzian(ps):

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -357,7 +357,7 @@ class Kymo(ConfocalImage):
         color_channel,
         aspect_ratio=0.25,
         reduce=np.mean,
-        kymo_args={},
+        kymo_args=None,
         adjustment=no_adjustment,
         **kwargs,
     ):
@@ -376,7 +376,7 @@ class Kymo(ConfocalImage):
         reduce : callable
             The :mod:`numpy` function which is going to reduce multiple samples into one. Forwarded
             to :meth:`Slice.downsampled_over() <lumicks.pylake.channel.Slice.downsampled_over()>`
-        kymo_args : dict
+        kymo_args : Optional[dict]
             Forwarded to :func:`matplotlib.pyplot.imshow()`
         adjustment : lk.ColorAdjustment
             Color adjustments to apply to the output image.
@@ -393,7 +393,7 @@ class Kymo(ConfocalImage):
         _, (ax1, ax2) = plt.subplots(2, 1, sharex="all")
 
         # plot kymo
-        self.plot(channel=color_channel, axes=ax1, adjustment=adjustment, **kymo_args)
+        self.plot(channel=color_channel, axes=ax1, adjustment=adjustment, **(kymo_args or {}))
         ax1.set_xlabel(None)
         xlim_kymo = ax1.get_xlim()  # Stored since plotting the force channel will change the limits
 

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -6,7 +6,7 @@ import numpy as np
 from deprecated.sphinx import deprecated
 from skimage.measure import block_reduce
 
-from .adjustments import ColorAdjustment
+from .adjustments import no_adjustment
 from .detail.confocal import (
     ConfocalImage,
     ScanAxis,
@@ -287,7 +287,7 @@ class Kymo(ConfocalImage):
         self,
         channel="rgb",
         *,
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
         axes=None,
         image_handle=None,
         show_title=True,
@@ -358,7 +358,7 @@ class Kymo(ConfocalImage):
         aspect_ratio=0.25,
         reduce=np.mean,
         kymo_args={},
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
         **kwargs,
     ):
         """Plot kymo with force channel downsampled over scan lines
@@ -430,7 +430,7 @@ class Kymo(ConfocalImage):
         color_channel,
         pixels_per_bin=1,
         hist_ratio=0.25,
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
         **kwargs,
     ):
         """Plot kymo with histogram along position axis
@@ -470,7 +470,7 @@ class Kymo(ConfocalImage):
         color_channel,
         pixels_per_bin=1,
         hist_ratio=0.25,
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
         **kwargs,
     ):
         """Plot kymo with histogram along time axis

--- a/lumicks/pylake/kymotracker/detail/localization_models.py
+++ b/lumicks/pylake/kymotracker/detail/localization_models.py
@@ -1,7 +1,5 @@
 import numpy as np
-from scipy import integrate
 from dataclasses import dataclass
-from typing import ClassVar
 
 __all__ = ["LocalizationModel", "GaussianLocalizationModel"]
 

--- a/lumicks/pylake/kymotracker/detail/peakfinding.py
+++ b/lumicks/pylake/kymotracker/detail/peakfinding.py
@@ -112,7 +112,7 @@ def refine_peak_based_on_moment(
     subpixel_offset = convolve2d(data, dir_kernel, "same") / (m0 + eps)
 
     max_coordinates = subpixel_offset.shape[0]
-    for iteration in range(max_iter):
+    for _ in range(max_iter):
         offsets = subpixel_offset[coordinates, time_points]
         (out_of_bounds,) = np.nonzero(abs(offsets) > 0.5)
         coordinates[out_of_bounds] += np.sign(offsets[out_of_bounds]).astype(int)

--- a/lumicks/pylake/kymotracker/detail/stitch.py
+++ b/lumicks/pylake/kymotracker/detail/stitch.py
@@ -1,5 +1,4 @@
 import numpy as np
-from copy import deepcopy
 
 
 def distance_line_to_point(line_pt1, line_pt2, point):

--- a/lumicks/pylake/kymotracker/detail/trace_line_2d.py
+++ b/lumicks/pylake/kymotracker/detail/trace_line_2d.py
@@ -1,7 +1,6 @@
 import enum
 import numpy as np
 from dataclasses import dataclass
-from typing import List
 from .geometry_2d import is_in_2d, is_opposite, calculate_image_geometry, get_candidate_generator
 from .scoring_functions import build_score_matrix
 

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -156,13 +156,13 @@ def track_greedy(
 
     if track_width <= 0:
         # Must be positive otherwise refinement fails
-        raise ValueError(f"track_width should be larger than zero")
+        raise ValueError("track_width should be larger than zero")
 
     if pixel_threshold <= 0:
-        raise ValueError(f"pixel_threshold should be larger than zero")
+        raise ValueError("pixel_threshold should be larger than zero")
 
     if diffusion < 0:
-        raise ValueError(f"diffusion should be positive")  # Must be positive or score model fails
+        raise ValueError("diffusion should be positive")  # Must be positive or score model fails
 
     kymograph_data = kymograph.get_image(channel)
 
@@ -381,7 +381,7 @@ def refine_tracks_centroid(tracks, track_width=None):
 
     if track_width <= 0:
         # Must be positive otherwise refinement fails
-        raise ValueError(f"track_width should be larger than zero")
+        raise ValueError("track_width should be larger than zero")
 
     track_width_pixels = np.ceil(track_width / tracks._kymo.pixelsize[0])
 

--- a/lumicks/pylake/nb_widgets/image_editing.py
+++ b/lumicks/pylake/nb_widgets/image_editing.py
@@ -30,7 +30,7 @@ def add_selector(axes, callback, button=None, interactive=True, **kwargs):
 
 class ImageStackAxes(Axes):
     def __init__(
-        self, *args, image, frame=0, channel="rgb", show_title=True, plot_kwargs={}, **kwargs
+        self, *args, image, frame=0, channel="rgb", show_title=True, plot_kwargs, **kwargs
     ):
         """Custom axes to handle mouse events for rotating images about a defined tether.
 
@@ -94,7 +94,7 @@ class ImageStackAxes(Axes):
 
 class ImageEditorAxes(ImageStackAxes):
     def __init__(
-        self, *args, image, frame=0, channel="rgb", show_title=True, plot_kwargs={}, **kwargs
+        self, *args, image, frame=0, channel="rgb", show_title=True, plot_kwargs, **kwargs
     ):
         """Custom axes to handle mouse events for rotating images about a defined tether.
 
@@ -223,7 +223,7 @@ class ImageEditorWidget:
 
 
 class KymoEditorAxes(Axes):
-    def __init__(self, *args, kymo, channel="rgb", plot_kwargs={}, **kwargs):
+    def __init__(self, *args, kymo, channel="rgb", plot_kwargs, **kwargs):
         """Custom axes to handle mouse events for rotating images about a defined tether.
 
         Parameters

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -553,7 +553,7 @@ class KymoWidgetGreedy(KymoWidget):
         min_length=None,
         use_widgets=True,
         output_filename="kymotracks.txt",
-        slider_ranges={},
+        slider_ranges=None,
         **kwargs,
     ):
         """Create a widget for performing kymotracking.
@@ -617,6 +617,7 @@ class KymoWidgetGreedy(KymoWidget):
         algorithm_parameters = _get_default_parameters(kymo, channel)
 
         # TODO: remove line_width argument deprecation path
+        slider_ranges = slider_ranges or {}
         if "line_width" in slider_ranges.keys():
             warnings.warn(
                 DeprecationWarning(
@@ -696,12 +697,15 @@ class KymoWidgetGreedy(KymoWidget):
 
         threshold_slider_index = list(self._algorithm_parameters.keys()).index("pixel_threshold")
         threshold_slider = slider_box.children[threshold_slider_index].children[0]
-        threshold_slider_callback = lambda change: self._set_label(
-            "warning",
-            ""
-            if change["new"] > min_threshold
-            else f"Tracking with threshold of {change['new']} may be slow.",
-        )
+
+        def threshold_slider_callback(change):
+            self._set_label(
+                "warning",
+                ""
+                if change["new"] > min_threshold
+                else f"Tracking with threshold of {change['new']} may be slow.",
+            )
+
         threshold_slider.observe(
             threshold_slider_callback,
             "value",

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -482,15 +482,15 @@ class KymoWidget:
         self._track_connector.set_active(False)
 
         if value["new"] == "Track":
-            self._set_label("status", f"Drag right mouse button to track an ROI")
+            self._set_label("status", "Drag right mouse button to track an ROI")
             self._area_selector.set_active(True)
             self._adding = True
         elif value["new"] == "Remove Tracks":
-            self._set_label("status", f"Drag right mouse button to remove tracks from an ROI")
+            self._set_label("status", "Drag right mouse button to remove tracks from an ROI")
             self._area_selector.set_active(True)
             self._adding = False
         elif value["new"] == "Connect Tracks":
-            self._set_label("status", f"Drag right mouse button to connect two tracks")
+            self._set_label("status", "Drag right mouse button to connect two tracks")
             self._track_connector.set_active(True)
 
     def _show(self, use_widgets, **kwargs):

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -98,7 +98,7 @@ class DwelltimeBootstrap:
         upper = np.quantile(data, 1 - (alpha / 2))
         return mean, (lower, upper)
 
-    def plot(self, alpha=0.05, n_bins=25, hist_kwargs={}, span_kwargs={}, line_kwargs={}):
+    def plot(self, alpha=0.05, n_bins=25, hist_kwargs=None, span_kwargs=None, line_kwargs=None):
         """Plot the bootstrap distributions for the parameters of a model.
 
         Parameters
@@ -107,18 +107,18 @@ class DwelltimeBootstrap:
             confidence intervals are calculated as 100*(1-alpha)%
         n_bins : int
             number of bins in the histogram
-        hist_kwargs : dict
+        hist_kwargs : Optional[dict]
             dictionary of plotting kwargs applied to histogram
-        span_kwargs : dict
+        span_kwargs : Optional[dict]
             dictionary of plotting kwargs applied to the patch indicating the area
             spanned by the confidence intervals
-        line_kwargs : dict
+        line_kwargs : Optional[dict]
             dictionary of plotting kwargs applied to the line indicating the
             distribution means
         """
-        hist_kwargs = {"facecolor": "#c5c5c5", "edgecolor": "#888888", **hist_kwargs}
-        span_kwargs = {"facecolor": "tab:red", "alpha": 0.3, **span_kwargs}
-        line_kwargs = {"color": "k", **line_kwargs}
+        hist_kwargs = {"facecolor": "#c5c5c5", "edgecolor": "#888888", **(hist_kwargs or {})}
+        span_kwargs = {"facecolor": "tab:red", "alpha": 0.3, **(span_kwargs or {})}
+        line_kwargs = {"color": "k", **(line_kwargs or {})}
 
         def plot_axes(data, key, component, use_index):
             plt.hist(data, bins=n_bins, **hist_kwargs)
@@ -261,9 +261,9 @@ class DwelltimeModel:
         self,
         n_bins=25,
         bin_spacing="linear",
-        hist_kwargs={},
-        component_kwargs={},
-        fit_kwargs={},
+        hist_kwargs=None,
+        component_kwargs=None,
+        fit_kwargs=None,
         xscale=None,
         yscale=None,
     ):
@@ -273,9 +273,9 @@ class DwelltimeModel:
         self,
         n_bins=25,
         bin_spacing="linear",
-        hist_kwargs={},
-        component_kwargs={},
-        fit_kwargs={},
+        hist_kwargs=None,
+        component_kwargs=None,
+        fit_kwargs=None,
         xscale=None,
         yscale=None,
     ):
@@ -287,11 +287,11 @@ class DwelltimeModel:
             number of bins in the histogram
         bin_spacing : {"log", "linear"}
             determines how bin edges are spaced apart
-        hist_kwargs : dict
+        hist_kwargs : Optional[dict]
             dictionary of plotting kwargs applied to histogram
-        component_kwargs : dict
+        component_kwargs : Optional[dict]
             dictionary of plotting kwargs applied to the line plot for each component
-        fit_kwargs : dict
+        fit_kwargs : Optional[dict]
             dictionary of plotting kwargs applied to line plot for the total fit
         xscale : {"log", "linear", None}
             scaling for the x-axis; when `None` default is "linear"
@@ -314,9 +314,9 @@ class DwelltimeModel:
         bins = scale(*limits, n_bins)
         centers = bins[:-1] + (bins[1:] - bins[:-1]) / 2
 
-        hist_kwargs = {"facecolor": "#cdcdcd", "edgecolor": "#aaaaaa", **hist_kwargs}
-        component_kwargs = {"marker": "o", "ms": 3, **component_kwargs}
-        fit_kwargs = {"color": "k", **fit_kwargs}
+        hist_kwargs = {"facecolor": "#cdcdcd", "edgecolor": "#aaaaaa", **(hist_kwargs or {})}
+        component_kwargs = {"marker": "o", "ms": 3, **(component_kwargs or {})}
+        fit_kwargs = {"color": "k", **(fit_kwargs or {})}
 
         components = self.pdf(centers)
 
@@ -426,7 +426,7 @@ def exponential_mixture_log_likelihood(params, t, min_observation_time, max_obse
 
 
 def _exponential_mle_optimize(
-    n_components, t, min_observation_time, max_observation_time, initial_guess=None, options={}
+    n_components, t, min_observation_time, max_observation_time, initial_guess=None, options=None
 ):
     """Calculate the maximum likelihood estimate of the model parameters given measured dwelltimes.
 
@@ -443,7 +443,7 @@ def _exponential_mle_optimize(
     initial_guess : array_like
         initial guess for the model parameters ordered as
         [amplitude1, amplitude2, ..., lifetime1, lifetime2, ...]
-    options : dict
+    options : Optional[dict]
         additional optimization parameters passed to `minimize(..., options)`.
     """
     if np.any(np.logical_or(t < min_observation_time, t > max_observation_time)):

--- a/lumicks/pylake/population/mixture.py
+++ b/lumicks/pylake/population/mixture.py
@@ -171,7 +171,7 @@ class GaussianMixtureModel:
         components = np.vstack([stats.norm(m, s).pdf(x) for m, s in zip(self.means, self.std)])
         return self.weights.reshape((-1, 1)) * components
 
-    def hist(self, trace, n_bins=100, plot_kwargs={}, hist_kwargs={}):
+    def hist(self, trace, n_bins=100, plot_kwargs=None, hist_kwargs=None):
         """Plot a histogram of the data overlaid with the model PDF.
 
         Parameters
@@ -180,14 +180,14 @@ class GaussianMixtureModel:
             Data object to histogram.
         n_bins : int
             Number of histogram bins.
-        plot_kwargs : dict
+        plot_kwargs : Optional[dict]
             Plotting keyword arguments passed to the PDF line plot.
-        hist_kwargs : dict
+        hist_kwargs : Optional[dict]
             Plotting keyword arguments passed to the histogram plot.
         """
         import matplotlib.pyplot as plt
 
-        hist_kwargs = {"facecolor": "#c5c5c5", **hist_kwargs}
+        hist_kwargs = {"facecolor": "#c5c5c5", **(hist_kwargs or {})}
 
         lims = (np.min(trace.data), np.max(trace.data))
         bins = np.linspace(*lims, num=n_bins)
@@ -198,11 +198,11 @@ class GaussianMixtureModel:
         plt.hist(trace.data, bins=bins, density=True, **hist_kwargs)
         # reset color cycle
         plt.gca().set_prop_cycle(None)
-        plt.plot(x, g_components.T, **plot_kwargs)
+        plt.plot(x, g_components.T, **(plot_kwargs or {}))
         plt.ylabel("density")
         plt.xlabel(trace.labels.get("y", "signal"))
 
-    def plot(self, trace, trace_kwargs={}, label_kwargs={}):
+    def plot(self, trace, trace_kwargs=None, label_kwargs=None):
         """Plot a time trace with each data point labeled with the state assignment.
 
         Parameters
@@ -216,8 +216,8 @@ class GaussianMixtureModel:
         """
         import matplotlib.pyplot as plt
 
-        trace_kwargs = {"c": "#c5c5c5", **trace_kwargs}
-        label_kwargs = {"marker": "o", "ls": "none", "ms": 3, **label_kwargs}
+        trace_kwargs = {"c": "#c5c5c5", **(trace_kwargs or {})}
+        label_kwargs = {"marker": "o", "ls": "none", "ms": 3, **(label_kwargs or {})}
 
         labels = self.label(trace)
         trace.plot(**trace_kwargs)

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -103,3 +103,15 @@ def test_dwellcounts_from_statepath():
     dwells, ranges = _dwellcounts_from_statepath([], exclude_ambiguous_dwells=True)
     assert dwells == {}
     assert ranges == {}
+
+
+@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
+def test_plots(exponential_data):
+    """Check if `DwelltimeModel` fits can be plotted without an exception"""
+    dataset = exponential_data["dataset_2exp"]
+    fit = DwelltimeModel(dataset["data"], 1, **dataset["parameters"].observation_limits)
+    fit.hist()
+
+    np.random.seed(123)
+    fit.calculate_bootstrap(iterations=2)
+    fit.bootstrap.plot()

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -5,7 +5,7 @@ from itertools import zip_longest
 import numpy as np
 from deprecated import deprecated
 
-from .adjustments import ColorAdjustment
+from .adjustments import no_adjustment
 from .detail.confocal import ConfocalImage, _deprecate_basescan_plot_args, linear_colormaps
 from .detail.image import make_image_title, reconstruct_num_frames
 from .detail.imaging_mixins import FrameIndex, VideoExport
@@ -301,7 +301,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         reduce=np.mean,
         channel="rgb",
         figure_scale=0.75,
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
     ):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling
         function (e.g. np.mean) is evaluated for the time between a start and end time of a frame.
@@ -412,7 +412,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         channel="rgb",
         *,
         frame=0,
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
         axes=None,
         image_handle=None,
         show_title=True,
@@ -489,7 +489,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         start_frame=None,
         end_frame=None,
         fps=15,
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
         **kwargs,
     ):
         """Export multi-frame scan as video.
@@ -532,7 +532,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         start_frame=None,
         end_frame=None,
         fps=15,
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
         **kwargs,
     ):
         """Export multi-frame scan as video.
@@ -575,7 +575,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         start_frame=None,
         end_frame=None,
         fps=15,
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
         **kwargs,
     ):
         """Export multi-frame scan as video.
@@ -618,7 +618,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         start_frame=None,
         end_frame=None,
         fps=15,
-        adjustment=ColorAdjustment.nothing(),
+        adjustment=no_adjustment,
         **kwargs,
     ):
         """Export multi-frame scan as video.

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -350,7 +350,9 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         def post_update(image_handle, image):
             return adjustment._update_limits(image_handle, image, channel)
 
-        title_factory = lambda frame: make_image_title(self, frame, show_name=False)
+        def title_factory(frame):
+            return make_image_title(self, frame, show_name=False)
+
         frame_timestamps = self.frame_timestamp_ranges()
 
         plot_correlated(


### PR DESCRIPTION
**Why this PR?**
To help us not shoot ourselves in the feet.

`flake8` can hopefully help us stick to `PEP` and flag things that may become issues.

For now, I have excluded the test folders analogously to what we do with `black`. We should definitely still add them, but there were already many fixups and I didn't want this PR to be blocked on just this (since it will involve cleaning up the tests as well and that would overlap with what Tobias is doing now).

I fixed up all of the things it reported. It's many commits, but all of them are pretty simple individually. I'd recommend going commit by commit, since I clustered them by problem. Once approved, I will squash each class of error as one commit.

In the process I noticed that some dwelltime plots were untested, so I added a few tests whether those open without exception at least.

Finally, I debated whether to replace empty dictionaries with `None` or `MappingProxyType({})` and decided for the former as it would be less confusing to end users when looking at the function signature. Even though I'm aware that the latter also ensures that we don't modify the input variable.

Please also check the rules I excluded in `.flake8`. I added comments as to what and why. We can discuss whether we want to add more exclusions in the future. For now I stuck to making sure it plays nicely with `black` and to not flag some patterns that we stubbornly use (such as `*` imports).