### PR TITLE
test_imaging_mixins: ignore RuntimeWarning raised by numpy >= 1.24

### DIFF
--- a/lumicks/pylake/tests/test_imaging_mixins.py
+++ b/lumicks/pylake/tests/test_imaging_mixins.py
@@ -115,6 +115,10 @@ def test_export_tiff_int(tmp_path):
         export_image16.export_tiff(tmp_path / "float16", dtype=np.float16)
 
 
+@pytest.mark.filterwarnings(
+    # Numpy 1.24 raises a RuntimeWarning upon overflow during type cast (see call with `clip=True`)
+    "ignore:overflow encountered in cast:RuntimeWarning:lumicks.pylake.detail.imaging_mixins:48"
+)
 def test_export_tiff_float(tmp_path):
     images = np.ones(shape=(2, 10, 10, 3))  # (n, h, w, c)
     export_image32 = tiffexport_factory(images * np.finfo(np.float32).max)


### PR DESCRIPTION
**Why?**
Numpy >= 1.24 raises a `RuntimeWarning` during casting if an floating point error occurs: 
https://github.com/numpy/numpy/releases/tag/v1.24.0
https://github.com/numpy/numpy/pull/21437

This causes `test_imaging_mixins` to fail:
![numpy_1 24_overflow_warning](https://user-images.githubusercontent.com/28353120/208438032-f3f957f6-7ed1-46d2-811f-323ceea09992.PNG)

The affected funtion is `TiffExport.export_tiff()`

**Solution**
Ignore the warning in the tests.
