### PR TITLE
mock_file: Add comment that `MockDataFile_v2` is an external dependency

### DIFF
--- a/lumicks/pylake/tests/data/mock_file.py
+++ b/lumicks/pylake/tests/data/mock_file.py
@@ -46,6 +46,7 @@ class MockDataFile_v1:
 
 
 class MockDataFile_v2(MockDataFile_v1):
+    # CAVE: Please respect that `MockDataFile_v2` is used by another Lumicks project
 
     def get_file_format_version(self):
         return 2


### PR DESCRIPTION
## Description
One project uses unit tests. One of the tests uses the class `MockDataFile_v2` from Pylake. To ensure the corresponding team will be aware of future changes of `MockDataFile_v2`, I added a comment to this class mentioning the external usage.