### PR TITLE
plotting: allow users to add a scale bar to their plots if they want

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## v1.0.0 | In development
+## v1.0.0 | t.b.d.
 
 #### New features
 
 * Added API for notes, i.e. `file.notes` returns a dictionary of notes.
+* Added option to add a scale bar to by providing a [`lk.ScaleBar()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ScaleBar.html) to plotting or export functions.
 
 ## v0.13.3 | 2023-01-26
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,6 +18,7 @@ If you are just looking to get started, read the :doc:`/tutorial/index` first.
     point_scan.PointScan
     ImageStack
     ColorAdjustment
+    ScaleBar
 
     :template: instance.rst
 

--- a/docs/tutorial/imagestack.rst
+++ b/docs/tutorial/imagestack.rst
@@ -103,6 +103,8 @@ for each of the channels. This can be accomplished by providing a :class:`~lumic
 
 .. image:: figures/imagestack/imagestack_adjust_absolute.png
 
+Similarly, you can add a scale bar to your plots by providing a :class:`~lumicks.pylake.ScaleBar` to plotting or export functions.
+
 By default the limits should be provided in absolute values, although percentiles can be used instead for convenience::
 
     plt.figure()

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -49,8 +49,9 @@ Note that the axes are labeled with the appropriate time and position units.
 The first argument `channel` accepts the strings "red", "green", "blue", or "rgb". We also see that the color limits can be set easily using
 the :class:`~lumicks.pylake.ColorAdjustment` class. The first two arguments act like the `vmin` and `vmax` arguments used with
 :func:`plt.imshow() <matplotlib.pyplot.imshow()>` if `mode="absolute"`. In the second plot, we use `mode=percentile` to automatically calculate
-the limits at the 0th and 99th percentile of all of the pixel values. In addition, this method also accepts keyword arguments that are passed to
-:func:`plt.imshow() <matplotlib.pyplot.imshow()>` internally.
+the limits at the 0th and 99th percentile of all of the pixel values.
+Similarly, you can add a scale bar to your plots by providing a :class:`~lumicks.pylake.ScaleBar` to plotting or export functions.
+In addition, this method also accepts keyword arguments that are passed to :func:`plt.imshow() <matplotlib.pyplot.imshow()>` internally.
 
 There are also a number of custom colormaps for plotting single channel images. These are available from :data:`~lumicks.pylake.colormaps`;
 the available colormaps are: `.red`, `.green`, `.blue`, `.magenta`, `.yellow`, and `.cyan`. For example, we can plot the blue channel image

--- a/docs/tutorial/scans.rst
+++ b/docs/tutorial/scans.rst
@@ -56,6 +56,8 @@ This can be accomplished by providing a :class:`~lumicks.pylake.ColorAdjustment`
 
     scan.plot(channel="rgb", adjustment=lk.ColorAdjustment([0, 0, 0], [4, 4, 4]))
 
+Similarly, you can add a scale bar to your plots by providing a :class:`~lumicks.pylake.ScaleBar` to plotting or export functions.
+
 There are also a number of custom colormaps for plotting single channel images. These are available from :data:`~lumicks.pylake.colormaps`; the available colormaps are:
 `.red`, `.green`, `.blue`, `.magenta`, `.yellow`, and `.cyan`. For example, we can plot the blue channel image with the cyan colormap::
 

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -13,6 +13,7 @@ from .__about__ import (
 from .file_download import *
 from .benchmark import benchmark
 from .adjustments import ColorAdjustment, colormaps
+from .scalebar import ScaleBar
 from .image_stack import ImageStack, CorrelatedStack
 from .piezo_tracking.piezo_tracking import *
 from .piezo_tracking.baseline import *

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -111,6 +111,7 @@ class VideoExport:
         stop_frame=None,
         fps=15,
         adjustment=no_adjustment,
+        scale_bar=None,
         **kwargs,
     ):
         """Export a video
@@ -129,6 +130,8 @@ class VideoExport:
             Frame rate.
         adjustment : lk.ColorAdjustment
             Color adjustments to apply to the output image.
+        scale_bar : lk.ScaleBar
+            Scale bar to add to the figure.
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`."""
         from matplotlib import animation
@@ -155,6 +158,7 @@ class VideoExport:
                 frame=frame,
                 image_handle=image_handle,
                 adjustment=adjustment,
+                scale_bar=scale_bar,
                 **kwargs,
             )
 

