### PR TITLE
other: assertions to exceptions (part 2)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,9 @@
   * FdFitter: When adding data to a fit, adding data with more than one dimension will raise a `ValueError`.
   * FdFitting: Attempting to evaluate a parameter trace with `lk.parameter_trace()` for a parameter that is not part of the model now results in a `ValueError`.
   * FdFitting: Attempting to compute a parameter trace while providing an incomplete set of parameters will now result in a `ValueError`.
-  
+  * Attempting to use `Slice.downsampled_over()` or `Slice.downsampled_like()` with timestamps ranges or another channel that doesn't overlap with the channel now produces a `ValueError`.
+  * Attempting to construct a `TimeSeries` where the length of the timestamp array is not equal to the length of the data array results in a `ValueError`.
+
 #### New features
 
 * Added API for notes, i.e. `file.notes` returns a dictionary of notes.

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
   * FdFitting: Attempting to compute a parameter trace while providing an incomplete set of parameters will now result in a `ValueError`.
   * Attempting to use `Slice.downsampled_over()` or `Slice.downsampled_like()` with timestamps ranges or another channel that doesn't overlap with the channel now produces a `ValueError`.
   * Attempting to construct a `TimeSeries` where the length of the timestamp array is not equal to the length of the data array results in a `ValueError`.
+  * `FdEnsemble` alignment now produces a `ValueError` if fewer than 2 datasets are provided.
 
 #### New features
 

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
   * Attempting to construct a `TimeSeries` where the length of the timestamp array is not equal to the length of the data array results in a `ValueError`.
   * `FdEnsemble` alignment now produces a `ValueError` if fewer than 2 datasets are provided.
   * Image reconstruction now raises a `ValueError` if the length of the data and infowave are not equal.
+  * Plotting: When creating a plot providing `axes` and an `image_handle`, a `ValueError` is raised when those `axes` do not belong to the `image_handle` provided. 
 
 #### New features
 

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
   * Image reconstruction now raises a `ValueError` if the length of the data and infowave are not equal.
   * Plotting: When creating a plot providing `axes` and an `image_handle`, a `ValueError` is raised when those `axes` do not belong to the `image_handle` provided. 
   * Widefield: Attempting to open multiple `TIFF` as a single ImageStack will now raise a `ValueError` if the alignment matrices of the individual `TIFF` are different.
+  * PowerSpectrum: Attempting to replace the power spectral values of a `PowerSpectrum` using `with_spectrum` using a vector of incorrect length will raise a `ValueError`.
 
 #### New features
 

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@
   * `FdEnsemble` alignment now produces a `ValueError` if fewer than 2 datasets are provided.
   * Image reconstruction now raises a `ValueError` if the length of the data and infowave are not equal.
   * Plotting: When creating a plot providing `axes` and an `image_handle`, a `ValueError` is raised when those `axes` do not belong to the `image_handle` provided. 
+  * Widefield: Attempting to open multiple `TIFF` as a single ImageStack will now raise a `ValueError` if the alignment matrices of the individual `TIFF` are different.
 
 #### New features
 

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
   * Attempting to use `Slice.downsampled_over()` or `Slice.downsampled_like()` with timestamps ranges or another channel that doesn't overlap with the channel now produces a `ValueError`.
   * Attempting to construct a `TimeSeries` where the length of the timestamp array is not equal to the length of the data array results in a `ValueError`.
   * `FdEnsemble` alignment now produces a `ValueError` if fewer than 2 datasets are provided.
+  * Image reconstruction now raises a `ValueError` if the length of the data and infowave are not equal.
 
 #### New features
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,6 +13,7 @@ If you are just looking to get started, read the :doc:`/tutorial/index` first.
     File
     channel.Slice
     fdcurve.FdCurve
+    fdensemble.FdEnsemble
     kymo.Kymo
     scan.Scan
     point_scan.PointScan

--- a/docs/tutorial/fdcurves.rst
+++ b/docs/tutorial/fdcurves.rst
@@ -77,7 +77,7 @@ Plot force versus time manually::
 FD Ensembles
 ------------
 
