### PR TITLE
`ImageStack` -> `Kymo`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 
 #### New features
 
+* Added API to create a `Kymo` from an [`ImageStack`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html). See [`ImageStack.to_kymo()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.to_kymo) for more information.
 * Added API for notes, i.e. `file.notes` returns a dictionary of notes.
 * Added option to add a scale bar to by providing a [`lk.ScaleBar()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ScaleBar.html) to plotting or export functions.
 * Implemented bias correction for centroid refinement that shrinks the window to reduce estimation bias. This bias correction can be toggled by passing a `bias_correction` argument to [`lk.track_greedy()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.track_greedy.html#) and [`lk.refine_tracks_centroid()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.refine_tracks_centroid.html).

--- a/docs/tutorial/figures/imagestack/imagestack_adjust_absolute.png
+++ b/docs/tutorial/figures/imagestack/imagestack_adjust_absolute.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2313c9141ba6508feb127ac709e37de16d1dd95a75175bc5b46698a0c1fc3df5
-size 190685
+oid sha256:c658081cb6203e2c9967ff45c44782320d2186688f3ebbe16bdbbb7ff19b11c8
+size 191274

--- a/docs/tutorial/figures/imagestack/imagestack_adjust_percentile.png
+++ b/docs/tutorial/figures/imagestack/imagestack_adjust_percentile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6667140b1b84969c3b7ad2bdf9b33a40391724e65ca17fb2f84efb1c06066ea4
-size 218669
+oid sha256:6e5be253eeaedbea615911e835d6390b632f83a771c71f365b0f4d094ce07ea3
+size 219595

--- a/docs/tutorial/figures/imagestack/imagestack_correlated.png
+++ b/docs/tutorial/figures/imagestack/imagestack_correlated.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36afff6c9685d0b078f63d0377ef6459623b18052d5c6cf7d5c6d77bd4395329
-size 320643
+oid sha256:5e39644f38e477e29cdb0c2a9faeb8189418c3dcf9967dd4666294e7ee7a7fdc
+size 314285

--- a/docs/tutorial/figures/imagestack/imagestack_cropped.png
+++ b/docs/tutorial/figures/imagestack/imagestack_cropped.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:167e93f7a42aff765c20e1e11e9aea4f8778d4ee37c7d388e873f034830e483a
-size 140438
+oid sha256:7bc6de4bfb1def7dc1a1ca0eb8f1df4dab52eff266bc655c6d7275b91dc30e0b
+size 141047

--- a/docs/tutorial/figures/imagestack/imagestack_kymo.png
+++ b/docs/tutorial/figures/imagestack/imagestack_kymo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80b8cf549d6ab69da7c3ee821027672c3c53f7b73bc135df9c93504a79ef21dd
+size 214514

--- a/docs/tutorial/figures/imagestack/imagestack_red.png
+++ b/docs/tutorial/figures/imagestack/imagestack_red.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:98c894ad56a35fd79c7350c4ca93a81851e7a3308eeb979e6eb6595842aab3e3
-size 131812
+oid sha256:8b8faa91e7f1d3d45f669d417103fed5d60a0585bcf80db44f5b987b8f034878
+size 132313

--- a/docs/tutorial/figures/imagestack/imagestack_red_cropped.png
+++ b/docs/tutorial/figures/imagestack/imagestack_red_cropped.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f57068edf46d667c4ac1db726af5e8af4e6808f9e2cb04781976e570f4d6cd9e
-size 158652
+oid sha256:ffaac32e93fff64c4b6cb6781d315daecfc936d808865b34bf0e7d7d5f6df66a
+size 191345

--- a/docs/tutorial/figures/imagestack/imagestack_tether.png
+++ b/docs/tutorial/figures/imagestack/imagestack_tether.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f77db6813efc8a7354c91ebaa7c63ecb4970c6db212119365d920d591904913
-size 94640
+oid sha256:89304b0ece6ab96846cab93c6a57f026c387dea7497e15256d6e76fd24f0a91e
+size 105397

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -98,8 +98,8 @@ class Kymo(ConfocalImage):
 
         The normalized shutter function is defined as :math:`c(t)`, where :math:`c(t)` represents
         whether the shutter is open or closed. :math:`c(t)` is normalized w.r.t. area. For no
