### PR TITLE
dwelltime analysis: correctly handle minimum observable time

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,14 @@
 * Added support for slicing `PointScan`.
 * Added the ability to specify a cropping region when exporting to an h5-file using `file.save_as(filename, crop_time_range=(starting_timestamp, ending_timestamp))`.
 
+#### Bug fixes
+
+* Fixed issue in dwell time analysis that could lead to biased estimates for kymographs with very few events. Before this fix `KymoTrackGroup.fit_binding_times()` relied on the assumption that the shortest observed track is actually the minimum observable dwell time. This assumption is valid for kymographs with many events; however, this becomes problematic when multiple kymographs with few events each are analyzed globally. In this case, binding times will be underestimated. With this fix, the minimum observable dwell time is calculated from the kymograph scan line time and the set minimum track length.
+  * The old (incorrect) behavior is maintained as default until the next major release (`v2.0.0`) to ensure backward compatibility.
+  * **To enable the fixed behavior immediately (recommended), specify `observed_minimum=False` when calling `KymoTrackGroup.fit_binding_times()`.**
+  * To maintain the old legacy behavior use `observed_minimum=True`.
+  * Note that CSVs exported from the kymotracking widget before `v1.2.0` will contain insufficient metadata to make use of the improved analysis. To recover this metadata, use `lk.filter_tracks()` on the `KymoTrackGroup` with a specified `min_length`. This filters short events and stores the new minimum observable duration in the group.
+
 #### Other changes
 
 * Dropped `opencv` dependency which was only used for calculating rotation matrices and performing the affine transformations required for image alignment. Pylake now uses `scikit-image` for this purpose.

--- a/docs/whatsnew/1.2.0/1_2_0.rst
+++ b/docs/whatsnew/1.2.0/1_2_0.rst
@@ -5,6 +5,23 @@ Pylake 1.2.0
 
 Here's a sneak peak at some of the highlights from the upcoming Pylake `v1.2.0` release...
 
+Correctly use the minimum observable time in dwell time analysis
+----------------------------------------------------------------
+
+In earlier versions of Pylake, binding time analysis would return biased estimates when analyzing kymographs with very few events.
+This was because `KymoTrackGroup.fit_binding_times()` relied on the assumption that the shortest track in the `KymoTrackGroup` represented the minimum observable dwell time.
+This assumption is likely valid for kymographs with many tracks but problematic when few events occur per kymograph. In this case, binding times will be underestimated.
+For more information see the :doc:`changelog</changelog>`.
+
+.. important::
+
+    The old (incorrect) behavior is maintained as default until the next major release (`v2.0.0`) to ensure
+    backward compatibility. To enable the fixed behavior, specify `observed_minimum=False` when calling
+    `KymoTrackGroup.fit_binding_times()`.
+
+    Note that CSVs exported from the kymotracker widget  before `v1.2.0` will contain insufficient metadata
+    to make use of the improved analysis. To create this metadata, use `lk.filter_tracks()` on the group with a specified `min_length` before further analysis.
+
 Generate colormaps according to emission wavelength
 ---------------------------------------------------
 

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -115,7 +115,7 @@ def kymogroups_2tracks():
                 track.coordinate_idx[use_frames],
                 kymo,
                 "red",
-                kymo.line_time_seconds
+                kymo.line_time_seconds,
             )
             for track in tracks
         ]
@@ -129,7 +129,7 @@ def kymogroups_2tracks():
                 np.full(n_frames - 3, c),
                 kymo,
                 "red",
-                kymo.line_time_seconds
+                kymo.line_time_seconds,
             )
             for c in centers
         ]
@@ -164,3 +164,23 @@ def kymogroups_close_tracks():
             for c in centers
         ]
     )
+
+
+@pytest.fixture
+def simulate_dwelltimes():
+    def simulate_poisson(scale, num_samples, min_time=0, max_time=np.inf):
+        samples = np.array([])
+        for _ in range(100):
+            new_samples = np.random.exponential(scale, num_samples)
+            samples = np.hstack(
+                (
+                    samples,
+                    new_samples[np.logical_and(new_samples >= min_time, new_samples < max_time)],
+                )
+            )
+            if samples.size > num_samples:
+                return samples[:num_samples]
+        else:
+            raise RuntimeError("Generated fewer samples than intended.")
+
+    return simulate_poisson

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -76,6 +76,11 @@ def blank_kymo():
 
 
 @pytest.fixture
+def blank_kymo_track_args(blank_kymo):
+    return [blank_kymo, "red", blank_kymo.line_time_seconds]
+
+
+@pytest.fixture
 def kymogroups_2tracks():
     _, _, photon_count, parameters = read_dataset_gaussian("kymo_data_2lines.npz")
     pixel_size = parameters[0].pixel_size
