### PR TITLE
ci: fix deprecation warning in latest `numpy`

### DIFF
--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -371,7 +371,7 @@ class Slice:
                     )
                 )
             # ratio of current/new frequencies must be integer to ensure equal timesteps
-            remainder = target_timestep % source_timestep
+            remainder = target_timestep % source_timestep[0]
             if remainder != 0:
                 if method == "ceil":
                     target_timestep -= remainder

--- a/lumicks/pylake/detail/tests/test_widefield.py
+++ b/lumicks/pylake/detail/tests/test_widefield.py
@@ -153,8 +153,7 @@ def test_tether():
     tether = widefield.Tether((0, 0), None)
     assert tether._ends is None
     np.testing.assert_allclose(tether.rot_matrix.matrix, widefield.TransformMatrix().matrix)
-    with pytest.raises(TypeError, match="did not return an iterable$"):
-        tether.ends
+    assert tether.ends is None
 
     # test coordinates of tether after rotation
     tether = widefield.Tether(origin, (point_1, point_2))

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -590,6 +590,9 @@ class TransformMatrix:
         coordinates: list
             list of (x, y) coordinates
         """
+        if not np.any(coordinates):
+            return coordinates
+
         coordinates = np.vstack(coordinates).T
         coordinates = np.vstack((coordinates, np.ones(coordinates.shape[1])))
 


### PR DESCRIPTION
This fixes a deprecation warning relating to the latest version of `numpy`. Silent conversion to a scalar from an array with dimensions is no longer permitted in the future.