-        motion blur, :math:`c(t) = \delta(t_{exposure})`, whereas for a constantly open shutter it is
-        defined as :math:`c(t) = 1 / \Delta t`.
+        motion blur, :math:`c(t) = \delta(t_\mathrm{exposure})`, whereas for a constantly open
+        shutter it is defined as :math:`c(t) = 1 / \Delta t`.
 
         The motion blur constant is defined as:
 
@@ -122,7 +122,7 @@ class Kymo(ConfocalImage):
         Raises
         ------
         NotImplementedError
-            if the motion blur is poorly defined for this type of kymograph.
+            if the motion blur is not defined for this kymograph.
         """
         if self._motion_blur_constant is None:
             raise NotImplementedError("No motion blur constant was defined for this kymograph.")

--- a/lumicks/pylake/kymotracker/detail/msd_estimation.py
+++ b/lumicks/pylake/kymotracker/detail/msd_estimation.py
@@ -876,12 +876,12 @@ def _cve(
     dt : float
         Time step
     blur_constant : float
-        Motion blur coefficient. Should be between 0 and 1/4.
+        Motion blur coefficient. Should be between 0 and 1/4 or `np.nan` if not clearly defined.
 
         The normalized shutter function is defined as :math:`c(t)`, where :math:`c(t)` represents
         whether the shutter is open or closed. :math:`c(t)` is normalized w.r.t. area. For no
-        motion blur, :math:`c(t) = \delta(t_{exposure})`, whereas for a constantly open shutter it is
-        defined as :math:`c(t) = 1 / \Delta t`.
+        motion blur, :math:`c(t) = \delta(t_{\mathrm{exposure}})`, whereas for a constantly open
+        shutter it is defined as :math:`c(t) = 1 / \Delta t`.
 
         With :math:`c(t)` defined as before, the motion blur constant is defined as:
 
@@ -900,6 +900,8 @@ def _cve(
         and the diffusion constant, the motion blur factor has no effect on the estimate of the
         diffusion constant itself, but it does affect the calculated uncertainties. In the case of
         a provided localization uncertainty, it does impact the estimate of the diffusion constant.
+
+        Note that if the blur constant is set to `np.nan`, not all estimates will be available.
     localization_var : Optional[float]
         Estimate of the localization error expressed as a variance, if it has been determined
         independently.
@@ -925,7 +927,7 @@ def _cve(
     .. [13] Vestergaard, C. L. (2016). Optimizing experimental parameters for tracking of diffusing
             particles. Physical Review E, 94(2), 022401.
     """
-    if not 0 <= blur_constant <= 0.25:
+    if not 0 <= blur_constant <= 0.25 and not np.isnan(blur_constant):
         raise ValueError("Motion blur constant should be between 0 and 1/4")
 
     if len(x) < 3:
