### PR TITLE
dwelltime: Improve numerics dwell time analysis

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@
 
 * Improve API description of the channel data in a default `FdCurve`.
 * Improved fitting performance dwell time analyses by implementing analytic gradient.
+* Added lower and upper bounds when fitting dwell time models. This prevents numerical issues that occur when approaching these extremes. Prior to this change, over-parameterized models could encounter numerical issues due to divisions by (near) zero. After this change, amplitudes are constrained to stay between `1e-9` and `1.0 - 1e-9`, while lifetimes are constrained to remain between `1e-8` and `1e8`.
+* Provided better initial guess for dwell time models with three or more components. Prior to this change, the dwelltime models involving three components or more would get an initial guess with an average lifetime beyond the mean of the observations.
 
 ## v1.0.0 | 2023-03-14
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 #### New features
 
 * Added [`DwelltimeModel.profile_likelihood()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.DwelltimeModel.html#lumicks.pylake.DwelltimeModel.profile_likelihood) for calculating profile likelihoods for dwell time analysis. These can be used to determine confidence intervals and assess whether the model has too many parameters (i.e., if a model with fewer components would be sufficient).
-  
+
 #### Bug fixes
 
 * Fixed bug that could lead to mutability of `Kymo` and `Scan` through `.get_image()` or `.timestamps`. This bug was introduced in `0.7.2`. Grabbing a single color image from a `Scan` or `Kymo` using `.get_image()` returns a reference to an internal image cache. This numpy array was write-able and modifying data in the returned image would result in future calls to `.get_image()` returning the modified data rather than the original `Kymo` or `Scan` image. Timestamps obtained from `.timestamps` were similarly affected. These arrays are now returned non-writeable.
@@ -13,6 +13,7 @@
 #### Improvements
 
 * Improve API description of the channel data in a default `FdCurve`.
+* Improved fitting performance dwell time analyses by implementing analytic gradient.
 
 ## v1.0.0 | 2023-03-14
 

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
 * Improved fitting performance dwell time analyses by implementing analytic gradient.
 * Added lower and upper bounds when fitting dwell time models. This prevents numerical issues that occur when approaching these extremes. Prior to this change, over-parameterized models could encounter numerical issues due to divisions by (near) zero. After this change, amplitudes are constrained to stay between `1e-9` and `1.0 - 1e-9`, while lifetimes are constrained to remain between `1e-8` and `1e8`.
 * Provided better initial guess for dwell time models with three or more components. Prior to this change, the dwelltime models involving three components or more would get an initial guess with an average lifetime beyond the mean of the observations.
+* Silenced false positive warnings about the optimization violating the bound constraints. Prior to this change, dwell time analysis would produce warnings about the optimizer exceeding bounds. These excursions beyond the bound are very small and have no effect on the model.
 
 ## v1.0.0 | 2023-03-14
 

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -977,8 +977,11 @@ def _handle_amplitude_constraint(
 
 def _exponential_mle_bounds(n_components, min_observation_time, max_observation_time):
     return (
-        *[(1e-9, 1.0) for _ in range(n_components)],
-        *[(min_observation_time * 0.1, max_observation_time * 1.1) for _ in range(n_components)],
+        *[(1e-9, 1.0 - 1e-9) for _ in range(n_components)],
+        *[
+            (max(min_observation_time * 0.1, 1e-8), min(max_observation_time * 1.1, 1e8))
+            for _ in range(n_components)
+        ],
     )
 
 
@@ -1028,7 +1031,8 @@ def _exponential_mle_optimize(
 
     if initial_guess is None:
         initial_guess_amplitudes = np.ones(n_components) / n_components
-        initial_guess_lifetimes = np.mean(t) * np.arange(1, n_components + 1)
+        fractions = np.arange(1, n_components + 1)
+        initial_guess_lifetimes = np.mean(t) * n_components * fractions / np.sum(fractions)
         initial_guess = np.hstack([initial_guess_amplitudes, initial_guess_lifetimes])
 
     bounds = _exponential_mle_bounds(n_components, min_observation_time, max_observation_time)

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -4,11 +4,14 @@ import re
 import matplotlib.pyplot as plt
 
 from lumicks.pylake import DwelltimeModel
+from lumicks.pylake.fitting.detail.derivative_manipulation import numerical_jacobian
 from lumicks.pylake.population.dwelltime import (
     _dwellcounts_from_statepath,
     DwelltimeBootstrap,
     _handle_amplitude_constraint,
     _exponential_mle_optimize,
+    _exponential_mixture_log_likelihood,
+    _exponential_mixture_log_likelihood_jacobian
 )
 
 
@@ -382,6 +385,68 @@ def test_invalid_models():
         np.array([0.25, 0.25, 0.5, 0.3, 0.3, 0.3]),
         np.array([True, True, True, False, True, True])
     )
+
+
+@pytest.mark.parametrize(
+    "params, t, min_observation_time, max_observation_time",
+    [
+        [[1.0, 0.4], np.arange(0.0, 10.0, 0.1), 0, np.inf],
+        [[0.25, 0.75, 0.4, 1.0], np.arange(0.0, 10.0, 0.1), 0, np.inf],
+        [[0.25, 0.75, 0.4, 1.0], np.arange(0.0, 10.0, 0.1), 0.5, np.inf],
+        [[0.25, 0.75, 0.4, 1.0], np.arange(0.0, 10.0, 0.1), 0.5, 1e6],
+        [[0.25, 0.75, 0.4, 1.0], np.arange(0.0, 10.0, 0.1), 0, 5],
+        [[0.3, 0.3, 0.1, 0.4, 1.0, 10.0], np.arange(1.0, 10.0, 0.1), 2, 5],
+        # Test "zero" parameters. Because we use a central differencing scheme for validating the
+        # gradient we have to set the amplitude at least the finite differencing stepsize away
+        # from the bound (otherwise we'd only observe half the gradient in the numerical scheme).
+        [[1e-4, 1.0, 0.4, 1.0], np.arange(0.0, 10.0, 0.1), 0, np.inf],
+        # Zero lifetime is problematic because of all the reciprocals.
+        [[0.4, 0.6, 1e-2, 1.0], np.arange(0.0, 10.0, 0.1), 0, np.inf],
+    ]
+)
+def test_analytic_gradient_exponential(params, t, min_observation_time, max_observation_time):
+    def fn(params):
+        return np.atleast_1d(
+            _exponential_mixture_log_likelihood(
+                np.array(params), t, min_observation_time, max_observation_time
+            )
+        )
+
+    np.testing.assert_allclose(
+        _exponential_mixture_log_likelihood_jacobian(
+            np.array(params), t, min_observation_time, max_observation_time
+        ),
+        numerical_jacobian(fn, params, dx=1e-5).flatten(),
+        rtol=1e-5,
+    )
+
+
+def test_analytic_gradient_exponential_used(monkeypatch):
+    """Verify that the dwell time model actually uses the gradient"""
+
+    def store_args(*args, **kwargs):
+        raise StopIteration
+
+    with monkeypatch.context() as m:
+        # Jacobian should be passed
+        model = DwelltimeModel(np.arange(0.0, 10.0, 0.1), n_components=2, use_jacobian=True)
+
+        m.setattr(
+            "lumicks.pylake.population.dwelltime._exponential_mixture_log_likelihood_jacobian",
+            store_args,
+        )
+
+        # Jacobian should be passed
+        with pytest.raises(StopIteration):
+            model.calculate_bootstrap(1)
+
+        # Jacobian should not be passed
+        model = DwelltimeModel(np.arange(0.0, 10.0, 0.1), n_components=2, use_jacobian=False)
+        model.calculate_bootstrap(1)
+
+        # Jacobian should be passed
+        with pytest.raises(StopIteration):
+            DwelltimeModel(np.arange(0.0, 10.0, 0.1), n_components=2, use_jacobian=True)
 
 
 def test_dwelltime_exponential_no_free_params(monkeypatch):

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -15,7 +15,6 @@ from lumicks.pylake.population.dwelltime import (
 )
 
 
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
 def test_likelihood(exponential_data):
     # single exponential data
     dataset = exponential_data["dataset_1exp"]
@@ -32,7 +31,6 @@ def test_likelihood(exponential_data):
     np.testing.assert_allclose(fit.bic, 4429.232045925579, rtol=1e-5)
 
 
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
 def test_optim_options(exponential_data):
     dataset = exponential_data["dataset_1exp"]
 
@@ -43,7 +41,6 @@ def test_optim_options(exponential_data):
     np.testing.assert_allclose(fit.lifetimes, [1.382336], rtol=1e-5)
 
 
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
 def test_fit_parameters(exponential_data):
     # single exponential data
     dataset = exponential_data["dataset_1exp"]
@@ -61,7 +58,6 @@ def test_fit_parameters(exponential_data):
 
 
 @pytest.mark.slow
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
 def test_bootstrap(exponential_data):
     # double exponential data
     dataset = exponential_data["dataset_2exp"]
@@ -89,7 +85,6 @@ def test_bootstrap(exponential_data):
 
 
 @pytest.mark.slow
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
 def test_dwelltime_profiles(exponential_data):
     dataset = exponential_data["dataset_2exp"]
     fit = DwelltimeModel(dataset["data"], 2, **dataset["parameters"].observation_limits)
@@ -176,7 +171,6 @@ def test_dwelltime_profiles_dunders(exponential_data):
 
 
 # TODO: remove with deprecation
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
 def test_empty_bootstrap(exponential_data):
     dataset = exponential_data["dataset_2exp"]
 
@@ -240,7 +234,6 @@ def test_dwellcounts_from_statepath():
     assert ranges == {}
 
 
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
 def test_plots(exponential_data):
     """Check if `DwelltimeModel` fits can be plotted without an exception"""
     dataset = exponential_data["dataset_2exp"]
@@ -255,7 +248,6 @@ def test_plots(exponential_data):
         bootstrap.plot()
 
 
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
 def test_invalid_bootstrap(exponential_data):
     dataset = exponential_data["dataset_2exp"]
     fit = DwelltimeModel(dataset["data"], 1, **dataset["parameters"].observation_limits)

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -90,7 +90,6 @@ def test_bootstrap(exponential_data):
 
 @pytest.mark.slow
 @pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
-@pytest.mark.filterwarnings("ignore:divide by zero encountered in log")
 def test_dwelltime_profiles(exponential_data):
     dataset = exponential_data["dataset_2exp"]
     fit = DwelltimeModel(dataset["data"], 2, **dataset["parameters"].observation_limits)


### PR DESCRIPTION
**Why this PR?**
This PR is number three in a story where we introduce more reliable uncertainty estimation.

This PR in particular provides three small improvements which we need to have things running smoothly:
- It provides the analytical gradient for the dwell time model. This improves performance when fitting dwelltime models. The performance improvement is typically a factor two or more).
- It adds a bound constraint on the estimated parameters to avoid numerical issues that occur when amplitudes or lifetimes go to zero.
- Finally, it suppresses a warning which is annoying to users and warns about something that doesn't impact the problem we are solving in a meaningful way.

One thing that might be worth noting prior to review is that I did notice all the reciprocals appearing in the gradient. I have a separate branch in which I changed the parametrization (and the associated gradient) to use rates `1/lifetime`, or use `log(amplitudes)` and `log(rates)`.

To my disappointment, in the cases I tested, these transformations don't actually improve performance or affect the results much at all. That's why I left them out of this PR. They also don't relax the requirement on the parameter bounds.

That said, the other improvements made in this PR _did_ make a difference.