### PR TITLE
fdfitter: improve docstrings for fd models

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,11 @@
 * `DwelltimeBootstrap` is now a frozen dataclass.
 * Attempting to access `DwelltimeModel.bootstrap` before sampling now raises a `RuntimeError`; however, see the deprecation note above for proper API to access bootstrapping distributions.
 
+#### Bugfixes
+
+* Fixed issue with model description not being available in Jupyter notebooks for some force-distance models.
+* Show validity criterion for Marko Siggia WLC models in terms of model parameters. Prior to this change the limit was simply denoted as `10 pN` where in reality it depends on the model parameters. The `10 pN` was a reasonable value for most DNA constructs.
+
 ## v0.13.2 | 2022-11-15
 
 #### New features

--- a/lumicks/pylake/fitting/detail/model_implementation.py
+++ b/lumicks/pylake/fitting/detail/model_implementation.py
@@ -61,10 +61,15 @@ def wlc_marko_siggia_force_equation_tex(d, Lp, Lc, kT):
 
 
 def wlc_marko_siggia_force(d, Lp, Lc, kT):
-    r"""Marko Siggia's Worm-like Chain (WLC) model
+    r"""Marko Siggia's Worm-like Chain (WLC) model.
 
-    This model [1]_ is based on only entropic contributions (valid for F << 10 pN). At higher forces
-    an extensible WLC model (which takes into account enthalpic stretching) should be used.
+    This model [1]_ is based on only entropic contributions. This model is valid for low forces
+    where $F << \frac{1}{4} \left(k_B T S_t^2 / L_p\right)^\frac{1}{3}$ [2]_.
+
+    Here $S_t$ is the stretch modulus in [pN], all other parameters are defined below.
+
+    At higher forces an extensible WLC model (which takes into account enthalpic stretching) should
+    be used.
 
     Here $S_t$ is the stretch modulus in [pN], all other parameters are defined below.
 
@@ -1003,10 +1008,15 @@ def wlc_marko_siggia_distance_coefficients(f, Lp, Lc, kT):
 
 
 def wlc_marko_siggia_distance(f, Lp, Lc, kT=4.11):
-    """Marko Siggia's Worm-like Chain (WLC) model.
+    r"""Marko Siggia's Worm-like Chain (WLC) model.
 
-    This model [1]_ is based on only entropic contributions (valid for F << 10 pN). At higher forces
-    an extensible WLC model (which takes into account enthalpic stretching) should be used.
+    This model [1]_ is based on only entropic contributions. This model is valid for low forces
+    where $F << \frac{1}{4} \left(k_B T S_t^2 / L_p\right)^\frac{1}{3}$ [2]_.
+
+    Here $S_t$ is the stretch modulus in [pN], all other parameters are defined below.
+
+    At higher forces an extensible WLC model (which takes into account enthalpic stretching) should
+    be used.
 
     Here $S_t$ is the stretch modulus in [pN], all other parameters are defined below.
 

--- a/lumicks/pylake/fitting/detail/model_implementation.py
+++ b/lumicks/pylake/fitting/detail/model_implementation.py
@@ -61,12 +61,35 @@ def wlc_marko_siggia_force_equation_tex(d, Lp, Lc, kT):
 
 
 def wlc_marko_siggia_force(d, Lp, Lc, kT):
