### PR TITLE
kymotrack: add photon counts as an attribute

### DIFF
--- a/docs/tutorial/figures/kymotracking/gau_refined_counts.png
+++ b/docs/tutorial/figures/kymotracking/gau_refined_counts.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48068958d0a541ac796b92a1f57b2d9c980fc7c090e04f21e821ff91c3c9edcb
+size 75376

--- a/docs/tutorial/figures/kymotracking/gaussian_refined_counts_offset.png
+++ b/docs/tutorial/figures/kymotracking/gaussian_refined_counts_offset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fc0788fd5024720b8638f71ef1346297aaf451d0600a3033911c4604f88eca9
+size 67459

--- a/docs/tutorial/figures/kymotracking/longest_track.png
+++ b/docs/tutorial/figures/kymotracking/longest_track.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d42ad6a65b0d825468e2da880c231d1b4971f3cca1f38d89d3b3af9cc6c38704
-size 56236
+oid sha256:2cadc4d283ccfe838a47ad4680ab5eb7e0551b0da96e20fa5562e7b72b2e4aea
+size 37342

--- a/docs/tutorial/figures/kymotracking/photon_counts_greedy.png
+++ b/docs/tutorial/figures/kymotracking/photon_counts_greedy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:327b81fab663ca5fb8f511315d4e90c99b7cf89cc47737ffdd7cfa2d13b4b130
+size 53896

--- a/lumicks/pylake/kymotracker/detail/localization_models.py
+++ b/lumicks/pylake/kymotracker/detail/localization_models.py
@@ -47,6 +47,21 @@ class LocalizationModel:
 
 
 @dataclass(frozen=True)
+class CentroidLocalizationModel(LocalizationModel):
+    """Helper class to hold refinement optimization parameters.
+
+    Parameters
+    -----------
+    position : numpy.ndarray
+        Spatial coordinates in physical units.
+    total_photons : numpy.ndarray
+        Array of integrated photon counts for each time point.
+    """
+
+    total_photons: np.ndarray
+
+
+@dataclass(frozen=True)
 class GaussianLocalizationModel(LocalizationModel):
     """Helper (base) class to hold refinement optimization parameters.
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -186,6 +186,24 @@ class KymoTrack:
     def _image(self):
         return self._kymo.get_image(self._channel)
 
+    @property
+    def photon_counts(self):
+        """Photon counts
+
+        Provides an estimate of the photon counts for each point in the track. The value is
+        calculated differently depending on the refinement method:
+
+        - for a tracks originating from tracking without additional refinement or from centroid
+          refinement, the counts are estimated by summing an odd number of pixels around the peak
+          position.
+        - for tracks originating from Gaussian refinement, the photon count estimate is given
+          by the fitted integrated area of the peak.
+        """
+        try:
+            return self._localization.total_photons
+        except AttributeError:
+            raise AttributeError("Photon counts are unavailable for this KymoTrack.")
+
     def __str__(self):
         return f"KymoTrack(N={len(self._time_idx)})"
 

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -220,7 +220,10 @@ def track_greedy(
     )
 
     tracks = [
-        KymoTrack(track.time_idx, track.coordinate_idx, kymograph, channel) for track in tracks
+        KymoTrack._from_centroid_estimate(
+            track.time_idx, track.coordinate_idx, kymograph, channel, half_width_pixels
+        )
+        for track in tracks
     ]
 
     return KymoTrackGroup(tracks)
@@ -470,8 +473,15 @@ def refine_tracks_centroid(tracks, track_width=None, bias_correction=True):
     track_ids = np.hstack(
         [np.full(len(track.time_idx), j) for j, track in enumerate(interpolated_tracks)]
     )
+
     new_tracks = [
-        track._with_coordinates(time_idx[track_ids == j], coordinate_idx[track_ids == j])
+        KymoTrack._from_centroid_estimate(
+            time_idx[track_ids == j],
+            coordinate_idx[track_ids == j],
+            interpolated_tracks[j]._kymo,
+            interpolated_tracks[j]._channel,
+            half_width_pixels,
+        )
         for j, track in enumerate(interpolated_tracks)
     ]
     return KymoTrackGroup(new_tracks)

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -1325,3 +1325,20 @@ def test_no_motion_blur(blank_kymo):
         "constant.",
     ):
         track.estimate_diffusion("cve", localization_variance=1)
+
+
+def test_photon_counts_api(blank_kymo):
+    with pytest.raises(AttributeError, match="Photon counts are unavailable for this KymoTrack."):
+        KymoTrack([1, 2, 3], [1, 2, 3], blank_kymo, "red").photon_counts
+
+    np.testing.assert_equal(
+        KymoTrack(
+            [1, 2, 3],
+            GaussianLocalizationModel(
+                [1, 2, 3], [1, 2, 5], [1, 1, 1], [0, 0, 0], [False, True, False]
+            ),
+            blank_kymo,
+            "red",
+        ).photon_counts,
+        [1, 2, 5],
+    )

--- a/lumicks/pylake/kymotracker/tests/test_loc_models.py
+++ b/lumicks/pylake/kymotracker/tests/test_loc_models.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from lumicks.pylake.kymotracker.detail.localization_models import *
+from lumicks.pylake.kymotracker.detail.localization_models import CentroidLocalizationModel
 
 
 def test_default_model():
@@ -107,14 +108,20 @@ def test_incompatible_add():
     ],
 )
 def test_gaussian_model_getitem(slc):
-    m1 = GaussianLocalizationModel(
-        np.arange(3) * 0.2,
-        np.array([5, 6, 8]),
-        np.array([0.5, 0.5, 0.6]),
-        np.array([1, 2, 1]),
-        np.array([False, True, False]),
-    )
+    all_fields = {
+        "position": np.arange(3) * 0.2,
+        "total_photons": np.array([5, 6, 8]),
+        "sigma": np.array([0.5, 0.5, 0.6]),
+        "background": np.array([1, 2, 1]),
+        "_overlap_fit": np.array([False, True, False]),
+    }
 
-    fields = ["position", "total_photons", "sigma", "background", "_overlap_fit"]
-    for f in fields:
-        np.testing.assert_allclose(getattr(m1[slc], f), getattr(m1, f)[slc])
+    for model, fields in (
+        (LocalizationModel, {"position": all_fields["position"]}),
+        (CentroidLocalizationModel, dict(list(all_fields.items())[:2])),
+        (GaussianLocalizationModel, all_fields),
+    ):
+        m1 = model(**fields)
+
+        for f in fields.keys():
+            np.testing.assert_allclose(getattr(m1[slc], f), getattr(m1, f)[slc])


### PR DESCRIPTION
**Why this PR?**
We need an attribute that just has the photon counts when we need them (no matter how they were refined). This is especially important since in the future, we'd like to have photon counts originating from Gaussian refinement as well.

<img width="583" alt="image" src="https://github.com/lumicks/pylake/assets/19836026/9ba2aebf-6db0-4be4-a3d9-d6722e2690b6">

*If you squint hard enough, maybe you can see some multimer binding*

Docs build here: https://lumicks-pylake.readthedocs.io/en/count_dem_photons/tutorial/kymotracking.html

There are two open points left remaining after this PR:
1. How to best deal with the file export/import when a track has been refined via different methods. I have opened a separate ticket to figure out a way how to handle this. The CSV format is not ideal for storing metadata and ideally, we should move to something more readily extensible.
2. If we want to explore multimer binding with this, we need a model that describes what we see well. For this, we ideally need some good multimer data. The data shown here is aggressively downsampled prior to analysis. Without it, the counts are relatively low, and the distributions far less peaky.