### PR TITLE
docs: add specific jupyter client to instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -47,9 +47,16 @@ The easiest way to install Python and SciPy is with `Anaconda`_, a free scientif
 
     conda config --add channels conda-forge
 
-#. We can install Pylake in this environment by invoking the following command::
+#. We can install Pylake in this environment by invoking the following command:
 
-    conda install lumicks.pylake
+    .. code-block::
+
+        conda install lumicks.pylake "jupyter_client<8"
+
+    .. note::
+
+        There is currently an `open issue <https://github.com/jupyter/notebook/issues/6748>`_ with Jupyter that results in communication problems between Jupyter notebooks and the Jupyter kernel.
+        As a workaround, we temporarily suggest adding the constraint `jupyter_client<8` to install an older version of this kernel.
 
 #. It should be possible to open a jupyter notebook in this environment by calling::
 
@@ -92,9 +99,16 @@ This concludes the Pylake installation procedure. Check out the :doc:`Tutorial <
 
     conda config --add channels conda-forge
 
-#. We can install Pylake in this environment by invoking the following command::
+#. We can install Pylake in this environment by invoking the following command:
 
-    conda install lumicks.pylake
+    .. code-block::
+
+        conda install lumicks.pylake "jupyter_client<8"
+
+    .. note::
+
+        There is currently an `open issue <https://github.com/jupyter/notebook/issues/6748>`_ with Jupyter that results in communication problems between Jupyter notebooks and the Jupyter kernel.
+        As a workaround, we temporarily suggest adding the constraint `jupyter_client<8` to install an older version of this kernel.
 
 #. You can open a Jupyter notebook in this environment by calling `jupyter notebook` from the terminal.
 
@@ -124,9 +138,16 @@ This concludes the Pylake installation procedure. Check out the :doc:`Tutorial <
 
     conda config --add channels conda-forge
 
-#. Install Pylake in this environment by invoking the following command::
+#. Install Pylake in this environment by invoking the following command:
 
-    conda install lumicks.pylake
+    .. code-block::
+
+        conda install lumicks.pylake "jupyter_client<8"
+
+    .. note::
+
+        There is currently an `open issue <https://github.com/jupyter/notebook/issues/6748>`_ with Jupyter that results in communication problems between Jupyter notebooks and the Jupyter kernel.
+        As a workaround, we temporarily suggest adding the constraint `jupyter_client<8` to install an older version of this kernel.
 
 #. You can open a jupyter notebook in this environment by calling::
 


### PR DESCRIPTION
**Why this PR?**
It seems that there are issues (see this open issue https://github.com/jupyter/notebook/issues/6721) between the latest version of jupyter `notebook` and the jupyter kernel.

This causes problems with the communication between the jupyter kernel and notebook.

To reproduce this problem, simply install the latest `notebook` and `matplotlib` from `conda-forge`. Enable the interactive mode with `%matplotlib notebook` and create a few plots. Note that the problem doesn't always occur immediately, but starts to happen after some time (in my tests, 5 or 6 plots usually does it).

I suggest adding this to the installation instructions **temporarily**, which instructs users to select an older version of the `jupyter_client` (which seemed to fix the problem on `windows` at least). It would be nice if someone can test these instructions on `mac` / `linux`.

Longer term, we should really think about shipping some sort of installer with everything pinned, where we test the combination of packages prior to release. Dealing with these kind of packaging issues can be very frustrating for our users and drive them away from using `pylake` in the first place, while pinning too many dependencies in the library itself might lead to unnecessary incompatibility with other packages.

```
[E 13:58:25.233 NotebookApp] Uncaught exception in ZMQStream callback
    Traceback (most recent call last):
      File "C:\Conda\envs\test_notebooks\lib\site-packages\zmq\eventloop\zmqstream.py", line 584, in _run_callback
        f = callback(*args, **kwargs)
      File "C:\Conda\envs\test_notebooks\lib\site-packages\zmq\eventloop\zmqstream.py", line 308, in stream_callback
        return callback(self, msg)
      File "C:\Conda\envs\test_notebooks\lib\site-packages\notebook\services\kernels\handlers.py", line 572, in _on_zmq_reply
        super()._on_zmq_reply(stream, msg)
      File "C:\Conda\envs\test_notebooks\lib\site-packages\notebook\base\zmqhandlers.py", line 256, in _on_zmq_reply
        self.write_message(msg, binary=isinstance(msg, bytes))
      File "C:\Conda\envs\test_notebooks\lib\site-packages\tornado\websocket.py", line 339, in write_message
        return self.ws_connection.write_message(message, binary=binary)
      File "C:\Conda\envs\test_notebooks\lib\site-packages\tornado\websocket.py", line 1086, in write_message
        fut = self._write_frame(True, opcode, message, flags=flags)
      File "C:\Conda\envs\test_notebooks\lib\site-packages\tornado\websocket.py", line 1061, in _write_frame
        return self.stream.write(frame)
      File "C:\Conda\envs\test_notebooks\lib\site-packages\tornado\iostream.py", line 546, in write
        self._handle_write()
      File "C:\Conda\envs\test_notebooks\lib\site-packages\tornado\iostream.py", line 976, in _handle_write
        self._write_buffer.advance(num_bytes)
      File "C:\Conda\envs\test_notebooks\lib\site-packages\tornado\iostream.py", line 182, in advance
        assert 0 < size <= self._size
    AssertionError
```