### PR TITLE
Update Kymotracking tutorial

### DIFF
--- a/docs/tutorial/figures/kymotracking/centroid_refinement.png
+++ b/docs/tutorial/figures/kymotracking/centroid_refinement.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c61042f57ba7dd727212a59d686ec05e97c1e1c722c9a0737595d4df1e8dfc9c
-size 77863
+oid sha256:a6b81dffc262969e345b3dbd452dc51c6110a3f40cc9cac5c5b44ba99895db90
+size 61379

--- a/docs/tutorial/figures/kymotracking/gaussian_refined.png
+++ b/docs/tutorial/figures/kymotracking/gaussian_refined.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a739601bd050123c6ff17f00c8e2ed11d0c295839a9ac4bfc5356c9c85afc8f
-size 248081
+oid sha256:97391992d9341fc45445e4128ae5d03880996a9d5d863aa1e01c8b0ccb62cc1f
+size 248096

--- a/docs/tutorial/figures/kymotracking/gaussian_refined_offset.png
+++ b/docs/tutorial/figures/kymotracking/gaussian_refined_offset.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:271c65c9639b6c5768e871c9d03265b8f2dd99921b43cad235a926e0020b07b9
-size 249155
+oid sha256:4864795de1699a6e1178ee0be65fcd9afcae085cdb7daa43039d53f2decb8645
+size 247960

--- a/docs/tutorial/figures/kymotracking/kymo_bind_histogram_1.png
+++ b/docs/tutorial/figures/kymotracking/kymo_bind_histogram_1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b32bfb291d9f5e221838f509ddd469f5dd2a9e761c208df344b88b697b41e0e6
-size 21790
+oid sha256:18aeeabac93c05b7ec20ee38708f35c87976eedc98a8210b2a32e324afb9b1cc
+size 18684

--- a/docs/tutorial/figures/kymotracking/kymo_bind_histogram_2.png
+++ b/docs/tutorial/figures/kymotracking/kymo_bind_histogram_2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1ae63b2711c59c19e8f2c310535b5266bf0fc64aefcc8124d448884524c713c
-size 21840
+oid sha256:6301ef1e37d0539c098da69a3e1490f5e2db97bccdafe26cb653c63d74139f84
+size 23054

--- a/docs/tutorial/figures/kymotracking/kymo_bind_histogram_3.png
+++ b/docs/tutorial/figures/kymotracking/kymo_bind_histogram_3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c11019cfdef9bb431baea9ec6323c0ce107c802e9546ea5199ad44930d75e3c
-size 19377
+oid sha256:f2b6df66213166ba93aa17e40c7d4ebc14854a7f57dc82872cc04519ca98e74b
+size 20212

--- a/docs/tutorial/figures/kymotracking/longest_track.png
+++ b/docs/tutorial/figures/kymotracking/longest_track.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78d3d3fd9fe141aa046ff5f59c4fc90c4fa85f435351eb9331dd4b822c3fc73a
-size 53451
+oid sha256:d42ad6a65b0d825468e2da880c231d1b4971f3cca1f38d89d3b3af9cc6c38704
+size 56236

--- a/docs/tutorial/figures/kymotracking/tracking_overlay.png
+++ b/docs/tutorial/figures/kymotracking/tracking_overlay.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c21fda39f874497fd37c2e7b3d59834adb62d9cd28c3a175c15cbee4ad6d1e5b
-size 262639
+oid sha256:63a1ca31f2e331d3312333a54f99e23fe5bcce758efaa63c2e2e7dbeb9afb0bc
+size 261965

--- a/docs/tutorial/figures/kymotracking/tracking_overlay_custom_args.png
+++ b/docs/tutorial/figures/kymotracking/tracking_overlay_custom_args.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:746d4b6087283acd33be6fb506602bcaa1265c1e1ccaf821f2fb9ead3a3adf2f
-size 264796
+oid sha256:1fb7e0c9088592b5ae4ab71a04fd1bb370e1b47fb9e68cfb20fd0c81ba38689f
+size 262457


### PR DESCRIPTION
**Why this PR?**
While testing enforced keyword arguments for kymotracking, I noticed there were some sections in the tutorial that were either broken or slightly changed results (after merging the default bias correction PR I think)

[docs build here](https://lumicks-pylake.readthedocs.io/en/kymotracking_docs_fixup/tutorial/kymotracking.html)