### PR TITLE
fdfitting: replace assertions with exceptions (part 1)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,10 @@
   * FdFitter: `FdFit.plot()` now raises a `KeyError` when trying to plot data that does not exist.
   * FdFitter: `FdFit.plot()` now raises a `RuntimeError` when trying to plot a fit with multiple models without selecting a model using angular brackets `[]` first.
   * FdFitter: `FdFit.profile()` now raises a `ValueError` when `max_step <= min_step` or `max_chi2_step <= min_chi2_step`.
+  * FdFitter: when inverting a model with `interpolate=True`, Pylake now raises a `ValueError` if the minimum or maximum is not finite.
+  * FdFitter: a `ValueError` is raised when adding incompatible models.
+  * FdFitter: When adding data to a fit, adding data with an unequal number of points for the dependent and independent variable will now raise a `ValueError`.
+  * FdFitter: When adding data to a fit, adding data with more than one dimension will raise a `ValueError`. 
   
 #### New features
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,9 @@
   * FdFitter: when inverting a model with `interpolate=True`, Pylake now raises a `ValueError` if the minimum or maximum is not finite.
   * FdFitter: a `ValueError` is raised when adding incompatible models.
   * FdFitter: When adding data to a fit, adding data with an unequal number of points for the dependent and independent variable will now raise a `ValueError`.
-  * FdFitter: When adding data to a fit, adding data with more than one dimension will raise a `ValueError`. 
+  * FdFitter: When adding data to a fit, adding data with more than one dimension will raise a `ValueError`.
+  * FdFitting: Attempting to evaluate a parameter trace with `lk.parameter_trace()` for a parameter that is not part of the model now results in a `ValueError`.
+  * FdFitting: Attempting to compute a parameter trace while providing an incomplete set of parameters will now result in a `ValueError`.
   
 #### New features
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,11 @@
   * Attempting to read `KymoTracks` from a `CSV` file that doesn't have the expected file format will result in an `IOError`.
   * Attempting to extend `KymoTracks` by `KymoTracks` originating from a different `Kymograph` now results in a `ValueError`.
   * Attempting to connect two tracks with the same start and ending time point now raises a `ValueError`. 
-
+  * FdFitter: `FdFit.fit()` now raises a `RuntimeError` when a fit has no data or fittable parameters.
+  * FdFitter: `FdFit.plot()` now raises a `KeyError` when trying to plot data that does not exist.
+  * FdFitter: `FdFit.plot()` now raises a `RuntimeError` when trying to plot a fit with multiple models without selecting a model using angular brackets `[]` first.
+  * FdFitter: `FdFit.profile()` now raises a `ValueError` when `max_step <= min_step` or `max_chi2_step <= min_chi2_step`.
+  
 #### New features
 
 * Added API for notes, i.e. `file.notes` returns a dictionary of notes.

--- a/lumicks/pylake/fitting/datasets.py
+++ b/lumicks/pylake/fitting/datasets.py
@@ -54,8 +54,7 @@ class Datasets:
         return count
 
     def _add_data(self, name, x, y, params=None):
-        """
-        Loads a data set.
+        """Loads a data set.
 
         Parameters
         ----------
@@ -66,8 +65,22 @@ class Datasets:
         y : array_like
             Dependent variable. NaNs are silently dropped.
         params : Optional[dict of {str : str or int}]
-            List of parameter transformations. These can be used to convert one parameter in the model, to a new
-            parameter name or constant for this specific data set (for more information, see the examples).
+            List of parameter transformations. These can be used to convert one parameter in the
+            model, to a new parameter name or constant for this specific data set (for more
+            information, see the examples).
+
+        Returns
+        -------
+        dataset : FitData
+            Handle to added dataset.
+
+        Raises
+        ------
+        KeyError
+            If the `name` of the dataset is not unique.
+        ValueError
+            If the independent and dependent variables are not one dimensional or are of unequal
+            length.
 
         Examples
         --------