-FD curves can be aligned by combining them in an fd ensemble.
+FD curves can be aligned by combining them in an :class:`~lumicks.pylake.fdensemble.FdEnsemble`.
 If all the fd curves of interest are in the same file, the ensemble can be defined as
 `fd_ensemble = lk.FdEnsemble(ensemble_file.fdcurves)`. If the fd curves are in different files, the ensemble can be defined as follows::
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -455,7 +455,7 @@ class Slice:
         timestamps = other_slice.timestamps
         delta_time = np.diff(timestamps)
 
-        if self._src.start >= timestamps[-1] or self._src.stop <= timestamps[0] - delta_time[0]:
+        if self._src.start >= timestamps[-1] or self._src.stop <= timestamps[0]:
             raise RuntimeError("No overlap between slices.")
 
         # When the frame rate changes, one frame is very long due to the delay of the camera. It

--- a/lumicks/pylake/detail/alignment.py
+++ b/lumicks/pylake/detail/alignment.py
@@ -2,13 +2,34 @@ import numpy as np
 from lumicks.pylake.detail.utilities import first
 
 
-def align_force_simple(fd_curves, distance_range=1):
+def align_force_simple(fd_curves, distance_range=1.0):
     """Aligns F,d curves to the first F,d curves in the ensemble by force
 
-    It evaluates the difference in offset by considering the mean of the early data points. The underlying assumption
-    is that the force does not increase substantially for the first part of the pulling curve and that curves have
-    been acquired starting from the same F,d point."""
-    assert len(fd_curves) > 1, "Alignment only makes sense for more than 1 curve"
+    It evaluates the difference in offset by considering the mean of the early data points. The
+    underlying assumption is that the force does not increase substantially for the first part of
+    the pulling curve and that curves have been acquired starting from the same F,d point.
+
+    Parameters
+    ----------
+    fd_curves : dict of lumicks.pylake.fdcurve.FdCurve
+        F,d curves to align
+    distance_range : float
+        Range of distance data to use for alignment.
+
+    Returns
+    -------
+    fd_curves : dict of lumicks.pylake.fdcurve.FdCurve
+        Force aligned F,d curves.
+
+    Raises
+    ------
+    ValueError
+        If less than two F,d curves are passed to `fd_curves`.
+    """
+    if len(fd_curves) < 2:
+        raise ValueError(
+            f"Alignment only makes sense when there is more than 1 curve, got {len(fd_curves)}."
+        )
 
     def get_offset(fd):
         force, distance = fd._sliced(distance_max=np.min(fd.d.data[fd.d.data > 0]) + distance_range)
@@ -21,14 +42,36 @@ def align_force_simple(fd_curves, distance_range=1):
     }
 
 
-def align_distance_simple(fd_curves, distance_range=1):
-    """Aligns F,d curves to the first F,d curve in the ensemble by distance. Note that force has to be aligned first.
+def align_distance_simple(fd_curves, distance_range=1.0):
+    """Aligns F,d curves to the first F,d curve in the ensemble by distance.
 
-    This method regresses a line to the last segment of each F,d curve and aligns the curves based on this regressed
-    line. Note that this requires the ends of the aligned F,d curves to be in a comparably folded state and obtained
-    in the elastic range of the force, distance curve. If any of these assumptions are not met, this method should not
-    be applied."""
-    assert len(fd_curves) > 1, "Alignment only makes sense for more than 1 curve"
+    This method regresses a line to the last segment of each F,d curve and aligns the curves based
+    on this regressed line. Note that this requires the ends of the aligned F,d curves to be in a
+    comparably folded state and obtained in the elastic range of the force, distance curve. If any
+    of these assumptions are not met, this method should not be applied. Note that force has to be
+    aligned first.
+
+    Parameters
+    ----------
+    fd_curves : dict of lumicks.pylake.fdcurve.FdCurve
+        F,d curves to align
+    distance_range : float
+        Range of distance data to use for alignment.
+
+    Returns
+    -------
+    fd_curves : dict of lumicks.pylake.fdcurve.FdCurve
+        Force aligned F,d curves.
+
+    Raises
+    ------
+    ValueError
+        If less than two F,d curves are passed to `fd_curves`.
+    """
+    if len(fd_curves) < 2:
+        raise ValueError(
+            f"Alignment only makes sense when there is more than 1 curve, got {len(fd_curves)}."
+        )
 
     def linear_fit(fd):
         force, distance = fd._sliced(distance_min=np.max(fd.d.data) - distance_range)
@@ -49,22 +92,34 @@ def align_distance_simple(fd_curves, distance_range=1):
 def align_fd_simple(fd_curves, distance_range_low, distance_range_high):
     """Aligns F,d curves to the first F,d curve in the ensemble.
 
