### PR TITLE
docs: swap order for consistency with changelog

### DIFF
--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -8,5 +8,5 @@ For a full list of new features and changes, please refer to the :doc:`changelog
     :caption: Contents
     :maxdepth: 1
 
-    1.0.0/1_0_0
     1.1.0/1_1_0
+    1.0.0/1_0_0


### PR DESCRIPTION
**Why this PR?**
Currently, the what's new section is in the opposite order when compared to the changelog. This PR fixes that.