### PR TITLE
export_tiff: fix bug when exporting with `clip=True`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -27,5 +27,8 @@ ignore =
     E501,
     # Don't complain about star imports.
     F403,F405,
+    # Don't complain about f"'{x}'" quotes. `!r` is not particularly readable, especially not for
+    # cases where one would have to resort to f"{str(x)!r}"
+    B028,
 
 show-source = True

--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 
 * Fixed issue with model description not being available in Jupyter notebooks for some force-distance models.
 * Show validity criterion for Marko Siggia WLC models in terms of model parameters. Prior to this change the limit was simply denoted as `10 pN` where in reality it depends on the model parameters. The `10 pN` was a reasonable value for most DNA constructs.
+* Fixed bug which occurred when exporting images to TIFF files of a numerical type with insufficient range for the data with the flag `clip=True`. Prior to this change, values exceeding the range of the numerical type were not clearly defined. After this change values below and above the supported range are clipped to the lowest or highest value of the data type respectively.
 
 ## v0.13.2 | 2022-11-15
 

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -38,12 +38,15 @@ class TiffExport:
         def cast_image(image, dtype=np.float32, clip=False):
             # Check if requested dtype can fit image values without an overflow
             info = np.finfo(dtype) if np.dtype(dtype).kind == "f" else np.iinfo(dtype)
-            if not clip and (np.min(image) < info.min or np.max(image) > info.max):
-                raise RuntimeError(
-                    f"Can't safely export image with `dtype={dtype.__name__}` channels."
-                    f" Switch to a larger `dtype` in order to safely store everything"
-                    f" or pass `force=True` to clip the data."
-                )
+            if np.min(image) < info.min or np.max(image) > info.max:
+                if clip:
+                    image = np.clip(image, info.min, info.max)
+                else:
+                    raise RuntimeError(
+                        f"Can't safely export image with `dtype={dtype.__name__}` channels. "
+                        f"Switch to a larger `dtype` in order to safely store everything or pass "
+                        f"`clip=True` to clip the data."
+                    )
 
             return image.astype(dtype)
 


### PR DESCRIPTION
Fixed bug which occurred when exporting images to TIFF files of a numerical type with insufficient range for the data with the flag `clip=True`. Prior to this change, values exceeding the range of the numerical type were not clearly defined. After this change values below and above the supported range are clipped to the lowest or highest value of the data type respectively.

I also added some data validation to the test (reading in the TIFF file whether it is actually what we think it should be).