### PR TITLE
kymotracking: fix window rounding

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 
 #### Bugfixes
 
+* Fixed a bug that resulted in an incorrect round-off of the window size to pixels when kymotracking. This bug resulted in using one more pixel on each side than intended for specific `track_widths`. Track width is selected by rounding to the next odd window size. Prior to this change, the number of points used would increase on even window sizes. As a result, requesting a track width of `2.5` pixels, would result in using a window of size `5`. Currently, requested a track width of `3` pixels results in a window of size 3, while `3.1` rounds up to the next odd window size (`5`). This bug affected the kymo tracking widget (tracking, refinement and photon count sampling during saving), `lk.track_greedy()` and `lk.refine_tracks_centroid()`.
 * Fixed issue with model description not being available in Jupyter notebooks for some force-distance models.
 * Show validity criterion for Marko Siggia WLC models in terms of model parameters. Prior to this change the limit was simply denoted as `10 pN` where in reality it depends on the model parameters. The `10 pN` was a reasonable value for most DNA constructs.
 * Fixed bug which occurred when exporting images to TIFF files of a numerical type with insufficient range for the data with the flag `clip=True`. Prior to this change, values exceeding the range of the numerical type were not clearly defined. After this change values below and above the supported range are clipped to the lowest or highest value of the data type respectively.

--- a/changelog.md
+++ b/changelog.md
@@ -16,8 +16,15 @@
 
 #### Bug fixes
 
+* Fixed a bug that resulted in an incorrect round-off of the window size to pixels when kymotracking. This bug resulted in using one more pixel on each side than intended for specific `track_widths`. Track width is selected by rounding to the next odd window size. Prior to this change, the number of points used would increase on even window sizes. As a result, requesting a track width of `2.5` pixels, would result in using a window of size `5`. Currently, requested a track width of `3` pixels results in a window of size 3, while `3.1` rounds up to the next odd window size (`5`). This bug affected the kymo tracking widget (tracking, refinement and photon count sampling during saving), `lk.track_greedy()` and `lk.refine_tracks_centroid()`.
+* Updated default slider ranges for the Kymotracker widget to reflect minimum track width required for tracking.
+* Fixed issue with model description not being available in Jupyter notebooks for some force-distance models.
+* Show validity criterion for Marko Siggia WLC models in terms of model parameters. Prior to this change the limit was simply denoted as `10 pN` where in reality it depends on the model parameters. The `10 pN` was a reasonable value for most DNA constructs.
+* Fixed bug which occurred when exporting images to TIFF files of a numerical type with insufficient range for the data with the flag `clip=True`. Prior to this change, values exceeding the range of the numerical type were not clearly defined. After this change values below and above the supported range are clipped to the lowest or highest value of the data type respectively.
 * Fixed bug in `DwelltimeBootstrap.hist()` (previously named `DwelltimeBootstrap.plot()`, see below). Previously, only up to two components were plotted; now all components are plotted appropriately.
 * `DwelltimeBootstrap.hist()` now displays the original parameter estimate rather than the mean of the bootstrap distribution; the bootstrap distribution is used solely to calculate the confidence intervals via `DwelltimeBootstrap.get_interval()`.
+* Fixed a bug where `Scan.export_video()` and `CorrelatedStack.export_video()` would show elements from a previous plot.
+* Fixed a bug that caused a misalignment of half a pixel between the kymograph and its position histogram when using `Kymo.plot_with_position_histogram()`.
 
 #### Deprecations
 
@@ -32,13 +39,6 @@
 * Attempting to access `DwelltimeModel.bootstrap` before sampling now raises a `RuntimeError`; however, see the deprecation note above for proper API to access bootstrapping distributions.
 * Suppress legend entry for outline when invoking `KymoTrack.plot()`.
 * Allow pickling force calibration results (`CalibrationResults`). Prior to this change two functions involved in calculating upper parameter bounds prevented this class from being pickled.
-
-#### Bugfixes
-
-* Fixed a bug that resulted in an incorrect round-off of the window size to pixels when kymotracking. This bug resulted in using one more pixel on each side than intended for specific `track_widths`. Track width is selected by rounding to the next odd window size. Prior to this change, the number of points used would increase on even window sizes. As a result, requesting a track width of `2.5` pixels, would result in using a window of size `5`. Currently, requested a track width of `3` pixels results in a window of size 3, while `3.1` rounds up to the next odd window size (`5`). This bug affected the kymo tracking widget (tracking, refinement and photon count sampling during saving), `lk.track_greedy()` and `lk.refine_tracks_centroid()`.
-* Fixed issue with model description not being available in Jupyter notebooks for some force-distance models.
-* Show validity criterion for Marko Siggia WLC models in terms of model parameters. Prior to this change the limit was simply denoted as `10 pN` where in reality it depends on the model parameters. The `10 pN` was a reasonable value for most DNA constructs.
-* Fixed bug which occurred when exporting images to TIFF files of a numerical type with insufficient range for the data with the flag `clip=True`. Prior to this change, values exceeding the range of the numerical type were not clearly defined. After this change values below and above the supported range are clipped to the lowest or highest value of the data type respectively.
 
 ## v0.13.2 | 2022-11-15
 
