### PR TITLE
track_lines: two bug fixes and an improvement

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,10 @@
 * Added option to add a scale bar to by providing a [`lk.ScaleBar()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ScaleBar.html) to plotting or export functions.
 * Implemented bias correction for centroid refinement that shrinks the window to reduce estimation bias. This bias correction can be toggled by passing a `bias_correction` argument to [`lk.track_greedy()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.track_greedy.html#) and [`lk.refine_tracks_centroid()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.refine_tracks_centroid.html).
 
+#### Bug fixes
+
+* Fixed incorrect behaviour in `lk.track_lines()` by interpolating back to integer frame times. Prior to this change, `lk.track_lines()` would provide a subpixel accurate position along the time axis of the kymograph as well. However, this position was specified with respect to the coordinate system of the image, rather than actual acquisition times. As such, it would produce incorrect results when performing downstream analysis that rely on the time corresponding to an actual time. Note that `lk.track_greedy()` is not affected. 
+
 ## v0.13.3 | 2023-01-26
 
 #### New features

--- a/changelog.md
+++ b/changelog.md
@@ -37,7 +37,7 @@
 #### Bug fixes
 
 * Fixed incorrect behaviour in `lk.track_lines()` by interpolating back to integer frame times. Prior to this change, `lk.track_lines()` would provide a subpixel accurate position along the time axis of the kymograph as well. However, this position was specified with respect to the coordinate system of the image, rather than actual acquisition times. As such, it would produce incorrect results when performing downstream analysis that rely on the time corresponding to an actual time. Note that `lk.track_greedy()` is not affected.
-* Fixed bug in `lk.track_lines()` which made it return one more line than requested through the parameter `max_lines`.
+* Fixed bug in `lk.track_lines()` where one extra line was returned rather than the number requested through the parameter `max_lines`.
 
 ## v0.13.3 | 2023-01-26
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 #### Breaking changes
 
 * When performing particle tracking on kymographs, bias correction is now enabled by default; without this correction, kymographs with high background signal will suffer from biased localization estimates. To disable bias correction, specify `bias_correction=False` to [`lk.track_greedy()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.track_greedy.html#) and [`lk.refine_tracks_centroid()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.refine_tracks_centroid.html).
-* Made `lk.track_lines()` perform bias-corrected centroid refinement after tracking to improve localization accuracy. Note that the old behaviour can be recovered by passing `refine=False`.
+* `lk.track_lines()` now performs bias-corrected centroid refinement after tracking to improve localization accuracy. Note that the old behaviour can be recovered by passing `refine=False`.
 * Changed several `asserts` to `Exceptions`.
   * Attempting to read `KymoTracks` from a `CSV` file that doesn't have the expected file format will result in an `IOError`.
   * Attempting to extend `KymoTracks` by `KymoTracks` originating from a different `Kymograph` now results in a `ValueError`.

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### Breaking changes
 
 * When performing particle tracking on kymographs, bias correction is now enabled by default; without this correction, kymographs with high background signal will suffer from biased localization estimates. To disable bias correction, specify `bias_correction=False` to [`lk.track_greedy()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.track_greedy.html#) and [`lk.refine_tracks_centroid()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.refine_tracks_centroid.html).
+* Made `lk.track_lines()` perform bias-corrected centroid refinement after tracking to improve localization accuracy. Note that the old behaviour can be recovered by passing `refine=False`.
 * Changed several `asserts` to `Exceptions`.
   * Attempting to read `KymoTracks` from a `CSV` file that doesn't have the expected file format will result in an `IOError`.
   * Attempting to extend `KymoTracks` by `KymoTracks` originating from a different `Kymograph` now results in a `ValueError`.
@@ -35,7 +36,8 @@
 
 #### Bug fixes
 
-* Fixed incorrect behaviour in `lk.track_lines()` by interpolating back to integer frame times. Prior to this change, `lk.track_lines()` would provide a subpixel accurate position along the time axis of the kymograph as well. However, this position was specified with respect to the coordinate system of the image, rather than actual acquisition times. As such, it would produce incorrect results when performing downstream analysis that rely on the time corresponding to an actual time. Note that `lk.track_greedy()` is not affected. 
+* Fixed incorrect behaviour in `lk.track_lines()` by interpolating back to integer frame times. Prior to this change, `lk.track_lines()` would provide a subpixel accurate position along the time axis of the kymograph as well. However, this position was specified with respect to the coordinate system of the image, rather than actual acquisition times. As such, it would produce incorrect results when performing downstream analysis that rely on the time corresponding to an actual time. Note that `lk.track_greedy()` is not affected.
+* Fixed bug in `lk.track_lines()` which made it return one more line than requested through the parameter `max_lines`.
 
 ## v0.13.3 | 2023-01-26
 

--- a/lumicks/pylake/kymotracker/detail/trace_line_2d.py
+++ b/lumicks/pylake/kymotracker/detail/trace_line_2d.py
@@ -319,7 +319,7 @@ def detect_lines_from_geometry(
         if masked_derivative[idx[0], idx[1]] == KymoCode.seen:
             continue
 
-        if masked_derivative[idx[0], idx[1]] >= thresh or len(lines) > max_lines:
+        if masked_derivative[idx[0], idx[1]] >= thresh or len(lines) >= max_lines:
             break
 
         # Traverse the line. Note that traverse_line modifies the masked_derivative image by marking some as seen.

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -279,7 +279,6 @@ def track_lines(
     continuation_threshold=0.005,
     angle_weight=10.0,
     rect=None,
-    refine=True,
 ):
     """Track particles on an image using an algorithm that looks for line-like structures.
 
@@ -287,7 +286,8 @@ def track_lines(
     and the API is still subject to change without a prior deprecation notice.
 
     This function tracks particles in an image. It takes a pixel image, and traces lines on it.
-    These lines can subsequently be refined and/or used to extract intensities or other parameters.
+    These lines are subsequently refined and/or used to extract intensities or other parameters.
+    Refinement is performed using a bias-corrected centroid optimization according to [2]_.
 
     This method is based on sections 1, 2 and 3 from [1]_. This method attempts to find lines purely
     based on differential geometric considerations. It blurs the image based with a user specified
@@ -299,9 +299,6 @@ def track_lines(
     ambiguity arises, on which point to connect next, a score comprised of the distance to the next
     subpixel minimum and angle between the successive normal vectors is computed. The candidate
     with the lowest score is then selected.
-
-    If desired (`refine=True`), each spot is subsequently refined by performing a bias-corrected
-    centroid optimization according to [2]_.
 
     For more information, please refer to the paper.
 
@@ -326,8 +323,6 @@ def track_lines(
     rect : tuple of two coordinates
         Only perform tracking over a subset of the image. Coordinates should be given as:
         ((min_time, min_coord), (max_time, max_coord)).
-    refine : bool
-        Perform bias corrected centroid refinement after tracking the lines.
 
     Returns
     -------
@@ -336,8 +331,7 @@ def track_lines(
     Raises
     ------
     ValueError
-        If the line_width is not larger than zero if no refinement is enabled (`refine=False`) or 3
-        pixels if refinement is selected.
+        If the line_width is not larger than 3 pixels if refinement is selected.
 
     References
     ----------
@@ -373,11 +367,7 @@ def track_lines(
         ]
     )
 
-    return (
-        refine_tracks_centroid(kymotrack_group, track_width=line_width, bias_correction=True)
-        if refine
-        else kymotrack_group
-    )
+    return refine_tracks_centroid(kymotrack_group, track_width=line_width, bias_correction=True)
 
 
 @deprecated(

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -93,7 +93,7 @@ def kymogroups_2tracks():
     _, n_frames = kymo.get_image("red").shape
 
     tracks = KymoTrackGroup(
-        [KymoTrack(np.arange(0.0, n_frames), np.full(n_frames, c), kymo, "red") for c in centers]
+        [KymoTrack(np.arange(0, n_frames), np.full(n_frames, c), kymo, "red") for c in centers]
     )
 
     # introduce gaps into tracks
@@ -108,7 +108,7 @@ def kymogroups_2tracks():
     # crop the ends of initial tracks and make new set of tracks with one cropped and the second full
     truncated_tracks = KymoTrackGroup(
         [
-            KymoTrack(np.arange(1.0, n_frames - 2), np.full(n_frames - 3, c), kymo, "red")
+            KymoTrack(np.arange(1, n_frames - 2), np.full(n_frames - 3, c), kymo, "red")
             for c in centers
         ]
     )
@@ -135,5 +135,5 @@ def kymogroups_close_tracks():
     _, n_frames = kymo.get_image("red").shape
 
     return KymoTrackGroup(
-        [KymoTrack(np.arange(0.0, n_frames), np.full(n_frames, c), kymo, "red") for c in centers]
+        [KymoTrack(np.arange(0, n_frames), np.full(n_frames, c), kymo, "red") for c in centers]
     )

--- a/lumicks/pylake/kymotracker/tests/test_image_sampling.py
+++ b/lumicks/pylake/kymotracker/tests/test_image_sampling.py
@@ -34,12 +34,12 @@ def test_sampling():
         KymoTrack([0, 1, 2, 3, 4], [4, 4, 4, 4, 4], test_img, "red").sample_from_image(0), [0, 0, 1, 1, 0]
     )
 
-    kymotrack = KymoTrack([0.1, 1.1, 2.1, 3.1, 4.1], [0.1, 1.1, 2.1, 3.1, 4.1], test_img, "red")
+    kymotrack = KymoTrack([0, 1, 2, 3, 4], [0.1, 1.1, 2.1, 3.1, 4.1], test_img, "red")
     np.testing.assert_allclose(kymotrack.sample_from_image(50), [0, 2, 3, 2, 0])
     np.testing.assert_allclose(kymotrack.sample_from_image(2), [0, 2, 3, 2, 0])
     np.testing.assert_allclose(kymotrack.sample_from_image(1), [0, 2, 2, 2, 0])
     np.testing.assert_allclose(kymotrack.sample_from_image(0), [0, 1, 1, 1, 0])
-    kymotrack = KymoTrack([0.1, 1.1, 2.1, 3.1, 4.1], [4.1, 4.1, 4.1, 4.1, 4.1], test_img, "red")
+    kymotrack = KymoTrack([0, 1, 2, 3, 4], [4.1, 4.1, 4.1, 4.1, 4.1], test_img, "red")
     np.testing.assert_allclose(kymotrack.sample_from_image(0), [0, 0, 1, 1, 0])
 
 

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -985,3 +985,8 @@ def test_invalid_ensemble_diffusion(blank_kymo):
 )
 def test_half_kernel(window, pixelsize, result):
     assert _to_half_kernel_size(window, pixelsize) == result
+
+
+def test_integral_times_kymotrack(blank_kymo):
+    with pytest.raises(TypeError, match="Time indices should be of integer type, got float64"):
+        KymoTrack([1.0, 2.0, 3.0], [1.0, 2.0, 3.0], blank_kymo, "red")

--- a/lumicks/pylake/kymotracker/tests/test_lines_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_lines_algorithm.py
@@ -191,3 +191,16 @@ def test_lines_refine():
     kymo = _kymo_from_array(image, "r", line_time_seconds=0.5)
     lines = track_lines(kymo, "red", 4, 1)
     np.testing.assert_allclose(lines[0].coordinate_idx, [3.0, 4.0, 5.0, 6.0, 8.0])
+
+
+def test_tracking_max_lines():
+    image = np.ones((30, 20))
+    for k in range(1, 7):
+        image[4 * k, 2:-1] = 10
+
+    kymo = _kymo_from_array(image, "r", line_time_seconds=0.5)
+    lines = track_lines(kymo, "red", line_width=3, max_lines=100)
+    assert len(lines) > 5  # Note that it finds more than 6, some single spurious noise peaks
+
+    lines = track_lines(kymo, "red", line_width=3, max_lines=4)
+    assert len(lines) == 4

--- a/lumicks/pylake/kymotracker/tests/test_lines_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_lines_algorithm.py
@@ -189,11 +189,5 @@ def test_lines_refine():
         image[k, k] = 10
 
     kymo = _kymo_from_array(image, "r", line_time_seconds=0.5)
-
-    for refine, reference_values in zip(
-        (True, False),
-        ([3.0, 4.0, 5.0, 6.0, 8.0], [2.999466, 4.000197, 5.017996, 6.181978, 8.719971]),
-    ):
-        lines = track_lines(kymo, "red", 4, 1, refine=refine)
-        np.testing.assert_allclose(lines[0].coordinate_idx, reference_values)
-
+    lines = track_lines(kymo, "red", 4, 1)
+    np.testing.assert_allclose(lines[0].coordinate_idx, [3.0, 4.0, 5.0, 6.0, 8.0])

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -7,16 +7,16 @@ from lumicks.pylake.tests.data.mock_confocal import generate_kymo
 
 
 def test_kymotrack_interpolation(blank_kymo):
-    time_idx = np.array([1.0, 3.0, 5.0])
+    time_idx = np.array([1, 3, 5])
     coordinate_idx = np.array([1.0, 3.0, 3.0])
     kymotrack = KymoTrack(time_idx, coordinate_idx, blank_kymo, "red")
     interpolated = kymotrack.interpolate()
-    np.testing.assert_allclose(interpolated.time_idx, [1.0, 2.0, 3.0, 4.0, 5.0])
+    np.testing.assert_equal(interpolated.time_idx, [1, 2, 3, 4, 5])
     np.testing.assert_allclose(interpolated.coordinate_idx, [1.0, 2.0, 3.0, 3.0, 3.0])
 
     # Test whether concatenation still works after interpolation
-    np.testing.assert_allclose(
-        (interpolated + kymotrack).time_idx, [1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 3.0, 5.0]
+    np.testing.assert_equal(
+        (interpolated + kymotrack).time_idx, [1, 2, 3, 4, 5, 1, 3, 5]
     )
     np.testing.assert_allclose(
         (interpolated + kymotrack).coordinate_idx, [1.0, 2.0, 3.0, 3.0, 3.0, 1.0, 3.0, 3.0]

--- a/lumicks/pylake/kymotracker/tests/test_stitching.py
+++ b/lumicks/pylake/kymotracker/tests/test_stitching.py
@@ -23,7 +23,7 @@ def test_stitching(blank_kymo):
     segment_1c = KymoTrack([-1, 0, 1], [0, 0, 1], blank_kymo, "red")
 
     radius = 0.05
-    segment_1d = KymoTrack([0.0, 1.0], [radius + 0.01, radius + 0.01], blank_kymo, "red")
+    segment_1d = KymoTrack([0, 1], [radius + 0.01, radius + 0.01], blank_kymo, "red")
 
     # Out of stitch range (maximum extension = 1)
     assert len(stitch_kymo_lines([segment_1, segment_3, segment_2], radius, 1, 2)) == 3
@@ -52,13 +52,13 @@ def test_stitching(blank_kymo):
     # Check whether the alignment has to work in both directions
     # - and - should connect
     track1, track2 = KymoTrack(
-        [0, 1], [0, 0], blank_kymo, "red"), KymoTrack([2, 2.01], [0, 0], blank_kymo, "red"
+        [0, 1], [0, 0], blank_kymo, "red"), KymoTrack([2, 3], [0, 0], blank_kymo, "red"
     )
     assert len(stitch_kymo_lines([track1, track2], radius, 1, 2)) == 1
 
     # - and | should not connect.
     track1, track2 = KymoTrack(
-        [0, 1], [0, 0], blank_kymo, "red"), KymoTrack([2, 2.01], [0, 1], blank_kymo, "red"
+        [0, 1], [0, 0], blank_kymo, "red"), KymoTrack([2, 3], [0, 1], blank_kymo, "red"
     )
     assert len(stitch_kymo_lines([track1, track2], radius, 1, 2)) == 2
 


### PR DESCRIPTION
*Why this PR?*
This PR fixes a number of bugs present in `track_lines`.

Note, this PR builds on top of https://github.com/lumicks/pylake/pull/452 since it needs the bias corrected refinement.

1. `track_lines` typically returned one more track than requested.
2. `track_lines` could return non-integer time indices, which made very little sense (since they were x-coordinates along the image axis, rather than actual acquisition time points). It could also return _multiple_ points per kymograph line.
3. Because `track_lines` really looked for line structures rather than act tailored to kymographs, the endpoints were pretty arbitrary. Reason being that if a line moves downward near the end, you just get the last point on the line-like structure, even though you should get a point around the middle of that frame as the true position. This PR makes that behaviour better by performing a bias-corrected centroid refinement step at the end. While, I know that in most cases a composable API is preferable, I think that in this case, adding the centroid refinement as a core step in the algorithm helps prevent user error.

See below for an example where I deliberately made it hit into all possible failure modes described above:

![track_lines_old](https://user-images.githubusercontent.com/19836026/217580722-95d3c392-8643-4146-b063-0e99971d861b.png)
Note the multiple points on the right most frame and how it is off-center.

If we interpolate to integer, we get something better, but we still see that the last points are incorrect:
![track_lines_new_no_refinement](https://user-images.githubusercontent.com/19836026/217580886-19f35281-6ec5-4bb7-859e-8ed663719212.png)

Finally, with all the fixes in place, we get a good result:
![track_lines_new](https://user-images.githubusercontent.com/19836026/217580938-8b317f33-66b9-4762-97fe-cd934aa46d36.png)

With these changes, it becomes a better tracking algorithm than it was:

![image](https://user-images.githubusercontent.com/19836026/217582003-f0355e35-bf74-4d08-ab4b-f72bfc252c15.png)

I think more improvement is likely possible (but not urgent for now). For instance, X and Y are filtered with the same kernel width; despite being dimensions with a very different meaning. It seems likely that future improvements could be achieved by looking into that further.