### PR TITLE
kymotracking: add bias reduction step into the centroid estimator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
 
 * Added API for notes, i.e. `file.notes` returns a dictionary of notes.
 * Added option to add a scale bar to by providing a [`lk.ScaleBar()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ScaleBar.html) to plotting or export functions.
+* Implemented bias correction for centroid refinement that shrinks the window to reduce estimation bias. This bias correction can be toggled by passing a `bias_correction` argument to [`lk.track_greedy()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.track_greedy.html#) and [`lk.refine_tracks_centroid()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.refine_tracks_centroid.html).
 
 ## v0.13.3 | 2023-01-26
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 #### Breaking changes
 
+* When performing particle tracking on kymographs, bias correction is now enabled by default; without this correction, kymographs with high background signal will suffer from biased localization estimates. To disable bias correction, specify `bias_correction=False` to [`lk.track_greedy()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.track_greedy.html#) and [`lk.refine_tracks_centroid()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.refine_tracks_centroid.html).
 * Changed several `asserts` to `Exceptions`.
   * Attempting to read `KymoTracks` from a `CSV` file that doesn't have the expected file format will result in an `IOError`.
   * Attempting to extend `KymoTracks` by `KymoTracks` originating from a different `Kymograph` now results in a `ValueError`.

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,3 +1,15 @@
+@article{berglund2008fast,
+  title={Fast, bias-free algorithm for tracking single particles with variable size and shape},
+  author={Berglund, Andrew J and McMahon, Matthew D and McClelland, Jabez J and Liddle, J Alexander},
+  journal={Optics express},
+  volume={16},
+  number={18},
+  pages={14064--14075},
+  year={2008},
+  publisher={Optica Publishing Group}
+}
+
+
 @article{vestergaard2014optimal,
   title={Optimal estimation of diffusion coefficients from single-particle trajectories},
   author={Vestergaard, Christian L and Blainey, Paul C and Flyvbjerg, Henrik},

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -168,6 +168,11 @@ don't have an explicit point on the track associated with them. Using :func:`~lu
 can refine the tracks found by the algorithm. This function interpolates the tracks such that each time point gets its
 own point on the track. Subsequently, these points are then refined using a brightness weighted centroid.
 
+Brightness weighted centroid refinement can suffer from a bias when there is background signal. This bias artificially
+pulls the localization towards the center of the pixel. By default, Pylake corrects for this by including a
+step that shrinks the window such that the spot always lands exactly in the middle of the window. For more information
+on this, please refer to :cite:`berglund2008fast`.
+
 Let's perform track refinement with two different values for `track_width` and plot the longest track::
 
     # re-track our kymo

--- a/docs/zrefs.rst
+++ b/docs/zrefs.rst
@@ -26,7 +26,9 @@ Kymotracker
 
 The line algorithm was based on sections 1, 2 and 3 from :cite:`steger1998unbiased` to find line centers based on local
 geometric considerations. The greedy algorithm was based on two papers. It initially detects feature points based on
-:cite:`sbalzarini2005feature`, followed by line tracing inspired by :cite:`mangeol2016kymographclear`.
+:cite:`sbalzarini2005feature`, followed by line tracing inspired by :cite:`mangeol2016kymographclear`. Instead of
+subtracting the background and thresholding the values below zero to zero, we perform a bias correction for background
+by symmetrizing the used window (:cite:`berglund2008fast`).
 
 Diffusion constant estimation
 -----------------------------

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -74,7 +74,7 @@ def track_greedy(
     diffusion=0.0,
     sigma_cutoff=2.0,
     rect=None,
-    bias_correction=False,
+    bias_correction=True,
     line_width=None,
 ):
     """Track particles on an image using a greedy algorithm.
@@ -377,7 +377,7 @@ def refine_lines_centroid(lines, line_width):
     return refine_tracks_centroid(lines, track_width)
 
 
-def refine_tracks_centroid(tracks, track_width=None, bias_correction=False):
+def refine_tracks_centroid(tracks, track_width=None, bias_correction=True):
     """Refine the tracks based on the brightness-weighted centroid.
 
     This function interpolates the determined tracks (in time) and then uses the pixels in the

--- a/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
@@ -135,7 +135,10 @@ def test_default_parameters(kymo_pixel_calibrations):
 
         # To verify this for the width, we have to make sure we go to the next odd window size.
         tracks = track_greedy(
-            kymo, "red", track_width=default_width / kymo.pixelsize[0] + 2, pixel_threshold=None
+            kymo, "red",
+            track_width=default_width / kymo.pixelsize[0] + 2,
+            pixel_threshold=None,
+            bias_correction=False,
         )
         with pytest.raises(AssertionError):
             for ref, track in zip(ref_tracks, tracks):

--- a/lumicks/pylake/kymotracker/tests/test_peakfinding.py
+++ b/lumicks/pylake/kymotracker/tests/test_peakfinding.py
@@ -8,6 +8,7 @@ from lumicks.pylake.kymotracker.detail.peakfinding import (
     merge_close_peaks,
     bounds_to_centroid_data,
     unbiased_centroid,
+    _clip_kernel_to_edge,
 )
 
 
@@ -134,3 +135,17 @@ def test_bounds_to_centroid_data(bounds, selection_ref, center_ref, weights_ref)
 )
 def test_unbiased_centroid_estimator(data, ref_estimate):
     np.testing.assert_allclose(unbiased_centroid(data), ref_estimate)
+
+
+@pytest.mark.parametrize(
+    "coords, data_shape, half_width, ref",
+    [
+        (np.arange(0, 11), 11, 3, np.array([0, 1, 2, 3, 3, 3, 3, 3, 2, 1, 0])),
+        (np.arange(0, 11), 11, 4, np.array([0, 1, 2, 3, 4, 4, 4, 3, 2, 1, 0])),
+        (np.arange(1, 12), 12, 3, np.array([1, 2, 3, 3, 3, 3, 3, 3, 2, 1, 0])),
+        (np.arange(1, 12), 12, 4, np.array([1, 2, 3, 4, 4, 4, 4, 3, 2, 1, 0])),
+        (np.array([3, 4, 8, 9, 28, 29]), 30, 4, np.array([3, 4, 4, 4, 1, 0])),
+    ],
+)
+def test_clip_halfwidth(coords, data_shape, half_width, ref):
+    np.testing.assert_allclose(_clip_kernel_to_edge(half_width, coords, data_shape), ref)

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -45,7 +45,7 @@ def test_refinement_2d():
     )
 
     track = KymoTrack(time_idx[::2], coordinate_idx[::2], kymo, "red")