@@ -83,11 +96,19 @@ class Datasets:
 
         x = np.asarray(x, dtype=np.float64)
         y = np.asarray(y, dtype=np.float64)
-        assert x.ndim == 1, "Independent variable should be one dimension"
-        assert y.ndim == 1, "Dependent variable should be one dimension"
-        assert len(x) == len(
-            y
-        ), "Every value for the independent variable should have a corresponding data point"
+        if x.ndim != 1:
+            raise ValueError(
+                f"Independent variable x should be one dimensional, but has shape {x.shape}."
+            )
+        if y.ndim != 1:
+            raise ValueError(
+                f"Dependent variable y should be one dimensional, but has shape {y.shape}."
+            )
+        if len(x) != len(y):
+            raise ValueError(
+                "Every value for the independent variable x should have a corresponding data point "
+                "for the dependent variable y."
+            )
 
         filter_nan = np.logical_not(np.logical_or(np.isnan(x), np.isnan(y)))
         y = y[filter_nan]
@@ -114,22 +135,22 @@ class Datasets:
 
         Parameters
         ----------
-            data : str
-                Name of the data set to plot (optional, omission plots all for that model).
-            fmt : str
-                Format string, forwarded to :func:`matplotlib.pyplot.plot`.
-            independent : array_like
-                Array with values for the independent variable (used when plotting the model).
-            legend : bool
-                Show legend (default: True).
-            plot_data : bool
-                Show data (default: True).
-            overrides : dict
-                Parameter / value pairs which override parameter values in the current fit. Should be a dict of
-                {str: float} that provides values for parameters which should be set to particular values in the plot
-                (default: None);
-            ``**kwargs``
-                Forwarded to :func:`matplotlib.pyplot.plot`.
+        data : str
+            Name of the data set to plot (optional, omission plots all for that model).
+        fmt : str
+            Format string, forwarded to :func:`matplotlib.pyplot.plot`.
+        independent : array_like
+            Array with values for the independent variable (used when plotting the model).
+        legend : bool
+            Show legend (default: True).
+        plot_data : bool
+            Show data (default: True).
+        overrides : dict
+            Parameter / value pairs which override parameter values in the current fit. Should be a dict of
+            {str: float} that provides values for parameters which should be set to particular values in the plot
+            (default: None);
+        ``**kwargs``
+            Forwarded to :func:`matplotlib.pyplot.plot`.
 
         Examples
         --------
@@ -204,8 +225,7 @@ class Datasets:
 
 class FdDatasets(Datasets):
     def add_data(self, name, f, d, params=None):
-        """
-        Adds a data set to this fit.
+        """Adds a data set to this fit.
 
         Parameters
         ----------
@@ -218,6 +238,19 @@ class FdDatasets(Datasets):
         params : Optional[dict of {str : str or int}]
             List of parameter transformations. These can be used to convert one parameter in the model, to a new
             parameter name or constant for this specific data set (for more information, see the examples).
+
+        Returns
+        -------
+        dataset : FitData
+            Handle to added dataset.
+
+        Raises
+        ------
+        KeyError
+            If the `name` of the dataset is not unique.
+        ValueError
+            If the independent and dependent variables are not one dimensional or are of unequal
+            length.
 
         Examples
         --------

--- a/lumicks/pylake/fitting/detail/link_functions.py
+++ b/lumicks/pylake/fitting/detail/link_functions.py
@@ -10,28 +10,49 @@ def generate_conditions(data_sets, parameter_lookup, model_params):
 
     Parameters
     ----------
-    data_sets : list of Data
+    data_sets : dict of FitData
         References to data
     parameter_lookup : OrderedDict[str, int]
         Lookup table for looking up parameter indices by name
     model_params : list of str
         Base model parameter names
