### PR TITLE
profile_likelihood: make sure plots work in the `n_components=1` case

### DIFF
--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -207,7 +207,7 @@ class DwelltimeProfiles:
             profiling (default: 0.05).
         """
         if self.n_components == 1:
-            next(iter(self.profiles), significance_level=alpha).plot()
+            next(iter(self.profiles.values())).plot(significance_level=alpha)
         else:
             plot_idx = np.reshape(np.arange(1, len(self.profiles) + 1), (-1, 2)).T.flatten()
             for idx, profile in zip(plot_idx, self.profiles.values()):

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -123,14 +123,12 @@ def test_dwelltime_profiles(exponential_data):
         profiles.get_interval("amplitude", 0, 0.001)
 
 
-@pytest.mark.filterwarnings("ignore:Values in x were outside bounds")
-@pytest.mark.filterwarnings("ignore:divide by zero encountered")
-@pytest.mark.filterwarnings("ignore:invalid value encountered")
-def test_dwelltime_profile_plots():
+@pytest.mark.parametrize("n_components", [2, 1])
+def test_dwelltime_profile_plots(n_components):
     """Verify that the threshold moves appropriately"""
     fit = DwelltimeModel(
         np.array([10.0, 5.0, 4.0, 3.0, 3.0, 2.0, 2.0, 1.0]),
-        2,
+        n_components,
         min_observation_time=1e-4,
         max_observation_time=1e4,
     )


### PR DESCRIPTION
**Why this PR?**
Found this plotting bug while working on the generalization of dwelltime analysis.

Not sure how this happened or why it wasn't covered, but luckily it was caught before this feature was ever released. Added a test so that this case is covered as well.

I left the test and fix as separate commits so you can verify that it does indeed hit the bug. I'll squash them down to one commit before merging.