-    refined_track = refine_tracks_centroid([track], 5)[0]
+    refined_track = refine_tracks_centroid([track], 5, bias_correction=False)[0]
     np.testing.assert_allclose(refined_track.time_idx, time_idx)
     np.testing.assert_allclose(refined_track.coordinate_idx, coordinate_idx + offset)
 

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -277,9 +277,9 @@ def test_bias_corrected_refinement_background(kymogroups_2tracks):
 
     assert np.allclose(
         refined[0].position,
-        [3.53198535, 3.56770477, 3.48393027, 3.33972994, 3.48729841],
+        [3.53199999, 3.56773634, 3.48390805, 3.33971131, 3.48724068],
     )
     assert np.allclose(
         refined[1].position,
-        [5.06661771, 4.83971404, 4.9625, 5.088, 5.02488394],
+        [5.06666451, 4.83968723, 4.9625, 5.088, 5.02488394],
     )

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -277,9 +277,9 @@ def test_bias_corrected_refinement_background(kymogroups_2tracks):
 
     assert np.allclose(
         refined[0].position,
-        [3.53199999, 3.56773634, 3.48390805, 3.33971131, 3.487240685],
+        [3.53198535, 3.56770477, 3.48393027, 3.33972994, 3.48729841],
     )
     assert np.allclose(
         refined[1].position,
-        [5.06666451, 4.83968723, 4.9625, 5.088, 5.02488394],
+        [5.06661771, 4.83971404, 4.9625, 5.088, 5.02488394],
     )

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -265,7 +265,7 @@ def test_refine_track_width_units(kymograph, region_select):
     kymo_widget._refine()
 
     # With this track_width we'll include the two dim pixels in the test data
-    true_coordinate = [12.176471] * 15
+    true_coordinate = [12.299547] * 15
     true_coordinate[2] = 12
     true_coordinate[3] = 12
     np.testing.assert_allclose(kymo_widget.tracks[0].coordinate_idx, true_coordinate)


### PR DESCRIPTION
**Why this PR?**
Subpixel estimates can be very biased when using a simple centroid estimator when there is appreciable background. The reason is that the subpixel deviation is normalized by the total intensity over area used for the estimate. When the background is high, this results in a contraction of the subpixel correction towards the center.

**How to review this PR?**
I recommend going commit by commit. In the first few commits, I set up the algorithm in pure Python.  The beforelast commit vectorizes the algorithm. This makes it a bit trickier to read, but the performance gains are worthwhile.

**Description**
This PR is an implementation of [this ](https://opg.optica.org/oe/fulltext.cfm?uri=oe-16-18-14064&id=171315) paper. In a nutshell, the paper shows that under mild assumptions the bias is proportional to how far the spot is from the center. Instead of trying to remove the background, they suggest adjusting the window such that the spot is centered (including removing fractional parts of the window).

What you see below is a histogram of 1000 localizations for each of the 40 spot locations tried. The black lines indicate the mean (center) and 1 sigma bounds. The yellow line indicates the true value used for simulation.

![image](https://user-images.githubusercontent.com/19836026/213771337-d5be711a-01dd-443c-b1e5-0c13b69cb1e7.png)

The variance of this estimator goes up when the window size gets bigger, therefore it is important to choose the window size somewhat appropriate for the spot size. This same effect is not true for Gaussian refinement.