### PR TITLE
docs: add logical mask example

### DIFF
--- a/docs/tutorial/fdfitting.rst
+++ b/docs/tutorial/fdfitting.rst
@@ -174,6 +174,14 @@ when loading the data from `DNA/Lc` to `DNA/Lc_RecA`::
     distance2 = fd2.d[mask2].data
     fit.add_data("RecA", force2, distance2, params={"DNA/Lc": "DNA/Lc_RecA"})
 
+Multiple criteria can be combined into a single mask by using `numpy`'s logical operators.
+For example, to select all forces up to `30` pN and ensure a distance larger than `1.5` micron::
+
+    example_mask = np.logical_and(fd1.f.data <= 30, fd1.d.data > 1.5)
+
+Adding a third condition that the distance has to be `< 4` micron can be done as follows (note the double brackets)::
+
+    example_mask = np.logical_and.reduce((fd1.f.data <= 30, fd1.d.data > 1.5, fd1.d.data < 4.0))
 
 Setting parameter bounds
 ************************

--- a/lumicks/pylake/force_calibration/detail/driving_input.py
+++ b/lumicks/pylake/force_calibration/detail/driving_input.py
@@ -1,5 +1,5 @@
 import numpy as np
-import scipy.signal
+import scipy.signal.windows
 from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
 
 
@@ -78,7 +78,7 @@ def estimate_driving_input_parameters(
 
     # Multiply the signal with a Gaussian window after removing any constant offset (which would
     # lead to the spectral bin belonging to the offset bleeding into higher frequencies).
-    gauss_window = scipy.signal.gaussian(M=num_points, std=std, sym=False)
+    gauss_window = scipy.signal.windows.gaussian(M=num_points, std=std, sym=False)
     windowed_data = gauss_window * (driving_data - np.mean(driving_data))
     windowed_fft = np.fft.rfft(windowed_data)
 


### PR DESCRIPTION
**Why this PR?**
This has come up in support twice now. Might as well add a sentence or two to show people how to combine different criteria when boolean array indexing the data. Also noticed some deprecated import location in `scipy` that I fixed up.

Docs build here: https://lumicks-pylake.readthedocs.io/en/add_logic_example/tutorial/fdfitting.html#adding-data-to-the-fit