--- a/lumicks/pylake/detail/tests/test_plotting.py
+++ b/lumicks/pylake/detail/tests/test_plotting.py
@@ -106,6 +106,7 @@ def _plot_interface_parameters(image=False, stack=False):
         ["general", ("axes", Parameter.KEYWORD_ONLY)],
         ["image", ("image_handle", Parameter.KEYWORD_ONLY)],
         ["general", ("show_title", Parameter.KEYWORD_ONLY)],
+        ["general", ("show_axes", Parameter.KEYWORD_ONLY)],
         ["general", ("kwargs", Parameter.VAR_KEYWORD)],
     ]
 

--- a/lumicks/pylake/detail/tests/test_plotting.py
+++ b/lumicks/pylake/detail/tests/test_plotting.py
@@ -107,6 +107,7 @@ def _plot_interface_parameters(image=False, stack=False):
         ["image", ("image_handle", Parameter.KEYWORD_ONLY)],
         ["general", ("show_title", Parameter.KEYWORD_ONLY)],
         ["general", ("show_axes", Parameter.KEYWORD_ONLY)],
+        ["image", ("scale_bar", Parameter.KEYWORD_ONLY)],
         ["general", ("kwargs", Parameter.VAR_KEYWORD)],
     ]
 

--- a/lumicks/pylake/image_stack.py
+++ b/lumicks/pylake/image_stack.py
@@ -303,6 +303,7 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
         image_handle=None,
         show_title=True,
         show_axes=True,
+        scale_bar=None,
         **kwargs,
     ):
         """Plot a frame from the image stack for the requested color channel(s)
@@ -324,6 +325,8 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
             Controls display of auto-generated plot title
         show_axes : bool, optional
             Setting show_axes to False hides the axes.
+        scale_bar : lk.ScaleBar, optional
+            Scale bar to add to the figure.
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`. These arguments are ignored if
             `image_handle` is provided.
@@ -337,6 +340,11 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
 
         if show_axes is False:
             axes.set_axis_off()
+
+        # TODO: Use pixel calibration once available in the metadata
+        positional_unit = "px"
+        if scale_bar and not image_handle:
+            scale_bar._attach_scale_bar(axes, 100, 100, positional_unit, positional_unit)
 
         image = self._get_frame(frame)._get_plot_data(channel, adjustment=adjustment)
 

--- a/lumicks/pylake/image_stack.py
+++ b/lumicks/pylake/image_stack.py
@@ -302,6 +302,7 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
         axes=None,
         image_handle=None,
         show_title=True,
+        show_axes=True,
         **kwargs,
     ):
         """Plot a frame from the image stack for the requested color channel(s)
@@ -321,6 +322,8 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
             reconstruct them (better for performance).
         show_title : bool, optional
             Controls display of auto-generated plot title
+        show_axes : bool, optional
+            Setting show_axes to False hides the axes.
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`. These arguments are ignored if
             `image_handle` is provided.
@@ -331,6 +334,10 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
             The image handle representing the plotted image.
         """
         axes = get_axes(axes=axes, image_handle=image_handle)
+
+        if show_axes is False:
+            axes.set_axis_off()
+
         image = self._get_frame(frame)._get_plot_data(channel, adjustment=adjustment)
 
         default_kwargs = dict(cmap="gray")

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -291,6 +291,7 @@ class Kymo(ConfocalImage):
         axes=None,
         image_handle=None,
         show_title=True,
+        show_axes=True,
         **kwargs,
     ):
         """Plot a kymo for the requested color channel(s).
@@ -308,6 +309,8 @@ class Kymo(ConfocalImage):
             reconstruct them (better for performance).
         show_title : bool, optional
             Controls display of auto-generated plot title
+        show_axes : bool, optional
+            Setting show_axes to False hides the axes.
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`. These arguments are ignored if
             `image_handle` is provided.