@@ -72,8 +72,6 @@
 * Fixed a bug where single pixel detections in a `KymoTrackGroup` would contribute values with a dwell time of zero. These are now dropped, the correct minimally observable time is set appropriately and a warning is issued.
 * Fixed slicing of a `Kymo` where slicing from a time point inside the last line to the end (e.g. `kymo["5s":]`) resulted in a `Kymo` which returned errors upon trying to access its contents.
 * Fixed a minor bug in force calibration. In rare cases it was possible that the procedure to generate an initial guess for the power spectral fit failed. This seemed to occur when the spectrum supplied is a mostly flat plateau. After the fix, an alternative method to compute an initial guess is applied in cases where the regular method fails. Note that successful calibrations were not at risk for being incorrect due to this bug since they would have resulted in an exception rather than an invalid result.
-* Fixed a bug where `Scan.export_video()` and `CorrelatedStack.export_video()` would show elements from a previous plot.
-* Fixed a bug that caused a misalignment of half a pixel between the kymograph and its position histogram when using `Kymo.plot_with_position_histogram()`.
 
 #### Deprecations
 

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -23,7 +23,7 @@ def kymo_integration_test_data():
     return generate_kymo(
         "test",
         raw_test_data(),
-        pixel_size_nm=5000,
+        pixel_size_nm=50,
         start=int(4e9),
         dt=int(5e9 / 100),
         samples_per_pixel=3,

--- a/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
@@ -88,7 +88,7 @@ def test_greedy_algorithm_input_validation(kymo_integration_test_data):
 
     for track_width in (-1, 0, 2.99 * test_data.pixelsize_um[0]):
         with pytest.raises(
-            ValueError, match=re.escape("track_width should at least be 3 pixels (0.150 [um])")
+            ValueError, match=re.escape("track_width must at least be 3 pixels (0.150 [um])")
         ):
             track_greedy(test_data, "red", track_width=track_width, pixel_threshold=10)
 

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -2,6 +2,7 @@ import re
 import pytest
 import matplotlib.pyplot as plt
 from lumicks.pylake.kymotracker.kymotrack import *
+from lumicks.pylake.kymotracker.kymotracker import _to_half_kernel_size
 from lumicks.pylake.kymotracker.detail.localization_models import *
 from lumicks.pylake import filter_tracks
 from lumicks.pylake.kymo import _kymo_from_array
@@ -969,3 +970,16 @@ def test_invalid_ensemble_diffusion(blank_kymo):
     kymotracks = KymoTrackGroup([KymoTrack([], [], blank_kymo, "red")])
     with pytest.raises(ValueError, match=re.escape("Invalid method (egg) selected")):
         kymotracks.ensemble_diffusion("egg")
+
+
+@pytest.mark.parametrize(
+    "window, pixelsize, result",
+    [
+        # fmt:off
+        (1.0, 1.0, 0), (2.0, 1.0, 1), (3.0, 1.0, 1), (3.01, 1.0, 2), (4.0, 1.0, 2), (4.99, 1.0, 2),
+        (1.0, 2.0, 0), (2.0, 2.0, 0), (6.0, 2.0, 1), (6.01, 2.0, 2), (7.0, 2.0, 2), (7.99, 2.0, 2),
+        # fmt:on
+    ]
+)
+def test_half_kernel(window, pixelsize, result):
+    assert _to_half_kernel_size(window, pixelsize) == result

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 import numpy as np
 from lumicks.pylake.kymotracker.kymotracker import *
 from lumicks.pylake.kymotracker.kymotrack import KymoTrack, KymoTrackGroup
@@ -82,8 +83,13 @@ def test_refinement_track(loc, inv_sigma=0.3):
 
 
 def test_refinement_error(kymo_integration_test_data):
-    with pytest.raises(ValueError, match="track_width should be larger than zero"):
-        refine_tracks_centroid([KymoTrack([0], [25], kymo_integration_test_data, "red")], 0)[0]
+    with pytest.raises(
+        ValueError, match=re.escape("track_width must at least be 3 pixels (0.150 [um])")
+    ):
+        refine_tracks_centroid([KymoTrack([0], [25], kymo_integration_test_data, "red")], 0.149)[0]
+
+    # This should be fine though
+    refine_tracks_centroid([KymoTrack([0], [25], kymo_integration_test_data, "red")], 0.15)[0]
 
     with pytest.warns(DeprecationWarning):
         with pytest.raises(ValueError, match="line_width may not be smaller than 1"):

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -11,6 +11,7 @@ from lumicks.pylake.kymotracker.kymotracker import track_greedy
 from lumicks.pylake import filter_tracks, refine_tracks_centroid
 from lumicks.pylake.nb_widgets.detail.mouse import MouseDragCallback
 from lumicks.pylake.kymotracker.kymotrack import KymoTrackGroup, import_kymotrackgroup_from_csv
+from lumicks.pylake.kymotracker.kymotracker import _to_half_kernel_size
 from lumicks.pylake.nb_widgets.detail.undostack import UndoStack
 
 
@@ -118,10 +119,6 @@ class KymoWidget:
     @tracks.setter
     def tracks(self, new_tracks):
         self._tracks_history.state = new_tracks
-
-    @property
-    def _track_width_pixels(self):
-        return np.ceil(self._algorithm_parameters["track_width"].value / self._kymo.pixelsize[0])
 
     def _track_kymo(self, click, release):
         """Handle mouse release event.
@@ -277,7 +274,9 @@ class KymoWidget:
         try:
             self.save_tracks(
                 self._output_filename,
-                sampling_width=int(np.ceil(0.5 * self._track_width_pixels)),
+                sampling_width=_to_half_kernel_size(
+                    self._algorithm_parameters["track_width"].value, self._kymo.pixelsize[0]
+                ),
             )
             self._set_label("status", f"Saved {self._output_filename}")
         except (RuntimeError, IOError) as exception:

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -808,7 +808,7 @@ def _get_default_parameters(kymo, channel):
             "How big a particle needs to appear to be tracked as a single molecule.",
             "float",
             4 * position_scale,
-            *(0.0, 15.0 * position_scale),
+            *(3.0 * position_scale, 15.0 * position_scale),
             True,
             r"Expected spot size defines how big a bound particle needs to appear as on the "
             r"kymograph for it to be tracked as a single molecule. This parameter should be set to "

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -247,8 +247,16 @@ def test_stitch_anywhere(start, stop, same_track, kymograph, mockevent):
 
 
 def test_refine_track_width_units(kymograph, region_select):
+    # The lines of interest here are located at coordinate pixel 12 and 15. The line at 12 will
+    # start to incorporate contributions from the line at 15 if the window size is bigger than 5
+    # pixels, since a window of 7 leads to a half kernel size of n = 3 which is the lowest window
+    # size to incorporate this contribution.
     kymo_widget = KymoWidgetGreedy(
-        kymograph, "red", axis_aspect_ratio=1, track_width=2, use_widgets=False
+        kymograph,
+        "red",
+        axis_aspect_ratio=1,
+        track_width=5 * kymograph.pixelsize[0] + 0.0001,
+        use_widgets=False,
     )
     in_um, in_s = calibrate_to_kymo(kymograph)
 
@@ -349,9 +357,9 @@ def test_keyword_args(kymograph):
     "gain,line_time,pixel_size,ref_values",
     (
         # fmt:off
-        (1, 2.0, 5.0, {"pixel_threshold": (97, 1, 99), "track_width": (4 * 5, 0 * 5, 15 * 5), "sigma": (2 * 5, 1 * 5, 5 * 5), "vel": (0, -5 * 5/2, 5 * 5/2)}),
-        (0, 2.0, 5.0, {"pixel_threshold": (1, 1, 2), "track_width": (4 * 5, 0 * 5, 15 * 5), "sigma": (2 * 5, 1 * 5, 5 * 5), "vel": (0, -5 * 5/2, 5 * 5/2)}),
-        (1, 4.0, 4.0, {"pixel_threshold": (97, 1, 99), "track_width": (4 * 4, 0 * 4, 15 * 4), "sigma": (2 * 4, 1 * 4, 5 * 4), "vel": (0, -5 * 4/4, 5 * 4/4)}),
+        (1, 2.0, 5.0, {"pixel_threshold": (97, 1, 99), "track_width": (4 * 5, 3 * 5, 15 * 5), "sigma": (2 * 5, 1 * 5, 5 * 5), "vel": (0, -5 * 5/2, 5 * 5/2)}),
+        (0, 2.0, 5.0, {"pixel_threshold": (1, 1, 2), "track_width": (4 * 5, 3 * 5, 15 * 5), "sigma": (2 * 5, 1 * 5, 5 * 5), "vel": (0, -5 * 5/2, 5 * 5/2)}),
+        (1, 4.0, 4.0, {"pixel_threshold": (97, 1, 99), "track_width": (4 * 4, 3 * 4, 15 * 4), "sigma": (2 * 4, 1 * 4, 5 * 4), "vel": (0, -5 * 4/4, 5 * 4/4)}),
         # fmt:on
     ),
 )


### PR DESCRIPTION
**Why this PR?**
While performing an analysis in preparation of the new bias corrected centroid method, I noticed that the track width rounding is inconsistent.

Track width should always be rounded upwards to an odd number of pixels (since there needs to be a defined center pixel for the centroid refinement to work). We were rounding upwards too quickly, meaning that we typically took windows that are bigger than requested. Selecting a window that's exactly 3 pixels big, would give you a window of 5. I also noticed that we were calculating these `half_kernel` sizes in multiple places, so I spun it out to a separate private function.

![image](https://user-images.githubusercontent.com/19836026/213456479-b500bc81-308c-477c-9f08-77f63c9531e7.png)

While doing this, I noticed that once you correct the windows it becomes apparent that you could set windows that were smaller than three pixels (for which centroid refinement will not work). These cases now raise an exception instead.

In this PR I also update the slider ranges we provide for the widgets (to make sure that we can't select invalid windows).