### PR TITLE
Refactor dwell time analysis to remove explicit constraint

### DIFF
--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -633,10 +633,10 @@ def test_fit_binding_times(blank_kymo):
     tracks = KymoTrackGroup([k1, k2, k3, k4])
 
     dwells = tracks.fit_binding_times(1)
-    np.testing.assert_allclose(dwells.lifetimes, [1.002547])
+    np.testing.assert_allclose(dwells.lifetimes, [1.002744], rtol=1e-5)
 
     dwells = tracks.fit_binding_times(1, exclude_ambiguous_dwells=False)
-    np.testing.assert_allclose(dwells.lifetimes, [1.25710457])
+    np.testing.assert_allclose(dwells.lifetimes, [1.257], rtol=1e-5)
 
 
 def test_fit_binding_times_nonzero(blank_kymo):

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -6,7 +6,10 @@ from lumicks.pylake import DwelltimeModel
 from lumicks.pylake.population.dwelltime import _dwellcounts_from_statepath
 
 
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
+# ignore warnings for all tests
+pytestmark = pytest.mark.filterwarnings("ignore:divide by zero encountered in log")
+
+
 def test_likelihood(exponential_data):
     # single exponential data
     dataset = exponential_data["dataset_1exp"]
@@ -23,18 +26,16 @@ def test_likelihood(exponential_data):
     np.testing.assert_allclose(fit.bic, 4429.232045925579, rtol=1e-5)
 
 
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
 def test_optim_options(exponential_data):
     dataset = exponential_data["dataset_1exp"]
 
     fit = DwelltimeModel(dataset["data"], 1, **dataset["parameters"].observation_limits, tol=1e-1)
-    np.testing.assert_allclose(fit.lifetimes, [1.442235], rtol=1e-5)
+    np.testing.assert_allclose(fit.lifetimes, [1.443046], rtol=1e-5)
 
     fit = DwelltimeModel(dataset["data"], 1, **dataset["parameters"].observation_limits, max_iter=2)
-    np.testing.assert_allclose(fit.lifetimes, [1.382336], rtol=1e-5)
+    np.testing.assert_allclose(fit.lifetimes, [1.433627], rtol=1e-5)
 
 
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
 def test_fit_parameters(exponential_data):
     # single exponential data
     dataset = exponential_data["dataset_1exp"]
@@ -46,13 +47,12 @@ def test_fit_parameters(exponential_data):
     # double exponential data
     dataset = exponential_data["dataset_2exp"]
     fit = DwelltimeModel(dataset["data"], 2, **dataset["parameters"].observation_limits)
-    np.testing.assert_allclose(fit.amplitudes, [0.46513486, 0.53486514], rtol=1e-5)
-    np.testing.assert_allclose(fit.lifetimes, [1.50630877, 5.46212603], rtol=1e-5)
-    np.testing.assert_allclose(fit.rate_constants, [1 / 1.50630877, 1 / 5.46212603], rtol=1e-5)
+    np.testing.assert_allclose(fit.amplitudes, [0.465166, 0.534834], rtol=1e-5)
+    np.testing.assert_allclose(fit.lifetimes, [1.506357, 5.462286], rtol=1e-5)
+    np.testing.assert_allclose(fit.rate_constants, [1 / 1.506357, 1 / 5.462286], rtol=1e-5)
 
 
 @pytest.mark.slow
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
 def test_bootstrap(exponential_data):
     # double exponential data
     dataset = exponential_data["dataset_2exp"]
@@ -63,11 +63,11 @@ def test_bootstrap(exponential_data):
 
     with pytest.warns(DeprecationWarning):
         mean, ci = bootstrap.calculate_stats("amplitude", 0)
-        np.testing.assert_allclose(mean, 0.4642469883372174, rtol=1e-5)
-        np.testing.assert_allclose(ci, (0.3647038711684928, 0.5979550940729152), rtol=1e-5)
+        np.testing.assert_allclose(mean, 0.464252, rtol=1e-5)
+        np.testing.assert_allclose(ci, (0.364703, 0.597969), rtol=1e-5)
 
     ci = bootstrap.get_interval("amplitude", 0, alpha=0.05)
-    np.testing.assert_allclose(ci, (0.3647038711684928, 0.5979550940729152), rtol=1e-5)
+    np.testing.assert_allclose(ci, (0.364703, 0.597969), rtol=1e-5)
     np.random.seed()
 
     more_bootstrap = bootstrap.extend(iterations=10)
@@ -80,7 +80,6 @@ def test_bootstrap(exponential_data):
 
 
 # TODO: remove with deprecation
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
 def test_empty_bootstrap(exponential_data):
     dataset = exponential_data["dataset_2exp"]
 
@@ -99,7 +98,7 @@ def test_empty_bootstrap(exponential_data):
             match=re.escape(
                 "The bootstrap distribution is currently empty. Use `DwelltimeModel.calculate_bootstrap()` "
                 "to sample a distribution before attempting downstream analysis."
-            )
+            ),
         ):
             fit.bootstrap
 


### PR DESCRIPTION
**Why this PR?**

Previously we used the `SLSQP` algorithm which supports constraints in order to ensure fractional amplitudes sum to 1. Now, for a model with `K` components, `K-1` amplitude parameters are passed, with the final term calculated within the log likelihood function.

This allows us to switch to `L-BFGS-B` and has the added benefit that for a single component model, the amplitude parameter is not included in the optimization, but inherently set to 1.