@@ -318,6 +321,9 @@ class Kymo(ConfocalImage):
             The image handle representing the plotted image.
         """
         axes = get_axes(axes=axes, image_handle=image_handle)
+
+        if show_axes is False:
+            axes.set_axis_off()
 
         image = self._get_plot_data(channel, adjustment)
 

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -292,6 +292,7 @@ class Kymo(ConfocalImage):
         image_handle=None,
         show_title=True,
         show_axes=True,
+        scale_bar=None,
         **kwargs,
     ):
         """Plot a kymo for the requested color channel(s).
@@ -311,6 +312,8 @@ class Kymo(ConfocalImage):
             Controls display of auto-generated plot title
         show_axes : bool, optional
             Setting show_axes to False hides the axes.
+        scale_bar : lk.ScaleBar, optional
+            Scale bar to add to the figure.
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`. These arguments are ignored if
             `image_handle` is provided.
@@ -324,6 +327,9 @@ class Kymo(ConfocalImage):
 
         if show_axes is False:
             axes.set_axis_off()
+
+        if scale_bar and not image_handle:
+            scale_bar._attach_scale_bar(axes, 60.0, 1.0, "s", self._calibration.unit_label)
 
         image = self._get_plot_data(channel, adjustment)
 

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -688,7 +688,7 @@ class Kymo(ConfocalImage):
             from lumicks import pylake
             import matplotlib.pyplot as plt
 
-            # Loading a stack.
+            # Loading a kymograph.
             h5_file = pylake.File("example.h5")
             _, kymo = h5_file.kymos.popitem()
             widget = kymo.crop_and_calibrate("green", 48.502)

--- a/lumicks/pylake/point_scan.py
+++ b/lumicks/pylake/point_scan.py
@@ -24,7 +24,7 @@ class PointScan(BaseScan):
         return getattr(self, f"{channel}_photon_count")
 
     @_deprecate_basescan_plot_args
-    def plot(self, channel="rgb", *, axes=None, show_title=True, **kwargs):
+    def plot(self, channel="rgb", *, axes=None, show_title=True, show_axes=True, **kwargs):
         """Plot photon counts for the selected channel(s).
 
         Parameters
@@ -35,6 +35,8 @@ class PointScan(BaseScan):
             If supplied, the axes instance in which to plot.
         show_title : bool, optional
             Controls display of auto-generated plot title
+        show_axes : bool, optional
+            Setting show_axes to False hides the axes.
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.plot`
 
@@ -45,6 +47,10 @@ class PointScan(BaseScan):
         """
         channels = ["red", "green", "blue"] if channel == "rgb" else [channel]
         axes = get_axes(axes=axes)
+
+        if show_axes is False:
+            axes.set_axis_off()
+
         for channel in channels:
             count = self._get_plot_data(channel)
             time = (count.timestamps - count.timestamps[0]) * 1e-9

--- a/lumicks/pylake/scalebar.py
+++ b/lumicks/pylake/scalebar.py
@@ -94,6 +94,24 @@ class ScaleBar:
         Font size to use for the labels.
     **kwargs
         additional arguments passed to :class:`matplotlib.offsetbox.AnchoredOffsetBox`.
+
+    Examples
+    --------
+    ::
+
+        import lumicks.pylake as lk
+
+        # Loading a kymograph.
+        h5_file = pylake.File("example.h5")
+        _, kymo = h5_file.kymos.popitem()
+
+        # Show default scale bar
+        kymo.plot("green", scale_bar=lk.ScaleBar())
+        plt.show()
+
+        # Show scale bar with a scale of 10 seconds on the x axis
+        kymo.plot("green", scale_bar=lk.ScaleBar(size_x=10))
+        plt.show()
     """
 
     size_x: Optional[float] = None

