### PR TITLE
file: allow `str` for `omit_data` in `save_as`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 * Dropped `opencv` dependency which was only used for calculating rotation matrices and performing the affine transformations required for image alignment. Pylake now uses `scikit-image` for this purpose.
 * Use Unicode characters for µ and ² when plotting rather than TeX strings.
 * Deprecated fitting mode `"multiple"` in `lk.refine_tracks_gaussian()` as it could lead to spurious track crossings. See the entry for the fitting mode `"simultaneous"` under `New Features` for more information.
+* [`File.save_as()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.File.html#lumicks.pylake.File.save_as) data now allows passing in a single string for the `omit_data` parameter.
 
 ## v1.1.1 | 2023-06-13
 

--- a/lumicks/pylake/detail/h5_helper.py
+++ b/lumicks/pylake/detail/h5_helper.py
@@ -13,9 +13,10 @@ def write_h5(h5_file, output_filename, compression_level=5, omit_data=None):
         Output file name.
     compression_level : int
         Compression level for gzip compression.
-    omit_data : Optional[Set[str]]
+    omit_data : str or iterable of str, optional
         Which data sets to omit. Should be a set of h5 paths.
     """
+    omit_data = {omit_data} if isinstance(omit_data, str) else omit_data
 
     with h5py.File(output_filename, "w") as out_file:
 

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -312,7 +312,7 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
             Output file name.
         compression_level : int
             Compression level for gzip compression (default: 5).
-        omit_data : Optional[Set[str]]
+        omit_data : str or iterable of str, optional
             Which data sets to omit. Should be a set of h5 paths (e.g. {"Force HF/Force 1y"}).
             `fnmatch` patterns are used to specify which fields to omit, which means you can use
             wildcards as well (see examples below).
@@ -324,12 +324,23 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
             import lumicks.pylake as lk
 
             file = lk.File("example.h5")
-            file.save_as("smaller.h5", compression_level=9)  # Saves a file with a high compression level
 
-            file.save_as("no_hf.h5", omit_data={"Force HF/*"})  # Omit high frequency force data.
+            # Saves a file with a high compression level
+            file.save_as("smaller.h5", compression_level=9)
 
-            file.save_as("no_hf.h5", omit_data={"*/Force 1y"})  # Omit Force 1y data
+            # Omit high frequency force data.
+            file.save_as("no_hf.h5", omit_data="Force HF/*")
 
-            file.save_as("no_1y.h5", omit_data={"Force HF/Force 1y"})  # Omit high frequency force data for channel 1y
+            # Omit Force 1y data
+            file.save_as("no_hf.h5", omit_data="*/Force 1y")
+
+            # Omit Force 1y and 2y data
+            file.save_as("no_hf.h5", omit_data=("*/Force 1y", "*/Force 2y"))
+
+            # Omit high frequency force data for channel 1y
+            file.save_as("no_1y.h5", omit_data="Force HF/Force 1y")
+
+            # Omit Scan "1"
+            file.save_as("no_scan_1.h5", omit_data="Scan/1")
         """
         write_h5(self.h5, filename, compression_level, omit_data)

--- a/lumicks/pylake/tests/test_file/test_file.py
+++ b/lumicks/pylake/tests/test_file/test_file.py
@@ -264,16 +264,19 @@ def test_h5_export(tmpdir_factory, h5_file, save_h5):
     with pytest.raises(KeyError):
         assert np.any(omit_lf1y["Force LF"]["Force 1y"].data)
 
-    new_file = f"{tmpdir}/omit_1y.h5"
-    save_h5(f, new_file, 5, omit_data={"*/Force 1y"})
-    omit_1y = pylake.File(new_file)
+    for ix, drop_style in enumerate(
+        ({"*/Force 1y"}, ["*/Force 1y"], ("*/Force 1y", ), "*/Force 1y")
+    ):
+        new_file = f"{tmpdir}/omit_1y_{ix}.h5"
+        save_h5(f, new_file, 5, omit_data=drop_style)
+        omit_1y = pylake.File(new_file)
 
-    np.testing.assert_allclose(omit_1y["Force LF"]["Force 1x"].data, f["Force LF"]["Force 1x"].data)
-    np.testing.assert_allclose(omit_1y["Force HF"]["Force 1x"].data, f["Force HF"]["Force 1x"].data)
-    with pytest.raises(KeyError):
-        np.testing.assert_allclose(omit_1y["Force HF"]["Force 1y"].data, f["Force HF"]["Force 1y"].data)
-    with pytest.raises(KeyError):
-        assert np.any(omit_1y["Force LF"]["Force 1y"].data)
+        np.testing.assert_allclose(omit_1y["Force LF"]["Force 1x"].data, f["Force LF"]["Force 1x"].data)
+        np.testing.assert_allclose(omit_1y["Force HF"]["Force 1x"].data, f["Force HF"]["Force 1x"].data)
+        with pytest.raises(KeyError):
+            np.testing.assert_allclose(omit_1y["Force HF"]["Force 1y"].data, f["Force HF"]["Force 1y"].data)
+        with pytest.raises(KeyError):
+            assert np.any(omit_1y["Force LF"]["Force 1y"].data)
 
     new_file = f"{tmpdir}/omit_hf.h5"
     save_h5(f, new_file, 5, omit_data={"Force HF/*"})


### PR DESCRIPTION
It's a tiny thing, but I noticed this while trying to export an `h5` file with a certain field removed. If you just pass a string to `omit_data`, it gets confusing since it iterates over the characters in that string. It doesn't give you a helpful error.

It should either accept a string and upconvert it to something iterable (which I did), or throw. I chose the former, because I don't see a reason to explicitly disallow the convenience option here (as most people would likely only exclude a single mask).

I also changed the doc format to the `numpydoc` format we use elsewhere.