### PR TITLE
deps: drop `opencv` in favor of `skimage` for affine transformations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 * Added `KymoTrack.plot_fit()` and `KymoTrackGroup.plot_fit()` to show the fitted model obtained from gaussian refinement.
 
+#### Other changes
+
+* Dropped `opencv` dependency which was only used for calculating rotation matrices and performing the affine transformations required for image alignment. Pylake now uses `scikit-image` for this purpose. 
+
 ## v1.1.0 | 2023-05-17
 
 #### New features

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,8 @@
 
 #### Other changes
 
-* Dropped `opencv` dependency which was only used for calculating rotation matrices and performing the affine transformations required for image alignment. Pylake now uses `scikit-image` for this purpose. 
+* Dropped `opencv` dependency which was only used for calculating rotation matrices and performing the affine transformations required for image alignment. Pylake now uses `scikit-image` for this purpose.
+* Don't import packages we rarely use immediately. Rather specifically import functionality from `scikit-image` and `scikit-learn` when we actually use it.
 
 ## v1.1.0 | 2023-05-17
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -304,18 +304,6 @@ If you have already activated the correct environment, but you still do not see 
 Frequently asked questions
 --------------------------
 
-**When importing lumicks.pylake on Windows I get an error with cv2**
-
-The full error message is::
-
-    ImportError: DLL load failed while importing cv2: The specified procedure could not be found.
-    
-To resolve this error, follow these steps:
-    
-* Remove Anaconda
-* Install the latest version of `Microsoft Visual C++ <https://visualstudio.microsoft.com/downloads/>`_
-* Follow the installation instructions for Pylake again
-
 .. _OpenSSL Error:
 
 **I tried the installation instructions on Windows, but I get a CondaSSLError**

--- a/lumicks/pylake/detail/tests/test_widefield.py
+++ b/lumicks/pylake/detail/tests/test_widefield.py
@@ -71,10 +71,13 @@ def test_transform_rotation(theta_deg, center, ref_matrix):
     np.testing.assert_allclose(coordinates, rot_points, atol=1e-8)
 
 
-def test_rotate_image():
-    rotation = widefield.TransformMatrix.rotation(25, (25, 50))
-    rotation_wrong_angle = widefield.TransformMatrix.rotation(25.01, (25, 50))
-    rotation_wrong_origin = widefield.TransformMatrix.rotation(25, (25.55, 50))
+@pytest.mark.parametrize("theta, center", [(25, (25, 50)), (45, (25, 30))])
+def test_rotate_image(theta, center):
+    rotation = widefield.TransformMatrix.rotation(theta, np.array(center))
+    rotation_wrong_angle = widefield.TransformMatrix.rotation(theta + 0.01, np.array(center))
+    rotation_wrong_origin = widefield.TransformMatrix.rotation(
+        theta, np.array((center[0] + 0.05, 50))
+    )
 
     original_spots = [(25, 50), (75, 50)]
     original_image = make_image_gaussians(original_spots)

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -3,7 +3,6 @@ from copy import copy
 from dataclasses import dataclass
 
 import numpy as np
-from skimage.measure import block_reduce
 
 from . import colormaps
 from .adjustments import no_adjustment
@@ -604,6 +603,8 @@ class Kymo(ConfocalImage):
         result = copy(self)
 
         def image_factory(_, channel):
+            from skimage.measure import block_reduce
+
             data = self._image(channel)
 
             return block_reduce(data, (position_factor, time_factor), func=reduce)[

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -1,6 +1,5 @@
 import itertools
 from copy import copy
-from sklearn.neighbors import KernelDensity
 from ..detail.utilities import replace_key_aliases
 from .detail.msd_estimation import *
 from .detail.localization_models import LocalizationModel, CentroidLocalizationModel
@@ -1529,6 +1528,8 @@ class KymoTrackGroup:
         roi: list or None
             ROI coordinates as `[[min_time, min_position], [max_time, max_position]]`.
         """
+        from sklearn.neighbors import KernelDensity
+
         self._validate_single_source("Binding profile")
         _kymo = self._kymos[0]
 

--- a/lumicks/pylake/population/mixture.py
+++ b/lumicks/pylake/population/mixture.py
@@ -1,5 +1,4 @@
 import numpy as np
-from sklearn.mixture import GaussianMixture
 from scipy import stats
 from .dwelltime import _dwellcounts_from_statepath
 
@@ -53,6 +52,8 @@ class GaussianMixtureModel:
     """
 
     def __init__(self, data, n_states, init_method, n_init, tol, max_iter):
+        from sklearn.mixture import GaussianMixture
+
         self.n_states = n_states
         self._model = GaussianMixture(
             n_components=n_states,

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         "matplotlib>=3.5",
         "tifffile>=2020.9.30",
         "tabulate>=0.8.8, <0.9",
-        "opencv-python-headless>=3.0",
         "cachetools>=3.1",
         "deprecated>=1.2.8",
         "scikit-learn>=0.18.0",


### PR DESCRIPTION
**Why this PR?**
We only use `opencv` for affine transformations. Considering that several other packages provide this functionality, we can also use one of the ones we already include. I did notice that there are small differences in the affine transforms; but considering we're not doing quantitative analysis with them yet, it should be fine. I suspect that this has to do with some speed optimizations OpenCV does (I note that the API docs have a difference between `INTER_LINEAR` and `INTER_LINEAR_EXACT` whereas the latter is not available for `warp_affine`).

We could also just use raw `scipy` for this (as `scikit-image` just calls theirs), but personally, I didn't like that one as much because of the double transpose needed on the `scipy` API.

I have also reduced the scope of a few imports that we rarely use.

![opencv](https://github.com/lumicks/pylake/assets/19836026/a12695df-fa00-496c-a015-73e1fd429b12)
OpenCV 4.7.0

![scikit-image](https://github.com/lumicks/pylake/assets/19836026/7b192dba-8c09-4df0-a9fb-ae0c9d8100b3)
scikit-image 0.20.0

![scipy](https://github.com/lumicks/pylake/assets/19836026/69f9c13a-6770-480a-9d2b-57f76a823d83)
scipy 1.10.1
