### PR TITLE
force calibration: improve docstrings

### DIFF
--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -636,9 +636,9 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
 
         Parameters
         ----------
-        driving_data : array_like
+        driving_data : numpy.ndarray
             Array of driving data.
-        force_voltage_data : array_like
+        force_voltage_data : numpy.ndarray
             Uncalibrated force data in volts.
         sample_rate : float
             Sample rate at which the signals we acquired.

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -231,7 +231,7 @@ class PassiveCalibrationModel:
     :doc:`tutorial</tutorial/force_calibration>` on force calibration for more information on the
     calibration methods implemented.
 
-    Attributes
+    Parameters
     ----------
     bead_diameter : float
         Bead diameter [um].
@@ -570,16 +570,18 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
     :doc:`tutorial</tutorial/force_calibration>` on force calibration for more information on the
     calibration methods implemented.
 
-    Attributes
+    Parameters
     ----------
+    driving_data : numpy.ndarray
+        Array of driving data.
+    force_voltage_data : numpy.ndarray
+        Uncalibrated force data in volts.
     sample_rate : float
-        Sample rate at which the signals we acquired.
+        Sample rate at which the signals were acquired.
     bead_diameter : float
         Bead diameter [um].
-    driving_frequency : float
-        Estimated driving frequency [Hz].
-    driving_amplitude : float
-        Estimated driving amplitude [m].
+    driving_frequency_guess : float
+        Guess of the driving frequency.
     viscosity : float, optional
         Liquid viscosity [Pa*s].
         When omitted, the temperature will be used to look up the viscosity of water at that
@@ -588,17 +590,29 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
         Liquid temperature [Celsius].
     num_windows : int, optional
         Number of windows to average for the uncalibrated force. Using a larger number of
-        windows potentially increases the bleed, but may be useful when the SNR is low.
+        windows potentially increases spectral bleed from adjacent peaks, but may be useful when
+        the SNR is low.
     hydrodynamically_correct : bool, optional
-        Enable hydrodynamically correct spectrum.
+        Enable hydrodynamically correct model.
     distance_to_surface : float, optional
-        Distance from bead center to the surface [um].
+        Distance from bead center to the surface [um]
         When specifying `None`, the model will use an approximation which is only suitable for
         measurements performed deep in bulk.
     rho_sample : float, optional
-        Density of the sample [kg/m^3]. Only used when using hydrodynamic corrections.
+        Density of the sample [kg/m**3]. Only used when using hydrodynamically correct model.
     rho_bead : float, optional
-        Density of the bead [kg/m^3]. Only used when using hydrodynamic corrections.
+        Density of the bead [kg/m**3]. Only used when using hydrodynamically correct model.
+    fast_sensor : bool
+        Fast sensor? Fast sensors do not have the diode effect included in the model.
+
+    Attributes
+    ----------
+    driving_frequency : float
+        Estimated driving frequency [Hz].
+    driving_amplitude : float
+        Estimated driving amplitude [m].
+    viscosity : float, optional
+        Liquid viscosity [Pa*s].
 
     Raises
     ------
@@ -689,45 +703,6 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
         rho_bead=1060.0,
         fast_sensor=False,
     ):