-    """Marko Siggia's Worm-like Chain model based on only entropic contributions. Valid for
-    F < 10 pN) [1]_.
+    r"""Marko Siggia's Worm-like Chain (WLC) model
+
+    This model [1]_ is based on only entropic contributions (valid for F << 10 pN). At higher forces
+    an extensible WLC model (which takes into account enthalpic stretching) should be used.
+
+    Here $S_t$ is the stretch modulus in [pN], all other parameters are defined below.
+
+    At higher forces an extensible WLC model (which takes into account enthalpic stretching) should
+    be used.
+
+    This model has force as the dependent variable. Differs from exact WLC solution by up to -10%
+    near F=0.1 pN. Approaches exact WLC solution at lower and higher forces [2]_.
+
+    Parameters
+    ----------
+    d : array_like
+        extension [um]
+    Lp : float
+        persistence length [nm]
+    Lc : float
+        contour length [um]
+    kT : float
+        Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
 
     References
     ----------
     .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
     """
     if Lp <= 0 or Lc <= 0 or kT <= 0:
         raise ValueError("Persistence length, contour length and kT must be bigger than 0")
@@ -106,7 +129,9 @@ def ewlc_odijk_distance_equation_tex(f, Lp, Lc, St, kT=4.11):
 
 
 def ewlc_odijk_distance(f, Lp, Lc, St, kT=4.11):
-    """Odijk's Extensible Worm-like Chain model [1]_ [2]_.
+    """Odijk's Extensible Worm-Like Chain model with distance as the dependent variable
+
+    Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_.
 
     Parameters
     ----------
@@ -165,6 +190,10 @@ def twlc_distance_equation_tex(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
 def twlc_distance(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     """Twistable Worm-like Chain model [1]_.
 
+    Twistable Worm-like Chain model [1]_ [2]_ that takes into account untwisting of the DNA at
+    high forces. Note that it is generally recommended to fit this model with force as the
+    dependent variable [2]_.
+
     Parameters
     ----------
     f : array_like
@@ -189,7 +218,9 @@ def twlc_distance(f, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     References
     ----------
     .. [1] P. Gross et al., Quantifying how DNA stretches, melts and changes twist under tension,
-    Nature Physics 7, 731-736 (2011).
+           Nature Physics 7, 731-736 (2011).
+    .. [2] Broekmans, Onno D., et al. DNA twist stability changes with magnesium (2+) concentration,
+           Physical review letters 116.25, 258102 (2016).
     """
     if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
         raise ValueError(
@@ -261,7 +292,9 @@ def efjc_distance_equation_tex(f, Lp, Lc, St, kT=4.11):
 
 
 def efjc_distance(f, Lp, Lc, St, kT=4.11):
-    """Extensible Freely-Jointed Chain [1]_ [2]_.
+    """Extensible Freely jointed chain model.
+
+    Useful for modelling single stranded DNA [1]_ [2]_.
 
     Parameters
     ----------
@@ -366,7 +399,9 @@ def ewlc_odijk_force_equation_tex(d, Lp, Lc, St, kT=4.11):
 
 
 def ewlc_odijk_force(d, Lp, Lc, St, kT=4.11):
-    """Inverted Odijk's Worm-like Chain model [1]_ [2]_.
+    """Odijk's Extensible Worm-Like Chain model with force as the dependent variable
+
+    Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_.
 
     Parameters
     ----------
@@ -645,13 +680,17 @@ def twlc_solve_force_equation_tex(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
 def twlc_solve_force(d, Lp, Lc, St, C, g0, g1, Fc, kT=4.11):
     """Inverted Twistable Worm-like Chain model
 
-    Inverted form of the Twistable Worm-like Chain model that takes into account untwisting of the
-    DNA at high forces.
+    Twistable Worm-like Chain model [1]_ [2]_ that takes into account untwisting of the DNA at
+    high forces. This model uses a more performant implementation for inverting the model. It
+    inverts the model by interpolating the forward curve and using this interpolant to invert the
+    function.
 
     References
     ----------
     .. [1] P. Gross et al., Quantifying how DNA stretches, melts and changes twist under tension,
            Nature Physics 7, 731-736 (2011).
+    .. [2] Broekmans, Onno D., et al. DNA twist stability changes with magnesium (2+) concentration,
+           Physical review letters 116.25, 258102 (2016).
 
     Parameters
     ----------
@@ -765,10 +804,24 @@ def ewlc_marko_siggia_force_equation_tex(d, Lp, Lc, St, kT=4.11):
 
 
 def ewlc_marko_siggia_force(d, Lp, Lc, St, kT=4.11):
-    """Modified Marko Siggia's Worm-like Chain model with distance as dependent parameter.
+    """Marko Siggia's Worm-like Chain model with force as the dependent variable
 
-    Modification of Marko-Siggia formula [1] to incorporate enthalpic stretching. Has limitations
-    similar to Marko-Siggia near `F = 0.1 pN` [2]_.
+    Modified Marko Siggia's Worm-like Chain model. Modification of Marko-Siggia formula [1]_
+    to incorporate enthalpic stretching. Has limitations similar to Marko-Siggia
+    near F = 0.1 pN [2]_.
+
+    Parameters
+    ----------
+    d : array_like
+        extension [um]
+    Lp : float
+        persistence length [nm]
+    Lc : float
+        contour length [um]
+    St : float
+        stretching modulus [pN]
+    kT : float
+        Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
 
     References
     ----------
@@ -781,7 +834,6 @@ def ewlc_marko_siggia_force(d, Lp, Lc, St, kT=4.11):
             "Persistence length, contour length, stretch modulus and kT must be bigger than 0"
         )
 
