### PR TITLE
kymotrack/kymotrackgroup: allow plotting the localization fit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.0 | t.b.d.
+
+#### New features
+
+* Added `KymoTrack.plot_fit()` to show the fitted model obtained from gaussian refinement.
+
 ## v1.1.0 | 2023-05-17
 
 #### New features

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 #### New features
 
-* Added `KymoTrack.plot_fit()` to show the fitted model obtained from gaussian refinement.
+* Added `KymoTrack.plot_fit()` and `KymoTrackGroup.plot_fit()` to show the fitted model obtained from gaussian refinement.
 
 ## v1.1.0 | 2023-05-17
 

--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -30,6 +30,51 @@ def first(iterable, condition=lambda x: True):
     return next(x for x in iterable if condition(x))
 
 
+def replace_key_aliases(dictionary, *key_alias_lists):
+    """Replace key aliases by a specific one.
+
+    This function is especially useful for validating user-supplied plotting kwargs against
+    pylake-supplied default plotting parameters. For instance, a user could supply either
+    `color="red"` or `c="red"` to specify the line color.
+
+    Parameters
+    ----------
+    dictionary : dict
+        Python dictionary.
+    *key_alias_lists : list
+        Each argument is a list of key aliases. When a key in this list is found, it is converted
+        to the first alias for that key in the list.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys replaced by their first alias.
+
+    Raises
+    ------
+    ValueError
+        If multiple keys are provided for the same alias.
+
+    Examples
+    --------
+    ::
+
+        def plot_line(x, y, **kwargs):
+            default_kwargs = {"color": "red"}
+            plt.plot(x, y, **default_kwargs | replace_key_aliases(kwargs, ["color", "c"])
+    """
+    for aliases in key_alias_lists:
+        used_keys = [key for key in aliases if key in dictionary.keys()]
+        if len(used_keys) > 1:
+            raise ValueError(
+                f"Multiple keys provided which are aliases for same property: {used_keys}"
+            )
+        elif len(used_keys) == 1:
+            dictionary[aliases[0]] = dictionary.pop(used_keys[0])
+
+    return dictionary
+
+
 def unique(input_list):
     unique_list = []
     [unique_list.append(x) for x in input_list if x not in unique_list]

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -538,6 +538,34 @@ def test_empty_binding_histogram():
         KymoTrackGroup([]).plot_binding_histogram("binding")
 
 
+def test_kymotrackgroup_tracks_in_frame(blank_kymo):
+    tracks = KymoTrackGroup([])
+    assert len(tracks._tracks_in_frame(0)) == 0
+
+    tracks = KymoTrackGroup(
+        [
+            KymoTrack(np.array([0, 3, 5]), np.array([1.0, 3.0, 3.0]), blank_kymo, "red"),
+            KymoTrack(np.array([3, 4, 5]), np.array([1.0, 3.0, 3.0]), blank_kymo, "red"),
+        ]
+    )
+
+    # For each of the KymoTrack frames we get a list of track indices and indices that correspond to
+    # the index within the track of where we intersect with this frame of the kymograph.
+    reference_values = (
+        (0, [(0, 0)]),
+        (1, []),
+        (2, []),
+        (3, [(0, 1), (1, 0)]),
+        (4, [(1, 1)]),
+        (5, [(0, 2), (1, 2)]),
+    )
+    for kymo_frame_idx, reference_data in reference_values:
+        tracks_in_frame = tracks._tracks_in_frame(kymo_frame_idx)
+        assert len(tracks_in_frame) == len(reference_data)
+        for track_data, reference_track_data in zip(tracks_in_frame, reference_data):
+            np.testing.assert_equal(track_data, reference_track_data)
+
+
 def test_kymotrackgroup_copy(blank_kymo):
     k1 = KymoTrack(np.array([1, 2, 3]), np.array([1, 1, 1]), blank_kymo, "red")
     k2 = KymoTrack(np.array([6, 7, 8]), np.array([2, 2, 2]), blank_kymo, "red")

--- a/lumicks/pylake/kymotracker/tests/test_loc_models.py
+++ b/lumicks/pylake/kymotracker/tests/test_loc_models.py
@@ -9,7 +9,7 @@ def test_default_model():
     np.testing.assert_allclose(m.position, [0.0, 0.03, 0.06, 0.09, 0.12])
 
 
-def test_gaussian_model():
+def test_gaussian_model_evaluate():
     m = GaussianLocalizationModel(
         np.arange(3) * 0.2,
         np.array([5, 6, 8]),
@@ -18,6 +18,16 @@ def test_gaussian_model():
         np.full(3, False),
     )
     np.testing.assert_allclose(m.position, [0.0, 0.2, 0.4])
+
+    position_axis = np.arange(0.0, 5 * 0.2, 0.2)
+    ref_data = [
+        [1.79788456, 1.73654028, 1.57938311, 1.38837211, 1.22184167],
+        [2.88384834, 2.95746147, 2.88384834, 2.69525973, 2.46604653],
+        [1.85186135, 2.00635527, 2.06384608, 2.00635527, 1.85186135],
+    ]
+
+    for idx, ref in enumerate(ref_data):
+        np.testing.assert_allclose(m.evaluate(position_axis, idx, 0.2), ref)
 
 
 def test_gaussian_model_overlap():
@@ -88,7 +98,7 @@ def test_incompatible_add():
 
     with pytest.raises(
         TypeError,
-        match="Incompatible localization models GaussianLocalizationModel and LocalizationModel."
+        match="Incompatible localization models GaussianLocalizationModel and LocalizationModel.",
     ):
         m1 + m2
 


### PR DESCRIPTION
**Why this PR?**
It is good for users to be able to verify their localization fits, to make sure nothing went wrong. This PR adds two methods to be able to plot them quickly.

![peak2](https://github.com/lumicks/pylake/assets/19836026/64f3798c-eab4-4145-b1d5-5a29699ff2ee)

Why is it important to plot this? Well, if a user chooses a window that's too small, they might inadvertently find themselves in the situation where the baseline eats up a large chunk of the amplitude, such as here:

<img width="577" alt="image" src="https://github.com/lumicks/pylake/assets/19836026/a13eac4a-ba9d-49db-99f7-f437641ecf72">

A similar situation would happen if you take a window that is too large, but fail to track one of the peaks inside the window.

I intend to add something to the tutorial about this feature (and how to verify that your fits are good etc), but I will keep that for the next PR since there are two PRs with changes that impact the plots in that section.