### PR TITLE
kymotracker: add `split` action

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### New features
 
 * Added [`DwelltimeModel.profile_likelihood()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.DwelltimeModel.html#lumicks.pylake.DwelltimeModel.profile_likelihood) for calculating profile likelihoods for dwell time analysis. These can be used to determine confidence intervals and assess whether the model has too many parameters (i.e., if a model with fewer components would be sufficient).
+* Added functionality to split tracks in the Kymotracking widget.
 
 #### Bug fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 * Provided better initial guess for dwell time models with three or more components. Prior to this change, the dwelltime models involving three components or more would get an initial guess with an average lifetime beyond the mean of the observations.
 * Silenced false positive warnings about the optimization violating the bound constraints. Prior to this change, dwell time analysis would produce warnings about the optimizer exceeding bounds. These excursions beyond the bound are very small and have no effect on the model.
 * Parameters corresponding to Gaussian refinement are now preserved when two refined tracks are concatenated.
+* Set the minimum value for the `Min length` slider in the Kymotracking widget to `2`.
 
 ## v1.0.0 | 2023-03-14
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 * Added lower and upper bounds when fitting dwell time models. This prevents numerical issues that occur when approaching these extremes. Prior to this change, over-parameterized models could encounter numerical issues due to divisions by (near) zero. After this change, amplitudes are constrained to stay between `1e-9` and `1.0 - 1e-9`, while lifetimes are constrained to remain between `1e-8` and `1e8`.
 * Provided better initial guess for dwell time models with three or more components. Prior to this change, the dwelltime models involving three components or more would get an initial guess with an average lifetime beyond the mean of the observations.
 * Silenced false positive warnings about the optimization violating the bound constraints. Prior to this change, dwell time analysis would produce warnings about the optimizer exceeding bounds. These excursions beyond the bound are very small and have no effect on the model.
+* Parameters corresponding to Gaussian refinement are now preserved when two refined tracks are concatenated.
 
 ## v1.0.0 | 2023-03-14
 

--- a/lumicks/pylake/kymotracker/detail/localization_models.py
+++ b/lumicks/pylake/kymotracker/detail/localization_models.py
@@ -1,5 +1,5 @@
 import numpy as np
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, fields
 
 __all__ = ["LocalizationModel", "GaussianLocalizationModel"]
 
@@ -29,6 +29,21 @@ class LocalizationModel:
             Size of the kymograph in physical units.
         """
         return self.with_position(size - self.position)
+
+    def __add__(self, other):
+        if other.__class__ is not self.__class__:
+            raise TypeError(
+                f"Incompatible localization models {self.__class__.__name__} and "
+                f"{other.__class__.__name__}."
+            )
+
+        init_kwargs = {
+            f.name: np.hstack((getattr(self, f.name), getattr(other, f.name))) for f in fields(self)
+        }
+        return self.__class__(**init_kwargs)
+
+    def __getitem__(self, item):
+        return self.__class__(**{f.name: getattr(self, f.name)[item] for f in fields(self)})
 
 
 @dataclass(frozen=True)

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -625,6 +625,14 @@ def test_kymotrackgroup_copy(blank_kymo):
 
 def test_kymotrack_concat_gaussians(blank_kymo):
     k1 = KymoTrack(np.array([1, 2, 3]), np.array([1, 1, 1]), blank_kymo, "red")
+    k1g = KymoTrack(
+        np.array([1, 2, 3]),
+        GaussianLocalizationModel(
+            np.full(3, 2), np.full(3, 7), np.full(3, 0.5), np.ones(3), np.full(3, False)
+        ),
+        blank_kymo,
+        "red",
+    )
     k2 = KymoTrack(
         np.array([6, 7, 8]),
         GaussianLocalizationModel(
@@ -638,10 +646,16 @@ def test_kymotrack_concat_gaussians(blank_kymo):
     assert isinstance(k1._localization, LocalizationModel)
     assert isinstance(k2._localization, GaussianLocalizationModel)
 
-    # test merging clears gaussian parameters
+    # test merging gaussian and non-gaussian localized lines clears gaussian parameters
     group._merge_tracks(k1, 2, k2, 2)
     assert len(group) == 1
     assert isinstance(group[0]._localization, LocalizationModel)
+
+    # test whether merging two gaussian localized lines preserves the localization
+    group = KymoTrackGroup([k1g, k2])
+    group._merge_tracks(k1g, 2, k2, 2)
+    assert len(group) == 1
+    assert isinstance(group[0]._localization, GaussianLocalizationModel)
 
 
 @pytest.mark.parametrize("num_pixels, pixelsize_um", [(10, 0.1), (15, 0.2)])

--- a/lumicks/pylake/kymotracker/tests/test_loc_models.py
+++ b/lumicks/pylake/kymotracker/tests/test_loc_models.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from lumicks.pylake.kymotracker.detail.localization_models import *
 
 
@@ -51,3 +52,69 @@ def test_gaussian_model_with_position():
 
     m3 = m2._flip(5.0)
     np.testing.assert_allclose(m3.position, [5.0 - 0.5, 5.0 - 0.6, 5.0 - 0.7])
+
+
+def test_gaussian_model_add():
+    m1 = GaussianLocalizationModel(
+        np.arange(3) * 0.2,
+        np.array([5, 6, 8]),
+        np.array([0.5, 0.5, 0.6]),
+        np.array([1, 2, 1]),
+        np.array([False, True, False]),
+    )
+
+    m2 = GaussianLocalizationModel(
+        np.arange(5, 8, 1) * 0.2,
+        np.array([3, 2, 1]),
+        np.array([0.3, 0.4, 0.2]),
+        np.array([2, 1, 3]),
+        np.array([False, False, True]),
+    )
+
+    added = m1 + m2
+    np.testing.assert_allclose(added.position, [0.0, 0.2, 0.4, 1.0, 1.2, 1.4])
+    np.testing.assert_allclose(added.total_photons, [5, 6, 8, 3, 2, 1])
+    np.testing.assert_allclose(added.sigma, [0.5, 0.5, 0.6, 0.3, 0.4, 0.2])
+    np.testing.assert_allclose(added.background, [1, 2, 1, 2, 1, 3])
+    np.testing.assert_allclose(added._overlap_fit, [False, True, False, False, False, True])
+
+
+def test_incompatible_add():
+    m1 = GaussianLocalizationModel(
+        np.arange(3), np.arange(3), np.arange(3), np.arange(3), np.zeros(3, dtype=bool)
+    )
+    m2 = LocalizationModel(np.arange(3))
+
+    with pytest.raises(
+        TypeError,
+        match="Incompatible localization models GaussianLocalizationModel and LocalizationModel."
+    ):
+        m1 + m2
+
+
+@pytest.mark.parametrize(
+    "slc",
+    [
+        slice(None, None, None),
+        slice(1, None, None),
+        slice(1, 1, None),
+        slice(1, 2, None),
+        slice(1, 3, None),
+        slice(None, 2, None),
+        slice(1, -1, None),
+        slice(None, -1, None),
+        slice(1, 4, 2),
+    ],
+)
+def test_gaussian_model_getitem(slc):
+    m1 = GaussianLocalizationModel(
+        np.arange(3) * 0.2,
+        np.array([5, 6, 8]),
+        np.array([0.5, 0.5, 0.6]),
+        np.array([1, 2, 1]),
+        np.array([False, True, False]),
+    )
+
+    fields = ["position", "total_photons", "sigma", "background", "_overlap_fit"]
+    for f in fields:
+        np.testing.assert_allclose(getattr(m1[slc], f), getattr(m1, f)[slc])

--- a/lumicks/pylake/nb_widgets/detail/mouse.py
+++ b/lumicks/pylake/nb_widgets/detail/mouse.py
@@ -10,7 +10,9 @@ class MouseDragEvent:
 
 
 class MouseDragCallback:
-    def __init__(self, axes, button, drag_callback, press_callback=None, release_callback=None):
+    def __init__(
+        self, axes, button, drag_callback=None, press_callback=None, release_callback=None
+    ):
         """Callback handler to handle mouse dragging for a particular button. Callback is called
         with x, y, dx, dy as arguments.
 
@@ -20,13 +22,13 @@ class MouseDragCallback:
             Axes to attach the callback to.
         button : int
             Which button to respond to (0: Left, 3: Right).
-        drag_callback : callable
+        drag_callback : callable, optional
             Which function to call when dragging takes place. Note that this function should have
             the following input signature: fun(MouseDragEvent). MouseDragEvent contains x, y,
             dx and dy which are all defined in data coordinates.
-        press_callback : callable
+        press_callback : callable, optional
             Function to call when drag is initiated. Must return True if it is a valid drag.
-        release_callback : callable
+        release_callback : callable, optional
             Function to call when drag is released.
         """
         self._axes = axes
@@ -52,12 +54,17 @@ class MouseDragCallback:
             self._callback_ids["press"] = self._axes.get_figure().canvas.mpl_connect(
                 "button_press_event", lambda event: self.button_down(event)
             )
+
             self._callback_ids["release"] = self._axes.get_figure().canvas.mpl_connect(
                 "button_release_event", lambda event: self.button_release(event)
             )
-            self._callback_ids["motion"] = self._axes.get_figure().canvas.mpl_connect(
-                "motion_notify_event", lambda event: self.handle_motion(event)
-            )
+
+            if self._drag_callback:
+                self._callback_ids["motion"] = self._axes.get_figure().canvas.mpl_connect(
+                    "motion_notify_event", lambda event: self.handle_motion(event)
+                )
+
+            self._axes.get_figure().canvas.flush_events()
         else:
             self.dragging = False
 

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -743,7 +743,7 @@ def _get_default_parameters(kymo, channel):
             "Minimum number of frames a spot has to be detected in to be considered.",
             "int",
             3,
-            *(1, 10),
+            *(2, 10),
             True,
             r"Minimum length defines the minimum number of points a tracked line must contain for "
             r"it to be considered valid. Reducing this parameter can be effective in reducing "

--- a/lumicks/pylake/nb_widgets/tests/test_mouse.py
+++ b/lumicks/pylake/nb_widgets/tests/test_mouse.py
@@ -62,7 +62,7 @@ def test_mouse_drag(mockevent):
 def test_set_active():
     ax = open_plot()
     button = 1
-    mouse_drag = MouseDragCallback(ax, button, [])
+    mouse_drag = MouseDragCallback(ax, button, lambda x: x)
 
     # Callbacks should be on initially
     for cib in mouse_drag._callback_ids.values():


### PR DESCRIPTION
**Why this PR?**
Nothing too exciting, but requested more than once, this PR adds a split action to the kymotracker.

![split_tracks](https://user-images.githubusercontent.com/19836026/232106238-b3335c43-9da9-4d52-b653-2d7620629f2c.gif)

Note that I piggybacked a few improvements for the localization data on this PR, which allows us to not lose the Gaussian refinement metadata if it exists.