### PR TITLE
confocal: ensure immutability

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.1 | t.b.d.
+
+#### Bug fixes
+
+* Fixed bug that could lead to mutability of `Kymo` and `Scan` through `.get_image()` or `.timestamps`. This bug was introduced in `0.7.2`. Grabbing a single color image from a `Scan` or `Kymo` using `.get_image()` returned a reference to an internal image cache. This means that modifying data in the returned image would result in future calls to `.get_image()` returning the modified data rather than the original `Kymo` or `Scan` image. Timestamps obtained from `.timestamps` were similarly affected.
+
 ## v1.0.0 | 2023-03-14
 
 Happy π-day!

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -277,8 +277,16 @@ class ConfocalImage(BaseScan, TiffExport):
         """Returns a reconstructed image.
 
         Warning: Do *not* modify or return this image without making a copy, as it will return a
-        reference to the cached image, which makes the `ConfocalImage` mutable."""
-        assert channel in ("red", "green", "blue")
+        reference to the cached image, which makes the `ConfocalImage` mutable.
+
+        Parameters
+        ----------
+        channel : str
+            Channel to return. Must be "red", "green" or "blue".
+        """
+        if channel not in ("red", "green", "blue"):
+            raise ValueError(f'Channel must be "red", "green" or "blue", got "{channel}".')
+
         return self._image_factory(self, channel)
 
     @cachetools.cachedmethod(lambda self: self._cache)
@@ -286,8 +294,18 @@ class ConfocalImage(BaseScan, TiffExport):
         """Returns reconstructed timestamps.
 
         Warning: Do *not* modify or return this image without making a copy, as it will return a
-        reference to the cached image, which makes the `ConfocalImage` scan mutable."""
-        assert channel == "timestamps"
+        reference to the cached image, which makes the `ConfocalImage` scan mutable.
+
+        Parameters
+        ----------
+        channel : str
+            Must be "timestamps".
+        reduce : callable
+            Function to reduce sample timestamps into aggregate timestamps.
+        """
+        if channel != "timestamps":
+            raise ValueError(f'channel must be "timestamps", got "{channel}"')
+
         return self._timestamp_factory(self, reduce)
 
     def _get_plot_data(self, channel, adjustment=no_adjustment, frame=None):

--- a/lumicks/pylake/tests/test_imaging_confocal/test_confocal.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_confocal.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pytest
 from lumicks.pylake.detail.confocal import ScanAxis, ScanMetaData
+from lumicks.pylake.kymo import _kymo_from_array
 
-from ..data.mock_confocal import generate_scan_json
+from ..data.mock_confocal import generate_scan_json, generate_scan, generate_kymo
 
 
 @pytest.mark.parametrize(
@@ -97,3 +98,24 @@ def test_scanmetadata_from_json(axes, shape, pixel_sizes_nm, scan_order):
     assert np.all(
         [oa == sa for oa, sa in zip(metadata.ordered_axes, [scan_axes[i] for i in scan_order])]
     )
+
+
+@pytest.mark.parametrize(
+    "item, has_timestamps",
+    [
+        (generate_kymo("Mock", np.ones((5, 5))), True),
+        (generate_scan("Mock", np.ones((5, 5)), [1, 1]), True),
+        (_kymo_from_array(np.ones((5, 5)), "r", 1), False),
+    ],
+)
+def test_immutable_returns(item, has_timestamps):
+    """Ensure that users cannot modify data in the cache."""
+    red = item.get_image("red")
+    red[2, 2] = 100
+    assert item.get_image("red")[2, 2] == 1
+
+    if has_timestamps:
+        ts = item.timestamps
+        ref_ts = ts[2, 2]
+        ts[2, 2] = 100
+        assert item.timestamps[2, 2] == ref_ts


### PR DESCRIPTION
**Why this PR?**
This PR fixes a bug that could lead to mutability of `Kymo` and `Scan` through references returned from `.get_image()` or `.timestamps`.

This bug was introduced in https://github.com/lumicks/pylake/pull/82 and released as part of `0.7.2`. Grabbing a single color image from a `Scan` or `Kymo` using `.get_image()` resulted in a reference to an internal image cache being returned.

Note: I kept the regression test separate so you can verify that it works, but I will squash it before merging.