@@ -998,7 +1000,8 @@ def estimate_diffusion_cve(
     dt : float
         Time step
     blur_constant : float
-        Motion blur coefficient. Should be between 0 and 1/4.
+        Motion blur coefficient. Should be between 0 and 1/4 or `np.nan` if not defined. Note that
+        if `np.nan` is specified, not all estimates will be available.
     unit : str
         Unit that the diffusion constant is specified in.
     unit_label : str

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo.py
@@ -304,7 +304,7 @@ def test_downsample_channel_downsampled_kymo(kymo_h5_file):
 
     # Down-sampling by time should invalidate plot_with_force as it would correspond to
     # non-contiguous sampling
-    with pytest.raises(NotImplementedError, match="Per-pixel timestamps are no longer available"):
+    with pytest.raises(NotImplementedError, match="Line timestamp ranges are no longer available"):
         kymo.downsampled_by(time_factor=2).plot_with_force("1x", "red")
 
 
@@ -447,8 +447,8 @@ def test_downsampled_kymo():
     assert not kymo_ds.contiguous
 
     with pytest.raises(
-            NotImplementedError,
-            match=re.escape("Per-pixel timestamps are no longer available after downsampling"),
+        NotImplementedError,
+        match=re.escape("Per-pixel timestamps are no longer available after downsampling"),
     ):
         kymo_ds.timestamps
 

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo.py
@@ -42,6 +42,7 @@ def test_kymo_properties(test_kymos):
     np.testing.assert_allclose(kymo.center_point_um["z"], 0)
     np.testing.assert_allclose(kymo.size_um, [0.050])
     np.testing.assert_allclose(kymo.pixel_time_seconds, 0.1875)
+    np.testing.assert_allclose(kymo.motion_blur_constant, 0)  # We neglect motion blur for confocal
 
 
 def test_empty_kymo_properties(test_kymos):
@@ -451,6 +452,12 @@ def test_downsampled_kymo():
         match=re.escape("Per-pixel timestamps are no longer available after downsampling"),
     ):
         kymo_ds.timestamps
+
+    with pytest.raises(
+        NotImplementedError,
+        match=re.escape("No motion blur constant was defined for this kymograph"),
+    ):
+        kymo_ds.motion_blur_constant
 
     # Verify that we can pass a different reduce function
     np.testing.assert_allclose(kymo.downsampled_by(time_factor=2, reduce=np.mean).get_image("red"), ds / 2)

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo_from_array.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo_from_array.py
@@ -134,6 +134,7 @@ def test_from_array_no_pixelsize(test_kymos):
 
     assert arr_kymo._metadata.center_point_um == {key: None for key in ("x", "y", "z")}
     assert arr_kymo._metadata.num_frames == 0
+    assert arr_kymo._motion_blur_constant is None
 
 
 def test_throw_on_file_access(test_kymos):


### PR DESCRIPTION
**Why this PR?**
It's valuable for users to be able to generate `Kymos` from their camera stacks.

Turns this:
![image](https://user-images.githubusercontent.com/19836026/223748400-8af66aa4-e362-4373-9a4b-1a00ca6e75cd.png)

Into this:
![image](https://user-images.githubusercontent.com/19836026/223748465-5f2d0c0d-826d-46d5-8039-dc18649439cd.png)

Doing nothing more than this:

```python
stack_tether = stack.define_tether((6.94423, 4.22381), (20.47474,  4.08063))
kymograph = stack_tether.to_kymo(adjacent_lines=5)
```

This requires a re-assessment on how we treat motion blur, as camera images typically have far more motion blur, resulting in biased estimates if not correctly taken into account during specific downstream analyses (such as diffusion estimation using `cve`).

This PR introduces a new property on the `Kymo` which keeps track of this motion blur constant.

- For camera's computing the motion blur is relatively straightforward. It should simply be `(1/6) * exposure / line_time`.
- For `Kymo`'s generated from 2D `Scans` we will eventually also need a particular motion blur constant that is also different. This is more complicated since the exposure window will have gaps (gaps can be worse than having the shutter continuously open).
- For downsampled kymos we also need different handling.
- For regular confocal images we neglect the motion blur (`R=0`) as its effect on a 1D `Scan` is very small. We could consider incorporating this in the future as an improvement.

In this PR we specify the motion blur constant as `None` for non-standard `Kymo`s. We will add their correct definitions as we go, since every addition needs some testing.

Note that I will merge the docs update into the PR introducing the functionality prior to merging.

Docs build [here](https://lumicks-pylake.readthedocs.io/en/to_kymo/tutorial/imagestack.html#constructing-a-kymograph-from-an-image-stack) and [here](https://lumicks-pylake.readthedocs.io/en/to_kymo/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.to_kymo).