### PR TITLE
Format `Actions` section in API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ autosummary_generate = True
 # types are used
 autodoc_type_aliases = {"npt.ArrayLike": "numpy.typing.ArrayLike"}
 
-napoleon_custom_sections = ["Actions"]
+napoleon_custom_sections = [("Actions", "params_style")]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),

--- a/lumicks/pylake/correlated_stack.py
+++ b/lumicks/pylake/correlated_stack.py
@@ -372,9 +372,14 @@ class CorrelatedStack(FrameIndex, TiffExport, VideoExport):
 
         Actions
         -------
-
-            * scrolling through frames using the mouse wheel
-            * left-click to define the location of the tether
+        mouse wheel
+            Scroll through frames of the stack.
+        left-click
+            Define the location of the tether. First click defines the start of the tether
+            and second click defines the end. Subsequent clicks will cycle back to re-defining
+            the start, etc.
+        right-click and drag
+            Define the ROI to be cropped.
 
         Parameters
         ----------
@@ -427,6 +432,11 @@ class CorrelatedStack(FrameIndex, TiffExport, VideoExport):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling
         function (e.g. `np.mean`) is evaluated for the time between a start and end time of a
         frame.
+
+        Actions
+        -------
+        left-click in the left axes
+            Show the corresponding image frame in the right axes.
 
         Parameters
         ----------

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -653,8 +653,8 @@ class Kymo(ConfocalImage):
 
         Actions
         -------
-
-            * left-click and drag to define the cropped ROI
+        left-click and drag
+            Define the cropped ROI.
 
         Parameters
         ----------

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -309,6 +309,11 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         Note: In environments which support interactive figures (e.g. jupyter notebook with
         ipywidgets or interactive python) this plot will be interactive.
 
+        Actions
+        -------
+        left-click in the left axes
+            Show the corresponding image frame in the right axes.
+
         Parameters
         ----------
         channel_slice : pylake.channel.Slice


### PR DESCRIPTION
**Why this PR?**
Just something simple I noticed, our custom `Actions` section for docstrings could be formatted a bit better to match the `Parameters` section. Also added actions for `plot_correlated`. [Build here](https://lumicks-pylake.readthedocs.io/en/interactive_widget_docs/index.html)

Before
![image](https://user-images.githubusercontent.com/61475504/207067454-7cb72c2c-1c98-48cf-a623-974fdcc020f8.png)

After
![image](https://user-images.githubusercontent.com/61475504/207067386-882aa220-622c-4b9b-b94a-16c2971b844b.png)
