### PR TITLE
cve: allow passing in localization variance

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@
 * Added the `lk.GaussianMixtureModel.extract_dwell_times()` method to calculate dwell-times for all states from channel data.
 * Added `lk.colormaps` with custom colormaps for plotting single-channel images. Note: this is a `namedtuple` so you can access the attributes using the dot notation (for example `kymo.plot("blue", cmap=lk.colormaps.cyan)`). The available attributes are `red`, `green`, `blue`, `magenta`, `yellow`, `cyan`.
 * Added `localization_variance` to [DiffusionEstimate](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymotracker.detail.msd_estimation.DiffusionEstimate.html). This quantity is useful for determining the diffusive SNR.
+* Added `variance_of_localization_variance` to [DiffusionEstimate](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymotracker.detail.msd_estimation.DiffusionEstimate.html) when calculating an ensemble CVE. This provides an estimate of the variance of the averaged localization uncertainty.
+* Added option to pass a localization variance and its uncertainty to [https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymotracker.kymotrack.KymoTrack.html#lumicks.pylake.kymotracker.kymotrack.KymoTrack.estimate_diffusion](KymoTrack.estimate_diffusion()).
 
 ## v0.13.2 | 2022-11-15
 

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -710,23 +710,34 @@ def test_disallowed_diffusion_est(blank_kymo):
 
 
 @pytest.mark.parametrize(
-    "loc_var, loc_var_var, ref_diff, ref_std, ref_count, ref_loc",
+    "localization_var, var_of_localization_var, diffusion_ref, std_err_ref, count_ref,"
+    "localization_variance_ref",
     [
         (None, None, 1.5, 1.3928388277184118, 5, -1.0),
         (0.1, 0.01, 0.4, 0.33466401061363027, 5, 0.1),
     ],
 )
-def test_diffusion_cve(blank_kymo, loc_var, loc_var_var, ref_diff, ref_std, ref_count, ref_loc):
+def test_diffusion_cve(
+    blank_kymo,
+    localization_var,
+    var_of_localization_var,
+    diffusion_ref,
+    std_err_ref,
+    count_ref,
+    localization_variance_ref,
+):
     """Test the API for the covariance based estimator"""
     k = KymoTrack(np.arange(5), np.arange(5), blank_kymo, "red")
     cve_est = k.estimate_diffusion(
-        "cve", localization_variance=loc_var, variance_of_localization_variance=loc_var_var
+        "cve",
+        localization_variance=localization_var,
+        variance_of_localization_variance=var_of_localization_var,
     )
 
-    np.testing.assert_allclose(cve_est.value, ref_diff)
-    np.testing.assert_allclose(cve_est.std_err, ref_std)
-    np.testing.assert_allclose(cve_est.num_points, ref_count)
-    np.testing.assert_allclose(cve_est.localization_variance, ref_loc)
+    np.testing.assert_allclose(cve_est.value, diffusion_ref)
+    np.testing.assert_allclose(cve_est.std_err, std_err_ref)
+    np.testing.assert_allclose(cve_est.num_points, count_ref)
+    np.testing.assert_allclose(cve_est.localization_variance, localization_variance_ref)
 
     assert cve_est.num_lags is None
     assert cve_est.method == "cve"


### PR DESCRIPTION
**Why this PR?**
Because we're leaving some precision on the table right now when it comes to CVE-based diffusion estimates.



When calculating per track diffusion constants, the estimator variances can be quite large. In the case where all the diffusion constants are the same, we can determine an ensemble estimate which often has a higher precision simply owing to the fact that more data goes into this estimate. This comes at the cost of being able to determine individual diffusion constants for separate tracks however.

For CVE specifically, the ensemble estimate provides a good estimate of the localization variance and the variance of that estimator. We can use this estimate when computing per track diffusion estimates to reduce the number of parameters that we are forced to simultaneously estimate on a per track basis.

![image](https://user-images.githubusercontent.com/19836026/206564580-0cfb3a59-a1b6-40fc-a9c4-cfde875b3e45.png)
In the graph we see the result of a bootstrap. Here I generated 100 realizations of 10 tracks of 5 steps at varying diffusive SNRs (a measure for diffusion / localization uncertainty). We see the performance of three estimators:
1. The first is an estimate based on a single track which shows the highest variance
2. An ensemble of tracks (`N=10` tracks of `M=8` steps) which shows the lowest variance (but which is not a fair comparison because this variance is done on a per track basis) and, 
3. The per track variance when using an earlier estimate for the localization uncertainty.

Note: I deliberately left the more detailed documentation out of this PR because a followup PR that describes this procedure and its relation to existing methods for diffusion estimation.