+
+    Returns
+    -------
+    conditions : list of Condition
+        Unique simulation conditions
+    data_link : list of list of FitData
+        Link between conditions and datasets (used to look up which datasets belong to which
+        condition).
+
+    Raises
+    ------
+    RuntimeError
+        If the parameters as found in the dataset are incompatible with the model parameters.
+    RuntimeError
+        If the parameter transformations contain transformed parameter names that are not in the
+        combined parameter list.
     """
     # Quickly concatenate the parameter transformations corresponding to this condition
     str_conditions = []
     for data_set in data_sets.values():
         str_conditions.append(data_set.condition_string)
 
-        assert set(data_set.transformations.keys()) == set(
-            model_params
-        ), "Source parameters in data parameter transformations are incompatible with the specified model parameters."
+        if set(data_set.transformations.keys()) != set(model_params):
+            raise RuntimeError(
+                "Source parameters in the data parameter transformations of data_sets are "
+                "incompatible with the specified model parameters in model_params."
+            )
 
         target_params = [x for x in data_set.transformations.values() if isinstance(x, str)]
-        assert set(target_params).issubset(
-            parameter_lookup.keys()
-        ), "Parameter transformations contain transformed parameter names that are not in the combined parameter list."
+        if not set(target_params).issubset(parameter_lookup.keys()):
+            raise RuntimeError(
+                "Parameter transformations of data_sets contain transformed parameter names that "
+                "are not in the combined parameter list parameter_lookup."
+            )
 
-    # Determine unique parameter conditions and the indices to get the appropriate unique condition from data index.
+    # Determine unique parameter conditions and the indices to get the appropriate unique condition
+    # from data index.
     unique_condition_strings, indices = unique_idx(str_conditions)
     indices = np.asarray(indices)
 

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -19,7 +19,6 @@ from copy import deepcopy
 
 import uuid
 import inspect
-import types
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/lumicks/pylake/fitting/parameter_trace.py
+++ b/lumicks/pylake/fitting/parameter_trace.py
@@ -3,9 +3,11 @@ import scipy.optimize as optim
 
 
 def parameter_trace(model, params, inverted_parameter, independent, dependent, **kwargs):
-    """Invert a model with respect to one parameter. This function fits a unique parameter for every data point in
-    this data-set while keeping all other parameters fixed. This can be used to for example invert the model with
-    respect to the contour length or some other parameter.
+    """Fit a model with respect to one parameter for each data point.
+
+    This function fits a unique parameter value for every data point in this data-set while keeping
+    all other parameters fixed. This can be used to for example invert the model with respect to
+    the contour length or some other parameter.
 
     Parameters
     ----------
@@ -21,6 +23,20 @@ def parameter_trace(model, params, inverted_parameter, independent, dependent, *
         Vector of values for the dependent variable
     **kwargs :
         Forwarded to scipy.optimize.least_squares
+
+    Returns
+    -------
+    parameter_trace : np.ndarray
+        Array of fitted parameter values for the parameter being fitted.
+
+    Raises
+    ------
+    ValueError
+        If specifying a parameter to invert over (`inverted_parameter`) that is not part of the
+        model.
+    ValueError
+        If a parameter required for model simulation is missing from the supplied parameters in
+        `params`.
 
     Examples
     --------
@@ -39,11 +55,14 @@ def parameter_trace(model, params, inverted_parameter, independent, dependent, *
         lcs = parameter_trace(model, current_fit[data_handle], "model/Lc", distance, force)
     """
     param_names = model.parameter_names
-    assert (
-        inverted_parameter in params
-    ), f"Inverted parameter not in model parameter vector {params}."
+    if inverted_parameter not in params:
+        raise ValueError(
+            f"Inverted parameter {inverted_parameter} not in model parameters {params}."
+        )
+
     for key in param_names:
-        assert key in params, f"Missing parameter {key} in supplied parameter vector."
+        if key not in params:
+            raise ValueError(f"Missing parameter {key} in supplied params.")
 
     # Grab reference parameter vector and index for the parameter list
     param_vector = [params[key].value for key in param_names]

