### PR TITLE
widgets: Fix parameter description for minimum length

### DIFF
--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -843,7 +843,7 @@ def _get_default_parameters(kymo, channel):
             *(2, 10),
             True,
             r"Minimum length defines the minimum number of points a tracked line must contain for "
-            r"it to be considered valid. Reducing this parameter can be effective in reducing "
+            r"it to be considered valid. Increasing this parameter can be effective in reducing "
             r"tracking noise. Note that this length refers to the number of detected points, not "
             r"length in time!",
             abridged_name="Min length",


### PR DESCRIPTION
Reducing the min length parameter in the kymotracker widget does not, in fact, reduce noise but rather increase it. Fixed the extended description to state that _increasing_ the min length parameter does have a de-noising effect.