### PR TITLE
dwelltime analysis: enabling per observation pdf support limits for the `DwelltimeModel`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 
 * Added [`DwelltimeModel.profile_likelihood()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.DwelltimeModel.html#lumicks.pylake.DwelltimeModel.profile_likelihood) for calculating profile likelihoods for dwell time analysis. These can be used to determine confidence intervals and assess whether the model has too many parameters (i.e., if a model with fewer components would be sufficient).
 * Added functionality to split tracks in the Kymotracking widget.
-* Added functionality to provide minimum and maximum observation times per data point to `DwelltimeModel`.
+* Added functionality to provide minimum and maximum observation times per data point to `DwelltimeModel` and `DwelltimeBootstrap`.
 * Enabled adding `KymoTrackGroup`s with tracks from different source kymographs. *Note that certain features (e.g., `KymoTrackGroup.ensemble_msd()` and `KymoTrackGroup.ensemble_diffusion("ols")`) require that all source kymographs have the same pixel size and scan line times.*
 
 #### Bug fixes

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Added [`DwelltimeModel.profile_likelihood()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.DwelltimeModel.html#lumicks.pylake.DwelltimeModel.profile_likelihood) for calculating profile likelihoods for dwell time analysis. These can be used to determine confidence intervals and assess whether the model has too many parameters (i.e., if a model with fewer components would be sufficient).
 * Added functionality to split tracks in the Kymotracking widget.
+* Added functionality to provide minimum and maximum observation times per data point to `DwelltimeModel`.
 * Enabled adding `KymoTrackGroup`s with tracks from different source kymographs. *Note that certain features (e.g., `KymoTrackGroup.ensemble_msd()` and `KymoTrackGroup.ensemble_diffusion("ols")`) require that all source kymographs have the same pixel size and scan line times.*
 
 #### Bug fixes
@@ -13,6 +14,7 @@
 * Fixed bug that could lead to mutability of `Kymo` and `Scan` through `.get_image()` or `.timestamps`. This bug was introduced in `0.7.2`. Grabbing a single color image from a `Scan` or `Kymo` using `.get_image()` returns a reference to an internal image cache. This numpy array was write-able and modifying data in the returned image would result in future calls to `.get_image()` returning the modified data rather than the original `Kymo` or `Scan` image. Timestamps obtained from `.timestamps` were similarly affected. These arrays are now returned non-writeable.
 * Fixed a bug that would round the center of the window to the incorrect pixel when using `KymoTrack.sample_from_image()`. Pixels are defined with their origin at the center of the pixel, whereas this function incorrectly assumed that the origin was on the edge of the pixel. The effects of this bug are larger for small windows.
 * Fixed a bug where we passed a `SampleFormat` tag while saving to `tiff` using `tifffile`. However, `tifffile` infers the `SampleFormat` automatically from the datatype of the `numpy` array it is passed. This produced warnings on the latest version of `tifffile` when running the benchmark.
+* Ensure that the probability density returns zero outside its support for `DwelltimeModel.pdf()`. Prior to this change, non-zero values would be returned outside the observation limits of the dwelltime model.
 
 #### Improvements
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 * Fixed a bug that would round the center of the window to the incorrect pixel when using `KymoTrack.sample_from_image()`. Pixels are defined with their origin at the center of the pixel, whereas this function incorrectly assumed that the origin was on the edge of the pixel. The effects of this bug are larger for small windows.
 * Fixed a bug where we passed a `SampleFormat` tag while saving to `tiff` using `tifffile`. However, `tifffile` infers the `SampleFormat` automatically from the datatype of the `numpy` array it is passed. This produced warnings on the latest version of `tifffile` when running the benchmark.
 * Ensure that the probability density returns zero outside its support for `DwelltimeModel.pdf()`. Prior to this change, non-zero values would be returned outside the observation limits of the dwelltime model.
+* Fixed a bug where `DwelltimeModel.hist()` produces one less bin than requested with `n_bins`.
 
 #### Improvements
 

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -797,7 +797,7 @@ class DwelltimeModel:
         else:
             raise ValueError("spacing must be either 'log' or 'linear'")
 
-        bins = scale(*limits, n_bins)
+        bins = scale(*limits, n_bins + 1)
         hist_kwargs = {"facecolor": "#cdcdcd", "edgecolor": "#aaaaaa", **(hist_kwargs or {})}
         component_kwargs = {"marker": "o", "ms": 3, **(component_kwargs or {})}
         fit_kwargs = {"color": "k", **(fit_kwargs or {})}

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -92,6 +92,26 @@ def test_fit_parameters(exponential_data):
     np.testing.assert_allclose(fit.rate_constants, [1 / 1.50634996, 1 / 5.46227291], rtol=1e-5)
 
 
+@pytest.mark.parametrize(
+    "min_obs, max_obs, ref_ci",
+    [
+        (0.1, 1.4, (0.2663655, 1.4679362)),
+        (np.array([0.1, 0.1, 0.3, 0.3]), 1.3, (0.2068400, 1.3463159)),
+        (0.1, np.array([0.5, 0.5, 1.3, 1.3]), (0.7838319, 1.4147650)),
+        (
+            np.array([0.1, 0.1, 0.3, 0.3]), np.array([0.5, 0.5, 1.3, 1.3]), (0.3497069, 1.3528150)
+        ),
+    ]
+)
+def test_bootstrap_multi(min_obs, max_obs, ref_ci):
+    np.random.seed(123)
+    data = np.array([0.2, 0.3, 0.6, 1.2])
+    fit = DwelltimeModel(data, 1, min_observation_time=min_obs, max_observation_time=max_obs)
+    bootstrap = fit.calculate_bootstrap(iterations=4)
+    ci = bootstrap.get_interval("lifetime", 0)
+    np.testing.assert_allclose(ci, ref_ci, rtol=1e-5)
+
+
 @pytest.mark.slow
 def test_bootstrap(exponential_data):
     # double exponential data


### PR DESCRIPTION
**Why this PR?**
This model forms the backend for the dwell time analysis on a `KymoLineGroup`.

To enable global analysis, we need to take into account that observations coming from different kymographs may have had different support (different range of possible observation times). For example, the minimum observable dwelltime depends on the line time of a kymograph.

One thing that's unexpectedly a little tricky is how to handle plotting. When dealing with two different observation limits, it is entirely possible that one covers a bin only partially. This means that we have to take into account both the weighting inside the pdf, but also the effect discretization has on the model.

Not taking the partial bin effect into account:
![image](https://user-images.githubusercontent.com/19836026/234267537-8bbddf1d-3e9a-4d31-8c73-14b3c23535c1.png)

Taking both into account:
![image](https://user-images.githubusercontent.com/19836026/234266934-e79a0a22-f650-4755-bfdb-ab23cfe7370f.png)

If you discretize less, you can see what's really happening here:
![image](https://user-images.githubusercontent.com/19836026/234280681-d8f3da99-a470-43b1-b91a-2d1d7791a1c8.png)

For now, I just evaluate the PDF at a larger number of points. Basically, for every bin I sample a set number of points. The `10000` default is somewhat arbitrary, but it doesn't take very long at all, and should be fine enough for all purposes.