--- a/lumicks/pylake/fitting/tests/test_condition_handling.py
+++ b/lumicks/pylake/fitting/tests/test_condition_handling.py
@@ -25,17 +25,23 @@ def test_build_conditions():
         [1, 2, 3],
         parse_transformation(param_names, {"c": "i_should_not_exist"}),
     )
-    with pytest.raises(AssertionError):
-        assert generate_conditions(
-            {"name1": d1, "name2": d2, "name4": d4}, parameter_lookup, param_names
-        )
+    with pytest.raises(
+        RuntimeError,
+        match="Parameter transformations of data_sets contain transformed parameter names that are "
+              "not in the combined parameter list parameter_lookup"
+    ):
+        generate_conditions({"name1": d1, "name2": d2, "name4": d4}, parameter_lookup, param_names)
 
     # Tests whether we pick up on when a parameter exists in the model, but there's no
     # transformation for it.
     d5 = FitData("name5", [1, 2, 3], [1, 2, 3], parse_transformation(param_names))
     param_names = ["a", "b", "c", "i_am_new"]
     parameter_lookup = OrderedDict(zip(param_names, np.arange(len(param_names))))
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        RuntimeError,
+        match="Source parameters in the data parameter transformations of data_sets are "
+              "incompatible with the specified model parameters in model_params"
+    ):
         assert generate_conditions(
             {"name1": d1, "name2": d2, "name5": d5}, parameter_lookup, param_names
         )

--- a/lumicks/pylake/fitting/tests/test_fit.py
+++ b/lumicks/pylake/fitting/tests/test_fit.py
@@ -2,6 +2,7 @@ from lumicks.pylake.fitting.models import ewlc_odijk_distance, ewlc_odijk_force
 from lumicks.pylake.fitting.model import Model
 from lumicks.pylake.fitting.fit import Fit, FdFit, Params, Datasets
 from lumicks.pylake.fitting.parameters import Parameter
+import re
 import pytest
 import numpy as np
 import matplotlib.pyplot as plt
@@ -390,6 +391,10 @@ def test_parameter_availability():
 def test_data_loading():
     m = Model("M", lambda x, a: a * x)
     fit = Fit(m)
+
+    with pytest.raises(RuntimeError, match="This model has no data associated with it."):
+        fit.fit()
+
     fit._add_data("test", [1, np.nan, 3], [2, np.nan, 4])
     np.testing.assert_allclose(fit[m].data["test"].x, [1, 3])
     np.testing.assert_allclose(fit[m].data["test"].y, [2, 4])
@@ -408,6 +413,16 @@ def test_data_loading():
 
     with pytest.raises(AssertionError):
         fit._add_data("test4", [[1, 3, 5]], [[2, 4, 5]])
+
+
+def test_no_free_parameters():
+    fit = FdFit(ewlc_odijk_force("DNA"))
+    fit._add_data("RecA", [1, 2, 3], [1, 2, 3])
+    for pars in ("DNA/Lp", "DNA/Lc", "DNA/St"):
+        fit[pars].fixed = True
+
+    with pytest.raises(RuntimeError, match="This model has no free parameters"):
+        fit.fit()
 
 
 def test_parameter_access():
@@ -560,7 +575,7 @@ def test_plotting():
     fit[m]._add_data("data_1", [1, 2, 3], [2, 3, 4])
     fit.plot()
     fit.plot("data_1")
-    with pytest.raises(AssertionError):
+    with pytest.raises(KeyError, match="Did not find dataset with name non-existent-data"):
         fit.plot("non-existent-data")
 
     fit.plot(overrides={"DNA/Lc": 12})
@@ -580,18 +595,20 @@ def test_plotting():
     fit[m2]._add_data("dataset_2", [1, 2, 3], [2, 3, 4], {"protein/Lc": "protein/Lc_2"})
     fit[m2]._add_data("dataset 3", [1, 2, 3], [2, 3, 4], {"protein/Lc": "protein/Lc_2"})
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        RuntimeError, match=re.escape("Please select a model to plot using fit[model].plot(...)")
+    ):
         fit.plot()
 
     fit[m].plot()
     fit[m2].plot()
     fit[m].plot("data_1")
 
