### PR TITLE
kymo: fix alignment `Kymo.plot_with_position_histogram()`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,7 @@
 * Fixed slicing of a `Kymo` where slicing from a time point inside the last line to the end (e.g. `kymo["5s":]`) resulted in a `Kymo` which returned errors upon trying to access its contents.
 * Fixed a minor bug in force calibration. In rare cases it was possible that the procedure to generate an initial guess for the power spectral fit failed. This seemed to occur when the spectrum supplied is a mostly flat plateau. After the fix, an alternative method to compute an initial guess is applied in cases where the regular method fails. Note that successful calibrations were not at risk for being incorrect due to this bug since they would have resulted in an exception rather than an invalid result.
 * Fixed a bug where `Scan.export_video()` and `CorrelatedStack.export_video()` would show elements from a previous plot.
+* Fixed a bug that caused a misalignment of half a pixel between the kymograph and its position histogram when using `Kymo.plot_with_position_histogram()`.
 
 #### Deprecations
 

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -454,6 +454,7 @@ class Kymo(ConfocalImage):
         image = self.get_image(color_channel)
         pixel_width = self.pixelsize[0]
         edges, counts, bin_widths = histogram_rows(image, pixels_per_bin, pixel_width)
+        edges = edges - pixel_width / 2  # pixel centers are defined at the center of a pixel
 
         gs = GridSpec(1, 2, width_ratios=(1, hist_ratio))
         ax_kymo = plt.subplot(gs[0])


### PR DESCRIPTION
It's a ~~rotate~~ translate!

Before:
![image](https://user-images.githubusercontent.com/19836026/207391055-f0ad017f-8a4f-4a38-918b-bfd6c3f10629.png)

After:
![image](https://user-images.githubusercontent.com/19836026/207390901-c98ea76c-571c-4e31-a11a-aeee5b4f57d0.png)