@@ -93,14 +98,25 @@ def kymogroups_2tracks():
     _, n_frames = kymo.get_image("red").shape
 
     tracks = KymoTrackGroup(
-        [KymoTrack(np.arange(0, n_frames), np.full(n_frames, c), kymo, "red") for c in centers]
+        [
+            KymoTrack(
+                np.arange(0, n_frames), np.full(n_frames, c), kymo, "red", kymo.line_time_seconds
+            )
+            for c in centers
+        ]
     )
 
     # introduce gaps into tracks
     use_frames = np.array([0, 1, -2, -1])
     gapped_tracks = KymoTrackGroup(
         [
-            KymoTrack(track.time_idx[use_frames], track.coordinate_idx[use_frames], kymo, "red")
+            KymoTrack(
+                track.time_idx[use_frames],
+                track.coordinate_idx[use_frames],
+                kymo,
+                "red",
+                kymo.line_time_seconds
+            )
             for track in tracks
         ]
     )
@@ -108,7 +124,13 @@ def kymogroups_2tracks():
     # crop the ends of initial tracks and make new set of tracks with one cropped and the second full
     truncated_tracks = KymoTrackGroup(
         [
-            KymoTrack(np.arange(1, n_frames - 2), np.full(n_frames - 3, c), kymo, "red")
+            KymoTrack(
+                np.arange(1, n_frames - 2),
+                np.full(n_frames - 3, c),
+                kymo,
+                "red",
+                kymo.line_time_seconds
+            )
             for c in centers
         ]
     )
@@ -135,5 +157,10 @@ def kymogroups_close_tracks():
     _, n_frames = kymo.get_image("red").shape
 
     return KymoTrackGroup(
-        [KymoTrack(np.arange(0, n_frames), np.full(n_frames, c), kymo, "red") for c in centers]
+        [
+            KymoTrack(
+                np.arange(0, n_frames), np.full(n_frames, c), kymo, "red", kymo.line_time_seconds
+            )
+            for c in centers
+        ]
     )

--- a/lumicks/pylake/kymotracker/tests/test_image_sampling.py
+++ b/lumicks/pylake/kymotracker/tests/test_image_sampling.py
@@ -29,7 +29,7 @@ def test_sampling():
     )
 
     # Tests the bound handling
-    kymotrack = KymoTrack([0, 1, 2, 3, 4], [0, 1, 2, 3, 4], test_img, "red")
+    kymotrack = KymoTrack([0, 1, 2, 3, 4], [0, 1, 2, 3, 4], test_img, "red", 0)
     np.testing.assert_allclose(kymotrack.sample_from_image(
         50, correct_origin=True), [0, 2, 3, 2, 0]
     )
@@ -37,20 +37,20 @@ def test_sampling():
     np.testing.assert_allclose(kymotrack.sample_from_image(1, correct_origin=True), [0, 2, 2, 2, 0])
     np.testing.assert_allclose(kymotrack.sample_from_image(0, correct_origin=True), [0, 1, 1, 1, 0])
     np.testing.assert_allclose(
-        KymoTrack([0, 1, 2, 3, 4], [4, 4, 4, 4, 4], test_img, "red").sample_from_image(
+        KymoTrack([0, 1, 2, 3, 4], [4, 4, 4, 4, 4], test_img, "red", 0).sample_from_image(
             0, correct_origin=True
         ),
         [0, 0, 1, 1, 0],
     )
 
-    kymotrack = KymoTrack([0, 1, 2, 3, 4], [0.1, 1.1, 2.1, 3.1, 4.1], test_img, "red")
+    kymotrack = KymoTrack([0, 1, 2, 3, 4], [0.1, 1.1, 2.1, 3.1, 4.1], test_img, "red", 0)
     np.testing.assert_allclose(kymotrack.sample_from_image(
         50, correct_origin=True), [0, 2, 3, 2, 0]
     )
     np.testing.assert_allclose(kymotrack.sample_from_image(2, correct_origin=True), [0, 2, 3, 2, 0])
     np.testing.assert_allclose(kymotrack.sample_from_image(1, correct_origin=True), [0, 2, 2, 2, 0])
     np.testing.assert_allclose(kymotrack.sample_from_image(0, correct_origin=True), [0, 1, 1, 1, 0])
-    kymotrack = KymoTrack([0, 1, 2, 3, 4], [4.1, 4.1, 4.1, 4.1, 4.1], test_img, "red")
+    kymotrack = KymoTrack([0, 1, 2, 3, 4], [4.1, 4.1, 4.1, 4.1, 4.1], test_img, "red", 0)
     np.testing.assert_allclose(kymotrack.sample_from_image(0, correct_origin=True), [0, 0, 1, 1, 0])
 
 
@@ -71,7 +71,7 @@ def test_kymotrack_regression_sample_from_image_clamp():
         samples_per_pixel=1,
         line_padding=0
     )
