### PR TITLE
docs: improve force calibration docs

### DIFF
--- a/docs/theory/force_calibration/figures/back_focal.png
+++ b/docs/theory/force_calibration/figures/back_focal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05f4e529d0b40b07c42cd6a7b827a4414da6d703f0dbe87c6f6a9c2b001062fd
+size 39302

--- a/docs/theory/force_calibration/figures/freq_dependence_near.png
+++ b/docs/theory/force_calibration/figures/freq_dependence_near.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0e580108818a5c0fc2f13ff97a3abb4a87b2faec8bb1397a67c09d7dfbc8455
+size 24007

--- a/docs/theory/force_calibration/figures/freq_dependent_drag_zero.png
+++ b/docs/theory/force_calibration/figures/freq_dependent_drag_zero.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b157bc3156ce7f7bfe29f8d42c8adb1603a459c53704baf91913aa56fee2e949
+size 24760


### PR DESCRIPTION
**Why this PR?**
These improvements to the docs were made based on feedback.

The aim is three-fold:
1. To make the connection between te diffusion equation and the full optical trap calibration equation a little bit more clear. Before, it appeared as though the drag only appeared once we got to the trapping part (but it was always there in the diffusion equation).
2. To provide some guidance on the direction of the biases when you average too little, or use an unsuitable model.
3. To sketch the calibration setup a little bit, showing a schematic of where the force/displacement detection is taking place.

Docs build: https://lumicks-pylake.readthedocs.io/en/fixup_force_calib_docs/theory/force_calibration/force_calibration.html