### PR TITLE
Generate colormaps from wavelengths

### DIFF
--- a/docs/tutorial/figures/kymographs/kymo_wavelength_cmap.png
+++ b/docs/tutorial/figures/kymographs/kymo_wavelength_cmap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28f6bac24fe809a7a9107aa1c721975dffcd4816e3621e4874a4c3d5e5d5ee96
+size 936194

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -68,6 +68,26 @@ with the cyan colormap::
 
 .. image:: figures/kymographs/kymo_blue.png
 
+We can also use the `lk.colormaps.from_wavelength()` method to generate a color map approximating the color of a particular wavelength::
+
+    adjustment = lk.ColorAdjustment(0, 99, mode="percentile")
+
+    plt.figure()
+    plt.subplot(2, 1, 1)
+    kymo.plot(channel="green", adjustment=adjustment)
+    plt.title("default 'green' colormap")
+    plt.subplot(2, 1, 2)
+    kymo.plot(
+        channel="green",
+        adjustment=adjustment,
+        cmap=lk.colormaps.from_wavelength(590)
+    )
+    plt.title("emission @ 590 nm")
+    plt.tight_layout()
+    plt.show()
+
+.. image:: figures/kymographs/kymo_wavelength_cmap.png
+
 The kymograph can also be exported to TIFF format::
 
     kymo.export_tiff("image.tiff")

--- a/docs/whatsnew/1.2.0/1_2_0.rst
+++ b/docs/whatsnew/1.2.0/1_2_0.rst
@@ -1,0 +1,20 @@
+Pylake 1.2.0
+============
+
+.. only:: html
+
+Here's a sneak peak at some of the highlights from the upcoming Pylake `v1.2.0` release...
+
+Generate colormaps according to emission wavelength
+---------------------------------------------------
+
+By default, single-channel images arising from fluorophores excited with the red, green, and blue lasers
+are plotted with the corresponding `lk.colormaps.red`, `lk.colormaps.green`, and `lk.colormaps.blue`
+colormaps, respectively. However, the actual light emitted is always red-shifted from the excitation color.
+Now you can plot single-channel images with the approximate color of the signal emitted based on the
+emission wavelength using the `from_wavelength()` method of :data:`~lumicks.pylake.colormaps`.
+
+.. figure:: wavelength_cmaps.png
+
+    Kymographs showing tracks in three color channels using the default colormaps (left) and colormaps
+    corresponding to the actual emission colors (right).

--- a/docs/whatsnew/1.2.0/wavelength_cmaps.png
+++ b/docs/whatsnew/1.2.0/wavelength_cmaps.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55e1e1ed3772798fd626b53a7882c7c5faa83b86af828b5982cfed31ed335137
+size 429759

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -8,5 +8,6 @@ For a full list of new features and changes, please refer to the :doc:`changelog
     :caption: Contents
     :maxdepth: 1
 
+    1.2.0/1_2_0
     1.1.0/1_1_0
     1.0.0/1_0_0


### PR DESCRIPTION
**Why this PR?**
The original idea came up during a feedback session with a customer who pointed out that "blue channel" data is plotted as blue (corresponding to the excitation color), however the actual emission color is green (red-shifted). Taking it a bit further, I found a paper with equations to approximate RGB values from wavelengths in the visible spectrum

*note: I started up the what's new section for 1.2.0 already here. I think it's easier to build this up as we go along rather than right before release; the intro text reads "sneak peak for 1.2.0" so we'd just need to change this to "has been released" in the final PR*

[docs build here](https://lumicks-pylake.readthedocs.io/en/wavelength_cmap/)