--- a/lumicks/pylake/scalebar.py
+++ b/lumicks/pylake/scalebar.py
@@ -1,0 +1,138 @@
+from dataclasses import dataclass, field
+from matplotlib.offsetbox import AnchoredOffsetbox, AuxTransformBox, VPacker, HPacker, TextArea
+from typing import Optional, Union
+
+
+def _create_scale_legend(
+    transform,
+    size_x,
+    size_y,
+    label_x,
+    label_y,
+    loc,
+    color,
+    separation,
+    barwidth,
+    fontsize,
+    **kwargs,
+):
+    """Draws a scale legend for the current axis.
+
+    Parameters
+    ----------
+    transform : :class:`matplotlib.transforms.CompositeGenericTransform`
+        The coordinate frame (typically axes.transData).
+    size_x, size_y : float or None
+        Length of the scale bars in data units. `0` or `None` omits the scale.
+    label_x, label_y : str or None
+        Labels for the scale bars. None results in no label on the scale.
+    loc : str or int
+        Position in the containing axis.  Valid locations are 'upper left', 'upper center',
+        'upper right', 'center left', 'center', 'center right', 'lower left', 'lower center',
+        'lower right'.
+    color : Matplotlib color
+        Color to use for the text and labels.
+    separation : float
+        separation between labels and bars in points.
+    bar_width : float or None
+        Width of the scale bar(s)
+    fontsize : float or None
+        Font size to use for the labels.
+    **kwargs
+        additional arguments passed to :class:`matplotlib.offsetbox.AnchoredOffsetBox`."""
+    from matplotlib.patches import Rectangle
+
+    bars = AuxTransformBox(transform)
+    bar_args = {"ec": color, "lw": barwidth, "fc": None}
+
+    if size_x:
+        bars.add_artist(Rectangle(xy=(0, size_y), width=size_x, height=0, **bar_args))
+
+    if size_y:
+        bars.add_artist(Rectangle(xy=(0, 0), width=0, height=size_y, **bar_args))
+
+    textprops = {"color": color, "fontsize": fontsize}
+    if size_x and label_x:
+        xlabel = TextArea(label_x, textprops=textprops)
+        bars = VPacker(children=[bars, xlabel], align="center", pad=0, sep=separation)
+
+    if size_y and label_y is not None:
+        ylabel = TextArea(label_y, textprops=textprops)
+
+        if size_x and label_x is not None:
+            # Add a dummy label with the same text such that the label is properly centered.
+            # Without this dummy element, the label ends up in the middle of the full vertical
+            # height of the scales and the text underneath.
+            dummy = TextArea(label_x, textprops={**textprops, "visible": False})
+            ylabel = VPacker(children=[ylabel, dummy], align="center", pad=0, sep=0)
+
+        bars = HPacker(children=[ylabel, bars], align="center", pad=0, sep=separation)
+
+    return AnchoredOffsetbox(loc, child=bars, frameon=False, **kwargs)
+
+
+@dataclass
+class ScaleBar:
+    """Draws a scale legend for the current axis.
+
+    Parameters
+    ----------
+    size_x, size_y : float or None
+        Width of the scale bars in data units. `0` or `None` omits the scale.
+    label_x, label_y : str or None
+        Labels for the scale bars. None results in no label on the scale.
+    loc : position in the containing axis
+        Valid locations are 'upper left', 'upper center', 'upper right', 'center left',
+        'center', 'center right', 'lower left', 'lower center', 'lower right'.
+    color : Matplotlib color
+        Color to use for the text and labels.
+    separation : float
+        separation between labels and bars in points.
+    bar_width : float or None
+        Width of the scale bar(s)
+    fontsize : float or None
+        Font size to use for the labels.
+    **kwargs
+        additional arguments passed to :class:`matplotlib.offsetbox.AnchoredOffsetBox`.
+    """
+
+    size_x: Optional[float] = None
+    size_y: Optional[float] = None
+    label_x: Optional[str] = None
+    label_y: Optional[str] = None
+    loc: Union[str, int] = "upper right"
+    color: str = "white"
+    separation: Optional[float] = 2.0
+    barwidth: Optional[float] = None
+    fontsize: Optional[float] = None
+    kwargs: dict = field(default_factory=dict)
+
+    def _attach_scale_bar(self, axis, size_x, size_y, x_unit, y_unit):
+        """Attach scale bar to an axis
+
+        axis : :class:`matplotlib.pyplot.axis`
+            Axis to attach scale bar to
+        size_x, size_y : float
+            Length of the scale bars in data units.
+            These values are only used if the user did not explicitly set one during initialization.
+            Note that `0` or `None` omits the scale.
+        x_unit, y_unit : str
+            Units of the axis this is being added to.
+            This value is only used if the user did not explicitly set one during initialization."""
+
+        size_x = self.size_x if self.size_x is not None else size_x
+        size_y = self.size_y if self.size_y is not None else size_y
+        scale_bar = _create_scale_legend(
+            axis.transData,
+            size_x,
+            size_y,
+            self.label_x if self.label_x is not None else f"{size_x} {x_unit}",
+            self.label_y if self.label_y is not None else f"{size_y} {y_unit}",
+            self.loc,
+            self.color,
+            self.separation,
+            self.barwidth,
+            self.fontsize,
+            **self.kwargs,
+        )
+        axis.add_artist(scale_bar)

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -424,6 +424,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         image_handle=None,
         show_title=True,
         show_axes=True,
