### PR TITLE
dwelltimes: take into account maximum possible dwelltime

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### New features
 
 * Added `KymoTrack.plot_fit()` and `KymoTrackGroup.plot_fit()` to show the fitted model obtained from gaussian refinement.
+* Add option to take maximum possible binding time for a particular binding event into account by specifying `correct_for_max_observation_time=True` when using `KymoTrackGroup.fit_binding_times()`. When set to `True`, it is taken into account that a binding time that initiates at a particular point in the kymograph, could at most have a length corresponding to the remaining time until the kymograph ends. Note that failing to take this into account can lead to a downward bias when estimating binding times. The magnitude of this bias depends on the ratio of the rate being determined and the kymograph duration. 
 
 ## v1.1.0 | 2023-05-17
 


### PR DESCRIPTION
**Why this PR?**
When computing the likelihood for a dwelltime event, we use a likelihood function based on an exponential distribution with limited support. The limits of this support are the minimum observed time and the maximum is given by the kymograph duration.

In reality however, it is not possible to actually observe the kymograph duration unless the binding event initiated exactly at `t=0`.

Consider the following example with a line time of 0.07 seconds, a duration of 100 seconds, a `t_on` and `t_off` of 10 seconds and a `t_off` of 10 seconds. If we put this through a dwelltime analysis using the `duration` as maximum observable time for all tracks we obtain (N is very large here to get an asymptotic result):

![image](https://github.com/lumicks/pylake/assets/19836026/e1d4a154-ab93-4821-8b8f-06daa8bf266a)

If we however take into account correctly the time remaining in the kymograph, then the bias completely disappears:

![image](https://github.com/lumicks/pylake/assets/19836026/479d7dec-2839-468f-8950-907ef8576e14)

Thankfully, the bias depends on the off time, and in most experiments `t_off` << `t_kymograph`, but it would still be good to correct for it.
<img width="554" alt="image" src="https://github.com/lumicks/pylake/assets/19836026/3e4a10ce-82c9-455e-bdcb-22a6aae0e98c">

