### PR TITLE
tutorial notebooks: minor fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 * Fixed bug that could lead to mutability of `Kymo` and `Scan` through `.get_image()` or `.timestamps`. This bug was introduced in `0.7.2`. Grabbing a single color image from a `Scan` or `Kymo` using `.get_image()` returns a reference to an internal image cache. This numpy array was write-able and modifying data in the returned image would result in future calls to `.get_image()` returning the modified data rather than the original `Kymo` or `Scan` image. Timestamps obtained from `.timestamps` were similarly affected. These arrays are now returned non-writeable.
 
+#### Improvements
+
+* Improve API description of the channel data in a default `FdCurve`.
+
 ## v1.0.0 | 2023-03-14
 
 Happy π-day!

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,6 +25,9 @@ If you are just looking to get started, read the :doc:`/tutorial/index` first.
 
     colormaps
 
+    :template: function.rst
+
+    download_from_doi
 
 Force calibration
 -----------------

--- a/docs/examples/cas9_kymotracking/cas9_kymotracking.rst
+++ b/docs/examples/cas9_kymotracking/cas9_kymotracking.rst
@@ -36,7 +36,7 @@ Download the kymograph data
 
 The kymograph data is stored on Zenodo, a general-purpose open-access repository developed under the European OpenAIRE program and operated by CERN.
 Zenodo allows researchers to deposit data sets, research software, reports, and any other research related digital artifacts and allows them to be referenced by a Digital Object Identifier (DOI).
-We can download the kymograph we need directly from Zenodo using Pylake.
+We can download the kymograph we need directly from Zenodo using the function :func:`~lumicks.pylake.download_from_doi`.
 Since we don't want it in our working folder, we'll put it in a folder called `"test_data"`::
 
     filenames = lk.download_from_doi("10.5281/zenodo.4247279", "test_data")
@@ -100,7 +100,8 @@ This will provide us with a view of the kymograph and some dials to tune in algo
 custom `axis_aspect_ratio` which determines our field of view. This input is not necessary, but provides a better
 view of our data.
 
-We will be using the greedy algorithm. The `threshold` should typically be chosen somewhere between the expected
+We will be using the greedy algorithm. For more information on how it works, please refer to the :ref:`Pylake kymotracking tutorial<track_greedy>`.
+The `threshold` should typically be chosen somewhere between the expected
 baseline photon count and the photon count of a true track (note that you can see the local photon count between square
 brackets while hovering over the kymograph). The `track width` should roughly be set to the expected spot size (in the spatial dimension) of a
 track. The `window` should be chosen such that small gaps in a track can be overcome, but not so large that spurious
@@ -144,7 +145,7 @@ bead. This binding should be omitted from the analysis::
 
 .. image:: kymowidget.png
 
-One last thing to note is that we assigned the `KymoWidgetGreedy` to the variable `kymowidget`. That means that from
+One last thing to note is that we assigned the :class:`~lumicks.pylake.nb_widgets.kymotracker_widgets.KymoWidgetGreedy` to the variable `kymowidget`. That means that from
 this point on, we can interact with it through the handle name `kymowidget`.
 
 Exporting from the widget results in a file that contains the track coordinates in pixels and real units.
