### PR TITLE
pylake: Replace $math$ unit labels with Unicode variants

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 #### Other changes
 
 * Dropped `opencv` dependency which was only used for calculating rotation matrices and performing the affine transformations required for image alignment. Pylake now uses `scikit-image` for this purpose.
+* Use Unicode characters for µ and ² when plotting rather than TeX strings.
 
 ## v1.1.1 | 2023-06-13
 

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -244,7 +244,7 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
         return Continuous.from_dataset(force_group, "Force (pN)", calibration_data)
 
     def _get_distance(self, n):
-        return TimeSeries.from_dataset(self.h5["Distance"][f"Distance {n}"], r"Distance ($\mu$m)")
+        return TimeSeries.from_dataset(self.h5["Distance"][f"Distance {n}"], r"Distance (μm)")
 
     def _get_photon_count(self, name):
         return Continuous.from_dataset(self.h5["Photon count"][name], "Photon count")

--- a/lumicks/pylake/image_stack.py
+++ b/lumicks/pylake/image_stack.py
@@ -359,7 +359,7 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
         if show_axes is False:
             axes.set_axis_off()
 
-        positional_unit = "px" if not self.pixelsize_um else r"$\mu$m"
+        positional_unit = "px" if not self.pixelsize_um else r"μm"
         if scale_bar and not image_handle:
             scale = 1 if self.pixelsize_um else 100
             scale_bar._attach_scale_bar(axes, scale, scale, positional_unit, positional_unit)

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -79,7 +79,7 @@ class Kymo(ConfocalImage):
             else (
                 PositionCalibration()
                 if self.pixelsize_um[0] is None
-                else PositionCalibration("um", self.pixelsize_um[0], r"$\mu$m")
+                else PositionCalibration("um", self.pixelsize_um[0], r"μm")
             )
         )
 

--- a/lumicks/pylake/kymotracker/detail/msd_estimation.py
+++ b/lumicks/pylake/kymotracker/detail/msd_estimation.py
@@ -305,7 +305,7 @@ def calculate_ensemble_msd(
         effective_sample_size=effective_sample_size,
         unit=f"{unit}^2",
         _time_step=time_step,
-        _unit_label=f"{unit_label}$^2$",
+        _unit_label=f"{unit_label}²",
     )
 
 
@@ -1160,5 +1160,5 @@ def ensemble_ols(kymotracks, max_lag):
         localization_variance=intercept / 2.0,
         method="ensemble ols",
         unit=f"{src_calibration.unit}^2 / s",
-        _unit_label=f"{src_calibration.unit_label}$^2$/s",
+        _unit_label=f"{src_calibration.unit_label}²/s",
     )

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -634,7 +634,7 @@ class KymoTrack:
         lag_time, msd = self.msd(max_lag)
         plt.plot(lag_time, msd, **kwargs)
         plt.xlabel("Lag time [s]")
