### PR TITLE
release: release pylake v1.1.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,6 @@
 # Changelog
 
-## v1.1.1 | t.b.d.
-
-#### Other changes
+## v1.1.1 | 2023-06-13
 
 * Fixed parameter description for minimum length. It now correctly reads that increasing this parameter reduces tracking noise.
 * Rarely used but heavy packages like `opencv`, `scikit-image`, and `scikit-learn` are no longer loaded eagerly with `import lumicks.pylake`. Rather, they are loaded on-demand the first time that a feature needs them. This makes importing `pylake` itself faster and mitigates potential third-party issues (e.g. this makes the first issue from the [F.A.Q.](https://lumicks-pylake.readthedocs.io/en/v1.1.0/install.html#frequently-asked-questions) less severe as it no longer affects all users).

--- a/lumicks/pylake/__about__.py
+++ b/lumicks/pylake/__about__.py
@@ -1,5 +1,5 @@
 __title__ = "lumicks.pylake"
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __summary__ = "Bluelake data analysis tools"
 __url__ = "https://github.com/lumicks/pylake"
 


### PR DESCRIPTION
**Why this PR?**
This bugfix release partially mitigates the `opencv` issues we've been seeing (after this release it will only impact people actively using WIT stacks). It also includes a small bugfix of a label.