### PR TITLE
Fix some issues with dwelltime bootstrapping

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,11 @@
 * Deprecated the `DwelltimeModel.bootstrap` attribute; this attribute will be removed in a future release. Instead, `DwelltimeModel.calculate_bootstrap()` now returns a `DwelltimeBootstrap` instance directly. See the [population dynamics](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/population_dynamics.html#confidence-intervals-from-bootstrapping) documentation for more details.
 * Deprecated `DwelltimeBootstrap.plot()` and renamed to `DwelltimeBootstrap.hist()` to more closely match the figure that is generated.
 
+#### Other changes
+
+* `DwelltimeBootstrap` is now a frozen dataclass.
+* Attempting to access `DwelltimeModel.bootstrap` before sampling now raises a `RuntimeError`; however, see the deprecation note above for proper API to access bootstrapping distributions.
+
 ## v0.13.2 | 2022-11-15
 
 #### New features

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 * Added `variance_of_localization_variance` to [`DiffusionEstimate`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymotracker.detail.msd_estimation.DiffusionEstimate.html) when calculating an ensemble CVE. This provides an estimate of the variance of the averaged localization uncertainty.
 * Added option to pass a localization variance and its uncertainty to [`KymoTrack.estimate_diffusion()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymotracker.kymotrack.KymoTrack.html#lumicks.pylake.kymotracker.kymotrack.KymoTrack.estimate_diffusion).
 * Added option to calculate a diffusion estimate based on the ensemble MSDs using the Ordinary Least Squares (OLS) method.
+* Added `DwelltimeBootstrap.extend()` to draw additional samples for the distribution.
 
 #### Deprecations
 

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,8 @@
 #### Deprecations
 
 * Renamed `CorrelatedStack` to [`ImageStack`](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/imagestack.html).
+* Deprecated the `DwelltimeModel.bootstrap` attribute; this attribute will be removed in a future release. Instead, `DwelltimeModel.calculate_bootstrap()` now returns a `DwelltimeBootstrap` instance directly. See the [population dynamics](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/population_dynamics.html#confidence-intervals-from-bootstrapping) documentation for more details.
+* Deprecated `DwelltimeBootstrap.plot()` and renamed to `DwelltimeBootstrap.hist()` to more closely match the figure that is generated.
 
 ## v0.13.2 | 2022-11-15
 

--- a/docs/tutorial/population_dynamics.rst
+++ b/docs/tutorial/population_dynamics.rst
@@ -210,12 +210,14 @@ Confidence intervals from bootstrapping
 As an additional check, we can estimate confidence intervals (CI) for the parameters using bootstrapping.
 Here, a dataset with the same size as the original is randomly sampled (with replacement) from the original dataset. This random sample
 is then fit using the MLE method, just as for the original dataset. The fit results in a new estimate for the model parameters.
-This process is repeated many times, and the distribution of the resulting parameters can be analyzed to estimate certain statistics about them::
+This process is repeated many times, and the distribution of the resulting parameters can be analyzed to estimate certain statistics about them.
 
-    dwell_2.calculate_bootstrap(iterations=100)
+We can calculate a bootstrap distribution with :meth:`~lumicks.pylake.DwelltimeModel.calculate_bootstrap`::
+
+    bootstrap_2 = dwell_2.calculate_bootstrap(iterations=100)
 
     plt.figure()
-    dwell_2.bootstrap.plot(alpha=0.05)
+    bootstrap_2.hist(alpha=0.05)
     plt.show()
 
 .. image:: figures/population_dynamics/dwell2_bootstrap.png
@@ -230,10 +232,10 @@ are split. In fact, many amplitudes are estimated near zero which effectively re
 This analysis strongly indicates that the single exponential model is preferable. We can also look at
 the bootstrap for that model to verify the results are satisfactory::
 
-    dwell_1.calculate_bootstrap(iterations=100)
+    bootstrap_1 = dwell_1.calculate_bootstrap(iterations=100)
 
     plt.figure()
-    dwell_1.bootstrap.plot(alpha=0.05)
+    bootstrap_1.hist(alpha=0.05)
     plt.show()
 
 .. image:: figures/population_dynamics/dwell1_bootstrap.png

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -51,6 +51,25 @@ class DwelltimeBootstrap:
         samples = DwelltimeBootstrap._sample(optimized, iterations)
         return cls(optimized, samples[: optimized.n_components], samples[optimized.n_components :])
 
+    def extend(self, iterations):
+        """Extend the distribution by additional sampling iterations.
+
+        Parameters
+        ----------
+        iterations : int
+            number of iterations (random samples) to add to the bootstrap distribution
+        """
+        new_samples = DwelltimeBootstrap._sample(self.model, iterations)
+        n_components = self.model.n_components
+        new_amplitudes = new_samples[:n_components]
+        new_lifetimes = new_samples[n_components:]
+
+        return DwelltimeBootstrap(
+            self.model,
+            np.hstack([self.amplitude_distributions, new_amplitudes]),
+            np.hstack([self.lifetime_distributions, new_lifetimes]),
+        )
+
     @staticmethod
     def _sample(optimized, iterations):
 

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -58,11 +58,15 @@ def test_bootstrap(exponential_data):
     fit = DwelltimeModel(dataset["data"], 2, **dataset["parameters"].observation_limits)
 
     np.random.seed(123)
-    fit.calculate_bootstrap(iterations=50)
-    mean, ci = fit.bootstrap.calculate_stats("amplitude", 0)
+    bootstrap = fit.calculate_bootstrap(iterations=50)
+    mean, ci = bootstrap.calculate_stats("amplitude", 0)
     np.testing.assert_allclose(mean, 0.4642469883372174, rtol=1e-5)
     np.testing.assert_allclose(ci, (0.3647038711684928, 0.5979550940729152), rtol=1e-5)
     np.random.seed()
+
+    # TODO: delete after property removal
+    with pytest.warns(DeprecationWarning):
+        fit.bootstrap
 
 
 def test_dwellcounts_from_statepath():
@@ -113,5 +117,8 @@ def test_plots(exponential_data):
     fit.hist()
 
     np.random.seed(123)
-    fit.calculate_bootstrap(iterations=2)
-    fit.bootstrap.plot()
+    bootstrap = fit.calculate_bootstrap(iterations=2)
+    bootstrap.hist()
+
+    with pytest.warns(DeprecationWarning):
+        bootstrap.plot()

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import re
 
 from lumicks.pylake import DwelltimeModel
 from lumicks.pylake.population.dwelltime import _dwellcounts_from_statepath
@@ -67,6 +68,31 @@ def test_bootstrap(exponential_data):
     # TODO: delete after property removal
     with pytest.warns(DeprecationWarning):
         fit.bootstrap
+
+
+# TODO: remove with deprecation
+@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
+def test_empty_bootstrap(exponential_data):
+    dataset = exponential_data["dataset_2exp"]
+
+    for n_components in (1, 2):
+        fit = DwelltimeModel(
+            dataset["data"], n_components, **dataset["parameters"].observation_limits
+        )
+
+        bootstrap = fit._bootstrap
+        assert bootstrap.n_components == fit.n_components
+        assert bootstrap.n_samples == 0
+
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(
+            RuntimeError,
+            match=re.escape(
+                "The bootstrap distribution is currently empty. Use `DwelltimeModel.calculate_bootstrap()` "
+                "to sample a distribution before attempting downstream analysis."
+            )
+        ):
+            fit.bootstrap
 
 
 def test_dwellcounts_from_statepath():

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -65,6 +65,10 @@ def test_bootstrap(exponential_data):
     np.testing.assert_allclose(ci, (0.3647038711684928, 0.5979550940729152), rtol=1e-5)
     np.random.seed()
 
+    more_bootstrap = bootstrap.extend(iterations=10)
+    assert bootstrap.n_samples == 50
+    assert more_bootstrap.n_samples == 60
+
     # TODO: delete after property removal
     with pytest.warns(DeprecationWarning):
         fit.bootstrap


### PR DESCRIPTION
**Why this PR?**
Originally the issue was opened because trying to plot a bootstrap before sampling raised a cryptic exception. While figuring out how to best deal with this, I noticed some other things that could be improved

- would be better to just get rid of the `DwelltimeModel.bootstrap` attribute altogether to remove statefulness. Here I changed it to a property with a deprecation warning.
- also deprecated `DwelltimeBootstrap.plot()` and renamed to `DwelltimeBootstrap.hist()` in line with `DwelltimeModel`
- made `DwelltimeBootstrap` a frozen data class and added an `extend()` method to append new samples to the distribution. Again trying to get away from statefullness
- now trying to access `DwelltimeModel.bootstrap` before calling `DwelltimeModel.calculate_bootstrap()` raises a `RuntimeError`. This is a stopgap fix until the `bootstrap` property is removed in a future release

[Docs build here](https://lumicks-pylake.readthedocs.io/en/bootstrap_fixups/tutorial/population_dynamics.html#dwell-time-analysis) and [API changes here](https://lumicks-pylake.readthedocs.io/en/bootstrap_fixups/_api/lumicks.pylake.population.dwelltime.DwelltimeBootstrap.html)