+        scale_bar=None,
         **kwargs,
     ):
         """Plot a scan frame for the requested color channel(s).
@@ -445,6 +446,8 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             Controls display of auto-generated plot title
         show_axes : bool, optional
             Setting show_axes to False hides the axes.
+        scale_bar : lk.ScaleBar, optional
+            Scale bar to add to the figure.
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`. These arguments are ignored if
             `image_handle` is provided.
@@ -460,6 +463,10 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
 
         if show_axes is False:
             axes.set_axis_off()
+
+        positional_unit = r"$\mu$m"
+        if scale_bar and not image_handle:
+            scale_bar._attach_scale_bar(axes, 1.0, 1.0, positional_unit, positional_unit)
 
         image = self._get_plot_data(
             channel, adjustment, frame=frame if self.num_frames != 1 else None
@@ -482,8 +489,8 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             **{**default_kwargs, **kwargs},
         )
         scan_axes = self._metadata.ordered_axes
-        axes.set_xlabel(rf"{scan_axes[0].axis_label.lower()} ($\mu$m)")
-        axes.set_ylabel(rf"{scan_axes[1].axis_label.lower()} ($\mu$m)")
+        axes.set_xlabel(rf"{scan_axes[0].axis_label.lower()} ({positional_unit})")
+        axes.set_ylabel(rf"{scan_axes[1].axis_label.lower()} ({positional_unit})")
         if show_title:
             axes.set_title(make_image_title(self, frame))
 

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -423,6 +423,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         axes=None,
         image_handle=None,
         show_title=True,
+        show_axes=True,
         **kwargs,
     ):
         """Plot a scan frame for the requested color channel(s).
@@ -442,6 +443,8 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             reconstruct them (better for performance).
         show_title : bool, optional
             Controls display of auto-generated plot title