@@ -156,9 +157,9 @@ This sums the photon counts from `pixel_position - sampling_width` to (and inclu
 Analyzing the results
 ---------------------
 
-The tracks are available in `kymowidget.tracks`, which returns a `KymoTrackGroup` object. The group is a customized list of :class:`~lumicks.pylake.kymotracker.kymotrack.KymoTrack` objects
-which contain lists of position and time coordinates for each tracked particle. These can be accessed with the `KymoTrack.position` and
-`KymoTrack.seconds` properties, respectively. Let's grab the longest track we found, and have a look at its position over time::
+The tracks are available from the :attr:`~lumicks.pylake.nb_widgets.KymoWidgetGreedy.tracks` property, which returns a :class:`~lumicks.pylake.kymotracker.kymotrack.KymoTrackGroup` object.
+This is a customized list of :class:`~lumicks.pylake.kymotracker.kymotrack.KymoTrack` objects which in turn contain lists of position and time coordinates for each tracked particle.
+These coordinates can be accessed with the :attr:`~lumicks.pylake.kymotracker.kymotrack.KymoTrack.position` and :attr:`~lumicks.pylake.kymotracker.kymotrack.KymoTrack.seconds` properties, respectively. Let's grab the longest track we found, and have a look at its position over time::
 
     lengths = [len(track) for track in kymowidget.tracks]
 
@@ -219,7 +220,7 @@ compare them to the force::
 
 However, what we wanted to know was how the force affects initiation. To determine this, we will need to know the force
 at which events were started. To do this, we compare the `track_start_time` we just computed to the time in the force
-channel. What we want is the index with the smallest distance to our track start time. We can use `np.argmin()` for
+channel. What we want is the index with the smallest distance to our track start time. We can use :func:`numpy.argmin()` for
 this, which will return the index of the minimum value in a list. Once we have the index, we can quickly look up the
 force for each track start position::
 

--- a/docs/tutorial/fdcurves.rst
+++ b/docs/tutorial/fdcurves.rst
@@ -16,7 +16,6 @@ Once we have the data, we can load the HDF5 file and list all FD curves inside t
     >>> list(file.fdcurves)
     ['FD_5_control_forw']
 
-
 To visualizes an FD curve, you can use the built-in :meth:`.plot_scatter()
 <lumicks.pylake.fdcurve.FdCurve.plot_scatter()>` method::
 
@@ -27,8 +26,14 @@ To visualizes an FD curve, you can use the built-in :meth:`.plot_scatter()
 
 .. image:: figures/fdcurves/fdcurves_scatter.png
 
-Here, :attr:`.fdcurves <lumicks.pylake.File.fdcurves>` is a standard Python dictionary, so we can
-do all the things you can do with a regular dictionary. For example, we can iterate over all the FD curves in a file and plot them::
+An :class:`~lumicks.pylake.fdcurve.FdCurve` slices some force and distance data from the timeline data.
+You can find the range it uses for slicing in its :attr:`~lumicks.pylake.fdcurve.start` and :attr:`~lumicks.pylake.fdcurve.stop` property::
+
+    >>> all(file.downsampled_force2[fd.start:fd.stop].data == fd.f.data)
+    True
+
+The attribute :attr:`.fdcurves <lumicks.pylake.File.fdcurves>` is a standard Python dictionary, so we can do all the things you can do with a regular dictionary.
+For example, we can iterate over all the FD curves in a file and plot them::
 
     plt.figure()
     for name, fd in file.fdcurves.items():
@@ -40,6 +45,12 @@ do all the things you can do with a regular dictionary. For example, we can iter
 By default, the FD channel pair is `downsampled_force2` and `distance1`.
 This assumes that the force extension was done by moving trap 1, which is the most common.
 In that situation the force measured by trap 2 is more precise because that trap is static.
+
+.. note::
+
+    The default force channel used by an :class:`~lumicks.pylake.fdcurve.FdCurve` is `downsampled_force2`.
+    Channel names without a suffix represent a total force, e.g. :math:`\sqrt{F_{2, x}^2 + F_{2, y}^2}`.
+
 The channels can be switched with the following code::
 
     plt.figure()

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -398,6 +398,8 @@ by passing a width in pixels to sum counts over::
 How the algorithms work
 -----------------------
 
+.. _track_greedy:
+
 `track_greedy`
 ^^^^^^^^^^^^^^
 

--- a/lumicks/pylake/fdcurve.py
+++ b/lumicks/pylake/fdcurve.py
@@ -12,11 +12,31 @@ FdSlice = namedtuple("FdSlice", "f d")
 
 
 class FdCurve(DownsampledFD):
-    """An FD curve exported from Bluelake
+    r"""An FD curve exported from Bluelake
 
     By default, the primary force and distance channels are `downsampled_force2`
     and `distance1`. Alternatives can be selected using :func:`FdCurve.with_channels()`.
     Note that it does not modify the FD curve in place but returns a copy.
+
+    Note
+    ----
+    The default channel `downsampled_force2` is the total force on trap 2, e.g.
+    :math:`\sqrt{F_{2, x}^2 + F_{2, y}^2}`
+
+    Examples
+    --------
+    ::
+
+        import lumicks.pylake as lk
+        f = lk.File("fdcurves.h5")
+
+        # Show FdCurve "1"
+        fd_curve = f.fdcurves["1"]
+        fd_curve.plot()
+
+        # Make a new F,d curve based on the `start` and `stop` time of FdCurve "1", but only include
+        # the x-component of the force on trap 2
+        fd_curve = fd_curve.with_channels("2x", distance="1")
 
     Attributes
     ----------
@@ -206,7 +226,33 @@ class FdCurve(DownsampledFD):
         return FdSlice(f[valid_idx], d[valid_idx])
 
     def with_channels(self, force, distance):
-        """Return a copy of this FD curve with difference primary force and distance channels"""
+        r"""Return a copy of this FD curve with different primary force and distance channels
+
+        Parameters
+        ----------
+        force : str
+            Force channel to use (i.e. "1", "2", "1x", "1y").
+        distance : str
+            Distance channel to use (i.e. "1", "2").
+
+        Returns
+        -------
+        FdCurve
+
+        Examples
+        --------
+        ::
+
+            import lumicks.pylake as lk
+            f = lk.File("fdcurves.h5")
+
+            # Grab the FdCurve with the name "1"
+            fd_curve = f.fdcurves["1"]
+
+            # Make a new F,d curve based on the start and stop time of FdCurve "1" but only include
+            # the x-component of the force on trap 2
+            fd_curve = fd_curve.with_channels("2x", distance="1")
+        """
         new_fd = copy(self)
         new_fd._primary_force_channel = force
         new_fd._primary_distance_channel = distance

--- a/lumicks/pylake/file_download.py
+++ b/lumicks/pylake/file_download.py
@@ -80,8 +80,13 @@ def verify_hash(file_name, algorithm, reference_hash, chunk_size=65536):
 
 
 def download_from_doi(doi, target_path="", force_download=False, show_progress=True):
-    """Download files from a Zenodo DOI (i.e. 10.5281/zenodo.#######) and returns a file list in the
-    form of a List[str].
+    """Download files from a Zenodo DOI (i.e. 10.5281/zenodo.#######)
+
+    Note
+    ----
+    This function will not re-download files that have already been downloaded. You can therefore
+    safely use it at the start of a notebook or script without worrying that it will download
+    files unnecessarily.
 
     Parameters
     ----------
@@ -95,6 +100,11 @@ def download_from_doi(doi, target_path="", force_download=False, show_progress=T
         a freshly downloaded copy.
     show_progress : bool
         Show a progress bar while downloading.
+
+    Returns
+    -------
+    list of str
+        List of downloaded file names.
     """
     url = get_url_from_doi(doi)
 

--- a/lumicks/pylake/fitting/models.py
+++ b/lumicks/pylake/fitting/models.py
@@ -687,7 +687,10 @@ def marko_siggia_ewlc_distance(name):
 
 
 @deprecated(
-    reason=("This function will be removed in a future release. Use `wlc_force('name')` instead."),
+    reason=(
+        "This function will be removed in a future release. Use `wlc_marko_siggia_force('name')` "
+        "instead."
+    ),
     action="always",
     version="0.13.2",
 )
@@ -711,7 +714,8 @@ def marko_siggia_simplified(name):
 
 @deprecated(
     reason=(
-        "This function will be removed in a future release. Use `wlc_distance('name')` instead."
+        "This function will be removed in a future release. Use "
+        "`wlc_marko_siggia_distance('name')` instead."
     ),
     action="always",
     version="0.13.2",


### PR DESCRIPTION
**Why this PR?**
I was preparing to update the notebooks we have on Harbor to not use deprecated API. I noticed a few small errors in the deprecation warning and added some crosslinking in the kymotracking such that the notebook doesn't have to duplicate the entire algorithm description.

I also added a small commit which adds some more descriptions as to what is in an `FdCurve` as per customer request.

Docs build here: https://lumicks-pylake.readthedocs.io/en/minor_fixups/