-        """
-        Active Calibration Model.
-
-        This model fits data acquired in the presence of nanostage or mirror oscillation.
-
-        Parameters
-        ----------
-        driving_data : numpy.ndarray
-            Array of driving data.
-        force_voltage_data : numpy.ndarray
-            Uncalibrated force data in volts.
-        sample_rate : float
-            Sample rate at which the signals we acquired.
-        bead_diameter : float
-            Bead diameter [um].
-        driving_frequency_guess : float
-            Guess of the driving frequency.
-        viscosity : float, optional
-            Liquid viscosity [Pa*s].
-            When omitted, the temperature will be used to look up the viscosity of water at that
-            particular temperature.
-        temperature : float, optional
-            Liquid temperature [Celsius].
-        num_windows : int, optional
-            Number of windows to average for the uncalibrated force. Using a larger number of
-            windows potentially increases the bleed, but may be useful when the SNR is low.
-        hydrodynamically_correct : bool, optional
-            Enable hydrodynamically correct model.
-        distance_to_surface : float, optional
-            Distance from bead center to the surface [um]
-            When specifying `None`, the model will use an approximation which is only suitable for
-            measurements performed deep in bulk.
-        rho_sample : float, optional
-            Density of the sample [kg/m**3]. Only used when using hydrodynamically correct model.
-        rho_bead : float, optional
-            Density of the bead [kg/m**3]. Only used when using hydrodynamically correct model.
-        fast_sensor : bool
-            Fast sensor? Fast sensors do not have the diode effect included in the model.
-        """
         super().__init__(
             bead_diameter,
             viscosity,

--- a/lumicks/pylake/force_calibration/convenience.py
+++ b/lumicks/pylake/force_calibration/convenience.py
@@ -55,7 +55,7 @@ def calibrate_force(
 
     Parameters
     ----------
-    force_voltage_data : array_like
+    force_voltage_data : numpy.ndarray
         Uncalibrated force data in volts.
     bead_diameter : float
         Bead diameter [um].
@@ -69,7 +69,7 @@ def calibrate_force(
         particular temperature.
     active_calibration : bool, optional
         Active calibration, when set to True, driving_data must also be provided.
-    driving_data : array_like, optional
+    driving_data : numpy.ndarray, optional
         Array of driving data.
     driving_frequency_guess : float, optional
          Guess of the driving frequency. Required for active calibration.

--- a/lumicks/pylake/force_calibration/convenience.py
+++ b/lumicks/pylake/force_calibration/convenience.py
@@ -35,27 +35,23 @@ def calibrate_force(
 ) -> CalibrationResults:
     """Determine force calibration factors.
 
-    The power spectrum calibration algorithm implemented here is based on [1]_ [2]_ [3]_ [4]_ [5]_
-    [6]_.
+    This function can be used to perform both active and passive calibration.
 
-    References
-    ----------
-    .. [1] Berg-Sørensen, K. & Flyvbjerg, H. Power spectrum analysis for optical tweezers. Rev. Sci.
-           Instrum. 75, 594 (2004).
-    .. [2] Tolić-Nørrelykke, I. M., Berg-Sørensen, K. & Flyvbjerg, H. MatLab program for precision
-           calibration of optical tweezers. Comput. Phys. Commun. 159, 225–240 (2004).
-    .. [3] Hansen, P. M., Tolic-Nørrelykke, I. M., Flyvbjerg, H. & Berg-Sørensen, K.
-           tweezercalib 2.1: Faster version of MatLab package for precise calibration of optical
-           tweezers. Comput. Phys. Commun. 175, 572–573 (2006).
-    .. [4] Berg-Sørensen, K., Peterman, E. J. G., Weber, T., Schmidt, C. F. & Flyvbjerg, H. Power
-           spectrum analysis for optical tweezers. II: Laser wavelength dependence of parasitic
-           filtering, and how to achieve high bandwidth. Rev. Sci. Instrum. 77, 063106 (2006).
-    .. [5] Tolić-Nørrelykke, S. F, and Flyvbjerg, H, "Power spectrum analysis with least-squares
-           fitting: amplitude bias and its elimination, with application to optical tweezers and
-           atomic force microscope cantilevers." Review of Scientific Instruments 81.7 (2010)
-    .. [6] Tolić-Nørrelykke S. F, Schäffer E, Howard J, Pavone F. S, Jülicher F and Flyvbjerg, H.
-           Calibration of optical tweezers with positional detection in the back focal plane,
-           Review of scientific instruments 77, 103101 (2006).
+    - For experiments performed near the surface, it is recommended to provide a
+      `distance_to_surface`.
+    - For lateral calibration with beads larger than 1 micron, it is recommended to use the
+      hydrodynamically correct theory (`hydrodynamically_correct=True`), unless so close to the
+      surface (0.75 x diameter) that this model becomes invalid.
+    - For axial calibration the flag `axial=True` should be set.
+    - In the case of a pre-characterized diode, the values for its parameters can be passed to
+      `fixed_alpha` and `fixed_diode`.
+    - In the case of active calibration, it is mandatory to provide a nanostage signal, as well as a
+      guess of the driving frequency.
+
+    The power spectrum calibration algorithm implemented here is based on [1]_ [2]_ [3]_ [4]_ [5]_
+    [6]_. Please refer to the :doc:`theory section</theory/force_calibration/force_calibration>` and
+    :doc:`tutorial</tutorial/force_calibration>` on force calibration for more information on the
+    calibration methods implemented.
 
     Parameters
     ----------
@@ -105,6 +101,42 @@ def calibrate_force(
         Fix diode frequency to a particular frequency.
     fixed_alpha : float, optional
         Fix diode relaxation factor to particular value.
+
+    Raises
+    ------
+    ValueError
+        If physical parameters are provided that are outside their sensible range.
+    ValueError
+        If the distance from the bead center to the surface is set smaller than the bead radius.
+    ValueError
+        If the hydrodynamically correct model is enabled, but the distance to the surface is
+        specified below 0.75 times the bead diameter (this model is not valid so close to the
+        surface).
+    NotImplementedError
+        If the hydrodynamically correct model is selected in conjunction with axial force
+        calibration.
+    RuntimeError
+        If active calibration is selected, but the driving peak can't be found near the guess of
+        its frequency.
+
+    References
+    ----------
+    .. [1] Berg-Sørensen, K. & Flyvbjerg, H. Power spectrum analysis for optical tweezers. Rev. Sci.
+           Instrum. 75, 594 (2004).
+    .. [2] Tolić-Nørrelykke, I. M., Berg-Sørensen, K. & Flyvbjerg, H. MatLab program for precision
+           calibration of optical tweezers. Comput. Phys. Commun. 159, 225–240 (2004).
+    .. [3] Hansen, P. M., Tolic-Nørrelykke, I. M., Flyvbjerg, H. & Berg-Sørensen, K.
+           tweezercalib 2.1: Faster version of MatLab package for precise calibration of optical
+           tweezers. Comput. Phys. Commun. 175, 572–573 (2006).
+    .. [4] Berg-Sørensen, K., Peterman, E. J. G., Weber, T., Schmidt, C. F. & Flyvbjerg, H. Power
+           spectrum analysis for optical tweezers. II: Laser wavelength dependence of parasitic
+           filtering, and how to achieve high bandwidth. Rev. Sci. Instrum. 77, 063106 (2006).
+    .. [5] Tolić-Nørrelykke, S. F, and Flyvbjerg, H, "Power spectrum analysis with least-squares
+           fitting: amplitude bias and its elimination, with application to optical tweezers and
+           atomic force microscope cantilevers." Review of Scientific Instruments 81.7 (2010)
+    .. [6] Tolić-Nørrelykke S. F, Schäffer E, Howard J, Pavone F. S, Jülicher F and Flyvbjerg, H.
+           Calibration of optical tweezers with positional detection in the back focal plane,
+           Review of scientific instruments 77, 103101 (2006).
     """
     if active_calibration:
         if axial:

--- a/lumicks/pylake/force_calibration/convenience.py
+++ b/lumicks/pylake/force_calibration/convenience.py
@@ -137,6 +137,44 @@ def calibrate_force(
     .. [6] Tolić-Nørrelykke S. F, Schäffer E, Howard J, Pavone F. S, Jülicher F and Flyvbjerg, H.
            Calibration of optical tweezers with positional detection in the back focal plane,
            Review of scientific instruments 77, 103101 (2006).
+
+    Examples
+    --------
+    ::
+
+        import lumicks.pylake as lk
+        f = lk.File("calibration_file.h5")
+        force_slice = f.force1x
+
+        # Decalibrate existing data
+        volts = force_slice / force_slice.calibration[0]["Response (pN/V)"]
+
+        # Determine calibration factors using the viscosity of water at T=25 C.
+        lk.calibrate_force(volts.data, bead_diameter=0.58, temperature=25, sample_rate=78125)
+
+        # Determine calibration factors using the hydrodynamically correct model
+        lk.calibrate_force(
+            volts.data,
+            bead_diameter=4.89,
+            temperature=25,
+            sample_rate=78125,
+            hydrodynamically_correct=True
+        )
+
+        # Determine calibration factors using the hydrodynamically correct model with active
+        # calibration at a distance of 7 micron from the surface
+        driving_data = f["Nanostage position"]["X"]
+        lk.calibrate_force(
+            volts.data,
+            bead_diameter=4.89,
+            temperature=25,
+            sample_rate=78125,
+            hydrodynamically_correct=True,
+            distance_to_surface=7,
+            driving_data=driving_data.data,
+            driving_frequency_guess=37,
+            active_calibration=True
+        )
     """
     if active_calibration:
         if axial:

--- a/lumicks/pylake/force_calibration/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/power_spectrum.py
@@ -69,7 +69,7 @@ class PowerSpectrum:
         self.total_duration = data.size / sample_rate
         self.num_points_per_block = len(squared_fft_chunks)
 
-    def downsampled_by(self, factor, reduce=np.mean):
+    def downsampled_by(self, factor, reduce=np.mean) -> "PowerSpectrum":
         """Returns a spectrum downsampled by a given factor."""
         ba = copy(self)
         ba.frequency = downsample(self.frequency, factor, reduce)
@@ -78,7 +78,7 @@ class PowerSpectrum:
 
         return ba
 
-    def _exclude_range(self, excluded_ranges):
+    def _exclude_range(self, excluded_ranges) -> "PowerSpectrum":
         """Exclude given frequency ranges from the power spectrum.
 
         This function can be used to exclude noise peaks.
@@ -99,7 +99,7 @@ class PowerSpectrum:
         ps.power = ps.power[indices]
         return ps
 
-    def in_range(self, frequency_min, frequency_max):
+    def in_range(self, frequency_min, frequency_max) -> "PowerSpectrum":
         """Returns part of the power spectrum within a given frequency range."""
         ir = copy(self)
         mask = (self.frequency > frequency_min) & (self.frequency <= frequency_max)
@@ -107,15 +107,15 @@ class PowerSpectrum:
         ir.power = self.power[mask]
         return ir
 
-    def num_samples(self):
+    def num_samples(self) -> int:
         return self.frequency.size
 
-    def with_spectrum(self, power, num_points_per_block=1):
+    def with_spectrum(self, power, num_points_per_block=1) -> "PowerSpectrum":
         """Return a copy with a different spectrum
 
         Parameters
         ----------
-        power : np.ndarray
+        power : numpy.ndarray
             Vector of power spectral values
         num_points_per_block : int
             Number of points per block used to obtain power spectral values.

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -130,13 +130,13 @@ class CalibrationResults:
     def _repr_html_(self):
         return self._print_data(tablefmt="html")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self._print_data()
 
 
 def calculate_power_spectrum(
     data, sample_rate, fit_range=(1e2, 23e3), num_points_per_block=2000, excluded_ranges=None
-):
+) -> PowerSpectrum:
     """Compute power spectrum and return it as a
     :class:`~lumicks.pylake.force_calibration.power_spectrum.PowerSpectrum`.
 
@@ -158,7 +158,11 @@ def calculate_power_spectrum(
     Returns
     -------
     PowerSpectrum
-        Estimated power spectrum based.
+
+    Raises
+    ------
+    TypeError
+        If the data is not a one-dimensional numpy array.
     """
     if not isinstance(data, np.ndarray) or (data.ndim != 1):
         raise TypeError('Argument "data" must be a numpy vector')
@@ -177,11 +181,11 @@ def fit_power_spectrum(
     ftol=1e-7,
     max_function_evals=10000,
     bias_correction=True,
-):
-    """Power Spectrum Calibration
+) -> CalibrationResults:
+    """Fit a power spectrum.
 
-    The power spectrum calibration algorithm implemented here is based on [1]_ [2]_ [3]_ [4]_ [5]_
-    [6]_.
+    Performs force calibration. The power spectrum calibration algorithms implemented here are
+    based on [1]_ [2]_ [3]_ [4]_ [5]_ [6]_.
 
     Parameters
     ----------
@@ -206,6 +210,15 @@ def fit_power_spectrum(
     -------
     CalibrationResults
         Parameters obtained from the calibration procedure.
+
+    Raises
+    ------
+    RuntimeError
+        If there are fewer than 4 data points to fit in the power spectrum.
+    TypeError
+        If the supplied power spectrum is not of the type `PowerSpectrum`.
+    RuntimeError
+        If there is insufficient data to perform the analytical fit used as initial condition.
 
     References
     ----------


### PR DESCRIPTION
**Why this PR?**
While working on the calibration docs, I noticed the docstrings for these classes and methods were quite spartan.

I added some links to the relevant docs and examples to all of them.

Note that for the class docstring I have removed some of the documented attributes in favor of showing all parameters required for the constructor and only showing those attributes that the user might want to look at in a practical scenario (the ones that are actually computed from their inputs).

Also note that I repeat some of the exception names a few times because otherwise it didn't format correctly in the RST.

[Old](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.calibrate_force.html#lumicks.pylake.calibrate_force) [New](https://lumicks-pylake.readthedocs.io/en/fodocs/_api/lumicks.pylake.calibrate_force.html#lumicks.pylake.calibrate_force)

[Old](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.PassiveCalibrationModel.html) [New](https://lumicks-pylake.readthedocs.io/en/fodocs/_api/lumicks.pylake.PassiveCalibrationModel.html)

[Old](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ActiveCalibrationModel.html) [New](https://lumicks-pylake.readthedocs.io/en/fodocs/_api/lumicks.pylake.ActiveCalibrationModel.html)