### PR TITLE
Fixup GMM documentation

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -75,6 +75,10 @@ code.xref.any.py {
 }
 
 /* API docs, blocks */
+.rst-content  dl.py.property {
+  width: 100%;
+}
+
 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple)>dt {
   border-top: solid 5px var(--darkblue) !important;
   background-color: var(--lightblue) !important;

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -14,6 +14,12 @@ class DwelltimeBootstrap:
     This class should be initialized using :meth:`lk.DwelltimeModel.calculate_bootstrap()
     <lumicks.pylake.DwelltimeModel.calculate_bootstrap>` and should not be constructed manually.
 
+    .. warning::
+
+        This is early access alpha functionality. While usable, this has not yet been tested in a large number of
+        different scenarios. The API can still be subject to change without any prior deprecation notice! If you
+        use this functionality keep a close eye on the changelog for any changes that may affect your analysis.
+
     Attributes
     ----------
     model : :class:`~lumicks.pylake.DwelltimeModel`
@@ -223,6 +229,12 @@ class DwelltimeBootstrap:
 
 class DwelltimeModel:
     """Exponential mixture model optimization for dwelltime analysis.
+
+    .. warning::
+
+        This is early access alpha functionality. While usable, this has not yet been tested in a large number of
+        different scenarios. The API can still be subject to change without any prior deprecation notice! If you
+        use this functionality keep a close eye on the changelog for any changes that may affect your analysis.
 
     Parameters
     ----------

--- a/lumicks/pylake/population/mixture.py
+++ b/lumicks/pylake/population/mixture.py
@@ -138,8 +138,6 @@ class GaussianMixtureModel:
         -------
         dict:
             Dictionary of all dwell times (in seconds) for each state. Keys are state labels.
-        dict:
-            Dictionary of slicing indices for all dwell ranges for each state. Keys are state labels.
         """
         statepath = self.label(trace)
         dt_seconds = 1.0 / trace.sample_rate

--- a/lumicks/pylake/population/mixture.py
+++ b/lumicks/pylake/population/mixture.py
@@ -29,6 +29,12 @@ class GaussianMixtureModel:
     handle 1D data, model parameters are also returned as 1D arrays (:func:`numpy.squeeze()` is applied to
     the results) so that users do not have to be concerned with the shape of the output results.
 
+    .. warning::
+
+        This is early access alpha functionality. While usable, this has not yet been tested in a large number of
+        different scenarios. The API can still be subject to change without any prior deprecation notice! If you
+        use this functionality keep a close eye on the changelog for any changes that may affect your analysis.
+
     Parameters
     ----------
     data : numpy.ndarray


### PR DESCRIPTION
**Why this PR?**
I noticed there was an error in the `Return` section `GaussianMixtureModel.extract_dwell_times()`. I also took the opportunity to make some other general improvements to the other docstrings for the class

[Docs build here](https://lumicks-pylake.readthedocs.io/en/docstring_oops/_api/lumicks.pylake.GaussianMixtureModel.html#lumicks.pylake.GaussianMixtureModel)