### PR TITLE
kymotrackgroup: multi-kymo dwell time analysis

### DIFF
--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -1052,6 +1052,18 @@ class KymoTrackGroup:
         """
         export_kymotrackgroup_to_csv(filename, self, delimiter, sampling_width)
 
+    def _tracks_by_kymo(self):
+        """Find tracks for each `Kymo` in the group.
+
+        Returns
+        -------
+        dict of KymoTrackGroup
+            returns a dictionary where the keys are Kymos which the associated tracks
+        """
+        return [
+            KymoTrackGroup([track for track in self if track._kymo == kymo]) for kymo in self._kymos
+        ]
+
     def fit_binding_times(
         self, n_components, *, exclude_ambiguous_dwells=True, tol=None, max_iter=None
     ):

--- a/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
@@ -255,13 +255,6 @@ def test_multisource_not_implemented(kymos, coordinates):
             tracks, window=2, refine_missing_frames=False, overlap_strategy="ignore"
         )
 
-    with pytest.raises(
-        NotImplementedError,
-        match=(
-            r"Dwelltime analysis is not supported. This group contains tracks from 2 source kymographs."
-        ),
-    ):
-        tracks.fit_binding_times(n_components=1)
 
 def test_tracks_by_kymo(kymos, coordinates):
     time_indices, position_indices = coordinates
@@ -279,4 +272,3 @@ def test_tracks_by_kymo(kymos, coordinates):
         assert len(tracks_group) == len(tracks_raw)
         for track_group, track_raw in zip(tracks_group, tracks_raw):
             id(track_group) == id(track_raw)
-

--- a/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
@@ -262,3 +262,21 @@ def test_multisource_not_implemented(kymos, coordinates):
         ),
     ):
         tracks.fit_binding_times(n_components=1)
+
+def test_tracks_by_kymo(kymos, coordinates):
+    time_indices, position_indices = coordinates
+
+    def make_tracks(kymo):
+        return KymoTrackGroup(
+            [KymoTrack(t, p, kymo, "green") for t, p in zip(time_indices, position_indices)]
+        )
+
+    tracks = [make_tracks(k) for k in (kymos[0], kymos[-1])]
+    merged_group = (tracks[0] + tracks[-1])
+    tracks_from_group = merged_group._tracks_by_kymo()
+
+    for tracks_raw, tracks_group in zip(tracks, tracks_from_group):
+        assert len(tracks_group) == len(tracks_raw)
+        for track_group, track_raw in zip(tracks_group, tracks_raw):
+            id(track_group) == id(track_raw)
+


### PR DESCRIPTION
**Why this PR?**
The generalization of dwell time analysis to using multiple minimum and maximum observation times introduced in [this](https://github.com/lumicks/pylake/pull/501) PR was meant to support global analysis on `KymoTrackGroup`s containing lines originating from multiple kymographs. This PR hooks up these two.