### PR TITLE
ci: close figures before issuing another plot

### DIFF
--- a/lumicks/pylake/piezo_tracking/tests/test_piezo_tracking.py
+++ b/lumicks/pylake/piezo_tracking/tests/test_piezo_tracking.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import matplotlib.pyplot as plt
 from lumicks.pylake.channel import Slice, Continuous, TimeSeries
 from lumicks.pylake.piezo_tracking.piezo_tracking import (
     DistanceCalibration,
@@ -83,6 +84,9 @@ def test_from_file():
 def test_plots():
     distance_calibration = DistanceCalibration(*trap_pos_camera_distance(), 1)
     distance_calibration.plot()
+    # Needed since otherwise second plot will issue warning about changing layout (since they both
+    # call tight_layout()
+    plt.close('all')
     distance_calibration.plot_residual()
 
 

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -292,10 +292,12 @@ def test_plots(exponential_data):
     dataset = exponential_data["dataset_2exp"]
     fit = DwelltimeModel(dataset["data"], 1, **dataset["parameters"].observation_limits)
     fit.hist()
+    plt.close('all')
 
     np.random.seed(123)
     bootstrap = fit.calculate_bootstrap(iterations=2)
     bootstrap.hist()
+    plt.close('all')
 
     with pytest.warns(DeprecationWarning):
         bootstrap.plot()


### PR DESCRIPTION
**Why this PR?**
Just noticed that CI wasn't passing on another PR. `mpl` started warning us about layout changes when `tight_layout()` gets called twice (which is good). Probably better to just close the figure after we're done with it in the test, so that state doesn't propagate to the next plot in the test.