### PR TITLE
ci: add option to freeze reference data

### DIFF
--- a/.github/workflows/pylake_test.py
+++ b/.github/workflows/pylake_test.py
@@ -4,4 +4,4 @@ import os
 import pathlib
 
 os.chdir(str(pathlib.Path(lk.__file__).parent))
-sys.exit(lk.pytest(args=["--runslow", "--color=yes", "-Werror"]))
+sys.exit(lk.pytest(args=["--runslow", "--strict_reference_data", "--color=yes", "-Werror"]))

--- a/lumicks/pylake/tests/reference_data/freezing/forced_filename_1.npz
+++ b/lumicks/pylake/tests/reference_data/freezing/forced_filename_1.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4aaffc81991e41e21e7e9d9a099965a08ed0eb3f1f5f06a6d82eb6f7abe6f91
+size 312

--- a/lumicks/pylake/tests/reference_data/freezing/forced_filename_2.npz
+++ b/lumicks/pylake/tests/reference_data/freezing/forced_filename_2.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4aaffc81991e41e21e7e9d9a099965a08ed0eb3f1f5f06a6d82eb6f7abe6f91
+size 312

--- a/lumicks/pylake/tests/reference_data/freezing/freezing[1].npz
+++ b/lumicks/pylake/tests/reference_data/freezing/freezing[1].npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d79214c5f3867dc81ef40476eb6cfee35a35f74030cd8f2a4ed721301e1283b8
+size 312

--- a/lumicks/pylake/tests/reference_data/freezing/freezing[2].npz
+++ b/lumicks/pylake/tests/reference_data/freezing/freezing[2].npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d79214c5f3867dc81ef40476eb6cfee35a35f74030cd8f2a4ed721301e1283b8
+size 312

--- a/lumicks/pylake/tests/reference_data/freezing/mytest[1].npz
+++ b/lumicks/pylake/tests/reference_data/freezing/mytest[1].npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56acf6c9b8fbe5dedfa261aa94546b2a98e3055de9339d5798b3dbf6d16e4b73
+size 312

--- a/lumicks/pylake/tests/reference_data/freezing/mytest[2].npz
+++ b/lumicks/pylake/tests/reference_data/freezing/mytest[2].npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56acf6c9b8fbe5dedfa261aa94546b2a98e3055de9339d5798b3dbf6d16e4b73
+size 312

--- a/lumicks/pylake/tests/test_utilities.py
+++ b/lumicks/pylake/tests/test_utilities.py
@@ -200,3 +200,15 @@ def test_key_aliases(src_dict, aliases, result_dict, valid):
     else:
         with pytest.raises(ValueError):
             replace_key_aliases(src_dict, *aliases)
+
+
+@pytest.mark.parametrize("tst", [1, 2])
+def test_freezing(reference_data, tst):
+    test_data = np.array([[1, 2, 3], [1, 2, 5]])
+    np.testing.assert_allclose(test_data, reference_data(test_data))
+    test_data = np.array([[1, 2, 3], [1, 2, 6]])
+    np.testing.assert_allclose(test_data, reference_data(test_data, test_name="mytest"))
+    test_data = np.array([[1, 2, 3], [1, 2, 7]])
+    np.testing.assert_allclose(
+        test_data, reference_data(test_data, file_name=f"forced_filename_{tst}")
+    )


### PR DESCRIPTION
**Why this PR?**
For another PR I have in flight, I noticed I was about to hardcode a bunch of matrices as data. Instead, it seems better to store these as a file. This PR is supposed to make this a bit more convenient. It is intended as a convenience function for small amounts of data (if we go to bigger datasets we will likely need something else in addition to this).

The function can be used by importing the fixture `reference_data` and then polling the reference data like:

```python
np.testing.assert_allclose(test_data, reference_data("test_data_name", test_data))
```

If the test data does not exist yet, the test data is generated when this function is called. If it does exist, but is different then it raises an error. You can then choose to delete the reference file (which will result in a regeneration) or calling `pytest` with `--update_reference_data` (which will force an update).

On CI, the tests are run with `--strict_reference_data` which disallows regeneration (so that you don't accidentally forget to check in your reference data).