-    """Margo-Siggia's Worm-like Chain model with distance as dependent parameter."""
     c = -(St**3) * d * kT * (1.5 * Lc**2 - 2.25 * Lc * d + d**2) / (Lc**3 * (Lp * St + kT))
     b = (
         St**2
@@ -951,6 +1003,37 @@ def wlc_marko_siggia_distance_coefficients(f, Lp, Lc, kT):
 
 
 def wlc_marko_siggia_distance(f, Lp, Lc, kT=4.11):
+    """Marko Siggia's Worm-like Chain (WLC) model.
+
+    This model [1]_ is based on only entropic contributions (valid for F << 10 pN). At higher forces
+    an extensible WLC model (which takes into account enthalpic stretching) should be used.
+
+    Here $S_t$ is the stretch modulus in [pN], all other parameters are defined below.
+
+    At higher forces an extensible WLC model (which takes into account enthalpic stretching) should
+    be used.
+
+    This model has distance as the dependent variable. Differs from exact WLC solution by up to -10%
+    near F=0.1 pN. Approaches exact WLC solution at lower and higher forces [2]_.
+
+    Parameters
+    ----------
+    f : array_like
+        force [pN]
+    Lp : float
+        persistence length [nm]
+    Lc : float
+        contour length [um]
+    kT : float
+        Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
+
+    References
+    ----------
+    .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
+    """
+
     if Lp <= 0 or Lc <= 0 or kT <= 0:
         raise ValueError("Persistence length, contour length and kT must be bigger than 0")
 
@@ -1009,6 +1092,30 @@ def wlc_marko_siggia_distance_equation_tex(f, Lp, Lc, kT=4.11):
 
 
 def ewlc_marko_siggia_distance(f, Lp, Lc, St, kT=4.11):
+    """Marko Siggia's Worm-like Chain model with distance as the dependent variable.
+
+    Modified Marko Siggia's Worm-like Chain model. Modification of Marko-Siggia formula [1]_
+    to incorporate enthalpic stretching. Has limitations similar to Marko-Siggia
+    near F = 0.1 pN [2]_.
+
+    Parameters
+    ----------
+    f : array_like
+        force [pN]
+    Lp : float
+        persistence length [nm]
+    Lc : float
+        contour length [um]
+    St : float
+        stretching modulus [pN]
+    kT : float
+        Boltzmann's constant times temperature (default = 4.11 [pN nm]) [pN nm]
+
+    References
+    ----------
+    .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
+    .. [2] Wang, M. D., Yin, H., Landick, R., Gelles, J., & Block, S. M. (1997). Stretching DNA
+           with optical tweezers. Biophysical journal, 72(3), 1335-1346."""
     if Lp <= 0 or Lc <= 0 or St <= 0 or kT <= 0:
         raise ValueError(
             "Persistence length, contour length, stretch modulus and kT must be bigger than 0"

--- a/lumicks/pylake/fitting/models.py
+++ b/lumicks/pylake/fitting/models.py
@@ -46,7 +46,7 @@ distance_model_vars = {
 
 
 def force_offset(name):
-    """Offset on the the model output.
+    """Offset on the model output.
 
     Parameters
     ----------
@@ -75,7 +75,7 @@ def force_offset(name):
 
 
 def distance_offset(name):
-    """Offset on the the model output.
+    """Offset on the model output.
 
     Parameters
     ----------
@@ -104,11 +104,11 @@ def distance_offset(name):
 
 
 def ewlc_marko_siggia_force(name):
-    """Marko Siggia's Worm-like Chain model with force as dependent parameter.
+    """Marko Siggia's Worm-like Chain model with force as the dependent variable.
 
     Modified Marko Siggia's Worm-like Chain model. Modification of Marko-Siggia formula [1]_
     to incorporate enthalpic stretching. Has limitations similar to Marko-Siggia
-    near `F = 0.1 pN` [2]_.
+    near F = 0.1 pN [2]_.
 
     Parameters
     ----------
@@ -147,11 +147,11 @@ def ewlc_marko_siggia_force(name):
 
 
 def ewlc_marko_siggia_distance(name):
-    """Marko Siggia's Worm-like Chain model with distance as dependent parameter
+    """Marko Siggia's Worm-like Chain model with distance as the dependent variable
 
     Modified Marko Siggia's Worm-like Chain model. Modification of Marko-Siggia formula [1]_
     to incorporate enthalpic stretching. Has limitations similar to Marko-Siggia
-    near `F = 0.1 pN` [2]_.
+    near F = 0.1 pN [2]_.
 
     Parameters
     ----------
@@ -190,10 +190,13 @@ def ewlc_marko_siggia_distance(name):
 
 
 def wlc_marko_siggia_force(name):
-    """Marko Siggia's Worm-like Chain model.
+    """Marko Siggia's Worm-like Chain (WLC) model.
 
-    This model [1]_ is based on only entropic contributions (valid for F << 10 pN). This model has
-    force as a dependent variable.
+    This model [1]_ is based on only entropic contributions (valid for F << 10 pN). At higher forces
+    an extensible WLC model (which takes into account enthalpic stretching) should be used.
+
+    This model has force as the dependent variable. Differs from exact WLC solution by up to -10%
+    near F=0.1 pN. Approaches exact WLC solution at lower and higher forces [2]_.
 
     Parameters
     ----------
@@ -203,6 +206,8 @@ def wlc_marko_siggia_force(name):
     References
     ----------
     .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
     """
     from .model import Model
     from .detail.model_implementation import (
@@ -229,10 +234,13 @@ def wlc_marko_siggia_force(name):
 
 
 def wlc_marko_siggia_distance(name):
-    """Marko Siggia's Worm-like Chain model.
+    """Marko Siggia's Worm-like Chain (WLC) model.
 
-    This model is based on only entropic contributions [1]_ (valid for F << 10 pN). This model has
-    distance as a dependent variable.
+    This model [1]_ is based on only entropic contributions (valid for F << 10 pN). At higher forces
+    an extensible WLC model (which takes into account enthalpic stretching) should be used.
+
+    This model has distance as the dependent variable. Differs from exact WLC solution by up to -10%
+    near F=0.1 pN. Approaches exact WLC solution at lower and higher forces [2]_.
 
     Parameters
     ----------
@@ -242,6 +250,8 @@ def wlc_marko_siggia_distance(name):
     References
     ----------
     .. [1] J. Marko, E. D. Siggia. Stretching dna., Macromolecules 28.26, 8759-8770 (1995).
+    .. [2] M. D. Wang, H. Yin, R. Landick, J. Gelles, S. M. Block, Stretching DNA with optical
+           tweezers., Biophysical journal 72, 1335-46 (1997).
     """
     from .model import Model
     from .detail.model_implementation import (
@@ -268,7 +278,7 @@ def wlc_marko_siggia_distance(name):
 
 
 def ewlc_odijk_distance(name):
-    """Odijk's Extensible Worm-Like Chain model with distance as dependent variable
+    """Odijk's Extensible Worm-Like Chain model with distance as the dependent variable
 
     Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_.
 
@@ -358,7 +368,7 @@ def dsdna_ewlc_odijk_distance(name, dna_length_kbp, um_per_kbp=0.34, temperature
 
 
 def ewlc_odijk_force(name):
-    """Odijk's Extensible Worm-Like Chain model with force as dependent variable
+    """Odijk's Extensible Worm-Like Chain model with force as the dependent variable
 
     Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_. Note that
     this implementation was analytically solved and is significantly faster than fitting the model
@@ -401,7 +411,7 @@ def ewlc_odijk_force(name):
 
 
 def efjc_distance(name):
-    """Extensible Freely-Jointed Chain with distance as dependent parameter.
+    """Extensible Freely-Jointed Chain with distance as the dependent variable.
 
     Freely jointed chain model [1]_ [2]_. Useful for modelling single stranded DNA.
 
@@ -444,10 +454,10 @@ def efjc_distance(name):
 
 
 def ssdna_efjc_distance(name, dna_length_kb, um_per_kb=0.56, temperature=24.53608821):
-    """Model of ssDNA with distance as the dependent parameter.
+    """Model of ssDNA with distance as the dependent variable.
 
-    Extensible Freely-Jointed Chain model [1]_ [2]_ with distance as dependent parameter, using
-    user-specified kilobases with default parameters obtained from [3]_.
+    Extensible Freely-Jointed Chain model [1]_ [2]_ using user-specified kilobases with default
+    parameters obtained from [3]_.
 
     Parameters
     ----------
@@ -487,7 +497,7 @@ def ssdna_efjc_distance(name, dna_length_kb, um_per_kb=0.56, temperature=24.5360
 
 
 def efjc_force(name):
-    """Extensible Freely-Jointed Chain model with force as the dependent parameter.
+    """Extensible Freely-Jointed Chain model with force as the dependent variable.
 
     The Freely-Jointed Chain model [1]_ [2]_ is useful for modelling ssDNA.
 
@@ -510,7 +520,7 @@ def efjc_force(name):
 
 
 def twlc_distance(name):
-    """Twistable Worm-like Chain model with distance as dependent variable.
+    """Twistable Worm-like Chain model with distance as the dependent variable.
 
     Twistable Worm-like Chain model [1]_ [2]_ that takes into account untwisting of the DNA at
     high forces. Note that it is generally recommended to fit this model with force as the
@@ -613,11 +623,11 @@ def twlc_force(name):
     version="0.13.2",
 )
 def marko_siggia_ewlc_force(name):
-    """Marko Siggia's Worm-like Chain model with force as dependent parameter.
+    """Marko Siggia's Worm-like Chain model with force as the dependent variable.
 
     Modified Marko Siggia's Worm-like Chain model. Modification of Marko-Siggia formula [1]_
     to incorporate enthalpic stretching. Has limitations similar to Marko-Siggia
-    near `F = 0.1 pN` [2]_.
+    near F = 0.1 pN [2]_.
 
     Parameters
     ----------
@@ -642,11 +652,11 @@ def marko_siggia_ewlc_force(name):
     version="0.13.2",
 )
 def marko_siggia_ewlc_distance(name):
-    """Marko Siggia's Worm-like Chain model with distance as dependent parameter
+    """Marko Siggia's Worm-like Chain model with distance as the dependent variable
 
     Modified Marko Siggia's Worm-like Chain model. Modification of Marko-Siggia formula [1]_
     to incorporate enthalpic stretching. Has limitations similar to Marko-Siggia
-    near `F = 0.1 pN` [2]_.
+    near F = 0.1 pN [2]_.
 
     Parameters
     ----------
@@ -671,7 +681,7 @@ def marko_siggia_simplified(name):
     """Marko Siggia's Worm-like Chain model.
 
     This model [1]_ is based on only entropic contributions (valid for F << 10 pN). This model has
-    force as a dependent variable.
+    force as the dependent variable.
 
     Parameters
     ----------
@@ -696,7 +706,7 @@ def inverted_marko_siggia_simplified(name):
     """Marko Siggia's Worm-like Chain model.
 
     This model is based on only entropic contributions [1]_ (valid for F << 10 pN). This model has
-    distance as a dependent variable.
+    distance as the dependent variable.
 
     Parameters
     ----------
@@ -719,7 +729,7 @@ def inverted_marko_siggia_simplified(name):
     version="0.13.2",
 )
 def odijk(name):
-    """Odijk's Extensible Worm-Like Chain model with distance as dependent variable
+    """Odijk's Extensible Worm-Like Chain model with distance as the dependent variable
 
     Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_.
 
@@ -746,11 +756,10 @@ def odijk(name):
     version="0.13.2",
 )
 def dsdna_odijk(name, dna_length_kbp, um_per_kbp=0.34, temperature=24.53608821):
-    """Model for dsDNA with distance as the dependent variable.
+    """Model for dsDNA with distance as the dependent variable
 
-    Odijk's Extensible Worm-Like Chain model [1]_ [2]_ with distance as the dependent
-    variable using user-specified kilobase-pairs (useful for 10 pN < F < 30 pN). Default model
-    parameters were obtained from [3]_ [4]_ and [5]_.
+    Odijk's Extensible Worm-Like Chain model [1]_ [2]_ using user-specified kilobase-pairs
+    (useful for 10 pN < F < 30 pN). Default parameters were obtained from [3]_ [4]_ and [5]_.
 
     Parameters
     ----------
@@ -795,7 +804,7 @@ def dsdna_odijk(name, dna_length_kbp, um_per_kbp=0.34, temperature=24.53608821):
     version="0.13.2",
 )
 def inverted_odijk(name):
-    """Odijk's Extensible Worm-Like Chain model with force as dependent variable
+    """Odijk's Extensible Worm-Like Chain model with force as the dependent variable
 
     Odijk's Extensible Worm-Like Chain model [1]_ is useful for 10 pN < F < 30 pN [2]_. Note that
     this implementation was analytically solved and is significantly faster than fitting the
@@ -823,7 +832,7 @@ def inverted_odijk(name):
     version="0.13.2",
 )
 def freely_jointed_chain(name):
