### PR TITLE
Fixup DwelltimeBootstrap histograms

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,9 @@
 * Added option to calculate a diffusion estimate based on the ensemble MSDs using the Ordinary Least Squares (OLS) method.
 * Added `DwelltimeBootstrap.extend()` to draw additional samples for the distribution.
 
+#### Bug fixes
+* Fixed bug in `DwelltimeBootstrap.hist()` (previously named `DwelltimeBootstrap.plot()`, see below). Previously, only up to two components were plotted; now all components are plotted appropriately.
+
 #### Deprecations
 
 * Renamed `CorrelatedStack` to [`ImageStack`](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/imagestack.html).

--- a/changelog.md
+++ b/changelog.md
@@ -15,13 +15,16 @@
 * Added `DwelltimeBootstrap.extend()` to draw additional samples for the distribution.
 
 #### Bug fixes
+
 * Fixed bug in `DwelltimeBootstrap.hist()` (previously named `DwelltimeBootstrap.plot()`, see below). Previously, only up to two components were plotted; now all components are plotted appropriately.
+* `DwelltimeBootstrap.hist()` now displays the original parameter estimate rather than the mean of the bootstrap distribution; the bootstrap distribution is used solely to calculate the confidence intervals via `DwelltimeBootstrap.get_interval()`.
 
 #### Deprecations
 
 * Renamed `CorrelatedStack` to [`ImageStack`](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/imagestack.html).
 * Deprecated the `DwelltimeModel.bootstrap` attribute; this attribute will be removed in a future release. Instead, `DwelltimeModel.calculate_bootstrap()` now returns a `DwelltimeBootstrap` instance directly. See the [population dynamics](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/population_dynamics.html#confidence-intervals-from-bootstrapping) documentation for more details.
 * Deprecated `DwelltimeBootstrap.plot()` and renamed to `DwelltimeBootstrap.hist()` to more closely match the figure that is generated.
+* Deprecated `DwelltimeBootstrap.calculate_stats()`. This method is replaced with `DwelltimeBootstrap.get_interval()` which returns the `100*(1-alpha)` % confidence interval; unlike `DwelltimeBootstrap.calculate_stats()`, it does not return the mean.
 
 #### Other changes
 

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -180,7 +180,7 @@ class DwelltimeBootstrap:
             data = self.lifetime_distributions.squeeze()
             plot_axes(data, "lifetime", 0, False)
         else:
-            for component in range(2):
+            for component in range(self.n_components):
                 for column, key in enumerate(("amplitude", "lifetime")):
                     data = getattr(self, f"{key}_distributions")[component]
                     column += 1

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -60,8 +60,13 @@ def test_bootstrap(exponential_data):
 
     np.random.seed(123)
     bootstrap = fit.calculate_bootstrap(iterations=50)
-    mean, ci = bootstrap.calculate_stats("amplitude", 0)
-    np.testing.assert_allclose(mean, 0.4642469883372174, rtol=1e-5)
+
+    with pytest.warns(DeprecationWarning):
+        mean, ci = bootstrap.calculate_stats("amplitude", 0)
+        np.testing.assert_allclose(mean, 0.4642469883372174, rtol=1e-5)
+        np.testing.assert_allclose(ci, (0.3647038711684928, 0.5979550940729152), rtol=1e-5)
+
+    ci = bootstrap.get_interval("amplitude", 0, alpha=0.05)
     np.testing.assert_allclose(ci, (0.3647038711684928, 0.5979550940729152), rtol=1e-5)
     np.random.seed()
 


### PR DESCRIPTION
**Why this PR?**
While testing some other things, I noticed that only up to 2 components are shown for the histogram even if the model components > 2. Also changed so we use the estimated parameter rather than the mean of the bootstrap distribution to mark the plots