### PR TITLE
docs: fix docs links from notebook

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,9 @@ nbexport_pre_code = (
 %matplotlib inline
 """
 )
-nbexport_baseurl = ""
+target_version = os.environ.get("READTHEDOCS_VERSION")
+target_version = target_version if target_version is not None else "stable"
+nbexport_baseurl = f"https://lumicks-pylake.readthedocs.io/en/{target_version}/"
 nbexport_execute = False
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
**Why this PR?**
It's nice to have the links in the notebooks actually lead to the documentation online.

It took me a bit to find how to poll the URL the docs end up at. But you can find how the URL is composed from the root and `<lang>/<version>` tags [here](https://docs.readthedocs.io/en/stable/glossary.html#term-root-URL) and how to get the version from the environment variables [here](https://docs.readthedocs.io/en/stable/environment-variables.html#envvar-READTHEDOCS_VERSION). For local builds, this environment variable does not exist and we just point to `stable`.

Docs build where you can download a Jupyter notebook [here](https://lumicks-pylake.readthedocs.io/en/api_links/theory/diffusion/diffusion.html) and one with a more extreme branch name (to test name mangling by RtD) [here](https://lumicks-pylake.readthedocs.io/en/extreme-version-naming/theory/diffusion/diffusion.html).