### PR TITLE
Finalize global binding profile

### DIFF
--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -730,6 +730,18 @@ def test_binding_profile_histogram():
     with pytest.raises(ValueError, match="Number of time bins must be > 0."):
         tracks._histogram_binding_profile(0, 0.2, 4)
 
+    # disallowed for multiple source kymos
+    combined_tracks = tracks + KymoTrackGroup(
+        [KymoTrack(np.array([7, 8, 9]), np.array([1, 1, 1]), copy(kymo), "red")]
+    )
+    with pytest.raises(
+        NotImplementedError,
+        match=(
+            r"Binding profile is not supported. This group contains tracks from 2 source kymographs."
+        ),
+    ):
+        combined_tracks._histogram_binding_profile(n_time_bins=1, bandwidth=1, n_position_points=10)
+
 
 def test_fit_binding_times(blank_kymo):
     k1 = KymoTrack(np.array([0, 1, 2]), np.zeros(3), blank_kymo, "red")

--- a/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
@@ -218,26 +218,6 @@ def test_different_sources_different_attributes(kymos, coordinates):
         tracks1 + tracks2_bp
 
 
-def test_multisource_not_implemented(kymos, coordinates):
-    time_indices, position_indices = coordinates
-    tracks1 = KymoTrackGroup(
-        [KymoTrack(t, p, kymos[0], "green") for t, p in zip(time_indices, position_indices)]
-    )
-    tracks2 = KymoTrackGroup(
-        [KymoTrack(t, p, kymos[1], "green") for t, p in zip(time_indices, position_indices)]
-    )
-    tracks = tracks1 + tracks2
-
-    # TODO: the following features will be implemented in the future.
-    with pytest.raises(
-        NotImplementedError,
-        match=(
-            r"Binding profile is not supported. This group contains tracks from 2 source kymographs."
-        ),
-    ):
-        tracks._histogram_binding_profile(n_time_bins=1, bandwidth=1, n_position_points=10)
-
-
 def test_tracks_by_kymo(kymos, coordinates):
     time_indices, position_indices = coordinates
 


### PR DESCRIPTION
**Why this PR?**
For now we're going to specifically disallow plotting binding profiles for `KymoTrackGroup`s that have more than one source kymo. The usefulness of such a plot is questionable and there are a ton of corner cases that could cause problems and/or could be dealt with in multiple ways (none of which are ideal). We can revisit in the future depending on user feedback