### PR TITLE
`sample_from_image`: fix rounding issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 #### Bug fixes
 
 * Fixed bug that could lead to mutability of `Kymo` and `Scan` through `.get_image()` or `.timestamps`. This bug was introduced in `0.7.2`. Grabbing a single color image from a `Scan` or `Kymo` using `.get_image()` returns a reference to an internal image cache. This numpy array was write-able and modifying data in the returned image would result in future calls to `.get_image()` returning the modified data rather than the original `Kymo` or `Scan` image. Timestamps obtained from `.timestamps` were similarly affected. These arrays are now returned non-writeable.
+* Fixed a bug that would round the center of the window to the incorrect pixel when using `KymoTrack.sample_from_image()`. Pixels are defined with their origin at the center of the pixel, whereas this function incorrectly assumed that the origin was on the edge of the pixel. The effects of this bug are larger for small windows.
 
 #### Improvements
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -218,7 +218,10 @@ class KymoTrack:
 
     @property
     def coordinate_idx(self):
-        """Return spatial coordinates in units of pixels."""
+        """Return spatial coordinates in units of pixels.
+
+        Coordinates are defined w.r.t. pixel centers (i.e. 0, 0 is the center of the first pixel).
+        """
         return self._localization.position / self._kymo.pixelsize[0]
 
     @property
@@ -284,9 +287,14 @@ class KymoTrack:
         reduce : callable
             Function evaluated on the sample. (Default: np.sum which produces sum of photon counts).
         """
-        # Time and coordinates are being cast to an integer since we use them to index into a data array.
+        # Time and coordinates are being cast to an integer since we use them to index into a data
+        # array. Note that coordinate pixel centers are defined at integer coordinates.
         return [
-            reduce(self._image[max(int(c) - num_pixels, 0) : int(c) + num_pixels + 1, int(t)])
+            reduce(
+                self._image[
+                    max(int(c + 0.5) - num_pixels, 0) : int(c + 0.5) + num_pixels + 1, int(t)
+                ]
+            )
             for t, c in zip(self.time_idx, self.coordinate_idx)
         ]
 


### PR DESCRIPTION
**Why this PR?**
This PR fixes a bug that would round the center of the window to the incorrect pixel when using `KymoTrack.sample_from_image()`. Coming from the kymotracker, pixel coordinates are defined with their origin at the center of the pixel, whereas this function incorrectly assumed that the origin was on the left side of the pixel. The relative effect of this bug is larger for small windows.

Note that I use `int(x + 0.5)` rather than `int(round(x))` because I figured it'd make more sense to round consistent to slicing (define a pixel from `x - 0.5` up to (but not including) `x + 0.5`), whereas `round` uses banker's rounding (rounds to nearest even). In real-world situations this likely makes very little difference for us.

I realized that this bug was present while working on https://github.com/lumicks/pylake/pull/493 . I also want to note that despite fixing this bug, you will still not get the exact same sampling result if you flip the Kymo and redo the analysis (due to tiny rounding errors for localizations that happen to be exactly at the pixel edge).

Ideally, I think it would be better to allow for subpixel windows (similarly to how we handle bias-corrected centroid refinement), but I think we should discuss the implications of introducing that a bit more first. For now, I think fixing this bug is a clear improvement that can be done independently now.