-    Force is aligned by taking the mean of the lowest distances. Distance is aligned by considering the last segment
-    of each F,d curve. This method regresses a line to the last segment of each F,d curve and aligns the curves based
-    on this regressed line. Note that this requires the ends of the aligned F,d curves to be in a comparably folded
-    state and obtained in the elastic range of the force, distance curve. If any of these assumptions are not met, this
-    method should not be applied.
+    Force is aligned by taking the mean of the lowest distances. Distance is aligned by considering
+    the last segment of each F,d curve. This method regresses a line to the last segment of each
+    F,d curve and aligns the curves based on this regressed line. Note that this requires the ends
+    of the aligned F,d curves to be in a comparably folded state and obtained in the elastic range
+    of the force, distance curve. If any of these assumptions are not met, this method should not
+    be applied.
 
     Parameters
     ----------
-    fd_curves : Dict[lumicks.pylake.FdCurve]
+    fd_curves : dict of lumicks.pylake.fdcurve.FdCurve
         List of F,d curves to apply the method to.
     distance_range_low : float
         Range of distances to use for the force alignment. Distances in the range [smallest_distance,
         smallest_distance + distance_range_low) are used to determine the force offsets.
     distance_range_high : float
         Upper range of distances to use. Distances in the range [largest_distance - distance_range_high,
-        largest_distance] are used for the distance alignment."""
+        largest_distance] are used for the distance alignment.
+
+    Returns
+    -------
+    fd_curves : dict of lumicks.pylake.fdcurve.FdCurve
+        Aligned F,d curves.
+
+    Raises
+    ------
+    ValueError
+        If less than two F,d curves are passed to `fd_curves`.
+    """
     return align_distance_simple(
         align_force_simple(fd_curves, distance_range_low), distance_range_high
     )

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -117,8 +117,17 @@ def reconstruct_image_sum(data, infowave, shape):
     Returns
     -------
     np.ndarray
+
+    Raises
+    ------
+    ValueError
+        If the data size is not equal to the size of the info wave.
     """
-    assert data.size == infowave.size
+    if data.size != infowave.size:
+        raise ValueError(
+            f"Data size ({data.size}) must be the same as the infowave size ({infowave.size})"
+        )
+
     subset, valid_idx = discard_zeros(infowave)
     cumulative = np.cumsum(data[valid_idx])
     pixel_ends = cumulative[subset == InfowaveCode.pixel_boundary]
@@ -144,8 +153,17 @@ def reconstruct_image(data, infowave, shape, reduce=np.sum):
     Returns
     -------
     np.ndarray
+
+    Raises
+    ------
+    ValueError
+        If the data size is not equal to the size of the info wave.
     """
-    assert data.size == infowave.size
+    if data.size != infowave.size:
+        raise ValueError(
+            f"Data size ({data.size}) must be the same as the infowave size ({infowave.size})"
+        )
+
     subset, valid_idx = discard_zeros(infowave)
     # This should be:
     #   pixel_sizes = np.diff(np.flatnonzero(infowave == InfowaveCode.pixel_boundary))

--- a/lumicks/pylake/detail/plotting.py
+++ b/lumicks/pylake/detail/plotting.py
@@ -9,9 +9,8 @@ def get_axes(axes=None, image_handle=None):
     if axes is None:
         axes = plt.gca() if image_handle is None else image_handle.axes
     if image_handle:
-        assert (
-            axes == image_handle.axes
-        ), "Supplied image_handle with a different axes than the provided axes"
+        if axes != image_handle.axes:
+            raise ValueError("Supplied image_handle with a different axes than the provided axes")
     return axes
 
 

