### PR TITLE
docs: improve docstring for ConfocalImage.fast_axis

### DIFF
--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -418,7 +418,7 @@ class ConfocalImage(BaseScan, TiffExport):
 
     @property
     def fast_axis(self):
-        """The axis that was scanned (x or y)"""
+        """The axis that was scanned ("X" or "Y")"""
         return self._metadata.fast_axis
 
     @property


### PR DESCRIPTION
The current docstring of `ConfocalImage.fast_axis` states that `"""The axis that was scanned (x or y)"""`. It was unclear to me that this meant that the literal characters 'x' or 'y' were returned. I therefore propose to change the docstring to `"""The axis that was scanned ("X" or "Y")"""`, to indicate that the returned value is a string, and to make it explicit that the uppercase value is returned. 