### PR TITLE
diffusion: include gaussian refinement in warning

### DIFF
--- a/lumicks/pylake/kymotracker/detail/msd_estimation.py
+++ b/lumicks/pylake/kymotracker/detail/msd_estimation.py
@@ -584,17 +584,21 @@ def estimate_diffusion_constant_simple(
         if method == "gls":
             raise RuntimeError(
                 "Your tracks cannot have missing frames when using the GLS estimator. Refine your "
-                "tracks using `lk.refine_tracks_centroid()`. Please refer to "
-                "`help(lk.refine_tracks_centroid)` for more information."
+                "tracks using `lk.refine_tracks_centroid()` or `lk.refine_tracks_gaussian()`. "
+                "Please refer to `help(lk.refine_tracks_centroid)` or "
+                "`help(lk.refine_tracks_gaussian())` for more information."
             )
         elif method == "ols":
             warnings.warn(
                 RuntimeWarning(
                     "Your tracks have missing frames. Note that this results in a poor estimate of "
                     "the standard error of the estimate. To avoid this warning, you can refine "
-                    "your tracks using `lk.refine_tracks_centroid()`. Please refer to "
-                    "`help(lk.refine_tracks_centroid)` for more information."
-                )
+                    "your tracks using `lk.refine_tracks_centroid()` or "
+                    "`lk.refine_tracks_gaussian()`. Please refer to "
+                    "`help(lk.refine_tracks_centroid)` or `help(lk.refine_tracks_gaussian)` for "
+                    "more information."
+                ),
+                stacklevel=2,
             )
 
     frame_lags, msd = calculate_msd(frame_idx, coordinate, max_lag)

--- a/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
+++ b/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
@@ -295,8 +295,9 @@ def test_skipped_sample_protection():
         match=re.escape(
             "Your tracks have missing frames. Note that this results in a poor estimate of "
             "the standard error of the estimate. To avoid this warning, you can refine "
-            "your tracks using `lk.refine_tracks_centroid()`. Please refer to "
-            "`help(lk.refine_tracks_centroid)` for more information."
+            "your tracks using `lk.refine_tracks_centroid()` or `lk.refine_tracks_gaussian()`. "
+            "Please refer to `help(lk.refine_tracks_centroid)` or `help(lk.refine_tracks_gaussian)` "
+            "for more information."
         ),
     ):
         estimate_diffusion_constant_simple(lag_idx, lag_idx**2, 1, 5, method="ols")


### PR DESCRIPTION
**Why this PR?**
If we mention that centroid refinement is an option, we should also mention gaussian refinement. This omission was noticed by Aafke.