-    """Freely-Jointed Chain with distance as dependent parameter.
+    """Freely-Jointed Chain with distance as the dependent variable.
 
     Freely jointed chain model [1]_ [2]_. Useful for modelling single stranded DNA.
 
@@ -852,10 +861,10 @@ def freely_jointed_chain(name):
     version="0.13.2",
 )
 def ssdna_fjc(name, dna_length_kb, um_per_kb=0.56, temperature=24.53608821):
-    """Model of ssDNA with distance as the dependent parameter.
+    """Model of ssDNA with distance as the dependent variable.
 
-    Freely-Jointed Chain model [1]_ [2]_ with distance as dependent parameter, using
-    user-specified kilobases with default parameters obtained from [3]_.
+    Freely-Jointed Chain model [1]_ [2]_ using user-specified kilobases with default parameters
+    obtained from [3]_.
 
     Parameters
     ----------
@@ -890,7 +899,7 @@ def ssdna_fjc(name, dna_length_kb, um_per_kb=0.56, temperature=24.53608821):
     version="0.13.2",
 )
 def inverted_freely_jointed_chain(name):
-    """Freely-Jointed Chain model with force as the dependent parameter.
+    """Freely-Jointed Chain model with force as the dependent variable.
 
     The Freely-Jointed Chain model [1]_ [2]_ is useful for modelling ssDNA.
 
