### PR TITLE
`KymoTrackGroup._kymo` only valid for single source kymo

### DIFF
--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -845,10 +845,12 @@ class KymoTrackGroup:
 
     @property
     def _kymo(self):
-        try:
-            return self[0]._kymo
-        except IndexError:
+        if len(self._kymos) == 1:
+            return self._kymos[0]
+        elif len(self._kymos) == 0:
             raise RuntimeError("No kymo associated with this empty group (no tracks available)")
+        else:
+            raise RuntimeError("Group contains tracks from multiple source kymographs.")
 
     @property
     def _channel(self):

--- a/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
@@ -237,3 +237,25 @@ def test_tracks_by_kymo(kymos, coordinates):
             id(track_group) == id(track_raw)
 
     assert indices == [[0, 1, 2, 3, 8, 9, 10, 11], [4, 5, 6, 7]]
+
+
+def test_kymo_property(kymos, coordinates):
+    raw_tracks1 = [KymoTrack(t, p, kymos[0], "green") for t, p in zip(*coordinates)]
+    raw_tracks2 = [KymoTrack(t, p, kymos[1], "green") for t, p in zip(*coordinates)]
+
+    group = KymoTrackGroup(raw_tracks1)
+    assert id(group._kymo) == id(kymos[0])
+
+    group = KymoTrackGroup([])
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape("No kymo associated with this empty group (no tracks available)"),
+    ):
+        group._kymo
+
+    group = KymoTrackGroup([*raw_tracks1, *raw_tracks2])
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape("Group contains tracks from multiple source kymographs."),
+    ):
+        group._kymo


### PR DESCRIPTION
**Why this PR?**
`KymoTrackGroup._kymo` is still used in many places where we require a single source kymograph. Here, added an extra check that raises if `KymoTrackGroup._kymos` has more than a single item in order to avoid silent bugs where the criterion isn't met.

_**Update**_
Something weird happened with pushing from a new branch. Closing this and opening new PR