--- a/lumicks/pylake/detail/tests/test_plotting.py
+++ b/lumicks/pylake/detail/tests/test_plotting.py
@@ -24,7 +24,7 @@ def test_get_axes():
     ax = get_axes(axes=ax1, image_handle=ih1)
     assert ax is ax1
     with pytest.raises(
-        AssertionError, match="Supplied image_handle with a different axes than the provided axes"
+        ValueError, match="Supplied image_handle with a different axes than the provided axes"
     ):
         ax = get_axes(axes=ax1, image_handle=ih2)
 
@@ -39,7 +39,7 @@ def test_show_image():
     ih1 = ax1.imshow(im1)
 
     with pytest.raises(
-        AssertionError, match="Supplied image_handle with a different axes than the provided axes"
+        ValueError, match="Supplied image_handle with a different axes than the provided axes"
     ):
         show_image(im1, image_handle=ih1, axes=ax2)
 

--- a/lumicks/pylake/detail/tests/test_widefield.py
+++ b/lumicks/pylake/detail/tests/test_widefield.py
@@ -23,6 +23,13 @@ def test_transform_default():
     np.testing.assert_equal(transform.matrix, np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]))
 
 
+def test_transform_mul_type():
+    with pytest.raises(
+        TypeError, match="Operands must be of type `TransformMatrix`, got <class 'int'>."
+    ):
+        widefield.TransformMatrix() * 1
+
+
 def test_transform_inversion():
     theta = np.radians(20)
     m = np.array([[np.cos(theta), -np.sin(theta), 0], [np.sin(theta), np.cos(theta), 0], [0, 0, 1]])

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -129,6 +129,13 @@ class TiffStack:
         List of TIFF files recorded from a camera in Bluelake.
     align_requested : bool
         Whether color channel alignment is requested.
+
+    Raises
+    ------
+    ValueError
+        If any of the provided TIFF are not compatible. To be compatible, they both need to be RGB
+        or non-RGB. They need to have the same width and height and they need to have the same
+        alignment matrices.
     """
 
     def __init__(self, tiff_files, align_requested, roi=None, tether=None):
@@ -323,7 +330,20 @@ class ImageDescription:
             self._alignment = Alignment(align_requested, AlignmentStatus.missing, False)
 
     def verify_stack_similarity(self, other):
-        """Verifies that the metadata for these images reflects a compatible image"""
+        """Verifies that the metadata for these images reflects a compatible image
+
+        Parameters
+        ----------
+        other : ImageDescription
+            Image metadata
+
+        Raises
+        ------
+        ValueError
+            If the two `ImageDescription` are not compatible. To be compatible, they both need to
+            be RGB or non-RGB. They need to have the same width and height and they need to have
+            the same alignment matrices.
+        """
 
         if self.is_rgb != other.is_rgb:
             raise ValueError("Cannot mix RGB and non-RGB stacks.")
@@ -333,16 +353,24 @@ class ImageDescription:
 
         # We only allow merging stacks with the exact same alignment settings
         if self._alignment_matrices or other._alignment_matrices:
+            if self._alignment.do_alignment != other._alignment.do_alignment:
+                raise ValueError("Alignment matrices must be the same for stacks to be merged.")
+
             # Checks whether they both have alignment matrices and whether they are the same
-            try:
-                assert self._alignment.do_alignment == other._alignment.do_alignment
+            diff_keys = set(self._alignment_matrices.keys()) - set(other._alignment_matrices.keys())
+            if diff_keys:
+                raise ValueError(
+                    "Alignment matrices must be the same for stacks to be merged. The following "
+                    f"alignment matrices were found in one stack but not the other {diff_keys}."
+                )
 
-                # Check the actual matrices we have here
-                for channel, mat in self._alignment_matrices.items():
-                    assert mat == other._alignment_matrices[channel]
-
-            except (AssertionError, KeyError):  # Check different (assert) or missing (KeyError)
-                raise ValueError("Alignment matrices must be the same for the two stacks.")
+            # Check the actual matrices we have here
+            for channel, mat in self._alignment_matrices.items():
+                if mat != other._alignment_matrices[channel]:
+                    raise ValueError(
+                        "Alignment matrices must be the same for stacks to be merged. The "
+                        f"alignment matrix for channel {channel} is different."
+                    )
 
     @property
     def alignment_roi(self):
@@ -450,7 +478,8 @@ class TransformMatrix:
 
     def __mul__(self, mat):
         """Perform matrix multiplication such that `self * mat == np.matmul(self, mat)`."""
-        assert isinstance(mat, TransformMatrix), "Operands must be of type `TransformMatrix`."
+        if not isinstance(mat, TransformMatrix):
+            raise TypeError(f"Operands must be of type `TransformMatrix`, got {type(mat)}.")
         return TransformMatrix(np.matmul(self.matrix, mat.matrix)[:2])
 
     def __eq__(self, other):

--- a/lumicks/pylake/fdensemble.py
+++ b/lumicks/pylake/fdensemble.py
@@ -3,21 +3,22 @@ import numpy as np
 
 
 class FdEnsemble:
-    """An ensemble of FD curves exported from Bluelake.
+    """An ensemble of F,d curves exported from Bluelake.
 
-    This class provides a way to handle an ensemble of FD and perform procedures such as curve alignment on them.
+    This class provides a way to handle an ensemble of force distance curves and perform procedures
+    such as curve alignment on them.
+
+    Parameters
+    ----------
+    fd_curves : dict of :class:`~lumicks.pylake.fdcurve.FdCurve`
+        Dictionary of unprocessed :class:`~lumicks.pylake.fdcurve.FdCurve`.
 
     Attributes
     ----------
-    fd_curves : Dict[lumicks.pylake.FdCurve]
-        Dictionary of unprocessed FD curves.
-    fd_curves_processed : Dict[lumicks.pylake.FdCurve]
-        Dictionary of FD curves that were processed by the ensemble.
-
-    Methods
-    -------
-    align_linear(distance_range_low, distance_range_high)
-        Aligns F,d curves to the first F,d curve in the ensemble using two linear regressions.
+    fd_curves : dict of :class:`~lumicks.pylake.fdcurve.FdCurve`
+        Dictionary of unprocessed F,d curves.
+    fd_curves_processed : dict of :class:`~lumicks.pylake.fdcurve.FdCurve`
+        Dictionary of F,d curves that were processed by the ensemble.
 
     Examples
     --------
@@ -70,20 +71,24 @@ class FdEnsemble:
     def align_linear(self, distance_range_low, distance_range_high):
         """Aligns F,d curves to the first F,d curve in the ensemble.
 
