### PR TITLE
file: add API for note items

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.0 | In development
+
+#### New features
+
+* Added API for notes, i.e. `file.notes` returns a dictionary of notes.
+
 ## v0.13.3 | 2023-01-26
 
 #### New features

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -14,6 +14,7 @@ from .kymo import Kymo
 from .point_scan import PointScan
 from .scan import Scan
 from .marker import Marker
+from .note import Note
 
 __all__ = ["File"]
 
@@ -61,6 +62,7 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
                 ("FD Curve", "fdcurves"),
                 ("Kymograph", "kymos"),
                 ("Scan", "scans"),
+                ("Note", "notes"),
             ]
         )
 
@@ -289,6 +291,11 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
     def markers(self) -> Dict[str, Marker]:
         """Markers stored in the file"""
         return self._get_object_dictionary("Marker", Marker)
+
+    @property
+    def notes(self) -> Dict[str, Note]:
+        """Notes stored in the file"""
+        return self._get_object_dictionary("Note", Note)
 
     def save_as(self, filename, compression_level=5, omit_data=None):
         """Write a modified h5 file to disk.

--- a/lumicks/pylake/note.py
+++ b/lumicks/pylake/note.py
@@ -1,0 +1,24 @@
+import json
+
+
+class Note:
+    def __init__(self, file, note_data, json):
+        self.file = file
+        self.start = note_data["Start time (ns)"]
+        self.stop = note_data["Stop time (ns)"]
+        self.name = json["name"]
+        self.text = json["Note text"]
+
+    @staticmethod
+    def from_dataset(h5py_dset, file):
+        """
+        Construct Note class from dataset.
+
+        Parameters
+        ----------
+        h5py_dset : h5py.Dataset
+            The original HDF5 dataset containing Note information
+        file : lumicks.pylake.File
+            The parent file.
+        """
+        return Note(file, h5py_dset.attrs, json.loads(h5py_dset[()]))

--- a/lumicks/pylake/tests/data/mock_file.py
+++ b/lumicks/pylake/tests/data/mock_file.py
@@ -1,6 +1,6 @@
 import numpy as np
 import h5py
-
+import json
 
 # We generate mock data files for different versions of the Bluelake HDF5 file
 # format:
@@ -84,6 +84,19 @@ class MockDataFile_v2(MockDataFile_v1):
             payload_string = f', "payload":{payload}' if payload else ""
             dset = self.file["Marker"].create_dataset(
                 marker_name, data=f'{{"name":"{marker_name}"{payload_string}}}'
+            )
+
+            for i, v in attributes.items():
+                dset.attrs[i] = v
+    
+    def make_note(self, note_name, attributes, note_text):
+        if "Note" not in self.file:
+            self.file.create_group("Note")
+
+        if note_name not in self.file["Note"]:
+            payload = {"name": note_name, "Note text": note_text}
+            dset = self.file["Note"].create_dataset(
+                note_name, data=json.dumps(payload)
             )
 
             for i, v in attributes.items():

--- a/lumicks/pylake/tests/test_file/conftest.py
+++ b/lumicks/pylake/tests/test_file/conftest.py
@@ -62,6 +62,7 @@ def h5_file(tmpdir_factory, request):
             {"Start time (ns)": 200, "Stop time (ns)": 300},
             payload=mock_force_feedback_json(),
         )
+        mock_file.make_note("test_note", {"Start time (ns)": 100, "Stop time (ns)": 100}, "Note content")
         mock_file.make_fd()
 
         json_kymo = generate_scan_json([{"axis": 0, "num of pixels": 5, "pixel size (nm)": 10.0}])

--- a/lumicks/pylake/tests/test_file/test_file.py
+++ b/lumicks/pylake/tests/test_file/test_file.py
@@ -181,6 +181,9 @@ def test_repr_and_str(h5_file):
               - fast Y slow X
               - fast Y slow X multiframe
               - fast Y slow Z multiframe
+            
+            .notes
+              - test_note
 
             .force1x
               .calibration

--- a/lumicks/pylake/tests/test_file/test_file_items.py
+++ b/lumicks/pylake/tests/test_file/test_file_items.py
@@ -107,3 +107,14 @@ def test_kymos(h5_file):
             kymo.get_image("red"),
             np.transpose([[2, 0, 0, 0, 2], [0, 0, 0, 0, 0], [1, 0, 0, 0, 1], [0, 1, 1, 1, 0]]),
         )
+
+
+def test_notes(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+    if f.format_version == 2:
+        name = "test_note"
+        note = f.notes[name]
+        assert note.name == name
+        assert note.text == "Note content"
+        assert note.start == 100
+        assert note.stop == 100


### PR DESCRIPTION
Notes can be added as timeline events in Bluelake but currently, there is no easy way to load them back in `pylake`, this adds the API which is similar to the marker one.