@@ -918,7 +927,7 @@ def inverted_freely_jointed_chain(name):
     version="0.13.2",
 )
 def twistable_wlc(name):
-    """Twistable Worm-like Chain model with distance as dependent variable.
+    """Twistable Worm-like Chain model with distance as the dependent variable.
 
     Twistable Worm-like Chain model [1]_ [2]_ that takes into account untwisting of the DNA at
     high forces. Note that it is generally recommended to fit this model with force as the

--- a/lumicks/pylake/fitting/models.py
+++ b/lumicks/pylake/fitting/models.py
@@ -190,10 +190,17 @@ def ewlc_marko_siggia_distance(name):
 
 
 def wlc_marko_siggia_force(name):
-    """Marko Siggia's Worm-like Chain (WLC) model.
+    r"""Marko Siggia's Worm-like Chain (WLC) model.
 
-    This model [1]_ is based on only entropic contributions (valid for F << 10 pN). At higher forces
-    an extensible WLC model (which takes into account enthalpic stretching) should be used.
+    This model [1]_ is based on only entropic contributions. This model is valid at low forces [2]_:
+
+    .. math::
+
+        F << \frac{1}{4} \left(k_B T S_t^2 / L_p\right)^\frac{1}{3}
+
+    Where :math:`k_B` is the Boltzmann constant, :math:`T` is the temperature, :math:`S_t` is the
+    stretch modulus and :math:`L_p` is the persistence length. At higher forces an extensible WLC
+    model (which takes into account enthalpic stretching) should be used.
 
     This model has force as the dependent variable. Differs from exact WLC solution by up to -10%
     near F=0.1 pN. Approaches exact WLC solution at lower and higher forces [2]_.