-    with pytest.raises(AssertionError):
-        fit.plot(m, "non-existent-data")
+    with pytest.raises(KeyError, match="Did not find dataset with name non-existent-data"):
+        fit[m].plot("non-existent-data")
 
     fit[m2].plot("dataset 3")
-    with pytest.raises(AssertionError):
+    with pytest.raises(KeyError, match="Did not find dataset with name dataset 3"):
         fit[m].plot("dataset 3")
 
     fit[m].plot(overrides={"DNA/Lc": 12})

--- a/lumicks/pylake/fitting/tests/test_model_composition.py
+++ b/lumicks/pylake/fitting/tests/test_model_composition.py
@@ -89,7 +89,7 @@ def test_model_composition():
     np.testing.assert_allclose(m1._raw_call(t, p1), m2._raw_call(t, p2))
 
     # Check whether incompatible variables are found
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="These models are incompatible"):
         distance_offset("d") + force_offset("f")
 
     composite = distance_offset("d") + ewlc_odijk_distance("DNA")
@@ -134,6 +134,16 @@ def test_interpolation_inversion():
     parvec = [5.77336105517341, 7.014180463612673, 1500.0000064812095, 4.11]
     result = np.array([0.17843862, 0.18101283, 0.18364313, 0.18633117, 0.18907864])
     np.testing.assert_allclose(m._raw_call(np.arange(10, 250, 50) / 1000, parvec), result)
+
+
+@pytest.mark.parametrize(
+    "param", [{"independent_max": np.inf}, {"independent_min": -np.inf}]
+)
+def test_interpolation_invalid_range(param):
+    with pytest.raises(
+        ValueError, match="Inversion limits have to be finite when using interpolation method"
+    ):
+        ewlc_odijk_distance("Nucleosome").invert(**param, interpolate=True)
 
 
 def test_uuids():

--- a/lumicks/pylake/fitting/tests/test_parameter_inversion.py
+++ b/lumicks/pylake/fitting/tests/test_parameter_inversion.py
@@ -2,6 +2,7 @@ from lumicks.pylake.fitting.fit import Fit
 from lumicks.pylake.fitting.model import Model
 from lumicks.pylake.fitting.parameter_trace import parameter_trace
 import numpy as np
+import pytest
 
 
 def test_parameter_inversion():
@@ -51,3 +52,20 @@ def test_parameter_inversion():
     fit.params["f/b"].value = b_true
     fit.params["f/d"].value = 1.0
     np.testing.assert_allclose(parameter_trace(model, fit.params, "f/d", x, f_plus_g_data), d_true)
+
+
+def test_parameter_trace_invalid_args():
+    def f(independent, a, b):
+        return a + b * independent
+
+    model = Model("f", f)
+    data = {"dependent": np.arange(3), "independent": np.arange(3)}
+
+    with pytest.raises(
+        ValueError,
+        match="Inverted parameter f/c not in model parameters {'f/a': 5, 'f/b': 3}",
+    ):
+        parameter_trace(model, {"f/a": 5, "f/b": 3}, inverted_parameter="f/c", **data)
+
+    with pytest.raises(ValueError, match="Missing parameter f/b in supplied params"):
+        parameter_trace(model, {"f/a": 5}, inverted_parameter="f/a", **data)

--- a/lumicks/pylake/fitting/tests/test_profiles.py
+++ b/lumicks/pylake/fitting/tests/test_profiles.py
@@ -212,3 +212,14 @@ def test_fit_failure():
 
     with pytest.warns(RuntimeWarning, match="Optimization error encountered"):
         fit.profile_likelihood("model/a", num_steps=100, max_step=10, max_chi2_step=10.0)
