### PR TITLE
kymotrack: block label for edges

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 
 * `DwelltimeBootstrap` is now a frozen dataclass.
 * Attempting to access `DwelltimeModel.bootstrap` before sampling now raises a `RuntimeError`; however, see the deprecation note above for proper API to access bootstrapping distributions.
+* Suppress legend entry for outline when invoking `KymoTrack.plot()`.
 
 #### Bugfixes
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -292,7 +292,7 @@ class KymoTrack:
                 self.seconds,
                 self.position,
                 path_effects=[pe.Stroke(foreground="k", linewidth=linewidth * 2.5)],
-                **kwargs,
+                **{**kwargs, "label": "__no_label__"},
             )
 
         ax.plot(self.seconds, self.position, path_effects=[pe.Normal()], **kwargs)


### PR DESCRIPTION
**Why this PR?**
It's minor, but it's kind of annoying that when you plot with a label, you explicitly get the edge label for free.

![image](https://user-images.githubusercontent.com/19836026/213233945-195fc9d0-1971-4ae8-8e19-f27bfa85350b.png)
