### PR TITLE
deps: import rarely used dependencies on demand

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.1.1 | t.b.d.
+
+#### Other changes
+
+* Fixed parameter description for minimum length. It now correctly reads that increasing this parameter reduces tracking noise.
+* Rarely used but heavy packages like `opencv`, `scikit-image`, and `scikit-learn` are no longer loaded eagerly with `import lumicks.pylake`. Rather, they are loaded on-demand the first time that a feature needs them. This makes importing `pylake` itself faster and mitigates potential third-party issues (e.g. this makes the first issue from the [F.A.Q.](https://lumicks-pylake.readthedocs.io/en/v1.1.0/install.html#frequently-asked-questions) less severe as it no longer affects all users).
+
 ## v1.1.0 | 2023-05-17
 
 #### New features

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -1,7 +1,6 @@
 import numpy as np
 import re
 import json
-import cv2
 import tifffile
 import warnings
 import enum
@@ -537,7 +536,9 @@ class TransformMatrix:
         center: np.ndarray
             (x, y) point, center of rotation
         """
-        return cls(cv2.getRotationMatrix2D(tuple(center), theta, scale=1.0))
+        from cv2 import getRotationMatrix2D
+
+        return cls(getRotationMatrix2D(tuple(center), theta, scale=1.0))
 
     @classmethod
     def translation(cls, x, y):
@@ -562,6 +563,7 @@ class TransformMatrix:
         data: np.ndarray
             image data
         """
+        import cv2
 
         if np.all(np.equal(self.matrix, np.eye(3))):
             return data

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -3,7 +3,6 @@ from copy import copy
 from dataclasses import dataclass
 
 import numpy as np
-from skimage.measure import block_reduce
 
 from . import colormaps
 from .adjustments import no_adjustment
@@ -604,6 +603,8 @@ class Kymo(ConfocalImage):
         result = copy(self)
 
         def image_factory(_, channel):
+            from skimage.measure import block_reduce
+
             data = self._image(channel)
 
             return block_reduce(data, (position_factor, time_factor), func=reduce)[

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -1,6 +1,5 @@
 import itertools
 from copy import copy
-from sklearn.neighbors import KernelDensity
 from .detail.msd_estimation import *
 from .detail.localization_models import LocalizationModel
 from .. import __version__
@@ -1308,6 +1307,8 @@ class KymoTrackGroup:
         roi: list or None
             ROI coordinates as `[[min_time, min_position], [max_time, max_position]]`.
         """
+        from sklearn.neighbors import KernelDensity
+
         self._validate_single_source("Binding profile")
         _kymo = self._kymos[0]
 

--- a/lumicks/pylake/population/mixture.py
+++ b/lumicks/pylake/population/mixture.py
@@ -1,5 +1,4 @@
 import numpy as np
-from sklearn.mixture import GaussianMixture
 from scipy import stats
 from .dwelltime import _dwellcounts_from_statepath
 
@@ -53,6 +52,8 @@ class GaussianMixtureModel:
     """
 
     def __init__(self, data, n_states, init_method, n_init, tol, max_iter):
+        from sklearn.mixture import GaussianMixture
+
         self.n_states = n_states
         self._model = GaussianMixture(
             n_components=n_states,


### PR DESCRIPTION
**Why this PR?**
There are some dependencies we use relatively rarely. This PR makes sure we only import them as needed by importing them where they are used.

Note that I also added a changelog entry for a previous bugfix that didn't get one.