### PR TITLE
kymo/stack: make new plot for video export

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 * Fixed a bug where single pixel detections in a `KymoTrackGroup` would contribute values with a dwell time of zero. These are now dropped, the correct minimally observable time is set appropriately and a warning is issued.
 * Fixed slicing of a `Kymo` where slicing from a time point inside the last line to the end (e.g. `kymo["5s":]`) resulted in a `Kymo` which returned errors upon trying to access its contents.
 * Fixed a minor bug in force calibration. In rare cases it was possible that the procedure to generate an initial guess for the power spectral fit failed. This seemed to occur when the spectrum supplied is a mostly flat plateau. After the fix, an alternative method to compute an initial guess is applied in cases where the regular method fails. Note that successful calibrations were not at risk for being incorrect due to this bug since they would have resulted in an exception rather than an invalid result.
+* Fixed a bug where `Scan.export_video()` and `CorrelatedStack.export_video()` would show elements from a previous plot.
 
 #### Deprecations
 

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -162,7 +162,7 @@ class VideoExport:
             image_handle = plot_func(frame=start_frame + num, image_handle=image_handle)
             return plt.gca().get_children()
 
-        fig = plt.gcf()
+        fig = plt.figure()
         fig.patch.set_alpha(1.0)
         line_ani = animation.FuncAnimation(
             fig, plot, stop_frame - start_frame, interval=1, blit=True


### PR DESCRIPTION
**Why this PR?**
We don't want our video export to include things from previous plots.

```python
plt.figure()
plt.plot([1, 2, 3], [1, 2, 3])
f = lk.File("C:\\Dev\\AVI rendering\\20190828-105121 Scan DNA1_CII_incubate_2min.h5")
cs = f.scans.popitem()[1]
cs.export_video("rgb", "d:\\new.gif")
```

Old behaviour:
![old](https://user-images.githubusercontent.com/19836026/207340276-83e3d7dc-ddd4-4a24-a9ee-26dc6732ece2.gif)

New behaviour:
![new](https://user-images.githubusercontent.com/19836026/207340349-714fdbf3-fae3-40ac-84a0-945bd43807f9.gif)
