### PR TITLE
Enable `KymoTrackGroup` with multiple source `Kymo`s

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## v1.0.1 | t.b.d.
+## v1.1.0 | t.b.d.
 
 #### New features
 
 * Added [`DwelltimeModel.profile_likelihood()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.DwelltimeModel.html#lumicks.pylake.DwelltimeModel.profile_likelihood) for calculating profile likelihoods for dwell time analysis. These can be used to determine confidence intervals and assess whether the model has too many parameters (i.e., if a model with fewer components would be sufficient).
 * Added functionality to split tracks in the Kymotracking widget.
+* Enabled adding `KymoTrackGroup`s with tracks from different source kymographs. *Note that certain features (e.g., `KymoTrackGroup.ensemble_msd()` and `KymoTrackGroup.ensemble_diffusion("ols")`) require that all source kymographs have the same pixel size and scan line times.*
 
 #### Bug fixes
 

--- a/lumicks/pylake/kymotracker/detail/msd_estimation.py
+++ b/lumicks/pylake/kymotracker/detail/msd_estimation.py
@@ -1028,7 +1028,7 @@ def estimate_diffusion_cve(
     )
 
 
-def ensemble_cve(kymotracks):
+def ensemble_cve(kymotracks, calculate_localization_var=True):
     """Calculate ensemble-based CVE.
 
     Determines the weighted average of the mean and standard error of the CVE estimates.
@@ -1040,6 +1040,16 @@ def ensemble_cve(kymotracks):
     ----------
     kymotracks : lumicks.pylake.kymotracker.kymotrack.KymoTrackGroup
         Group of kymotracks
+    calculate_localization_var : bool
+        If localization variance can be calculated. Must be False if source kymographs
+        do not have the same line times or pixel sizes.
+
+    Warns
+    -----
+    RuntimeWarning
+        if `method == "cve"` and the source kymographs do not have the same line times
+        or pixel sizes. As a result, the localization variance and variance of the localization
+        variance not be available. Estimates that are unavailable are returned as `np.nan`.
 
     References
     ----------
@@ -1066,8 +1076,11 @@ def ensemble_cve(kymotracks):
     ensemble_mean, ensemble_mean_var = mean_var(
         np.array([c.value for c in cve_based]), counts, counts_sum
     )
-    ensemble_localization_var, var_of_localization_var = mean_var(
-        np.array([c.localization_variance for c in cve_based]), counts, counts_sum
+
+    ensemble_localization_var, var_of_localization_var = (
+        mean_var(np.array([c.localization_variance for c in cve_based]), counts, counts_sum)
+        if calculate_localization_var
+        else (np.nan, np.nan)
     )
 
     return DiffusionEstimate(

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -411,6 +411,7 @@ def refine_tracks_centroid(tracks, track_width=None, bias_correction=True):
            shape. Optics express, 16(18), 14064-14075.
     """
     tracks = KymoTrackGroup(tracks) if isinstance(tracks, (list, tuple)) else tracks
+    tracks._validate_single_source("Centroid refinement")
 
     if not tracks:
         return KymoTrackGroup([])
@@ -484,6 +485,8 @@ def refine_tracks_gaussian(
     """
     if overlap_strategy not in ("ignore", "skip", "multiple"):
         raise ValueError("Invalid overlap strategy selected.")
+
+    tracks._validate_single_source("Gaussian refinement")
 
     if not tracks:
         return KymoTrackGroup([])

--- a/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
@@ -1,0 +1,264 @@
+import re
+import pytest
+from copy import copy
+from lumicks.pylake.kymotracker.kymotrack import *
+from lumicks.pylake.kymotracker.kymotracker import refine_tracks_centroid, refine_tracks_gaussian
+from lumicks.pylake.kymo import _kymo_from_array
+
+
+@pytest.fixture(scope="module")
+def kymos():
+    image = np.random.poisson(10, size=(10, 10, 3))
+
+    def make_kymo(line_time_seconds, pixel_size_um):
+        return _kymo_from_array(
+            image,
+            "rgb",
+            start=np.int64(20e9),
+            line_time_seconds=line_time_seconds,
+            pixel_size_um=pixel_size_um,
+            name="big & long",
+        )
+
+    return (
+        make_kymo(10e-4, 0.05),
+        make_kymo(10e-4, 0.1),
+        make_kymo(10e-3, 0.05),
+        make_kymo(10e-3, 0.1),
+    )
+
+
+@pytest.fixture(scope="module")
+def coordinates():
+    time_indices = ([1, 2, 3], [4, 6, 7], [1, 2, 3], [4, 6, 7])
+    position_indices = ([4, 5, 6], [1, 7, 7], [1, 2, 3], [1, 2, 3])
+    return time_indices, position_indices
+
+
+def check_attributes(tracks, expected_line_times, expected_pixel_sizes, expected_calibration_unit):
+    assert set([kymo.line_time_seconds for kymo in tracks._kymos]) == set(expected_line_times)
+    assert set([kymo.pixelsize_um[0] for kymo in tracks._kymos]) == set(expected_pixel_sizes)
+    assert set([kymo._calibration.unit for kymo in tracks._kymos]) == set(expected_calibration_unit)
+
+
+def test_empty_constructor():
+    tracks = KymoTrackGroup([])
+    assert len(tracks) == 0
+    assert tracks._kymos == ()
+    check_attributes(tracks, [], [], [])
+
+    tracks = KymoTrackGroup([]) + tracks
+    assert len(tracks) == 0
+    assert tracks._kymos == ()
+    check_attributes(tracks, [], [], [])
+
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape("No channel associated with this empty group (no tracks available)"),
+    ):
+        tracks._channel
+
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape("No kymo associated with this empty group (no tracks available)"),
+    ):
+        tracks.plot()
+
+
+def test_constructor(kymos, coordinates):
+    kymo = kymos[0]
+    time_indices, position_indices = coordinates
+    raw_tracks = [KymoTrack(t, p, kymo, "green") for t, p in zip(time_indices, position_indices)]
+    raw_tracks_red = [KymoTrack(t, p, kymo, "red") for t, p in zip(time_indices, position_indices)]
+
+    # construct from single source
+    tracks = KymoTrackGroup(raw_tracks)
+    assert len(tracks) == 4
+    assert tracks._kymos == (kymo,)
+    check_attributes(tracks, [10e-4], [0.05], ["um"])
+
+    # construct with duplicate track
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Some tracks appear multiple times. The provided tracks must be unique."),
+    ):
+        tracks = KymoTrackGroup([*raw_tracks, raw_tracks[0]])
+
+    # construct from single source, different channels
+    with pytest.raises(
+        ValueError,
+        match=re.escape("All tracks must be from the same color channel."),
+    ):
+        tracks = KymoTrackGroup([*raw_tracks[:2], *raw_tracks_red[2:]])
+
+
+def test_extend_single_source(kymos, coordinates):
+    kymo = kymos[0]
+    time_indices, position_indices = coordinates
+    raw_tracks = [KymoTrack(t, p, kymo, "green") for t, p in zip(time_indices, position_indices)]
+    raw_tracks_red = [KymoTrack(t, p, kymo, "red") for t, p in zip(time_indices, position_indices)]
+
+    tracks1 = KymoTrackGroup(raw_tracks[:2])
+    tracks2 = KymoTrackGroup(raw_tracks[2:])
+
+    # add track
+    tracks = tracks1 + raw_tracks[2]
+    assert len(tracks) == 3
+    assert tracks._kymos == (kymo,)
+    check_attributes(tracks, [10e-4], [0.05], ["um"])
+
+    # add group
+    tracks = tracks1 + tracks2
+    assert len(tracks) == 4
+    assert tracks._kymos == (kymo,)
+    check_attributes(tracks, [10e-4], [0.05], ["um"])
+
+    # extend with single source, different channels
+    with pytest.raises(
+        ValueError,
+        match=re.escape("All tracks must be from the same color channel."),
+    ):
+        tracks1 + KymoTrackGroup(raw_tracks_red)
+
+
+def test_extend_empty(kymos, coordinates):
+    kymo = kymos[0]
+    time_indices, position_indices = coordinates
+    raw_tracks = [KymoTrack(t, p, kymo, "green") for t, p in zip(time_indices, position_indices)]
+
+    empty = KymoTrackGroup([])
+    tracks2 = KymoTrackGroup(raw_tracks)
+
+    # can't add a group to a track
+    with pytest.raises(
+        AttributeError, match="'KymoTrackGroup' object has no attribute '_localization'"
+    ):
+        tracks = tracks2[0] + empty
+
+    # add track
+    tracks = empty + tracks2[0]
+    assert len(tracks) == 1
+    assert tracks._kymos == (kymo,)
+    check_attributes(tracks, [10e-4], [0.05], ["um"])
+
+    # add group
+    tracks = empty + tracks2
+    assert len(tracks) == 4
+    assert tracks._kymos == (kymo,)
+    check_attributes(tracks, [10e-4], [0.05], ["um"])
+
+    tracks = tracks2 + empty
+    assert len(tracks) == 4
+    assert tracks._kymos == (kymo,)
+    check_attributes(tracks, [10e-4], [0.05], ["um"])
+
+
+def test_different_sources_same_attributes(kymos, coordinates):
+    kymo1 = kymos[0]
+    kymo2 = copy(kymos[0])
+    assert id(kymo1) != id(kymo2)
+
+    time_indices, position_indices = coordinates
+    tracks1 = KymoTrackGroup(
+        [KymoTrack(t, p, kymo1, "green") for t, p in zip(time_indices, position_indices)]
+    )
+    tracks2 = KymoTrackGroup(
+        [KymoTrack(t, p, kymo2, "green") for t, p in zip(time_indices, position_indices)]
+    )
+
+    tracks = tracks1[:2] + tracks2[2:]
+    assert len(tracks) == 4
+    assert tracks._kymos == (kymo1, kymo2)
+    check_attributes(tracks, [10e-4], [0.05], ["um"])
+
+
+def test_different_sources_different_attributes(kymos, coordinates):
+    time_indices, position_indices = coordinates
+
+    def make_tracks(kymo):
+        return KymoTrackGroup(
+            [KymoTrack(t, p, kymo, "green") for t, p in zip(time_indices, position_indices)]
+        )
+
+    # different line times
+    tracks1 = make_tracks(kymos[0])
+    tracks2 = make_tracks(kymos[2])
+
+    kymo_bp = kymos[0].calibrate_to_kbp(48)
+    tracks2_bp = make_tracks(kymo_bp)
+
+    tracks = tracks1 + tracks2
+    assert len(tracks) == 8
+    assert tracks._kymos == (kymos[0], kymos[2])
+    check_attributes(tracks, [10e-4, 10e-3], [0.05], ["um"])
+
+    # different pixel sizes
+    tracks1 = make_tracks(kymos[0])
+    tracks2 = make_tracks(kymos[1])
+
+    tracks = tracks1 + tracks2
+    assert len(tracks) == 8
+    assert tracks._kymos == (kymos[0], kymos[1])
+    check_attributes(tracks, [10e-4], [0.05, 0.1], ["um"])
+
+    # different line times and pixel sizes
+    tracks1 = make_tracks(kymos[0])
+    tracks2 = make_tracks(kymos[-1])
+
+    tracks = tracks1 + tracks2
+    assert len(tracks) == 8
+    assert tracks._kymos == (kymos[0], kymos[-1])
+    check_attributes(tracks, [10e-4, 10e-3], [0.05, 0.1], ["um"])
+
+    # extend with different calibrations
+    with pytest.raises(
+        ValueError,
+        match=r"All tracks must be calibrated in the same units, got {.+}\.",
+    ):
+        tracks1 + tracks2_bp
+
+
+def test_multisource_not_implemented(kymos, coordinates):
+    time_indices, position_indices = coordinates
+    tracks1 = KymoTrackGroup(
+        [KymoTrack(t, p, kymos[0], "green") for t, p in zip(time_indices, position_indices)]
+    )
+    tracks2 = KymoTrackGroup(
+        [KymoTrack(t, p, kymos[1], "green") for t, p in zip(time_indices, position_indices)]
+    )
+    tracks = tracks1 + tracks2
+
+    # TODO: the following features will be implemented in the future.
+    with pytest.raises(
+        NotImplementedError,
+        match=(
+            r"Binding profile is not supported. This group contains tracks from 2 source kymographs."
+        ),
+    ):
+        tracks._histogram_binding_profile(n_time_bins=1, bandwidth=1, n_position_points=10)
+
+    with pytest.raises(
+        NotImplementedError,
+        match=(
+            r"Centroid refinement is not supported. This group contains tracks from 2 source kymographs."
+        ),
+    ):
+        refine_tracks_centroid(tracks)
+
+    with pytest.raises(
+        NotImplementedError,
+        match=(
+            r"Gaussian refinement is not supported. This group contains tracks from 2 source kymographs."
+        ),
+    ):
+        refine_tracks_gaussian(
+            tracks, window=2, refine_missing_frames=False, overlap_strategy="ignore"
+        )
+
+    with pytest.raises(
+        NotImplementedError,
+        match=(
+            r"Dwelltime analysis is not supported. This group contains tracks from 2 source kymographs."
+        ),
+    ):
+        tracks.fit_binding_times(n_components=1)

--- a/lumicks/pylake/simulation/tests/test_diffusion.py
+++ b/lumicks/pylake/simulation/tests/test_diffusion.py
@@ -35,6 +35,3 @@ def test_add_simulated_tracks():
     params = {"diffusion_constant": 4, "steps": 10, "dt": 0.01, "num_tracks": 2}
     tracks = simulate_diffusive_tracks(**params) + simulate_diffusive_tracks(**params)
     assert len(tracks) == 4
-
-    with pytest.raises(ValueError, match="All tracks must have the same source kymograph"):
-        simulate_diffusive_tracks(**params) + simulate_diffusive_tracks(**{**params, "dt": 0.05})


### PR DESCRIPTION
**Why this PR?**
Enables global analysis across multiple kymos for various downstream analyses. The idea is that each kymo can be tracked separately and then you add all of the resulting groups together. This gives a single interface for downstream analyses regardless of single or multiple kymos tracked.

**Notes**
- Ensemble diffusion enabled for `cve` under all cases
- Ensemble diffusion for `ols` and ensemble MSD checks first if all line times and pixel sizes of the source kymos are the same; otherwise throw
- Exporting to CSV and flipping disabled for more than one source kymo
- Certain features currently raise `NotImplementedError` with this PR; will be implemented next in separate PRs
    - refinement algorithms (centroid and gaussian)
        - idea is to break combined group into single source groups, refine, and then rebuild to the original group
    - dwelltime analysis
        - idea is to allow `min` and `max` acquisition times for each dwell so that normalization constants can be calculated properly
    - `_histogram_binding_profile`
        - necessitates a change in the way time binning is performed to allow for unequal line times. This is maybe even a bug fix since currently if the number of scan lines is not a multiple of the number of frames requested per bin, the leftover scan lines are ignored in the result.
- Started a new test file to specifically test the source kymographs, including (hopefully) all possible combinations of conditions
- Tried to break this down into many commits with each only covering a certain feature or functionality; will squash it down a bit before merging