### PR TITLE
docs: fix mislabeling in figure title

### DIFF
--- a/docs/tutorial/figures/force_calibration/fast_sensors.png
+++ b/docs/tutorial/figures/force_calibration/fast_sensors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f960abb4b5ed95493a307ee1f8f63c77be423366d40a198db30bfc86daaa366
-size 320194
+oid sha256:ca69d29d2184140768598471bc3179ed6fb9ba820aeeceb4fd2f92138f6015c4
+size 331697

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -428,7 +428,7 @@ The following example data acquired on a fast sensor will illustrate why::
     plt.subplot(1, 3, 3)
     fit = lk.calibrate_force(**shared_parameters, hydrodynamically_correct=True, fast_sensor=True)
     fit.plot()
-    plt.title(f"Simple model + Fast (kappa={fit['kappa'].value:.2f})")
+    plt.title(f"Hydrodynamically correct + Fast (kappa={fit['kappa'].value:.2f})")
     plt.tight_layout()
     plt.show()
 


### PR DESCRIPTION
**Why this PR?**
This PR fixes a mislabeling in a figure title in the force calibration tutorial.

Credit goes to Michael B. for noticing this. 