### PR TITLE
confocal: non-writeable `.get_image()`, `.timestamps`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 #### Bug fixes
 
-* Fixed bug that could lead to mutability of `Kymo` and `Scan` through `.get_image()` or `.timestamps`. This bug was introduced in `0.7.2`. Grabbing a single color image from a `Scan` or `Kymo` using `.get_image()` returned a reference to an internal image cache. This means that modifying data in the returned image would result in future calls to `.get_image()` returning the modified data rather than the original `Kymo` or `Scan` image. Timestamps obtained from `.timestamps` were similarly affected.
+* Fixed bug that could lead to mutability of `Kymo` and `Scan` through `.get_image()` or `.timestamps`. This bug was introduced in `0.7.2`. Grabbing a single color image from a `Scan` or `Kymo` using `.get_image()` returns a reference to an internal image cache. This numpy array was write-able and modifying data in the returned image would result in future calls to `.get_image()` returning the modified data rather than the original `Kymo` or `Scan` image. Timestamps obtained from `.timestamps` were similarly affected. These arrays are now returned non-writeable.
 
 ## v1.0.0 | 2023-03-14
 

--- a/lumicks/pylake/tests/test_imaging_confocal/test_confocal.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_confocal.py
@@ -111,11 +111,15 @@ def test_scanmetadata_from_json(axes, shape, pixel_sizes_nm, scan_order):
 def test_immutable_returns(item, has_timestamps):
     """Ensure that users cannot modify data in the cache."""
     red = item.get_image("red")
-    red[2, 2] = 100
+
+    with pytest.raises(ValueError, match="assignment destination is read-only"):
+        red[2, 2] = 100
     assert item.get_image("red")[2, 2] == 1
 
     if has_timestamps:
         ts = item.timestamps
         ref_ts = ts[2, 2]
-        ts[2, 2] = 100
+
+        with pytest.raises(ValueError, match="assignment destination is read-only"):
+            ts[2, 2] = 100
         assert item.timestamps[2, 2] == ref_ts


### PR DESCRIPTION
**Why this PR?***
This is a fixup on https://github.com/lumicks/pylake/pull/483/commits/f553a95283321d51e22080bff37bdf11d089ff1b which made sure that users could not modify the internal cache by returning a copy every time. Unfortunately, this leads to questionable performance for things such as `KymotrackGroup.plot()`. Instead, it's better to just be explicit about our intent and return it as a non-writeable array and leave it up to the user whether they want a copy that they can modify or not.

Technically, this is breaking, but considering that we never intended users to modify the internal cache, I would sooner refer to the original behaviour as a bug.