+
+
+def test_invalid_input():
+    fit = Fit(Model("model", linear))
+    fit._add_data("data", np.arange(6), np.arange(6))
+
+    with pytest.raises(ValueError, match="max_step must be larger than min_step"):
+        fit.profile_likelihood("model/a", num_steps=100, max_step=10, min_step=12)
+
+    with pytest.raises(ValueError, match="max_chi2_step must be larger than min_chi2_step"):
+        fit.profile_likelihood("model/a", num_steps=100, max_chi2_step=10, min_chi2_step=12)

--- a/lumicks/pylake/fitting/tests/test_profiles.py
+++ b/lumicks/pylake/fitting/tests/test_profiles.py
@@ -4,7 +4,7 @@ import numpy as np
 from textwrap import dedent
 from lumicks.pylake.fitting.fit import Fit
 from lumicks.pylake.fitting.model import Model
-from lumicks.pylake.fitting.parameters import Parameter
+from lumicks.pylake.fitting.parameters import Parameter, Params
 
 
 def linear(x, a=1, b=1):
@@ -223,3 +223,29 @@ def test_invalid_input():
 
     with pytest.raises(ValueError, match="max_chi2_step must be larger than min_chi2_step"):
         fit.profile_likelihood("model/a", num_steps=100, max_chi2_step=10, min_chi2_step=12)
+
+
+def test_bad_runtime_option_change():
+    fit = Fit(Model("model", linear))
+    fit._add_data("data", np.arange(6), np.arange(6))
+    fit["model/a"].value = 1
+
+    def chi2(parameters):
+        return -2.0 * fit.log_likelihood(parameters, fit.sigma)
+
+    profile = fit.profile_likelihood("model/a", num_steps=1, min_step=1e-1, max_step=20)
+    with pytest.raises(
+        RuntimeError,
+        match="max_step must be larger than min_step, got max_step=20 and min_step=35.",
+    ):
+        profile.options["min_step"] = 35
+        profile.prepare_profile(chi2, fit._fit, fit.params, "model/a")
+
+    profile = fit.profile_likelihood("model/a", num_steps=1, min_step=1e-1, max_step=20)
+    with pytest.raises(
+        RuntimeError,
+        match="max_chi2_step must be larger than min_chi2_step, got max_chi2_step=0.25 and "
+        "min_chi2_step=35.",
+    ):
+        profile.options["min_chi2_step"] = 35
+        profile.prepare_profile(chi2, fit._fit, fit.params, "model/a")

--- a/lumicks/pylake/fitting/tests/test_stepping.py
+++ b/lumicks/pylake/fitting/tests/test_stepping.py
@@ -115,3 +115,15 @@ def test_minimum_step():
         np.testing.assert_allclose(
             p_trial, np.array([2.0 + cfg.min_abs_step, 2.0 + cfg.min_abs_step])
         )
+
+
+@pytest.mark.parametrize("pos, dir", [(5, 6), (3, 2)])
+def test_out_of_bounds_step_origin(pos, dir):
+    with pytest.raises(RuntimeError, match="Initial position was not in box constraints"):
+        # If we step even the tiniest increment over one of the bounds, it should fire!
+        clamp_step(
+            np.array([np.nextafter(pos, dir)]), np.asarray([1]), np.asarray([3]), np.asarray([5])
+        )
+
+    # Position itself should be fine
+    clamp_step(np.array([pos]), np.asarray([1]), np.asarray([3]), np.asarray([5]))


### PR DESCRIPTION
Inspired by @alessiamarcolini comment on [this PR](https://github.com/lumicks/pylake/pull/452), I decided to remove all the `assert`-based input validation we are doing since these can easily be disabled in production and generally a well named exception is more informative. These only cover issues that were improper behaviour before, so it shouldn't affect anyone that was using the API correctly; but the changes are technically breaking, so it's a good idea to do it before `1.0`.

This is PR 1 of N with changes pertaining to this. I tried to keep the commits small to make it easier to review, but I will squash it down a bit before merging.

I did a few drive-by fixups on some docstrings as well, but that's not the main focus of this PR.

I also noticed that in some cases, we weren't testing the correct thing. Please review commit by commit and see the commit message for more details.