### PR TITLE
Update install.rst: update installation instructions for China in faq

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -473,6 +473,6 @@ Install pip in the activated environment by invoking::
 
 Then install Pylake as follows::
 
-    pip install -i https://pypi.tuna.tsinghua.edu.cn/simple lumicks.pylake
+    pip install -i https://pypi.tuna.tsinghua.edu.cn/simple lumicks.pylake "jupyter_client<8"
 
 Important to note is that packages on `conda` and `pip` are typically *not* compatible. Therefore, whenever you use this environment, *only* use pip, and do not install additional dependencies via `conda install`, since this can break your environment.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -457,7 +457,7 @@ Since there is no mirror for `conda-forge`, Pylake then has to be installed usin
 
 If you normally manage your environments with `pip`, you can just invoke::
 
-    pip install -i https://pypi.tuna.tsinghua.edu.cn/simple lumicks.pylake
+    pip install -i https://pypi.tuna.tsinghua.edu.cn/simple lumicks.pylake "jupyter_client<8"
 
 If you use Anaconda, then it is best to create a new environment for this installation. You can do this as follows::
 


### PR DESCRIPTION
The installation instructions for China in the faq were missing "jupyter_client<8"