### PR TITLE
dwell time uncertainty analysis draft

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## v1.0.1 | t.b.d.
 
+#### New features
+
+* Added [DwelltimeModel.profile_likelihood()](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.DwelltimeModel.html#lumicks.pylake.DwelltimeModel.profile_likelihood) for calculating profile likelihoods for dwell time analysis. These can be used to determine confidence intervals and assess whether the model has too many parameters (a smaller model with fewer components would be sufficient).
+  
 #### Bug fixes
 
 * Fixed bug that could lead to mutability of `Kymo` and `Scan` through `.get_image()` or `.timestamps`. This bug was introduced in `0.7.2`. Grabbing a single color image from a `Scan` or `Kymo` using `.get_image()` returned a reference to an internal image cache. This means that modifying data in the returned image would result in future calls to `.get_image()` returning the modified data rather than the original `Kymo` or `Scan` image. Timestamps obtained from `.timestamps` were similarly affected.

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### New features
 
 * Added [DwelltimeModel.profile_likelihood()](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.DwelltimeModel.html#lumicks.pylake.DwelltimeModel.profile_likelihood) for calculating profile likelihoods for dwell time analysis. These can be used to determine confidence intervals and assess whether the model has too many parameters (a smaller model with fewer components would be sufficient).
+* Improved fitting performance dwell time analyses by implementing analytic gradient and better numerical conditioning.
   
 #### Bug fixes
 

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -604,11 +604,15 @@ def _generate_fitting_mask(n_components, params, fixed_param_mask):
             f"Invalid model. Sum of the provided amplitudes has to be 1 ({sum_fixed_amplitudes})."
         )
 
-    constraints = {
-        "type": "eq",
-        "fun": lambda x, n: 1 - sum(x[:n]) - sum_fixed_amplitudes,
-        "args": [num_free_amps],
-    }
+    constraints = (
+        {
+            "type": "eq",
+            "fun": lambda x, n: 1 - sum(x[:n]) - sum_fixed_amplitudes,
+            "args": [num_free_amps],
+        }
+        if num_free_amps > 0
+        else ()
+    )
 
     return fitted_param_mask, constraints
 

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -430,7 +430,7 @@ class DwelltimeModel:
         keys = [f"amplitude {idx}" for idx in range(self.n_components)] + [
             f"lifetime {idx}" for idx in range(self.n_components)
         ]
-        lower_bounds = np.zeros(2 * self.n_components)
+        lower_bounds = np.hstack((np.zeros(self.n_components), 1e-16 * np.ones(self.n_components)))
         upper_bounds = np.hstack((np.ones(self.n_components), np.inf * np.ones(self.n_components)))
         parameters = Params(
             **{
@@ -859,7 +859,7 @@ def _exponential_mle_optimize(
         (
             *[(np.finfo(float).eps, 1) for _ in range(n_components)],
             *[
-                (min_observation_time * 0.1, max_observation_time * 1.1)
+                (max(min_observation_time * 0.1, 1e-16), max_observation_time * 1.1)
                 for _ in range(n_components)
             ],
         )

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -1,7 +1,6 @@
 import numpy as np
 from scipy.special import logsumexp
 from scipy.optimize import minimize
-from functools import partial
 from dataclasses import dataclass, field
 import matplotlib.pyplot as plt
 from deprecated.sphinx import deprecated
@@ -95,6 +94,15 @@ class DwelltimeBootstrap:
 
     @staticmethod
     def _sample(optimized, iterations):
+        """Calculate bootstrap samples
+
+        Parameters
+        ----------
+        optimized : DwellTimeModel
+            An optimized DwellTimeModel to start from.
+        iterations : int
+            Number of samples to generate.
+        """
 
         n_data = optimized.dwelltimes.size
         samples = np.empty((optimized._parameters.size, iterations))
@@ -331,13 +339,13 @@ class DwelltimeModel:
     @property
     def aic(self):
         """Akaike Information Criterion."""
-        k = (2 * self.n_components) - 1  # number of parameters
+        k = (2 * self.n_components) - 1  # number of parameters minus number of constraints
         return 2 * k - 2 * self.log_likelihood
 
     @property
     def bic(self):
         """Bayesian Information Criterion."""
-        k = (2 * self.n_components) - 1  # number of parameters
+        k = (2 * self.n_components) - 1  # number of parameters minus number of constraints
         n = self.dwelltimes.size  # number of observations
         return k * np.log(n) - 2 * self.log_likelihood
 
@@ -544,8 +552,75 @@ def exponential_mixture_log_likelihood(params, t, min_observation_time, max_obse
     return -np.sum(log_likelihood)
 
 
+def _generate_fitting_mask(n_components, params, fixed_param_mask):
+    """Handle amplitude constraints
+
+    This function returns the mask of parameters to be fitted and amplitude constraint function.
+    It was split out from `_exponential_mle_optimize` to reduce cognitive load.
+
+    Parameters
+    ----------
+    n_components : int
+        number of components in the mixture model
+    params : array_like
+        model parameters
+    fixed_param_mask : array_like
+        logical mask of fixed parameters
+
+    Raises
+    ------
+    ValueError
+        If the sum of the provided fixed amplitudes exceeds 1.
+    ValueError
+        If all amplitudes are fixed but the amplitudes do not sum to 1.
+    """
+    if fixed_param_mask is None:
+        fixed_param_mask = np.zeros(params.shape, dtype=bool)
+    else:
+        if len(fixed_param_mask) != len(params):
+            raise ValueError(
+                f"Length of fixed parameter mask ({len(fixed_param_mask)}) is not equal to the "
+                f"number of model parameters ({len(params)})"
+            )
+
+    is_amplitude = np.hstack(
+        (np.array(np.ones(n_components), dtype=bool), np.array(np.zeros(n_components), dtype=bool))
+    )
+
+    # Contribution from amplitudes that are fixed.
+    fixed_amplitude_mask = np.logical_and(is_amplitude, fixed_param_mask)
+    sum_fixed_amplitudes = np.sum(params[fixed_amplitude_mask])
+    if sum_fixed_amplitudes > 1:
+        raise ValueError(
+            f"Invalid model. Sum of the fixed amplitudes is bigger than 1 ({sum_fixed_amplitudes})."
+        )
+
+    # Determine what actually needs to be fitted
+    fitted_param_mask = np.logical_not(fixed_param_mask)
+    num_free_amps = np.sum(np.logical_and(is_amplitude, fitted_param_mask))
+
+    if num_free_amps == 0 and not np.allclose(np.sum(sum_fixed_amplitudes), 1.0, atol=1e-6):
+        raise ValueError(
+            f"Invalid model. Sum of the provided amplitudes has to be 1 ({sum_fixed_amplitudes})."
+        )
+
+    constraints = {
+        "type": "eq",
+        "fun": lambda x, n: 1 - sum(x[:n]) - sum_fixed_amplitudes,
+        "args": [num_free_amps],
+    }
+
+    return fitted_param_mask, constraints
+
+
 def _exponential_mle_optimize(
-    n_components, t, min_observation_time, max_observation_time, initial_guess=None, options=None
+    n_components,
+    t,
+    min_observation_time,
+    max_observation_time,
+    initial_guess=None,
+    options=None,
+    fixed_param_mask=None,
 ):
     """Calculate the maximum likelihood estimate of the model parameters given measured dwelltimes.
 
@@ -559,11 +634,20 @@ def _exponential_mle_optimize(
         minimum observation time in seconds
     max_observation_time : float
         maximum observation time in seconds
-    initial_guess : array_like
+    initial_guess : array_like, optional
         initial guess for the model parameters ordered as
         [amplitude1, amplitude2, ..., lifetime1, lifetime2, ...]
-    options : Optional[dict]
+    options : dict, optional
         additional optimization parameters passed to `minimize(..., options)`.
+    fixed_param_mask : array_like, optional
+        logical mask of which parameters to fix during optimization
+
+    Raises
+    ------
+    ValueError
+        If the sum of the provided fixed amplitudes in the initial_guess exceeds 1.
+    ValueError
+        If all amplitudes are fixed but the amplitudes in the initial_guess do not sum to 1.
     """
     if np.any(np.logical_or(t < min_observation_time, t > max_observation_time)):
         raise ValueError(
@@ -571,34 +655,52 @@ def _exponential_mle_optimize(
             "appropriate values for `min_observation_time` and/or `max_observation_time`."
         )
 
-    cost_fun = partial(
-        exponential_mixture_log_likelihood,
-        t=t,
-        min_observation_time=min_observation_time,
-        max_observation_time=max_observation_time,
-    )
-
     if initial_guess is None:
         initial_guess_amplitudes = np.ones(n_components) / n_components
         initial_guess_lifetimes = np.mean(t) * np.arange(1, n_components + 1)
         initial_guess = np.hstack([initial_guess_amplitudes, initial_guess_lifetimes])
+    else:
+        # During optimization, we modify in-place, so we need to make sure that we make a copy
+        initial_guess = np.copy(initial_guess)
 
-    bounds = (
-        *[(np.finfo(float).eps, 1) for _ in range(n_components)],
-        *[(min_observation_time * 0.1, max_observation_time * 1.1) for _ in range(n_components)],
+    bounds = np.array(
+        (
+            *[(np.finfo(float).eps, 1) for _ in range(n_components)],
+            *[
+                (min_observation_time * 0.1, max_observation_time * 1.1)
+                for _ in range(n_components)
+            ],
+        )
     )
-    constraints = {"type": "eq", "fun": lambda x, n: 1 - sum(x[:n]), "args": [n_components]}
+
+    fitted_param_mask, constraints = _generate_fitting_mask(
+        n_components, initial_guess, fixed_param_mask
+    )
+
+    def cost_fun(params):
+        current_params = initial_guess
+        current_params[fitted_param_mask] = params
+
+        return exponential_mixture_log_likelihood(
+            current_params,
+            t=t,
+            min_observation_time=min_observation_time,
+            max_observation_time=max_observation_time,
+        )
+
     result = minimize(
         cost_fun,
-        initial_guess,
+        initial_guess[fitted_param_mask],
         method="SLSQP",
-        bounds=bounds,
         constraints=constraints,
+        bounds=bounds[fitted_param_mask],
         options=options,
     )
 
     # output parameters as [amplitudes, lifetimes], -log_likelihood
-    return result.x, -result.fun
+    fitted_params = np.copy(initial_guess)
+    fitted_params[fitted_param_mask] = result.x
+    return fitted_params, -result.fun
 
 
 def _dwellcounts_from_statepath(statepath, exclude_ambiguous_dwells):

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -706,6 +706,10 @@ def _exponential_mle_optimize(
             max_observation_time=max_observation_time,
         )
 
+    # Nothing to fit, return!
+    if np.sum(fitted_param_mask) == 0:
+        return initial_guess, -cost_fun([])
+
     result = minimize(
         cost_fun,
         initial_guess[fitted_param_mask],

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -3,11 +3,14 @@ import numpy as np
 import re
 
 from lumicks.pylake import DwelltimeModel
+from lumicks.pylake.fitting.detail.derivative_manipulation import numerical_jacobian
 from lumicks.pylake.population.dwelltime import (
     _dwellcounts_from_statepath,
     DwelltimeBootstrap,
     _generate_fitting_mask,
     _exponential_mle_optimize,
+    exponential_mixture_log_likelihood,
+    _exponential_mixture_log_likelihood_gradient
 )
 
 
@@ -289,3 +292,65 @@ def test_invalid_models():
         np.array([0.25, 0.25, 0.5, 0.3, 0.3, 0.3]),
         np.array([True, True, True, False, True, True])
     )
+
+
+@pytest.mark.parametrize(
+    "params, t, min_observation_time, max_observation_time",
+    [
+        [[1.0, 0.4], np.arange(0.0, 10.0, 0.1), 0, np.inf],
+        [[0.25, 0.75, 0.4, 1.0], np.arange(0.0, 10.0, 0.1), 0, np.inf],
+        [[0.25, 0.75, 0.4, 1.0], np.arange(0.0, 10.0, 0.1), 0.5, np.inf],
+        [[0.25, 0.75, 0.4, 1.0], np.arange(0.0, 10.0, 0.1), 0.5, 1e6],
+        [[0.25, 0.75, 0.4, 1.0], np.arange(0.0, 10.0, 0.1), 0, 5],
+        [[0.3, 0.3, 0.1, 0.4, 1.0, 10.0], np.arange(1.0, 10.0, 0.1), 2, 5],
+        # Test "zero" parameters. Because we use a central differencing scheme for validating the
+        # gradient we have to set the amplitude at least the finite differencing stepsize away
+        # from the bound (otherwise we'd only observe half the gradient in the numerical scheme).
+        [[1e-5, 1.0, 0.4, 1.0], np.arange(0.0, 10.0, 0.1), 0, np.inf],
+        # Zero lifetime is problematic because of all the reciprocals.
+        [[0.4, 0.6, 1e-2, 1.0], np.arange(0.0, 10.0, 0.1), 0, np.inf],
+    ]
+)
+def test_analytic_gradient_exponential(params, t, min_observation_time, max_observation_time):
+    def fn(params):
+        return np.atleast_1d(
+            exponential_mixture_log_likelihood(
+                np.array(params), t, min_observation_time, max_observation_time
+            )
+        )
+
+    np.testing.assert_allclose(
+        _exponential_mixture_log_likelihood_gradient(
+            np.array(params), t, min_observation_time, max_observation_time
+        ),
+        numerical_jacobian(fn, params, dx=1e-5).flatten(),
+        rtol=1e-5,
+    )
+
+
+def test_analytic_gradient_exponential_used(monkeypatch):
+    """Verify that the dwell time model actually uses the gradient"""
+
+    def store_args(*args, **kwargs):
+        raise StopIteration
+
+    with monkeypatch.context() as m:
+        # Jacobian should be passed
+        model = DwelltimeModel(np.arange(0.0, 10.0, 0.1), n_components=2, use_jacobian=True)
+
+        m.setattr(
+            "lumicks.pylake.population.dwelltime._exponential_mixture_log_likelihood_gradient",
+            store_args,
+        )
+
+        # Jacobian should be passed
+        with pytest.raises(StopIteration):
+            model.calculate_bootstrap(1)
+
+        # Jacobian should not be passed
+        model = DwelltimeModel(np.arange(0.0, 10.0, 0.1), n_components=2, use_jacobian=False)
+        model.calculate_bootstrap(1)
+
+        # Jacobian should be passed
+        with pytest.raises(StopIteration):
+            DwelltimeModel(np.arange(0.0, 10.0, 0.1), n_components=2, use_jacobian=True)

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -193,40 +193,70 @@ def test_integration_dwelltime_fixing_parameters(exponential_data):
         initial_guess=initial_params,
         fixed_param_mask=[False, True, False, True],
     )
-    np.testing.assert_allclose(pars, [0.8, 0.2, 4.27745463, 0.5])
+    np.testing.assert_allclose(pars, [0.8, 0.2, 4.27753, 0.5], rtol=1e-4)
 
 
 @pytest.mark.parametrize(
-    "n_components,params,fixed_param_mask,ref_fitted,ref_const_fun,free_amplitudes",
+    "n_components,params,fixed_param_mask,ref_fitted,ref_const_fun,free_amplitudes,ref_par",
     [
-        # 2 components, fix one amplitude
+        # fmt:off
+        # 2 components, fix one amplitude => everything fixed in the end
         [
             2, [0.3, 0.4, 0.3, 0.3], [True, False, False, False],
-            [False, True, True, True], 0.7, 1,
+            [False, False, True, True], None, 0, [0.3, 0.7, 0.3, 0.3],
         ],
         # 2 components, fix both amplitudes
         [
             2, [0.3, 0.7, 0.3, 0.3], [True, True, False, False],
-            [False, False, True, True], 0, 0,
+            [False, False, True, True], 0, 0, [0.3, 0.7, 0.3, 0.3]
         ],
         # 2 components, free amplitudes
         [
             2, [0.3, 0.7, 0.3, 0.3], [False, False, True, False],
-            [True, True, False, True], 0.75, 2,
+            [True, True, False, True], 0.75, 2, [0.3, 0.7, 0.3, 0.3],
         ],
+        # 3 components, fix one amplitude => End up with two free ones
+        [
+            3, [0.3, 0.4, 0.2, 0.3, 0.3, 0.3], [True, False, False, False, False, False],
+            [False, True, True, True, True, True], 1.6 / 3, 2, [0.3, 0.4, 0.2, 0.3, 0.3, 0.3],
+        ],
+        # 3 components, fix two amplitudes => Amplitudes are now fully determined
+        [
+            3, [0.3, 0.4, 0.2, 0.3, 0.3, 0.3], [True, True, False, False, False, False],
+            [False, False, False, True, True, True], 0, 0, [0.3, 0.4, 0.3, 0.3, 0.3, 0.3],
+        ],
+        # 1 component, no amplitudes required
+        [
+            1, [0.3, 0.5], [False, False],
+            [False, True], None, 0, [1.0, 0.5],
+        ],
+        # fmt:off
     ],
 )
-def test_parameter_fixing(n_components, params, fixed_param_mask, ref_fitted, ref_const_fun, free_amplitudes):
-    fitted_param_mask, constraints = _generate_fitting_mask(
+def test_parameter_fixing(
+    n_components,
+    params,
+    fixed_param_mask,
+    ref_fitted,
+    ref_const_fun,
+    free_amplitudes,
+    ref_par,
+):
+    fitted_param_mask, constraints, params = _generate_fitting_mask(
         n_components, np.array(params), np.array(fixed_param_mask)
     )
 
     assert np.all(fitted_param_mask == ref_fitted)
-    np.testing.assert_allclose(constraints["args"], free_amplitudes)
-    np.testing.assert_allclose(
-        constraints["fun"](np.arange(2 * n_components) / (2 * n_components), free_amplitudes),
-        ref_const_fun
-    )
+    np.testing.assert_allclose(params, ref_par)
+
+    if free_amplitudes:
+        np.testing.assert_allclose(constraints["args"], free_amplitudes)
+        np.testing.assert_allclose(
+            constraints["fun"](np.arange(2 * n_components) / (2 * n_components), free_amplitudes),
+            ref_const_fun
+        )
+    else:
+        assert not constraints
 
 
 def test_invalid_models():

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -38,17 +38,17 @@ def test_optim_options(exponential_data):
 def test_fit_parameters(exponential_data):
     # single exponential data
     dataset = exponential_data["dataset_1exp"]
-    fit = DwelltimeModel(dataset["data"], 1, **dataset["parameters"].observation_limits)
+    fit = DwelltimeModel(dataset["data"], 1, **dataset["parameters"].observation_limits, tol=1e-8)
     np.testing.assert_allclose(fit.amplitudes, [1])
     np.testing.assert_allclose(fit.lifetimes, [1.43481181], rtol=1e-5)
     np.testing.assert_allclose(fit.rate_constants, [1 / 1.43481181], rtol=1e-5)
 
     # double exponential data
     dataset = exponential_data["dataset_2exp"]
-    fit = DwelltimeModel(dataset["data"], 2, **dataset["parameters"].observation_limits)
-    np.testing.assert_allclose(fit.amplitudes, [0.46513486, 0.53486514], rtol=1e-5)
-    np.testing.assert_allclose(fit.lifetimes, [1.50630877, 5.46212603], rtol=1e-5)
-    np.testing.assert_allclose(fit.rate_constants, [1 / 1.50630877, 1 / 5.46212603], rtol=1e-5)
+    fit = DwelltimeModel(dataset["data"], 2, **dataset["parameters"].observation_limits, tol=1e-8)
+    np.testing.assert_allclose(fit.amplitudes, [0.46516346, 0.53483653], rtol=1e-5)
+    np.testing.assert_allclose(fit.lifetimes, [1.50634996, 5.46227291], rtol=1e-5)
+    np.testing.assert_allclose(fit.rate_constants, [1 / 1.50634996, 1 / 5.46227291], rtol=1e-5)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
**Why this PR?**
Dwell time analysis can take a long time.

This PR brings a number of things that speed up and hopefully make uncertainty analysis for dwell times more robust.

- Don't fit what ain't needed. For a single amplitude model, we shouldn't be fitting an amplitude. For a two component model with a constraint, we shouldn't be fitting amplitudes at all (solution is known). Basically this goes for any model where all but one amplitude is fixed.
- Some numerical fixes that could lead to instability in the gradients (mostly pertaining to the normalization constant).
- Analytic gradient which speeds up optimization by a factor of `2x`-`4x` on my machine.
- Profile likelihood approach which is a deterministic alternative to bootstrapping that can as a side effect give you a clear result on whether the model is overparametrized or not. If one of the amplitude's confidence intervals encapsulates zero, then it is.
- I didn't change it in this PR, but I think it would be wise to change the default tolerance we feed to `SLSQP` to something like `1e-8`. I don't think the default works well enough in most cases. I sometimes see lack of convergence.

I am debating whether to split this PR in two on monday given its scope creep.

![image](https://user-images.githubusercontent.com/19836026/227659006-831544a8-0b43-4ffd-a8fb-b542fd5fbffc.png)
_Well parameterized 3-component model (yes its possible!). Bootstrap (500 samples) 19 seconds without jacobian, 8.5 seconds with. Profiles take about 2 seconds._

![image](https://user-images.githubusercontent.com/19836026/227659760-2004b4c0-1bd3-4fdb-b991-813a8af6cfbd.png)
_Pathological case, 2 component model with 1 component with extremely low amplitude and counts (leading to non-identifiability). In this case bootstrap (500 samples) without Jacobian took 6.5 seconds and with 3.2 seconds. Unfortunately, profiling took exceedingly long in this case, clocking in at 8.6 seconds. Most of the time is spent on `tau_2`, which is effectively unbounded here._