-        Force is aligned by taking the mean of the lowest distances. Distance is aligned by considering the last segment
-        of each F,d curve. This method regresses a line to the last segment of each F,d curve and aligns the curves
-        based on this regressed line. Note that this requires the ends of the aligned F,d curves to be in a comparably
-        folded state and obtained in the elastic range of the force, distance curve. If any of these assumptions are not
-        met, this method should not be applied.
+        Force is aligned by taking the mean of the lowest distances. Distance is aligned by
+        considering the last segment of each F,d curve. This method regresses a line to the last
+        segment of each F,d curve and aligns the curves based on this regressed line. Note that
+        this requires the ends of the aligned F,d curves to be in a comparably folded state and
+        obtained in the elastic range of the force, distance curve. If any of these assumptions
+        are not met, this method should not be applied.
 
         Parameters
         ----------
         distance_range_low : float
-            Range of distances to use for the force alignment. Distances in the range [smallest_distance,
-            smallest_distance + distance_range_low) are used to determine the force offsets.
+            Range of distances to use for the force alignment. Distances in the range
+            `[smallest_distance, smallest_distance + distance_range_low]` are used to determine
+            the force offsets.
         distance_range_high : float
-            Upper range of distances to use. Distances in the range [largest_distance - distance_range_high,
-            largest_distance] are used for the distance alignment."""
+            Upper range of distances to use. Distances in the range
+            `[largest_distance - distance_range_high, largest_distance]` are used for the distance
+            alignment.
+        """
         self.fd_curves_processed = align_fd_simple(
             self.fd_curves, distance_range_low, distance_range_high
         )

--- a/lumicks/pylake/force_calibration/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/power_spectrum.py
@@ -111,8 +111,27 @@ class PowerSpectrum:
         return self.frequency.size
 
     def with_spectrum(self, power, num_points_per_block=1):
