### PR TITLE
`KymoTrackGroup`: more options for finding and removing tracks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 * Added option to add a scale bar to by providing a [`lk.ScaleBar()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ScaleBar.html) to plotting or export functions.
 * Implemented bias correction for centroid refinement that shrinks the window to reduce estimation bias. This bias correction can be toggled by passing a `bias_correction` argument to [`lk.track_greedy()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.track_greedy.html#) and [`lk.refine_tracks_centroid()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.refine_tracks_centroid.html).
 * Added `KymoTrackGroup.remove()` to remove a `KymoTrack` from a `KymoTrackGroup`.
+* Allow boolean array indexing (e.g. `tracks[[False, False, True]]`) and indexing with arrays of indices (e.g. `tracks[[1, 3]]`) for `KymoTrackGroup`. See the [API documentation](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymotracker.kymotrack.KymoTrackGroup.html#lumicks.pylake.kymotracker.kymotrack.KymoTrackGroup) for more information.
 
 #### Bug fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@
   * Widefield: Attempting to open multiple `TIFF` as a single ImageStack will now raise a `ValueError` if the alignment matrices of the individual `TIFF` are different.
   * PowerSpectrum: Attempting to replace the power spectral values of a `PowerSpectrum` using `with_spectrum` using a vector of incorrect length will raise a `ValueError`.
 * When removing tracks with the kymotracking widget, only tracks that are entirely in the selection rectangle will be removed. Prior to this change, any tracks intersecting with the selection rectangle would be removed.
+* Added checks which enforce `KymoTracks` in a `KymoTrackGroup` to be unique. Extending a `KymoTrackGroup` with `KymoTrack` instances that are already part of the group will now result in a `ValueError`. Similarly, constructing a new `KymoTrackGroup` with duplicate `KymoTracks` will also produce a `ValueError`.
 
 #### New features
 

--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
 * Added API for notes, i.e. `file.notes` returns a dictionary of notes.
 * Added option to add a scale bar to by providing a [`lk.ScaleBar()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ScaleBar.html) to plotting or export functions.
 * Implemented bias correction for centroid refinement that shrinks the window to reduce estimation bias. This bias correction can be toggled by passing a `bias_correction` argument to [`lk.track_greedy()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.track_greedy.html#) and [`lk.refine_tracks_centroid()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.refine_tracks_centroid.html).
+* Added `KymoTrackGroup.remove()` to remove a `KymoTrack` from a `KymoTrackGroup`.
 
 #### Bug fixes
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -599,6 +599,8 @@ class KymoTrackGroup:
     ------
     ValueError
         If the :class:`KymoTrack` instances weren't tracked on the same source kymograph.
+    ValueError
+        If the :class:`KymoTrack` instances provided in the list are not unique.
 
     Examples
     --------
@@ -624,6 +626,11 @@ class KymoTrackGroup:
     def __init__(self, kymo_tracks):
         self._src = kymo_tracks
         if self:
+            if len(set(kymo_tracks)) != len(kymo_tracks):
+                raise ValueError(
+                    "Some tracks appear multiple times. The provided tracks must be unique."
+                )
+
             self._validate_single_source(kymo_tracks)
 
     def _validate_single_source(self, kymo_tracks):
@@ -756,7 +763,7 @@ class KymoTrackGroup:
 
         self._src[self._src.index(starting_track)] = first_half + last_half
         if starting_track != ending_track:
-            self._src.remove(ending_track)
+            self.remove(ending_track)
 
     def __len__(self):
         return len(self._src)
@@ -776,6 +783,9 @@ class KymoTrackGroup:
         ValueError
             If the `KymoTrack` instances that we want to extend this one with weren't tracked on
             the same source kymograph.
+        ValueError
+            If any of the `KymoTrack` instaces we are trying to extend this group with are already
+            part of this group.
         """
 
         if not other:
@@ -795,6 +805,12 @@ class KymoTrackGroup:
 
             if self._channel != other_channel:
                 raise ValueError("All tracks must be from the same color channel.")
+
+        if len(set(other._src) | set(self._src)) != len(self._src) + len(other._src):
+            raise ValueError(
+                "Cannot extend this KymoTrackGroup with a KymoTrack that is already part of the "
+                "group"
+            )
 
         self._src.extend(other._src)
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -627,6 +627,20 @@ class KymoTrackGroup:
         new_group.extend(other)
         return new_group
 
+    def _get_track_by_id(self, python_id):
+        """Finds a track by its python identity
+
+        Parameters
+        ----------
+        python_id : int
+            python identity
+
+        Returns
+        -------
+        track : KymoTrack or None
+        """
+        return next((track for track in self._src if id(track) == python_id), None)
+
     def remove(self, track: KymoTrack):
         """Remove a KymoTrack from the KymoTrackGroup
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -162,6 +162,9 @@ class KymoTrack:
     def _image(self):
         return self._kymo.get_image(self._channel)
 
+    def __str__(self):
+        return f"KymoTrack(N={len(self._time_idx)})"
+
     def _with_coordinates(self, time_idx, localization):
         """Return a copy of the KymoTrack with new spatial/temporal coordinates."""
         return KymoTrack(

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -641,26 +641,6 @@ class KymoTrackGroup:
         except IndexError:
             raise RuntimeError("No channel associated with this empty group (no tracks available)")
 
-    def _concatenate_tracks(self, starting_track, ending_track):
-        """Concatenate two tracks together.
-
-        Parameters
-        ----------
-        starting_track : KymoTrack
-            Note that this track has to start before the second one.
-        ending_track : KymoTrack
-        """
-        if starting_track not in self._src or ending_track not in self._src:
-            raise RuntimeError("Both tracks need to be part of this group to be concatenated")
-
-        if starting_track.seconds[-1] >= ending_track.seconds[0]:
-            raise RuntimeError(
-                "First track needs to end before the second starts for concatenation"
-            )
-
-        self._src[self._src.index(starting_track)] = starting_track + ending_track
-        self._src.remove(ending_track)
-
     def _merge_tracks(self, starting_track, starting_node, ending_track, ending_node):
         """Connect two tracks from any given nodes, removing the points in between.
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -627,6 +627,16 @@ class KymoTrackGroup:
         new_group.extend(other)
         return new_group
 
+    def remove(self, track: KymoTrack):
+        """Remove a KymoTrack from the KymoTrackGroup
+
+        Parameters
+        ----------
+        track : KymoTrack
+            track to remove from the group
+        """
+        self._src.remove(track)
+
     @property
     def _kymo(self):
         try:

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -135,6 +135,31 @@ def test_kymotrack_group_getitem(blank_kymo):
         tracks[1] = 4
 
 
+@pytest.mark.parametrize(
+    "remove,remaining",
+    [
+        ([1], [True, False, True]),
+        ([0, 1], [False, False, True]),
+        ([2, 1], [True, False, False]),
+    ],
+)
+def test_kymotrackgroup_remove(blank_kymo, remove, remaining):
+    src_tracks = [
+        KymoTrack(np.array([1, 2, 3]), np.array([2, 3, 4]), blank_kymo, "red"),
+        KymoTrack(np.array([2, 3, 4]), np.array([3, 4, 5]), blank_kymo, "red"),
+        KymoTrack(np.array([3, 4, 5]), np.array([4, 5, 6]), blank_kymo, "red"),
+    ]
+
+    tracks = KymoTrackGroup(src_tracks)
+    for track in remove:
+        tracks.remove(src_tracks[track])
+    for track, should_be_present in zip(src_tracks, remaining):
+        if remaining:
+            assert track in tracks
+        else:
+            assert track not in tracks
+
+
 def test_kymotrack_group_extend(blank_kymo):
     k1 = KymoTrack(np.array([1, 2, 3]), np.array([2, 3, 4]), blank_kymo, "red")
     k2 = KymoTrack(np.array([2, 3, 4]), np.array([3, 4, 5]), blank_kymo, "red")

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -177,6 +177,27 @@ def test_kymotrackgroup_lookup(blank_kymo):
     assert tracks._get_track_by_id(id(k1)) is None
 
 
+def test_kymotrack_group_indexing(blank_kymo):
+    k0 = KymoTrack(np.array([1, 2, 3, 4]), np.array([2, 3, 4, 5]), blank_kymo, "red")
+    k1 = KymoTrack(np.array([2, 3, 4, 5, 6]), np.array([3, 4, 5, 6, 7]), blank_kymo, "red")
+    k2 = KymoTrack(np.array([3, 4, 5]), np.array([4, 5, 6]), blank_kymo, "red")
+    group = KymoTrackGroup([k0, k1, k2])
+
+    def verify_group(group, ref_list):
+        assert len(group) == len(ref_list)
+        for t1, t2 in zip(group, ref_list):
+            assert t1 is t2
+
+    # Boolean array indexing
+    verify_group(group[[len(t) > 3 for t in group]], [k0, k1])
+    verify_group(group[[len(t) < 4 for t in group]], [k2])
+
+    # Regular array indexing
+    verify_group(group[np.asarray([0, 2])], [k0, k2])
+    verify_group(group[[0, 2]], [k0, k2])
+    verify_group(group[[-2]], [k1])
+
+
 def test_kymotrack_group_extend(blank_kymo):
     k1 = KymoTrack(np.array([1, 2, 3]), np.array([2, 3, 4]), blank_kymo, "red")
     k2 = KymoTrack(np.array([2, 3, 4]), np.array([3, 4, 5]), blank_kymo, "red")

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -181,41 +181,6 @@ def test_kymotrack_group(blank_kymo):
         tracks1 + 5
 
 
-def test_kymotrack_concat(blank_kymo):
-    k1 = KymoTrack(np.array([1, 2, 3]), np.array([1, 1, 1]), blank_kymo, "red")
-    k2 = KymoTrack(np.array([6, 7, 8]), np.array([2, 2, 2]), blank_kymo, "red")
-    k3 = KymoTrack(np.array([3, 4, 5]), np.array([3, 3, 3]), blank_kymo, "red")
-    k4 = KymoTrack(np.array([8, 9, 10]), np.array([3, 3, 3]), blank_kymo, "red")
-    group = KymoTrackGroup([k1, k2, k3])
-
-    # Test whether overlapping time raises.
-    with pytest.raises(RuntimeError):
-        group._concatenate_tracks(k1, k3)
-
-    # Kymotracks have to be added sequentially. Check whether the wrong order raises.
-    with pytest.raises(RuntimeError):
-        group._concatenate_tracks(k2, k1)
-
-    # Check whether a track that's not in the group raises (should only be able to merge
-    # within group)
-    with pytest.raises(RuntimeError):
-        group._concatenate_tracks(k1, k4)
-
-    # Check whether a track that's not in the group raises (should only be able to merge
-    # within group)
-    with pytest.raises(RuntimeError):
-        group._concatenate_tracks(k4, k1)
-
-    # Check whether an invalid type raises correctly
-    with pytest.raises(RuntimeError):
-        group._concatenate_tracks(k1, 5)
-
-    # Finally do a correct merge
-    group._concatenate_tracks(k1, k2)
-    np.testing.assert_allclose(group[0].seconds, [1, 2, 3, 6, 7, 8])
-    np.testing.assert_allclose(group[1].seconds, [3, 4, 5])
-
-
 def test_kymotrack_merge():
     image = np.random.randint(0, 20, size=(10, 10, 3))
     kwargs = dict(line_time_seconds=10e-3, start=np.int64(20e9), pixel_size_um=0.05, name="test")
@@ -586,8 +551,8 @@ def test_kymotrack_concat_gaussians(blank_kymo):
     assert isinstance(k1._localization, LocalizationModel)
     assert isinstance(k2._localization, GaussianLocalizationModel)
 
-    # test concatenation clears gaussian parameters
-    group._concatenate_tracks(k1, k2)
+    # test merging clears gaussian parameters
+    group._merge_tracks(k1, 2, k2, 2)
     assert len(group) == 1
     assert isinstance(group[0]._localization, LocalizationModel)
 

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -39,6 +39,7 @@ def test_kymo_track(blank_kymo):
     assert k2._kymo == blank_kymo
     assert k1._channel == "red"
     assert k2._channel == "red"
+    assert str(k1) == "KymoTrack(N=3)"
 
 
 def test_kymotrack_selection(blank_kymo):
@@ -105,7 +106,7 @@ def test_kymotracks_removal(blank_kymo, rect, remaining_lines, fully_in_rect):
     verify(rect, [track for track, should_remain in zip(tracks, remaining_lines) if should_remain])
 
 
-def test_kymotrackgroup(blank_kymo):
+def test_kymotrack_group_getitem(blank_kymo):
     k1 = KymoTrack(np.array([1, 2, 3]), np.array([2, 3, 4]), blank_kymo, "red")
     k2 = KymoTrack(np.array([2, 3, 4]), np.array([3, 4, 5]), blank_kymo, "red")
     k3 = KymoTrack(np.array([3, 4, 5]), np.array([4, 5, 6]), blank_kymo, "red")
@@ -116,14 +117,29 @@ def test_kymotrackgroup(blank_kymo):
     assert len(tracks) == 4
     assert tracks[0] == k1
     assert tracks[1] == k2
+    assert tracks[-1] == k4
+    assert len(tracks[0:2]) == 2
     assert tracks[0:2][0] == k1
     assert tracks[0:2][1] == k2
+    assert tracks[1:3][0] == k2
+    assert tracks[1:3][1] == k3
+    assert tracks[2:-1][0] == k3
+    assert len(tracks[2:-1]) == 1
+    assert tracks[2:][0] == k3
+    assert tracks[2:][1] == k4
 
     with pytest.raises(IndexError):
         tracks[0:2][2]
 
     with pytest.raises(NotImplementedError):
         tracks[1] = 4
+
+
+def test_kymotrack_group_extend(blank_kymo):
+    k1 = KymoTrack(np.array([1, 2, 3]), np.array([2, 3, 4]), blank_kymo, "red")
+    k2 = KymoTrack(np.array([2, 3, 4]), np.array([3, 4, 5]), blank_kymo, "red")
+    k3 = KymoTrack(np.array([3, 4, 5]), np.array([4, 5, 6]), blank_kymo, "red")
+    k4 = KymoTrack(np.array([4, 5, 6]), np.array([5, 6, 7]), blank_kymo, "red")
 
     tracks = KymoTrackGroup([k1, k2])
     tracks.extend(KymoTrackGroup([k3, k4]))
@@ -137,7 +153,7 @@ def test_kymotrackgroup(blank_kymo):
         tracks.extend(5)
 
 
-def test_kymotrackgroup(blank_kymo):
+def test_kymotrack_group(blank_kymo):
     def validate_same(kymoline_group, ref_list, source_items, ref_kymo):
         assert [k for k in kymoline_group] == ref_list
         assert id(kymoline_group) not in (id(s) for s in source_items)

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -160,6 +160,23 @@ def test_kymotrackgroup_remove(blank_kymo, remove, remaining):
             assert track not in tracks
 
 
+def test_kymotrackgroup_lookup(blank_kymo):
+    k1 = KymoTrack(np.array([1, 2, 3]), np.array([2, 3, 4]), blank_kymo, "red")
+    k2 = KymoTrack(np.array([2, 3, 4]), np.array([3, 4, 5]), blank_kymo, "red")
+    k3 = KymoTrack(np.array([3, 4, 5]), np.array([4, 5, 6]), blank_kymo, "red")
+
+    tracks = KymoTrackGroup([k1, k2, k3])
+    assert tracks._get_track_by_id(id(k1)) is k1
+    assert tracks._get_track_by_id(id(k2)) is k2
+    tracks.remove(k2)
+    assert tracks._get_track_by_id(id(k2)) is None
+    assert tracks._get_track_by_id(id(k3)) is k3
+    assert tracks._get_track_by_id(-1) is None
+
+    tracks = KymoTrackGroup([])
+    assert tracks._get_track_by_id(id(k1)) is None
+
+
 def test_kymotrack_group_extend(blank_kymo):
     k1 = KymoTrack(np.array([1, 2, 3]), np.array([2, 3, 4]), blank_kymo, "red")
     k2 = KymoTrack(np.array([2, 3, 4]), np.array([3, 4, 5]), blank_kymo, "red")


### PR DESCRIPTION
**Why this PR?**
It adds some small convenience features.

- It allows a `KymoTrack` to be removed from the group with `.remove()`.
- It allows `KymoTrackGroup` to be indexed with a boolean array. This can be convenient when one wants to remove a whole bunch of elements at the same time.
- It removes `_concatenate_tracks`, which was unused internal api.
- Added private API for looking up a particular track in the group by it's python `id`.

Relevant section of the docs build [here](https://lumicks-pylake.readthedocs.io/en/no_track_uuids/_api/lumicks.pylake.kymotracker.kymotrack.KymoTrackGroup.html#lumicks.pylake.kymotracker.kymotrack.KymoTrackGroup)