@@ -234,10 +241,17 @@ def wlc_marko_siggia_force(name):
 
 
 def wlc_marko_siggia_distance(name):
-    """Marko Siggia's Worm-like Chain (WLC) model.
+    r"""Marko Siggia's Worm-like Chain (WLC) model.
 
-    This model [1]_ is based on only entropic contributions (valid for F << 10 pN). At higher forces
-    an extensible WLC model (which takes into account enthalpic stretching) should be used.
+    This model [1]_ is based on only entropic contributions. This model is valid at low forces [2]_:
+
+    .. math::
+
+        F << \frac{1}{4} \left(k_B T S_t^2 / L_p\right)^\frac{1}{3}
+
+    Where :math:`k_B` is the Boltzmann constant, :math:`T` is the temperature, :math:`S_t` is the
+    stretch modulus and :math:`L_p` is the persistence length. At higher forces an extensible WLC
+    model (which takes into account enthalpic stretching) should be used.
 
     This model has distance as the dependent variable. Differs from exact WLC solution by up to -10%
     near F=0.1 pN. Approaches exact WLC solution at lower and higher forces [2]_.


### PR DESCRIPTION
**Why this PR?**
This PR fixes three (small) things.

1. The F-d fitter uses the docstring provided in the implementation of the F-d model as `__repr_html__`. Some of these models had no description and therefore no description was provided to the user. This is fixed now.

I considered defining the docstring in the implementation only and reading that docstring from the API side (in `models.py`) but after doing so felt that the added complexity was not really warranted to deduplicate the sections that could be deduplicated. Reason being that for the render in the Jupyter `__repr_html__`, one usually wants to use `$a$` since it renders nicely; while in the docstring for the API side, one wants :math:`a` since that formats correctly to the online documentation.

2. The criterion for the validity of the inextensible worm-like chain was modified to reflect that in reality it depends on the model parameters. This equation comes from Wang et al [1].

3. It should be mentioned that none of the models is particularly valid at very low forces (around 0.1 pN for DNA). There are models that claim to fare better at such low forces, but we do not have them implemented yet (see [2]).

[1] https://www.sciencedirect.com/science/article/pii/S0006349597787800
[2] https://www.sciencedirect.com/science/article/pii/S0006349599772073

Docs build can be found here: 
https://lumicks-pylake.readthedocs.io/en/ms_validity/_api/lumicks.pylake.wlc_marko_siggia_force.html
https://lumicks-pylake.readthedocs.io/en/ms_validity/_api/lumicks.pylake.wlc_marko_siggia_distance.html