### PR TITLE
calibration: allow calibration class to be pickled

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 * `DwelltimeBootstrap` is now a frozen dataclass.
 * Attempting to access `DwelltimeModel.bootstrap` before sampling now raises a `RuntimeError`; however, see the deprecation note above for proper API to access bootstrapping distributions.
 * Suppress legend entry for outline when invoking `KymoTrack.plot()`.
+* Allow pickling force calibration results (`CalibrationResults`). Prior to this change two functions involved in calculating upper parameter bounds prevented this class from being pickled.
 
 #### Bugfixes
 

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -142,6 +142,16 @@ class NoFilter(FilterBase):
         return 1
 
 
+# These are used for parameter bounds in the DiodeModel and have to be defined non-locally to ensure
+# that the class can be pickled.
+def _one(_):
+    return 1.0
+
+
+def _nyquist(sample_rate):
+    return sample_rate / 2.0
+
+
 class DiodeModel(FilterBase):
     def __init__(self):
         self.fitted_params = [
@@ -151,7 +161,7 @@ class DiodeModel(FilterBase):
                 unit="Hz",
                 initial=14000,
                 lower_bound=0.0,
-                upper_bound=lambda sample_rate: sample_rate / 2,
+                upper_bound=_nyquist,
             ),
             Param(
                 name="alpha",
@@ -159,7 +169,7 @@ class DiodeModel(FilterBase):
                 unit="",
                 initial=0.3,
                 lower_bound=0.0,
-                upper_bound=lambda _: 1.0,
+                upper_bound=_one,
             ),
         ]
 


### PR DESCRIPTION
**Why this PR?**
For end users, it can be beneficial to be able to just pickle things without having to think about it.

Without this change, the `CalibrationResults` structure cannot be pickled because of the locally defined lambdas for the upper bounds.

Yes, defining a function `_one` that does nothing but return `1.0` also irks me. I considered making it a static method, but it felt like polluting the class.