-        """Return a copy with a different spectrum"""
-        assert len(power) == len(self.power), "Power has incorrect length"
+        """Return a copy with a different spectrum
+
+        Parameters
+        ----------
+        power : np.ndarray
+            Vector of power spectral values
+        num_points_per_block : int
+            Number of points per block used to obtain power spectral values.
+
+        Returns
+        -------
+        power_spectrum : PowerSpectrum
+            Power spectrum with new spectral density values.
+
+        Raises
+        ------
+        ValueError
+            If the power spectrum provided has a different length from the current one.
+        """
+        if len(power) != len(self.power):
+            raise ValueError("New power spectral density vector has incorrect length")
 
         ps = copy(self)
         ps.power = power

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
@@ -174,6 +174,9 @@ def test_replace_spectrum():
     np.testing.assert_allclose(replaced.sample_rate, power_spectrum.sample_rate)
     np.testing.assert_allclose(replaced.total_duration, power_spectrum.total_duration)
 
+    with pytest.raises(ValueError, match="New power spectral density vector has incorrect length"):
+        power_spectrum.with_spectrum(np.arange(7))
+
 
 @pytest.mark.parametrize(
     "exclusion_ranges, result_frequency, result_power",

--- a/lumicks/pylake/nb_widgets/tests/test_correlated_plot.py
+++ b/lumicks/pylake/nb_widgets/tests/test_correlated_plot.py
@@ -31,5 +31,5 @@ def test_plot_correlated():
     np.testing.assert_allclose(imgs[0].get_array(), np.ones((5, 4)))
 
     # When no data overlaps, we need to raise.
-    with pytest.raises(AssertionError, match="No overlap between range and selected channel"):
+    with pytest.raises(RuntimeError, match="No overlap between range and selected channel"):
         scan.plot_correlated(cc["500s":], channel="red", frame=1)

--- a/lumicks/pylake/tests/test_channels/test_channels.py
+++ b/lumicks/pylake/tests/test_channels/test_channels.py
@@ -177,6 +177,14 @@ def test_slice_properties():
         s._timesteps
 
 
+def test_unequal_length_timeseries():
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Number of data points (4) should be the same as number of timestamps (3)"),
+    ):
+        channel.TimeSeries(np.arange(4), np.arange(3))
+
+
 def test_labels():
     """Slicing must preserve labels"""
     size = 5
@@ -713,11 +721,21 @@ def test_downsampling_like():
     np.testing.assert_equal(t_downsampled[1:-1], ds.timestamps)
     np.testing.assert_allclose(y_downsampled[1:-1], ds.data)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(
+        NotImplementedError, match="Downsampled_like is only available for high frequency channels"
+    ):
         reference.downsampled_like(reference)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        TypeError, match="You did not pass a low frequency channel to serve as reference channel"
+    ):
         s.downsampled_like(s)
+
+    for offset in (-4 * 4, t_downsampled[-1] + 1):
+        with pytest.raises(RuntimeError, match="No overlap between slices"):
+            s = channel.Slice(channel.Continuous(np.array([1, 2, 3, 4]), with_offset(offset), 4))
+            s.downsampled_like(reference)
+
 
 def test_channel_plot():
     def testLine(x, y):

--- a/lumicks/pylake/tests/test_fdensemble.py
+++ b/lumicks/pylake/tests/test_fdensemble.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from lumicks.pylake.detail.alignment import align_force_simple, align_distance_simple, align_fd_simple
 from lumicks.pylake.fdcurve import FdCurve
@@ -146,3 +147,13 @@ def test_fd_ensemble_accessors():
 
     fd_ensemble.align_linear(20, 20)
     np.testing.assert_allclose(fd_ensemble.f, np.array([0, 1, 2, 0, 1, 2, 0, 1, 2]))
