### PR TITLE
mock_confocal: don't explicitly write SampleFormat.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 
 * Fixed bug that could lead to mutability of `Kymo` and `Scan` through `.get_image()` or `.timestamps`. This bug was introduced in `0.7.2`. Grabbing a single color image from a `Scan` or `Kymo` using `.get_image()` returns a reference to an internal image cache. This numpy array was write-able and modifying data in the returned image would result in future calls to `.get_image()` returning the modified data rather than the original `Kymo` or `Scan` image. Timestamps obtained from `.timestamps` were similarly affected. These arrays are now returned non-writeable.
 * Fixed a bug that would round the center of the window to the incorrect pixel when using `KymoTrack.sample_from_image()`. Pixels are defined with their origin at the center of the pixel, whereas this function incorrectly assumed that the origin was on the edge of the pixel. The effects of this bug are larger for small windows.
+* Fixed a bug where we passed a `SampleFormat` tag while saving to `tiff` using `tifffile`. However, `tifffile` infers the `SampleFormat` automatically from the datatype of the `numpy` array it is passed. This produced warnings on the latest version of `tifffile` when running the benchmark.
 
 #### Improvements
 

--- a/lumicks/pylake/tests/data/mock_widefield.py
+++ b/lumicks/pylake/tests/data/mock_widefield.py
@@ -185,8 +185,6 @@ def write_tiff_file(image, description, n_frames, filename):
 
     # Orientation = ORIENTATION.TOPLEFT
     tag_orientation = (274, "H", 1, 1, False)
-    # SampleFormat = SAMPLEFORMAT.UINT
-    tag_sample_format = (339, "H", channels, (1,) * channels, False)
 
     with tifffile.TiffWriter(filename) as tif:
         for n, frame in enumerate(movie):
@@ -198,5 +196,5 @@ def write_tiff_file(image, description, n_frames, filename):
                 software="Bluelake Unknown",
                 metadata=None,
                 contiguous=False,
-                extratags=(tag_orientation, tag_sample_format, tag_datetime),
+                extratags=(tag_orientation, tag_datetime),
             )


### PR DESCRIPTION
**Why this PR?**
We don't need to store the `SampleFormat` (which conveys the `datatype`) ourselves.

`tifffile` already infers this from the `numpy` `dtype` and sets this themselves in write [here](https://github.com/cgohlke/tifffile/blob/master/tifffile/tifffile.py#L2726)

It used to ignore it if it was already there, but in the most recent version it produces a [warning](https://github.com/cgohlke/tifffile/blob/master/tifffile/tifffile.py#L118). These warnings were visible when running the benchmark:

```
<tifffile.TiffWriter 'bench_tiff.tiff'> not writing extratag 339
<tifffile.TiffWriter 'bench_tiff.tiff'> not writing extratag 339
<tifffile.TiffWriter 'bench_tiff.tiff'> not writing extratag 339
```