### PR TITLE
fitting: fix incorrect model being used for `dsdna`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
 * Fixed a bug where we passed a `SampleFormat` tag while saving to `tiff` using `tifffile`. However, `tifffile` infers the `SampleFormat` automatically from the datatype of the `numpy` array it is passed. This produced warnings on the latest version of `tifffile` when running the benchmark.
 * Ensure that the probability density returns zero outside its support for `DwelltimeModel.pdf()`. Prior to this change, non-zero values would be returned outside the observation limits of the dwelltime model.
 * Fixed a bug where `DwelltimeModel.hist()` produces one less bin than requested with `n_bins`.
+* Fixed a bug where `lk.dsdna_ewlc_odijk_distance()` erroneously returned a model where force is the dependent variable rather than distance. This bug was introduced in `0.13.2`. Note that `lk.ewlc_odijk_distance()` was unaffected. It was specifically the convenience function with DNA parameters that was affected.
 
 #### Improvements
 

--- a/lumicks/pylake/fitting/models.py
+++ b/lumicks/pylake/fitting/models.py
@@ -371,7 +371,7 @@ def dsdna_ewlc_odijk_distance(name, dna_length_kbp, um_per_kbp=0.34, temperature
     """
     from scipy import constants
 
-    model = ewlc_odijk_force(name)
+    model = ewlc_odijk_distance(name)
     model.defaults[f"{name}/Lc"].value = dna_length_kbp * um_per_kbp
     model.defaults[f"{name}/Lp"].value = 50.0  # [3]
     model.defaults[f"{name}/St"].value = 1200.0  # [4, 5]

--- a/lumicks/pylake/fitting/tests/test_fd_models.py
+++ b/lumicks/pylake/fitting/tests/test_fd_models.py
@@ -181,3 +181,31 @@ def test_invalid_params_models(model, test_params):
             with pytest.raises(ValueError, match="must be bigger than 0"):
                 params[test_param] = value
                 model(**params)
+
+
+@pytest.mark.parametrize(
+    "convenience_model, ref_model, ref_params",
+    [
+        [
+            dsdna_ewlc_odijk_distance,
+            ewlc_odijk_distance,
+            {"m/Lc": 100 * 0.34, "m/Lp": 50.0, "m/St": 1200.0, "kT": 4.11},
+        ],
+        [
+            ssdna_efjc_distance,
+            efjc_distance,
+            {"m/Lc": 100 * 0.56, "m/Lp": 0.7, "m/St": 750.0, "kT": 4.11},
+        ],
+    ],
+)
+def test_convenience_models(convenience_model, ref_model, ref_params):
+    x = np.arange(1.0, 5.0)
+    model = convenience_model("m", 100)
+    params = dict(model.defaults)
+
+    for param in ref_params.keys():
+        np.testing.assert_allclose(params[param].value, ref_params[param])
+
+    # The convenience part is in the parameters, with the old parameters they should produce the
+    # exact same as what they are supposed to be based on
+    np.testing.assert_allclose(model(x, params), ref_model("m")(x, params))


### PR DESCRIPTION
**Why this PR?**
One of the API calls returns an incorrect model. This bug was introduced in Pylake v0.13.2 ( https://github.com/lumicks/pylake/pull/381 ).