### PR TITLE
docs: bump bibtex requirement

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,6 @@ numpy
 scipy
 sphinx==4.5.0
 sphinx_rtd_theme==1.0.0
-sphinxcontrib-bibtex==2.4.1
+sphinxcontrib-bibtex==2.5.0
 docutils<0.18
 myst-parser


### PR DESCRIPTION
Was working on some docs. Noticed they weren't building on 3.11.
 
Bumping the `bibtex` requirement is needed to support building docs on Python 3.11. See this issue: https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/284