+
+
+@pytest.mark.parametrize("alignment_function", [align_force_simple, align_distance_simple])
+def test_minimum_curves(alignment_function):
+    fds = {"fd1": make_mock_fd(force=np.arange(3), distance=np.arange(3), start=0)}
+
+    with pytest.raises(
+        ValueError, match="Alignment only makes sense when there is more than 1 curve, got 1"
+    ):
+        alignment_function(fds, distance_range=50)

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 import numpy as np
 from lumicks.pylake.adjustments import ColorAdjustment
 from lumicks.pylake.detail.image import (
@@ -28,6 +29,14 @@ def test_reconstruct():
     image = reconstruct_image_sum(the_data, infowave, (2,))
     assert image.shape == (2, 2)
     assert np.all(image == [[4, 8], [12, 0]])
+
+
+@pytest.mark.parametrize("reconstruction_func", [reconstruct_image_sum, reconstruct_image])
+def test_unequal_length(reconstruction_func):
+    with pytest.raises(
+        ValueError, match=re.escape("Data size (3) must be the same as the infowave size (2)")
+    ):
+        reconstruction_func(np.array([1, 2, 3]), np.array([1, 1]), (2, 1))
 
 
 def test_reconstruct_multiframe():

--- a/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
@@ -1,5 +1,6 @@
 import numpy as np
 import json
+import re
 import tifffile
 from pathlib import Path
 import pytest
@@ -956,13 +957,14 @@ def test_alignment_multistack_failure_modes(
     """Check whether we enforce that the metadata agrees."""
 
     def check_error(dataset1, dataset2, error_message):
-        with pytest.raises(ValueError, match=error_message):
+        with pytest.raises(ValueError, match=re.escape(error_message)):
             TiffStack([to_tiff(*dataset1[1:]), to_tiff(*dataset2[1:])], align_requested=False)
 
     check_error(
         rgb_alignment_image_data,
         rgb_alignment_image_data_offset,
-        "Alignment matrices must be the same",
+        "Alignment matrices must be the same for stacks to be merged. The alignment matrix for "
+        "channel 0 is different.",
     )
     check_error(
         rgb_alignment_image_data, gray_alignment_image_data, "Cannot mix RGB and non-RGB stacks"
@@ -975,7 +977,8 @@ def test_alignment_multistack_failure_modes(
     check_error(
         rgb_alignment_image_data,
         rgb_alignment_image_data_no_metadata,
-        "Alignment matrices must be the same",
+        "Alignment matrices must be the same for stacks to be merged. The following alignment "
+        "matrices were found in one stack but not the other {0, 1, 2}.",
     )
 
 

--- a/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
@@ -285,10 +285,10 @@ def test_correlation(shape):
     with pytest.raises(ValueError):
         cc.downsampled_over(stack[1:4].frame_timestamp_ranges(), where="up")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(RuntimeError, match="No overlap between range and selected channel."):
         cc["0ns":"20ns"].downsampled_over(stack[3:4].frame_timestamp_ranges())
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(RuntimeError, match="No overlap between range and selected channel."):
         cc["40ns":"70ns"].downsampled_over(stack[0:1].frame_timestamp_ranges())
 
     assert stack[0]._get_frame(0).start == 10

--- a/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
@@ -392,7 +392,7 @@ def test_image_stack_plotting(rgb_alignment_image_data):
     assert id(image) == id(plt.gca().get_images()[0])
 
     with pytest.raises(
-            AssertionError, match="Supplied image_handle with a different axes than the provided axes"
+        ValueError, match="Supplied image_handle with a different axes than the provided axes"
     ):
         stack.plot(channel="blue", frame=0, image_handle=image, axes=plt.axes(label="a new axes"))
     # Plot to a new axis


### PR DESCRIPTION
Inspired by @alessiamarcolini comment on [this PR](https://github.com/lumicks/pylake/pull/452), I decided to remove all the `assert`-based input validation we are doing since these can easily be disabled in production and generally a well named exception is more informative. These only cover issues that were improper behaviour before, so it shouldn't affect anyone that was using the API correctly; but the changes are technically breaking, so it's a good idea to do it before `1.0`.

This is PR 2 of N with changes pertaining to this. While the first one is very specific for `FdFitting`, this one is a bit more of a hodgepodge. I tried to keep the commits small to make it easier to review, but I will squash it down a bit before merging.

I did a few drive-by fixups on some docstrings as well, but that's not the main focus of this PR.

I also noticed that in some cases, we weren't testing the correct thing. Please review commit by commit and see the commit message for more details.

Docs build here: https://lumicks-pylake.readthedocs.io/en/assert_other