+        show_axes : bool, optional
+            Setting show_axes to False hides the axes.
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`. These arguments are ignored if
             `image_handle` is provided.
@@ -454,6 +457,9 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         if frame < 0:
             raise IndexError("negative indexing is not supported.")
         axes = get_axes(axes=axes, image_handle=image_handle)
+
+        if show_axes is False:
+            axes.set_axis_off()
 
         image = self._get_plot_data(
             channel, adjustment, frame=frame if self.num_frames != 1 else None

--- a/lumicks/pylake/tests/test_scalebar.py
+++ b/lumicks/pylake/tests/test_scalebar.py
@@ -1,0 +1,71 @@
+import pytest
+import matplotlib.pyplot as plt
+from lumicks.pylake.scalebar import _create_scale_legend
+
+
+def _validate_elements(ref_elements, item):
+    children = item.get_children()
+    if children:
+        for c in children:
+            _validate_elements(ref_elements, c)
+    else:
+        if ref_elements:
+            idx = ref_elements.index(str(item))
+            if idx is None:
+                raise AssertionError(f"Invalid item found {item}")
+            else:
+                ref_elements.pop(idx)
+        else:
+            raise AssertionError("Missing element")
+
+
+@pytest.mark.parametrize(
+    "size_x, size_y, label_x, label_y, loc, color, separation, barwidth, fontsize, reference",
+    [
+        # fmt:off
+        # All entries
+        (
+            1, 2, "x", "y", "upper right", "white", 2, 2, 16,
+            ["Text(0, 0, 'y')", "Text(0, 0, 'x')", "Rectangle(xy=(0, 2), width=1, height=0, angle=0)", "Rectangle(xy=(0, 0), width=0, height=2, angle=0)", "Text(0, 0, 'x')"]
+        ),
+        # No label for x
+        (
+            1, 2, None, "y", "upper right", "white", 2, 2, 16,
+            ["Text(0, 0, 'y')", "Rectangle(xy=(0, 2), width=1, height=0, angle=0)", "Rectangle(xy=(0, 0), width=0, height=2, angle=0)"]
+        ),
+        # No label for y
+        (
+            1, 2, "x", None, "upper right", "white", 2, 2, 16,
+            ["Rectangle(xy=(0, 2), width=1, height=0, angle=0)", "Rectangle(xy=(0, 0), width=0, height=2, angle=0)", "Text(0, 0, 'x')"]
+        ),
+        # No labels
+        (
+            1, 2, None, None, "upper right", "white", 2, 2, 16,
+            ["Rectangle(xy=(0, 2), width=1, height=0, angle=0)", "Rectangle(xy=(0, 0), width=0, height=2, angle=0)"]
+        ),
+        # Only one axis
+        (
+            1, 0, "x", "y", "upper right", "white", 2, 2, 16,
+            ["Rectangle(xy=(0, 0), width=1, height=0, angle=0)", "Text(0, 0, 'x')"],
+        ),
+        # Only one axis
+        (
+            0, 2, "x", "y", "upper right", "white", 2, 2, 16,
+            ["Text(0, 0, 'y')", "Rectangle(xy=(0, 0), width=0, height=2, angle=0)"],
+        ),
+        # fmt:on
+    ],
+)
+def test_scalebar(
+    size_x, size_y, label_x, label_y, loc, color, separation, barwidth, fontsize, reference
+):
+    """We validate that the correct elements exist by checking their string representation"""
+    plt.figure()
+    axes = plt.gca()
+    box = _create_scale_legend(
+        axes.transData, size_x, size_y, label_x, label_y, loc, color, separation, barwidth, fontsize
+    )
+
+    _validate_elements(reference, box)
+    if reference:
+        raise AssertionError(f"Not all elements were accounted for: {reference}")


### PR DESCRIPTION
**Why this PR?**
This request came up multiple times during the user sessions.

I figured I'd play a bit with `AnchoredOffsetBox` on a friday afternoon, and it allowed this to be rolled into a feature relatively painlessly. Because we just use `matplotlib` API, it plays nicely with interactive widgets:

![interactive_scale](https://user-images.githubusercontent.com/19836026/215551755-767d616c-dbcb-4696-9693-fd69f1dac859.gif)

Plays nicely with movie export:

![new](https://user-images.githubusercontent.com/19836026/215551727-34c6c4ad-57f8-40ce-9682-041e96639b3f.gif)

![corrstack](https://user-images.githubusercontent.com/19836026/215555624-1a64e7cf-8cf0-4cca-8f08-23b5dd411fb4.gif)

And it seems pretty easy to use. Note that adding a scale bar to `plot_correlated` is not yet supported, but it may be added in the future.

Also note that I went relatively minimal on the addition to the docs (since it's so similar to `ColorAdjustment` and the docstring for the function itself contains examples). Also note that `ImageStack` is essentially uncalibrated. I left a little `TODO` there to make sure that we update that once we add the relevant calibration metadata.

Docs build is here: https://lumicks-pylake.readthedocs.io/en/scalebar/
Interesting bit is here: https://lumicks-pylake.readthedocs.io/en/scalebar/_api/lumicks.pylake.ScaleBar.html