### PR TITLE
diffusion: Add ensemble OLS method.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * Added `localization_variance` to [`DiffusionEstimate`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymotracker.detail.msd_estimation.DiffusionEstimate.html). This quantity is useful for determining the diffusive SNR.
 * Added `variance_of_localization_variance` to [`DiffusionEstimate`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymotracker.detail.msd_estimation.DiffusionEstimate.html) when calculating an ensemble CVE. This provides an estimate of the variance of the averaged localization uncertainty.
 * Added option to pass a localization variance and its uncertainty to [`KymoTrack.estimate_diffusion()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymotracker.kymotrack.KymoTrack.html#lumicks.pylake.kymotracker.kymotrack.KymoTrack.estimate_diffusion).
+* Added option to calculate a diffusion estimate based on the ensemble MSDs using the Ordinary Least Squares (OLS) method.
 
 #### Deprecations
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -461,7 +461,7 @@ class KymoTrack:
                diffusing particles. Physical Review E, 94(2), 022401.
         """
         if method not in ("cve", "gls", "ols"):
-            raise ValueError('Invalid method selected. Method must be "gls" or "ols"')
+            raise ValueError('Invalid method selected. Method must be "cve", "gls" or "ols"')
 
         if not self._kymo.contiguous:
             raise NotImplementedError(

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -947,7 +947,7 @@ class KymoTrackGroup:
 
         return [k.estimate_diffusion(method, *args, **kwargs) for k in filtered_tracks]
 
-    def ensemble_diffusion(self, method):
+    def ensemble_diffusion(self, method, *, max_lag=None):
         """Determine ensemble based diffusion estimates.
 
         Determines ensemble based diffusion estimates for the entire group of KymoTracks. This
@@ -956,12 +956,17 @@ class KymoTrackGroup:
 
         Parameters
         ----------
-        method : {"cve"}
+        method : {"cve", "ols"}
             - "cve" : Covariance based estimator. Optimal if SNR > 1. Ensemble average is
               determined by determining the weighted average of the individual track estimates. The
               standard error is computed by determining the weighted average of the associated
               standard errors for each estimate (Equation 57 and 58 from Vestergaard [7]_). See
               :meth:`KymoTrack.estimate_diffusion` for more detailed information and references.
+            - "ols" : Ordinary least squares. Determines the ensemble mean squared displacements for
+              the entire KymoTrackGroup and estimates a diffusion constant for it. See
+              :meth:`KymoTrack.estimate_diffusion` for more detailed information and references.
+        max_lag : int
+            Maximum number of lags to include when using the ordinary least squares method (OLS).
 
         References
         ----------
@@ -971,8 +976,10 @@ class KymoTrackGroup:
         """
         if method == "cve":
             return ensemble_cve(self)
+        elif method == "ols":
+            return ensemble_ols(self, max_lag)
         else:
-            raise ValueError(f'Invalid method ({method}) selected. Method must be "cve".')
+            raise ValueError(f'Invalid method ({method}) selected. Method must be "cve" or "ols".')
 
     def ensemble_msd(self, max_lag=None, min_count=2) -> EnsembleMSD:
         r"""This method returns the weighted average of the Mean Squared Displacement (MSD) for all

--- a/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
+++ b/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
@@ -9,6 +9,7 @@ from lumicks.pylake.kymotracker.detail.msd_estimation import (
     _msd_diffusion_covariance,
     _diffusion_ols,
     _cve,
+    _determine_optimal_points_ensemble,
 )
 
 
@@ -150,6 +151,14 @@ def test_determine_points_from_data(diffusion, num_steps, step, noise, n_optimal
         coordinate = simulate_diffusion_1d(diffusion, num_steps, step, noise)
         np.testing.assert_allclose(
             determine_optimal_points(np.arange(num_steps), coordinate, max_iterations=100),
+            n_optimal,
+        )
+        np.testing.assert_allclose(
+            _determine_optimal_points_ensemble(
+                *calculate_msd(np.arange(num_steps), coordinate, max_lag=None),
+                len(coordinate),
+                max_iterations=100,
+            ),
             n_optimal,
         )
 


### PR DESCRIPTION
**Why this PR?**
This method provides an appropriate solution for estimating a diffusion constant when we have a large number of relatively short tracks with low SNR.

![image](https://user-images.githubusercontent.com/19836026/206808600-bdc01cf3-95d9-4425-8225-a855547ebfef.png)

![image](https://user-images.githubusercontent.com/19836026/207311082-2a24100c-ab0f-4e45-8653-8a1e083351c1.png)
Graph with the obtained standard error vs number of included points. Shown here is the standard deviation of `5000` runs of `30` tracks with `25` steps each. Dashed line indicates the recommended number of lags suggested by the OLS method.

![image](https://user-images.githubusercontent.com/19836026/207314480-29c5f31a-3506-4596-aacc-c1d37dcb7fcf.png)
![image](https://user-images.githubusercontent.com/19836026/207315801-d8bec115-18da-4867-b12e-9ee84aa11f65.png)
![image](https://user-images.githubusercontent.com/19836026/207317545-622875ef-7efb-4020-8df6-4582f78cd95e.png)
Graph with the obtained standard error vs number of included points. Shown here is the standard deviation of `100` runs of `20` tracks with `15` steps each. Dashed line indicates the recommended number of lags suggested by the OLS method.

![image](https://user-images.githubusercontent.com/19836026/207349746-6ec42a4e-115e-492e-8085-92b8cf2f0275.png)
Very long tracks but with a very poor SNR (leading to many lags being required). Here `steps=150` and `num_tracks=20`.

What is seen in this images is that most of the time, the optimal number is very close to the actual optimal variance.

Docs are part of a third PR that's still coming up.
If you want to read them, they are here: https://lumicks-pylake.readthedocs.io/en/diffusion_docs/theory/diffusion/diffusion.html