### PR TITLE
ensemble_msd: forward  kwargs  in `EnsembleMSD.plot()`

### DIFF
--- a/lumicks/pylake/kymotracker/detail/msd_estimation.py
+++ b/lumicks/pylake/kymotracker/detail/msd_estimation.py
@@ -113,8 +113,15 @@ class EnsembleMSD:
     def seconds(self):
         return self.lags * self._time_step
 
-    def plot(self):
-        plt.errorbar(self.seconds, self.msd, self.sem)
+    def plot(self, **kwargs):
+        """Plot Ensemble MSDs
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to :func:`matplotlib.pyplot.errorbar`.
+        """
+        plt.errorbar(self.seconds, self.msd, self.sem, **kwargs)
         plt.xlabel("Time [s]")
         plt.ylabel(f"Squared Displacement [{self._unit_label}]")
 


### PR DESCRIPTION
**Why this PR?**
It's very minor, but in most cases where we just `.plot()` a single thing we simply forward the `**kwargs`. I found myself essentially remaking this `plot()` function because it wasn't there. Figured I'd better just do the fixup at the source.