-        plt.ylabel(f"Mean Squared Displacement [{self._kymo._calibration.unit_label}$^2$]")
+        plt.ylabel(f"Mean Squared Displacement [{self._kymo._calibration.unit_label}²]")
 
     def estimate_diffusion(
         self,
@@ -762,7 +762,7 @@ class KymoTrack:
         frame_idx, positions = np.array(self.time_idx, dtype=int), np.array(self.position)
         unit_labels = {
             "unit": f"{self._kymo._calibration.unit}^2 / s",
-            "unit_label": f"{self._kymo._calibration.unit_label}$^2$/s",
+            "unit_label": f"{self._kymo._calibration.unit_label}²/s",
         }
 
         if method == "cve":

--- a/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
+++ b/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
@@ -646,7 +646,7 @@ def test_ensemble_msd():
     np.testing.assert_allclose(result.effective_sample_size, num_means)
     np.testing.assert_allclose(result.sem, np.sqrt(0.02 / ((num_means - 1) * num_means)))
     assert result.unit == "what_a_unit^2"
-    assert result._unit_label == "label_ahoy$^2$"
+    assert result._unit_label == "label_ahoy²"
 
 
 def test_ensemble_msd_unequal_points():
@@ -695,4 +695,4 @@ def test_ensemble_msd_plot():
     np.testing.assert_allclose(lines.get_xdata(), frame_diffs)
     np.testing.assert_allclose(lines.get_ydata(), frame_diffs**2)
     assert axis.xaxis.get_label().get_text() == "Time [s]"
-    assert axis.yaxis.get_label().get_text() == "Squared Displacement [label_unit$^2$]"
+    assert axis.yaxis.get_label().get_text() == "Squared Displacement [label_unit²]"

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -414,7 +414,7 @@ def test_diffusion_units(blank_kymo, calibration_coeff):
     diffusion_estimate = kymotrack.estimate_diffusion("ols", max_lag=2)
     np.testing.assert_allclose(diffusion_estimate.value, ref_constant)
     assert diffusion_estimate.unit == "um^2 / s"
-    assert diffusion_estimate._unit_label == "$\\mu$m$^2$/s"
+    assert diffusion_estimate._unit_label == "μm²/s"
 
 
 @pytest.mark.parametrize(
@@ -987,7 +987,7 @@ def test_diffusion_cve(
     assert cve_est.num_lags is None
     assert cve_est.method == "cve"
     assert cve_est.unit == "um^2 / s"
-    assert cve_est._unit_label == "$\\mu$m$^2$/s"
+    assert cve_est._unit_label == "μm²/s"
 
 
 def test_diffusion_invalid_loc_variance(blank_kymo):
@@ -1127,7 +1127,7 @@ def test_ensemble_msd_calibration_from_kymo(blank_kymo, kbp_calibration, line_wi
     np.testing.assert_allclose(result.effective_sample_size, np.ones(len(frame) - 1) * 3)
 
     assert result.unit == "kbp^2" if kbp_calibration else "um^2"
-    assert result._unit_label == "kbp$^2$" if kbp_calibration else "um$^2$"
+    assert result._unit_label == "kbp²" if kbp_calibration else "um²"
 
 
 def test_ensemble_api(blank_kymo):
@@ -1213,7 +1213,7 @@ def test_ensemble_ols(blank_kymo, max_lag, diffusion_ref, std_err_ref, localizat
     np.testing.assert_allclose(ensemble_diffusion.num_points, 15)
     assert ensemble_diffusion.method == "ensemble ols"
     assert ensemble_diffusion.unit == "um^2 / s"
-    assert ensemble_diffusion._unit_label == "$\\mu$m$^2$/s"
+    assert ensemble_diffusion._unit_label == "μm²/s"
 
 
 @pytest.mark.parametrize("max_lag", [None, 4])
@@ -1249,7 +1249,7 @@ def test_ensemble_ols_multiple_sources(blank_kymo, max_lag):
     np.testing.assert_allclose(ensemble_diffusion.num_points, 15)
     assert ensemble_diffusion.method == "ensemble ols"
     assert ensemble_diffusion.unit == "um^2 / s"
-    assert ensemble_diffusion._unit_label == "$\\mu$m$^2$/s"
+    assert ensemble_diffusion._unit_label == "μm²/s"
 
 
 def test_invalid_ensemble_diffusion(blank_kymo):

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -305,7 +305,7 @@ def test_widget_with_calibration(kymograph):
         widget._algorithm_parameters["track_width"].value, kymograph.pixelsize[0] * 4
     )
     np.testing.assert_allclose(widget._algorithm_parameters["track_width"].value, 1.6)
-    assert widget._axes.get_ylabel() == r"position ($\mu$m)"
+    assert widget._axes.get_ylabel() == r"position (μm)"
 
     kymo_bp = kymograph.calibrate_to_kbp(10.000)
     widget = KymoWidgetGreedy(kymo_bp, "red", axis_aspect_ratio=1, use_widgets=False)
@@ -385,9 +385,9 @@ def test_keyword_args(kymograph):
     "gain,line_time,pixel_size,ref_values",
     (
         # fmt:off
-        (1, 2.0, 5.0, {"pixel_threshold": (97, 1, 99, None), "track_width": (4 * 5, 3 * 5, 15 * 5, "$\\mu$m"), "sigma": (2 * 5, 1 * 5, 5 * 5, "$\\mu$m"), "velocity": (0, -5 * 5/2, 5 * 5/2, "$\\mu$m/s")}),
-        (0, 2.0, 5.0, {"pixel_threshold": (1, 1, 2, None), "track_width": (4 * 5, 3 * 5, 15 * 5, "$\\mu$m"), "sigma": (2 * 5, 1 * 5, 5 * 5, "$\\mu$m"), "velocity": (0, -5 * 5/2, 5 * 5/2, "$\\mu$m/s")}),
-        (1, 4.0, 4.0, {"pixel_threshold": (97, 1, 99, None), "track_width": (4 * 4, 3 * 4, 15 * 4, "$\\mu$m"), "sigma": (2 * 4, 1 * 4, 5 * 4, "$\\mu$m"), "velocity": (0, -5 * 4/4, 5 * 4/4, "$\\mu$m/s")}),
+        (1, 2.0, 5.0, {"pixel_threshold": (97, 1, 99, None), "track_width": (4 * 5, 3 * 5, 15 * 5, "μm"), "sigma": (2 * 5, 1 * 5, 5 * 5, "μm"), "velocity": (0, -5 * 5/2, 5 * 5/2, "μm/s")}),
+        (0, 2.0, 5.0, {"pixel_threshold": (1, 1, 2, None), "track_width": (4 * 5, 3 * 5, 15 * 5, "μm"), "sigma": (2 * 5, 1 * 5, 5 * 5, "μm"), "velocity": (0, -5 * 5/2, 5 * 5/2, "μm/s")}),
+        (1, 4.0, 4.0, {"pixel_threshold": (97, 1, 99, None), "track_width": (4 * 4, 3 * 4, 15 * 4, "μm"), "sigma": (2 * 4, 1 * 4, 5 * 4, "μm"), "velocity": (0, -5 * 4/4, 5 * 4/4, "μm/s")}),
         # fmt:on
     ),
 )

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -441,7 +441,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         if show_axes is False:
             axes.set_axis_off()
 
-        positional_unit = r"$\mu$m"
+        positional_unit = r"μm"
         if scale_bar and not image_handle:
             scale_bar._attach_scale_bar(axes, 1.0, 1.0, positional_unit, positional_unit)
 

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo.py
@@ -171,7 +171,7 @@ def test_plotting(test_kymos):
 
     # test original kymo is labeled with microns and
     # that kymo calibrated with base pairs has appropriate label
-    assert plt.gca().get_ylabel() == r"position ($\mu$m)"
+    assert plt.gca().get_ylabel() == r"position (μm)"
     plt.close()
 
     kymo_bp = kymo.calibrate_to_kbp(10.000)

--- a/lumicks/pylake/tests/test_scalebar.py
+++ b/lumicks/pylake/tests/test_scalebar.py
@@ -91,16 +91,16 @@ def validate_args(refs):
     "scale_args, refs, calibrate",
     [
         # fmt:off
-        ({}, [60.0, 1.0, "60.0 s", "1.0 $\\mu$m", "upper right", "white", 2.0, None, None], False),
-        ({"label_x": "hi"}, [60.0, 1.0, "hi", "1.0 $\\mu$m", "upper right", "white", 2.0, None, None], False),
+        ({}, [60.0, 1.0, "60.0 s", "1.0 μm", "upper right", "white", 2.0, None, None], False),
+        ({"label_x": "hi"}, [60.0, 1.0, "hi", "1.0 μm", "upper right", "white", 2.0, None, None], False),
         ({"label_y": "hi"}, [60.0, 1.0, "60.0 s", "hi", "upper right", "white", 2.0, None, None], False),
-        ({"size_x": 10}, [10.0, 1.0, "10 s", "1.0 $\\mu$m", "upper right", "white", 2.0, None, None], False),
-        ({"size_y": 10}, [60.0, 10.0, "60.0 s", "10 $\\mu$m", "upper right", "white", 2.0, None, None], False),
-        ({"loc": "lower right"}, [60.0, 1.0, "60.0 s", "1.0 $\\mu$m", "lower right", "white", 2.0, None, None], False),
-        ({"color": "blue"}, [60.0, 1.0, "60.0 s", "1.0 $\\mu$m", "upper right", "blue", 2.0, None, None], False),
-        ({"separation": 5}, [60.0, 1.0, "60.0 s", "1.0 $\\mu$m", "upper right", "white", 5.0, None, None], False),
-        ({"barwidth": 12}, [60.0, 1.0, "60.0 s", "1.0 $\\mu$m", "upper right", "white", 2.0, 12, None], False),
-        ({"fontsize": 16}, [60.0, 1.0, "60.0 s", "1.0 $\\mu$m", "upper right", "white", 2.0, None, 16], False),
+        ({"size_x": 10}, [10.0, 1.0, "10 s", "1.0 μm", "upper right", "white", 2.0, None, None], False),
+        ({"size_y": 10}, [60.0, 10.0, "60.0 s", "10 μm", "upper right", "white", 2.0, None, None], False),
+        ({"loc": "lower right"}, [60.0, 1.0, "60.0 s", "1.0 μm", "lower right", "white", 2.0, None, None], False),
+        ({"color": "blue"}, [60.0, 1.0, "60.0 s", "1.0 μm", "upper right", "blue", 2.0, None, None], False),
+        ({"separation": 5}, [60.0, 1.0, "60.0 s", "1.0 μm", "upper right", "white", 5.0, None, None], False),
+        ({"barwidth": 12}, [60.0, 1.0, "60.0 s", "1.0 μm", "upper right", "white", 2.0, 12, None], False),
+        ({"fontsize": 16}, [60.0, 1.0, "60.0 s", "1.0 μm", "upper right", "white", 2.0, None, 16], False),
         ({}, [60.0, 1.0, "60.0 s", "1.0 kbp", "upper right", "white", 2.0, None, None], True),
         ({"size_y": 2}, [60.0, 2.0, "60.0 s", "2 kbp", "upper right", "white", 2.0, None, None], True),
         # fmt:on
@@ -124,13 +124,13 @@ def test_scalebar_integration(monkeypatch):
     """ "For Scan and ImageStack we only test the defaults since we extensively tested Kymo"""
     with monkeypatch.context() as m:
         scan = generate_scan("test", np.random.randint(0, 10, size=(1, 2, 2)), [3, 2])
-        refs = [1.0, 1.0, "1.0 $\\mu$m", "1.0 $\\mu$m", "upper right", "white", 2.0, None, None]
+        refs = [1.0, 1.0, "1.0 μm", "1.0 μm", "upper right", "white", 2.0, None, None]
         m.setattr("lumicks.pylake.scalebar._create_scale_legend", validate_args(refs))
         scan.plot("red", scale_bar=ScaleBar())
 
     for description, ref_sizes in (
         ({}, [100, 100, "100 px", "100 px"]),
-        ({"Pixel calibration (nm/pix)": 500}, [1, 1, r"1 $\mu$m", r"1 $\mu$m"]),
+        ({"Pixel calibration (nm/pix)": 500}, [1, 1, r"1 μm", r"1 μm"]),
     ):
         with monkeypatch.context() as m:
             stack = ImageStack.from_dataset(


### PR DESCRIPTION
It's a mechanical replace. We came across this issue when looking at display units for kymotracker widget parameters, but decided to fix it across Pylake for consistency.

- "$\um$" becomes "μm" (Greek small letter mu)
- "$^2$" becomes "²" (superscript two)