### PR TITLE
tracking: only remove tracks fully in the selector

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
   * Plotting: When creating a plot providing `axes` and an `image_handle`, a `ValueError` is raised when those `axes` do not belong to the `image_handle` provided. 
   * Widefield: Attempting to open multiple `TIFF` as a single ImageStack will now raise a `ValueError` if the alignment matrices of the individual `TIFF` are different.
   * PowerSpectrum: Attempting to replace the power spectral values of a `PowerSpectrum` using `with_spectrum` using a vector of incorrect length will raise a `ValueError`.
+* When removing tracks with the kymotracking widget, only tracks that are entirely in the selection rectangle will be removed. Prior to this change, any tracks intersecting with the selection rectangle would be removed.
 
 #### New features
 

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -129,7 +129,7 @@ class KymoWidget:
 
         # Explicit copy to make modifications. Current state pushed to undo stack on assignment.
         tracks = copy(self.tracks)
-        tracks.remove_tracks_in_rect([p1, p2])
+        tracks.remove_tracks_in_rect([p1, p2], not self._adding)
 
         if self._adding:
             new_tracks = self._track(rect=[p1, p2])

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -100,9 +100,15 @@ def test_track_kymo(kymograph, region_select):
     kymo_widget._track_all()
     assert len(kymo_widget.tracks) == 3
 
+    # Use remove, but don't actually remove the track because it is only partially inside the
+    # rectangle.
+    kymo_widget._adding = False
+    kymo_widget._track_kymo(*region_select(in_s(12), in_um(8), in_s(15), in_um(9)))
+    assert len(kymo_widget.tracks) == 3
+
     # Remove a single track
     kymo_widget._adding = False
-    kymo_widget._track_kymo(*region_select(in_s(15), in_um(8), in_s(20), in_um(9)))
+    kymo_widget._track_kymo(*region_select(in_s(10), in_um(8), in_s(15), in_um(9)))
     assert len(kymo_widget.tracks) == 2
 
 


### PR DESCRIPTION
**Why this PR?**
User feedback indicated that the line removal logic of removing a track when only a subsection of a track fell in the rectangle selector was cumbersome when lines are in close proximity. This PR changes that requirement to enforcing that the entire track needs to fall in the selector to be removed. Note that for retracking the old behaviour is maintained (intentionally).

Old behavior:
![old_behaviour](https://user-images.githubusercontent.com/19836026/217950604-09349955-0254-45f9-9511-aaa81ec2d617.gif)

New behavior:
![new_behavior](https://user-images.githubusercontent.com/19836026/217950628-be8899cf-19b9-489e-a529-167b1cd92c71.gif)