-    assert np.array_equal(KymoTrack([0, 1], [2, 2], img, "red").sample_from_image(
+    assert np.array_equal(KymoTrack([0, 1], [2, 2], img, "red", 0).sample_from_image(
         0, correct_origin=True), [1, 3]
     )
 

--- a/lumicks/pylake/kymotracker/tests/test_io.py
+++ b/lumicks/pylake/kymotracker/tests/test_io.py
@@ -83,7 +83,9 @@ def test_kymotrackgroup_io(tmpdir_factory, dt, dx, delimiter, sampling_width, sa
 
     tracks = KymoTrackGroup(
         [
-            KymoTrack(np.array(time_idx), np.array(position_idx), kymo, "red")
+            KymoTrack(
+                np.array(time_idx), np.array(position_idx), kymo, "red", kymo.line_time_seconds
+            )
             for time_idx, position_idx in track_coordinates
         ]
     )
@@ -113,8 +115,8 @@ def test_kymotrackgroup_io(tmpdir_factory, dt, dx, delimiter, sampling_width, sa
 def test_export_sources(tmpdir_factory):
     kymo1 = _kymo_from_array(np.random.poisson(5, (5, 5, 3)), "rgb", 1e-4, start=20e9)
     kymo2 = copy(kymo1)
-    tracks1 = KymoTrackGroup([KymoTrack(np.arange(3), np.arange(3), kymo1, "red")])
-    tracks2 = KymoTrackGroup([KymoTrack(np.arange(5), np.arange(5), kymo2, "red")])
+    tracks1 = KymoTrackGroup([KymoTrack(np.arange(3), np.arange(3), kymo1, "red", 0)])
+    tracks2 = KymoTrackGroup([KymoTrack(np.arange(5), np.arange(5), kymo2, "red", 0)])
     tracks3 = tracks1 + tracks2
 
     testfile = f"{tmpdir_factory.mktemp('pylake')}/failed_test.csv"
@@ -158,7 +160,9 @@ def test_roundtrip_without_file(
 
     tracks = KymoTrackGroup(
         [
-            KymoTrack(np.array(time_idx), np.array(position_idx), kymo_integration_test_data, "red")
+            KymoTrack(
+                np.array(time_idx), np.array(position_idx), kymo_integration_test_data, "red", 0
+            )
             for time_idx, position_idx in track_coordinates
         ]
     )

--- a/lumicks/pylake/kymotracker/tests/test_io.py
+++ b/lumicks/pylake/kymotracker/tests/test_io.py
@@ -17,9 +17,15 @@ from lumicks.pylake.tests.data.mock_confocal import generate_kymo
 
 def compare_kymotrack_group(group1, group2):
     assert len(group1) == len(group2)
+    attributes = (
+        "coordinate_idx", "time_idx", "position", "seconds", "_minimum_observable_duration"
+    )
     for track1, track2 in zip(group1, group2):
-        for property in ("coordinate_idx", "time_idx", "position", "seconds"):
-            np.testing.assert_allclose(getattr(track1, property), getattr(track2, property))
+        for attr in attributes:
+            attr1, attr2 = getattr(track1, attr), getattr(track2, attr)
+            np.testing.assert_allclose(attr1, attr2)
+            if not (np.isscalar(attr1) and np.isscalar(attr2)):
+                assert len(attr1) == len(attr2)
 
 
 @pytest.mark.parametrize(

--- a/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
@@ -1,8 +1,6 @@
 import re
 import pytest
-from copy import copy
 from lumicks.pylake.kymotracker.kymotrack import *
-from lumicks.pylake.kymotracker.kymotracker import refine_tracks_centroid, refine_tracks_gaussian
 from lumicks.pylake.kymo import _kymo_from_array
 
 
@@ -68,8 +66,14 @@ def test_empty_constructor():
 def test_constructor(kymos, coordinates):
     kymo = kymos[0]
     time_indices, position_indices = coordinates
-    raw_tracks = [KymoTrack(t, p, kymo, "green") for t, p in zip(time_indices, position_indices)]
-    raw_tracks_red = [KymoTrack(t, p, kymo, "red") for t, p in zip(time_indices, position_indices)]
+    raw_tracks = [
+        KymoTrack(t, p, kymo, "green", kymo.line_time_seconds)
+        for t, p in zip(time_indices, position_indices)
+    ]
+    raw_tracks_red = [
+        KymoTrack(t, p, kymo, "red", kymo.line_time_seconds)
+        for t, p in zip(time_indices, position_indices)
+    ]
 
     # construct from single source
     tracks = KymoTrackGroup(raw_tracks)
@@ -95,8 +99,14 @@ def test_constructor(kymos, coordinates):
 def test_extend_single_source(kymos, coordinates):
     kymo = kymos[0]
     time_indices, position_indices = coordinates
-    raw_tracks = [KymoTrack(t, p, kymo, "green") for t, p in zip(time_indices, position_indices)]
-    raw_tracks_red = [KymoTrack(t, p, kymo, "red") for t, p in zip(time_indices, position_indices)]
+    raw_tracks = [
+        KymoTrack(t, p, kymo, "green", kymo.line_time_seconds)
+        for t, p in zip(time_indices, position_indices)
+    ]
+    raw_tracks_red = [
+        KymoTrack(t, p, kymo, "red", kymo.line_time_seconds)
+        for t, p in zip(time_indices, position_indices)
+    ]
 
     tracks1 = KymoTrackGroup(raw_tracks[:2])
     tracks2 = KymoTrackGroup(raw_tracks[2:])
@@ -124,7 +134,10 @@ def test_extend_single_source(kymos, coordinates):
 def test_extend_empty(kymos, coordinates):
     kymo = kymos[0]
     time_indices, position_indices = coordinates
-    raw_tracks = [KymoTrack(t, p, kymo, "green") for t, p in zip(time_indices, position_indices)]
+    raw_tracks = [
+        KymoTrack(t, p, kymo, "green", kymo.line_time_seconds)
+        for t, p in zip(time_indices, position_indices)
+    ]
 
     empty = KymoTrackGroup([])
     tracks2 = KymoTrackGroup(raw_tracks)
@@ -160,10 +173,16 @@ def test_different_sources_same_attributes(kymos, coordinates):
 
     time_indices, position_indices = coordinates
     tracks1 = KymoTrackGroup(
-        [KymoTrack(t, p, kymo1, "green") for t, p in zip(time_indices, position_indices)]
+        [
+            KymoTrack(t, p, kymo1, "green", kymo1.line_time_seconds)
+            for t, p in zip(time_indices, position_indices)
+        ]
     )
     tracks2 = KymoTrackGroup(
-        [KymoTrack(t, p, kymo2, "green") for t, p in zip(time_indices, position_indices)]
+        [
+            KymoTrack(t, p, kymo2, "green", kymo2.line_time_seconds)
+            for t, p in zip(time_indices, position_indices)
+        ]
     )
 
     tracks = tracks1[:2] + tracks2[2:]
@@ -177,7 +196,10 @@ def test_different_sources_different_attributes(kymos, coordinates):
 
     def make_tracks(kymo):
         return KymoTrackGroup(
-            [KymoTrack(t, p, kymo, "green") for t, p in zip(time_indices, position_indices)]
+            [
+                KymoTrack(t, p, kymo, "green", kymo.line_time_seconds)
+                for t, p in zip(time_indices, position_indices)
+            ]
         )
 
     # different line times
@@ -223,7 +245,10 @@ def test_tracks_by_kymo(kymos, coordinates):
 
     def make_tracks(kymo):
         return KymoTrackGroup(
-            [KymoTrack(t, p, kymo, "green") for t, p in zip(time_indices, position_indices)]
+            [
+                KymoTrack(t, p, kymo, "green", kymo.line_time_seconds)
+                for t, p in zip(time_indices, position_indices)
+            ]
         )
 
     tracks = [make_tracks(k) for k in (kymos[0], kymos[-1], kymos[0])]

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -402,6 +402,13 @@ def test_filter_tracks(blank_kymo):
     assert all([track1 == track2 for track1, track2 in zip(filter_tracks(tracks, 5), [k1, k3])])
     assert all([track1 == track2 for track1, track2 in zip(filter_tracks(tracks, 2), [k1, k2, k3])])
 
+    # Ensure that a non-identified minimum time still gets handled gracefully.
+    ktg = KymoTrackGroup([KymoTrack([1, 2, 3], [1, 2, 3], blank_kymo, "red", None)])
+    filtered = filter_tracks(ktg, 2)
+    np.testing.assert_allclose(
+        filtered[0]._minimum_observable_duration, blank_kymo.line_time_seconds
+    )
+
 
 def test_empty_group():
     """Validate that the refinement methods don't fail when applied to an empty group"""

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -1,7 +1,6 @@
 import pytest
 import re
 import numpy as np
-from lumicks.pylake.kymo import _kymo_from_array
 from lumicks.pylake.kymotracker.detail.localization_models import GaussianLocalizationModel
 from lumicks.pylake.kymotracker.kymotracker import *
 from lumicks.pylake.kymotracker.kymotrack import KymoTrack, KymoTrackGroup
@@ -10,10 +9,10 @@ from lumicks.pylake.kymo import _kymo_from_array
 from scipy.stats import norm
 
 
-def test_kymotrack_interpolation(blank_kymo):
+def test_kymotrack_interpolation(blank_kymo, blank_kymo_track_args):
     time_idx = np.array([1, 3, 5])
     coordinate_idx = np.array([1.0, 3.0, 3.0])
-    kymotrack = KymoTrack(time_idx, coordinate_idx, blank_kymo, "red")
+    kymotrack = KymoTrack(time_idx, coordinate_idx, *blank_kymo_track_args)
     interpolated = kymotrack.interpolate()
     np.testing.assert_equal(interpolated.time_idx, [1, 2, 3, 4, 5])
     np.testing.assert_allclose(interpolated.coordinate_idx, [1.0, 2.0, 3.0, 3.0, 3.0])
@@ -46,7 +45,7 @@ def test_refinement_2d():
         line_padding=0,
     )
 
-    track = KymoTrack(time_idx[::2], coordinate_idx[::2], kymo, "red")
+    track = KymoTrack(time_idx[::2], coordinate_idx[::2], kymo, "red", kymo.line_time_seconds)
     refined_track = refine_tracks_centroid([track], 5, bias_correction=False)[0]
     np.testing.assert_allclose(refined_track.time_idx, time_idx)
     np.testing.assert_allclose(refined_track.coordinate_idx, coordinate_idx + offset)
@@ -79,7 +78,7 @@ def test_refinement_track(loc, ref_counts):
         line_padding=0,
     )
 
-    track = refine_tracks_centroid([KymoTrack([0], [25], kymo, "red")], 5)[0]
+    track = refine_tracks_centroid([KymoTrack([0], [25], kymo, "red", 1)], 5)[0]
     np.testing.assert_allclose(track.coordinate_idx, loc, rtol=1e-2)
     np.testing.assert_equal(track.photon_counts, ref_counts)
 
@@ -92,7 +91,7 @@ def test_refinement_with_background(loc, ref_count):
     kymo = generate_kymo("", np.expand_dims(image, 1), pixel_size_nm=1000)
 
     # Without bias correction, we should see worse quality estimates
-    tracks = [KymoTrack([0], [25], kymo, "red")]
+    tracks = [KymoTrack([0], [25], kymo, "red", 1)]
     refinement_width = 5
     track = refine_tracks_centroid(tracks, refinement_width, bias_correction=False)[0]
     with pytest.raises(AssertionError):
@@ -105,13 +104,16 @@ def test_refinement_with_background(loc, ref_count):
 
 
 def test_refinement_error(kymo_integration_test_data):
+    args = [
+        [0], [25], kymo_integration_test_data, "red", kymo_integration_test_data.line_time_seconds
+    ]
     with pytest.raises(
         ValueError, match=re.escape("track_width must at least be 3 pixels (0.150 [um])")
     ):
-        refine_tracks_centroid([KymoTrack([0], [25], kymo_integration_test_data, "red")], 0.149)[0]
+        refine_tracks_centroid([KymoTrack(*args)], 0.149)[0]
 
     # This should be fine though
-    refine_tracks_centroid([KymoTrack([0], [25], kymo_integration_test_data, "red")], 0.15)[0]
+    refine_tracks_centroid([KymoTrack(*args)], 0.15)[0]
 
 
 def test_centroid_refinement_multiple_sources(kymogroups_2tracks, kymogroups_close_tracks):
@@ -250,7 +252,12 @@ def test_no_swap_gaussian_refinement():
         1,
     )
     group = KymoTrackGroup(
-        [KymoTrack(np.array([0, 1]), np.array([loc, loc]), kymo, "red") for loc in locations]
+        [
+            KymoTrack(
+                np.array([0, 1]), np.array([loc, loc]), kymo, "red", kymo.line_time_seconds
+            )
+            for loc in locations
+        ]
     )
 
     refined_group = refine_tracks_gaussian(
@@ -314,11 +321,46 @@ def test_gaussian_refinement_multiple_sources(kymogroups_2tracks, kymogroups_clo
         np.testing.assert_allclose(track.position, ref_track.position)
 
 
-def test_no_model_fit(blank_kymo):
+@pytest.mark.filterwarnings("ignore:There were")
+def test_gaussian_refinement_min_time_ordering():
+    kymo = _kymo_from_array(
+        np.ones((50, 50)), pixel_size_um=1, line_time_seconds=2, color_format="r"
+    )
+
+    k1 = KymoTrack(np.arange(5), np.zeros(5) + 2 * np.random.rand(5), kymo, "red", 5)
+    k2 = KymoTrack(np.arange(2, 7), np.ones(5) * 7 + 2 * np.random.rand(5), kymo, "red", 1)
+    k3 = KymoTrack(np.arange(5), np.ones(5) * 14 + 2 * np.random.rand(5), kymo, "red", 2)
+    ktg = KymoTrackGroup([k1, k2, k3])
+
+    refined = refine_tracks_gaussian(
+        ktg, overlap_strategy="skip", window=3, refine_missing_frames=False
+    )
+    for track, ref in zip(refined, (5, 1, 2)):
+        if len(track) > 0:
+            assert np.all(track._minimum_observable_duration == ref)
+
+
+@pytest.mark.filterwarnings("ignore:There were")
+def test_gaussian_refinement_min_time_ordering_skip_tracks():
+    kymo = _kymo_from_array(
+        np.ones((50, 50)), pixel_size_um=1, line_time_seconds=2, color_format="r"
+    )
+    k1 = KymoTrack(np.arange(5), np.zeros(5), kymo, "red", 4)
+    k2 = KymoTrack(np.arange(5), np.zeros(5), kymo, "red", 5)
+    k3 = KymoTrack(np.arange(5), np.ones(5) * 10, kymo, "red", 6)
+    ktg = KymoTrackGroup([k1, k2, k3])
+    refined = refine_tracks_gaussian(
+        ktg, overlap_strategy="skip", window=3, refine_missing_frames=False
+    )
+    assert refined[0]._minimum_observable_duration == 6
+    assert len(refined) == 1
+
+
+def test_no_model_fit(blank_kymo, blank_kymo_track_args):
     with pytest.raises(
         NotImplementedError, match="No model fit available for this localization method."
     ):
-        KymoTrack([1, 2, 3], [1, 2, 3], blank_kymo, "red")._model_fit(1)
+        KymoTrack([1, 2, 3], [1, 2, 3], *blank_kymo_track_args)._model_fit(1)
 
 
 @pytest.mark.parametrize("method", ["_model_fit", "plot_fit"])
@@ -333,7 +375,7 @@ def test_gaussian_model_fit(method):
         background=np.array([10, 15]),
         _overlap_fit=np.array([True, True]),
     )
-    track = KymoTrack(np.array([1, 3]), gauss_loc, kymo, "red")
+    track = KymoTrack(np.array([1, 3]), gauss_loc, kymo, "red", kymo.line_time_seconds)
     tested_method = getattr(track, method)
     ref_coords = np.arange(0, len(kymo_data) * pixel_size_um, 0.1 * pixel_size_um)
 
@@ -361,8 +403,8 @@ def test_gaussian_refinement_plotting():
     kymo = _kymo_from_array(np.tile([0, 1, 2, 1, 2, 1, 0], (4, 1)).T, "r", 1, pixel_size_um=1)
     group = KymoTrackGroup(
         [
-            KymoTrack(np.array([0, 2]), np.array([2, 2]), kymo, "red"),
-            KymoTrack(np.array([0, 1, 2]), np.array([4, 4, 4]), kymo, "red"),
+            KymoTrack(np.array([0, 2]), np.array([2, 2]), kymo, "red", kymo.line_time_seconds),
+            KymoTrack(np.array([0, 1, 2]), np.array([4, 4, 4]), kymo, "red", kymo.line_time_seconds),
         ]
     )
 
@@ -393,14 +435,36 @@ def test_gaussian_refinement_plotting():
         KymoTrackGroup([]).plot_fit(0)
 
 
-def test_filter_tracks(blank_kymo):
-    k1 = KymoTrack([1, 2, 3], [1, 2, 3], blank_kymo, "red")
-    k2 = KymoTrack([2, 3], [1, 2], blank_kymo, "red")
-    k3 = KymoTrack([2, 3, 4, 5], [1, 2, 4, 5], blank_kymo, "red")
+def test_filter_tracks(blank_kymo, blank_kymo_track_args):
+    k1 = KymoTrack([1, 2, 3], [1, 2, 3], *blank_kymo_track_args)
+    k2 = KymoTrack([2, 3], [1, 2], *blank_kymo_track_args)
+    k3 = KymoTrack([2, 3, 4, 5], [1, 2, 4, 5], *blank_kymo_track_args)
     tracks = KymoTrackGroup([k1, k2, k3])
     assert len(filter_tracks(tracks, 5)) == 0
-    assert all([track1 == track2 for track1, track2 in zip(filter_tracks(tracks, 5), [k1, k3])])
-    assert all([track1 == track2 for track1, track2 in zip(filter_tracks(tracks, 2), [k1, k2, k3])])
+
+    # We compare the positions since a track doesn't have a proper equality operator.
+    filtered = filter_tracks(tracks, 5)
+    assert all(
+        [
+            np.array_equal(track1.position, track2.position)
+            for track1, track2 in zip(filtered, [k1, k3])
+        ]
+    )
+    assert all([t._minimum_observable_duration == 4 * k1._kymo.line_time_seconds for t in filtered])
+
+    # Ensure that if we filter again with a shorter filter, we don't reduce the minimum observable
+    # time, since we wouldn't recover lines.
+    twice = filter_tracks(filtered, 2)
+    assert all([t._minimum_observable_duration == 4 * k1._kymo.line_time_seconds for t in twice])
+
+    filtered = filter_tracks(tracks, 2)
+    assert all(
+        [
+            np.array_equal(track1.position, track2.position)
+            for track1, track2 in zip(filtered, [k1, k2, k3])
+        ]
+    )
+    assert all([t._minimum_observable_duration == k1._kymo.line_time_seconds for t in filtered])
 
     # Ensure that a non-identified minimum time still gets handled gracefully.
     ktg = KymoTrackGroup([KymoTrack([1, 2, 3], [1, 2, 3], blank_kymo, "red", None)])

--- a/lumicks/pylake/kymotracker/tests/test_stitching.py
+++ b/lumicks/pylake/kymotracker/tests/test_stitching.py
@@ -14,16 +14,16 @@ def test_distance_line_to_point():
     assert distance_line_to_point(np.array([0, 0]), np.array([1, 0]), np.array([0, 1])) == 1.0
 
 
-def test_stitching(blank_kymo):
+def test_stitching(blank_kymo, blank_kymo_track_args):
 
-    segment_1 = KymoTrack([0, 1], [0, 1], blank_kymo, "red")
-    segment_2 = KymoTrack([2, 3], [2, 3], blank_kymo, "red")
-    segment_3 = KymoTrack([2, 3], [0, 0], blank_kymo, "red")
-    segment_1b = KymoTrack([0, 1], [0, 0], blank_kymo, "red")
-    segment_1c = KymoTrack([-1, 0, 1], [0, 0, 1], blank_kymo, "red")
+    segment_1 = KymoTrack([0, 1], [0, 1], *blank_kymo_track_args)
+    segment_2 = KymoTrack([2, 3], [2, 3], *blank_kymo_track_args)
+    segment_3 = KymoTrack([2, 3], [0, 0], *blank_kymo_track_args)
+    segment_1b = KymoTrack([0, 1], [0, 0], *blank_kymo_track_args)
+    segment_1c = KymoTrack([-1, 0, 1], [0, 0, 1], *blank_kymo_track_args)
 
     radius = 0.05
-    segment_1d = KymoTrack([0, 1], [radius + 0.01, radius + 0.01], blank_kymo, "red")
+    segment_1d = KymoTrack([0, 1], [radius + 0.01, radius + 0.01], *blank_kymo_track_args)
 
     # Out of stitch range (maximum extension = 1)
     assert len(stitch_kymo_lines([segment_1, segment_3, segment_2], radius, 1, 2)) == 3
@@ -52,28 +52,28 @@ def test_stitching(blank_kymo):
     # Check whether the alignment has to work in both directions
     # - and - should connect
     track1, track2 = KymoTrack(
-        [0, 1], [0, 0], blank_kymo, "red"), KymoTrack([2, 3], [0, 0], blank_kymo, "red"
+        [0, 1], [0, 0], *blank_kymo_track_args), KymoTrack([2, 3], [0, 0], *blank_kymo_track_args
     )
     assert len(stitch_kymo_lines([track1, track2], radius, 1, 2)) == 1
 
     # - and | should not connect.
     track1, track2 = KymoTrack(
-        [0, 1], [0, 0], blank_kymo, "red"), KymoTrack([2, 3], [0, 1], blank_kymo, "red"
+        [0, 1], [0, 0], *blank_kymo_track_args), KymoTrack([2, 3], [0, 1], *blank_kymo_track_args
     )
     assert len(stitch_kymo_lines([track1, track2], radius, 1, 2)) == 2
 
 
-def test_invalid_stitching(blank_kymo):
-    segment_1 = KymoTrack([0], [0], blank_kymo, "red")
-    segment_2 = KymoTrack([2], [2], blank_kymo, "red")
+def test_invalid_stitching(blank_kymo, blank_kymo_track_args):
+    segment_1 = KymoTrack([0], [0], *blank_kymo_track_args)
+    segment_2 = KymoTrack([2], [2], *blank_kymo_track_args)
 
     with pytest.raises(
         RuntimeError, match="Cannot extrapolate linearly with fewer than two timepoints"
     ):
         stitch_kymo_lines([segment_1, segment_2], radius=2, max_extension=2, n_points=2)
 
-    segment_1 = KymoTrack([0, 1], [0, 1], blank_kymo, "red")
-    segment_2 = KymoTrack([2, 3], [2, 2], blank_kymo, "red")
+    segment_1 = KymoTrack([0, 1], [0, 1], *blank_kymo_track_args)
+    segment_2 = KymoTrack([2, 3], [2, 2], *blank_kymo_track_args)
 
     with pytest.raises(
         ValueError, match="Cannot extrapolate linearly with fewer than two timepoints"

--- a/lumicks/pylake/kymotracker/tests/test_tracing.py
+++ b/lumicks/pylake/kymotracker/tests/test_tracing.py
@@ -10,8 +10,8 @@ from lumicks.pylake.kymotracker.kymotrack import KymoTrack
 from lumicks.pylake.kymotracker.detail.peakfinding import KymoPeaks
 
 
-def test_score_matrix(blank_kymo):
-    tracks = [KymoTrack([0], [3], blank_kymo, "red")]
+def test_score_matrix(blank_kymo, blank_kymo_track_args):
+    tracks = [KymoTrack([0], [3], *blank_kymo_track_args)]
     unique_coordinates = np.arange(0, 7)
     unique_times = np.arange(1, 7)
 

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -195,12 +195,14 @@ def test_stitch(kymograph, mockevent):
         np.array([1, 1, 1]),
         kymograph,
         "red",
+        kymograph.line_time_seconds,
     )
     k2 = KymoTrack(
         np.array([6, 7, 8]),
         np.array([3, 3, 3]),
         kymograph,
         "red",
+        kymograph.line_time_seconds,
     )
     kymo_widget.tracks = KymoTrackGroup([k1, k2])
 
@@ -241,12 +243,14 @@ def test_stitch_anywhere(start, stop, same_track, kymograph, mockevent):
         np.array([1, 1, 1, 3, 3]),
         kymograph,
         "red",
+        kymograph.line_time_seconds,
     )
     k2 = KymoTrack(
         np.array([6, 7, 8]),
         np.array([3, 3, 3]),
         kymograph,
         "red",
+        kymograph.line_time_seconds,
     )
     kymo_widget.tracks = KymoTrackGroup([k1, k2])
 
@@ -419,6 +423,7 @@ def test_split(kymograph, mockevent):
         np.array([1, 1, 1, 1, 1, 1, 1, 1, 1]),
         kymograph,
         "red",
+        kymograph.line_time_seconds,
     )
     kymo_widget.tracks = KymoTrackGroup([k1])
 

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -1061,6 +1061,7 @@ def _exponential_mle_optimize(
     options=None,
     fixed_param_mask=None,
     use_jacobian=True,
+    range_rel_tolerance=1e-6,
 ):
     """Calculate the maximum likelihood estimate of the model parameters given measured dwelltimes.
 
@@ -1082,6 +1083,9 @@ def _exponential_mle_optimize(
     fixed_param_mask : array_like, optional
         logical mask of which parameters to fix during optimization. When omitted, no parameter is
         assumed fixed.
+    range_rel_tolerance : float, optional
+        Relative tolerance when evaluating whether the dwell times are in the valid range.
+        Default: 1e-6.
 
     Raises
     ------
@@ -1090,7 +1094,12 @@ def _exponential_mle_optimize(
     ValueError
         If all amplitudes are fixed but the amplitudes in the initial_guess do not sum to 1.
     """
-    if np.any(np.logical_or(t < min_observation_time, t > max_observation_time)):
+    if np.any(
+        np.logical_or(
+            t < (min_observation_time - range_rel_tolerance * min_observation_time),
+            t > (max_observation_time + range_rel_tolerance * max_observation_time),
+        )
+    ):
         raise ValueError(
             "some data is outside of the bounded region. Please choose"
             "appropriate values for `min_observation_time` and/or `max_observation_time`."

--- a/lumicks/pylake/simulation/diffusion.py
+++ b/lumicks/pylake/simulation/diffusion.py
@@ -75,6 +75,7 @@ def simulate_diffusive_tracks(
                 ),
                 kymo=blank_kymo,
                 channel="red",
+                minimum_observable_duration=blank_kymo.line_time_seconds,
             )
             for _ in range(num_tracks)
         ]


### PR DESCRIPTION
**Why this PR?**
Currently, we take the minimum time of the available dwell times per kymograph as the minimally observable dwelltime. For kymographs with few events, this can be off as the lowest dwell time could simply not have been observed. This leads to a potentially large bias in the estimates obtained with global analysis (if few events per kymo are available). For kymographs with many events, the bias is likely to be small.

Highly recommend going commit by commit. I left the big testing update as a separate commit to try and separate the signal from the noise a bit.

<img width="561" alt="image" src="https://github.com/lumicks/pylake/assets/19836026/4f739ca6-33c2-4c26-85de-8dbb87ab1928">

Unfortunately, the ability to perform dwell time analysis on multiple Kymo's has been released in `1.1`, meaning that it was technically possible to get into the state where you would get such biases. This means we should not silently fix the behavior, but prompt the user to make the change knowingly by passing an extra flag. In the next major release, I would deprecate the old bad behavior.

What makes this especially painful is that for CSV files with tracks, we lack the required metadata to reconstruct what the minimum dwelltime was for a particular set of tracks. Considering that Pylake supports multi-ROI, these could even be different _within_ a `Kymo`.

The user essentially has three options.
- Filter the tracks by a known minimum length after loading (which recreates the metadata).
- Use the old behavior and assume a sufficient number of tracks have been acquired to get into the asymptotic state.
- Retrack.

I tried to put the options the user has at this points in the error message, but I feel I might have overloaded it with information. I would appreciate some feedback on this.

*What to look out for?*
1. Are we happy with handling it this way: First through emit a warning, making the old behavior the default, then deprecating in the future.
2. One thing I am not particularly happy with is the last commit. Unfortunately though, floating point error means that we cannot enforce this criterion exactly as some of the valid dwell times end up slightly under the criterion (by more than just one epsilon, so `np.nextafter` isn't an option). Right now I set up a relative tolerance for this, but better approaches are welcome. Note that simply changing the stored filter level as frames won't resolve the problem, since the error comes from the duration calculation rather than the bound.