### PR TITLE
confocal: faster pixel and line times.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 * Deprecated fitting mode `"multiple"` in `lk.refine_tracks_gaussian()` as it could lead to spurious track crossings. See the entry for the fitting mode `"simultaneous"` under `New Features` for more information.
 * [`File.save_as()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.File.html#lumicks.pylake.File.save_as) data now allows passing in a single string for the `omit_data` parameter.
 * Gracefully handle empty `Scan` after slicing. Previously, a slice operation on a `Scan` that resulted in no frames remaining raised a `NotImplementedError`. Now it returns an `EmptyScan`.
+* Improved performance of `Scan.pixel_time_seconds`, `Kymo.pixel_time_seconds` and `Kymo.line_time_seconds`.
 
 ## v1.1.1 | 2023-06-13
 

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -174,6 +174,16 @@ def reconstruct_image(data, infowave, shape, reduce=np.sum):
     return reshape_reconstructed_image(pixels, shape)
 
 
+def first_pixel_sample_indices(infowave):
+    """Returns start and stop index of the first pixel in the infowave"""
+    if infowave.size == 0:
+        return 0, 0
+
+    return np.argmax(infowave != InfowaveCode.discard), np.argmax(
+        infowave == InfowaveCode.pixel_boundary
+    )
+
+
 def histogram_rows(image, pixels_per_bin, pixel_width):
     bin_width = pixels_per_bin * pixel_width  # in physical units
     n_rows = image.shape[0]

--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -1,8 +1,52 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mpl
+import cachetools
 import math
 import contextlib
+
+
+def method_cache(name):
+    """A small convenience decorator to incorporate some really basic instance method memoization
+
+    Note: When used on properties, this one should be included _after_ the @property decorator.
+    Data will be stored in the `_cache` variable of the instance.
+
+    Parameters
+    ----------
+    name : str
+        Name of the instance method to memo-ize. Suggestion: the instance method name.
+
+    Examples
+    --------
+    ::
+
+        class Test:
+            def __init__(self):
+                self._cache = {}
+                ...
+
+            @property
+            @method_cache("example_property")
+            def example_property(self):
+                return 10
+
+            @method_cache("example_method")
+            def example_method(self, arguments):
+                return 5
+
+
+        test = Test()
+        test.example_property
+        test.example_method("hi")
+        test._cache
+        # test._cache will now show {('example_property',): 10, ('example_method', 'hi'): 5}
+    """
+
+    def key(_, *args, **kwargs):
+        return cachetools.keys.hashkey(name, *args, **kwargs)
+
+    return cachetools.cachedmethod(lambda self: self._cache, key=key)
 
 
 def use_docstring_from(copy_func):

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -68,13 +68,13 @@ def _default_line_time_factory(self: "Kymo"):
 def _default_line_timestamp_ranges_factory(self: "Kymo", exclude: bool):
     """Get start and stop timestamp of each line in the kymo."""
 
-    ts_min = self._timestamps("timestamps", reduce=np.min)[0]
+    ts_min = self._timestamps(reduce=np.min)[0]
 
     if exclude:
         # Take the max value of each line to account for unfinished final line
         # and add one sample to have proper slicing
         delta_ts = int(1e9 / self.infowave.sample_rate)
-        ts_max = self._timestamps("timestamps", reduce=np.max).max(axis=0) + delta_ts
+        ts_max = self._timestamps(reduce=np.max).max(axis=0) + delta_ts
     else:
         line_time = ts_min[1] - ts_min[0]
         ts_max = ts_min + line_time
@@ -617,7 +617,7 @@ class Kymo(ConfocalImage):
             return self._image(channel)[lower_pixels:upper_pixels, :]
 
         def timestamp_factory(_, reduce):
-            return self._timestamps("timestamps", reduce)[lower_pixels:upper_pixels, :]
+            return self._timestamps(reduce)[lower_pixels:upper_pixels, :]
 
         def pixelcount_factory(_):
             num_pixels = self._num_pixels
@@ -676,7 +676,7 @@ class Kymo(ConfocalImage):
             ill_defined("Line timestamp ranges")
 
         def timestamp_factory(_, reduce_timestamps):
-            ts = self._timestamps("timestamps", reduce_timestamps)
+            ts = self._timestamps(reduce_timestamps)
             full_blocks = ts[: round_down(ts.shape[0], position_factor), :]
             reshaped = full_blocks.reshape(-1, position_factor, ts.shape[1])
             return reduce_timestamps(reshaped, axis=1)

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from .detail.utilities import method_cache
 from . import colormaps
 from .adjustments import no_adjustment
 from .detail.confocal import (
@@ -252,6 +253,7 @@ class Kymo(ConfocalImage):
         return sliced_kymo
 
     @property
+    @method_cache("pixel_time_seconds")
     def pixel_time_seconds(self):
         """Pixel dwell time in seconds"""
         if self._has_default_factories():
@@ -324,6 +326,7 @@ class Kymo(ConfocalImage):
             return shape
 
     @property
+    @method_cache("line_time_seconds")
     def line_time_seconds(self):
         """Line time in seconds
 

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from . import colormaps
 from .adjustments import no_adjustment
+from .detail.utilities import method_cache
 from .detail.confocal import ConfocalImage
 from .detail.image import make_image_title, reconstruct_num_frames, first_pixel_sample_indices
 from .detail.imaging_mixins import FrameIndex, VideoExport
@@ -205,6 +206,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         return new_scan
 
     @property
+    @method_cache("pixel_time_seconds")
     def pixel_time_seconds(self):
         """Pixel dwell time in seconds"""
         if self._has_default_factories():

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -99,7 +99,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             return self._image(channel)[slices]
 
         def timestamp_factory(_, reduce_timestamps):
-            ts = self._timestamps("timestamps", reduce_timestamps)
+            ts = self._timestamps(reduce_timestamps)
             return ts[slices]
 
         result = copy(self)
@@ -270,8 +270,8 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             file.force1x[start:stop].plot()
         """
 
-        ts_min = self._timestamps("timestamps", reduce=np.min)
-        ts_max = self._timestamps("timestamps", reduce=np.max)
+        ts_min = self._timestamps(reduce=np.min)
+        ts_max = self._timestamps(reduce=np.max)
         delta_ts = int(1e9 / self.infowave.sample_rate)  # We want the sample beyond the end
         if ts_min.ndim == 2:
             return [(np.min(ts_min), np.max(ts_max) + delta_ts)]

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -7,6 +7,7 @@ from lumicks.pylake.detail.image import (
     reconstruct_image_sum,
     reconstruct_num_frames,
     histogram_rows,
+    first_pixel_sample_indices,
 )
 
 
@@ -226,3 +227,20 @@ def test_wavelength_to_xyz(wavelength, ref_xyz):
 def test_wavelength_to_cmap(wavelength, ref):
     cmap = colormaps.from_wavelength(wavelength)
     np.testing.assert_allclose(cmap([0, 0.5, 1]), ref)
+
+
+@pytest.mark.parametrize(
+    "data, ref_start, ref_stop",
+    [
+        ([1, 1, 2], 0, 2),
+        ([0, 0, 1, 1, 2], 2, 4),
+        ([2, 2, 2, 2], 0, 0),
+        ([0, 2, 2, 2, 2], 1, 1),
+        ([0, 1, 2, 1, 2], 1, 2),
+        ([], 0, 0),
+    ],
+)
+def test_first_pixel_sample_indices(data, ref_start, ref_stop):
+    start, stop = first_pixel_sample_indices(np.asarray(data))
+    assert start == ref_start
+    assert stop == ref_stop

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo.py
@@ -259,9 +259,7 @@ def test_plotting_with_force_downsampling(kymo_h5_file):
     #    np.testing.assert_allclose(np.mean(kymo.timestamps, axis=0)[:-1], ds.timestamps[:-1])
     # would have sufficed. However, in this case we need the following solution:
     ds = f.force2x.downsampled_over(ranges)
-    min_ts, max_ts = (
-        reduce(kymo._timestamps("timestamps", reduce), axis=0) for reduce in (np.min, np.max)
-    )
+    min_ts, max_ts = (reduce(kymo._timestamps(reduce), axis=0) for reduce in (np.min, np.max))
     target_timestamps = np.array(
         [
             np.mean(kymo.infowave[int(start) : int(stop) + 1].timestamps)
@@ -793,8 +791,7 @@ def test_kymo_slice_crop():
     np.testing.assert_allclose(sliced_cropped.get_image("red"), [[0, 0, 12], [12, 12, 0]])
     np.testing.assert_allclose(sliced_cropped._position_offset, 8e-3)
     np.testing.assert_equal(
-        sliced_cropped._timestamps("timestamps", reduce=np.min),
-        [[450e9, 595e9, 740e9], [475e9, 620e9, 765e9]],
+        sliced_cropped._timestamps(reduce=np.min), [[450e9, 595e9, 740e9], [475e9, 620e9, 765e9]]
     )
 
 

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo_from_array.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo_from_array.py
@@ -14,7 +14,7 @@ colors = ("red", "green", "blue")
 
 
 def make_kymo_from_array(kymo, image, color_format, no_pxsize=False):
-    start = kymo._timestamps("timestamps", np.min)[0, 0]
+    start = kymo._timestamps(np.min)[0, 0]
     exposure_time_sec = np.diff(kymo.line_timestamp_ranges(include_dead_time=False)[0])[0] * 1e-9
 
     return _kymo_from_array(

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_point_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_point_scan.py
@@ -8,7 +8,7 @@ def test_point_scans_basic(test_point_scans, reference_timestamps, reference_cou
     ps = test_point_scans["PointScan1"]
     ps_red = ps.red_photon_count
 
-    assert ps_red.data.shape == (64,)
+    assert ps_red.data.shape == (90,)
 
     np.testing.assert_allclose(ps_red.timestamps, reference_timestamps)
     np.testing.assert_allclose(ps_red.data, reference_counts)

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_scan.py
@@ -12,18 +12,20 @@ def test_scan_attrs(test_scans):
     assert repr(scan) == "Scan(pixels=(4, 5))"
 
     # fmt: off
-    reference_timestamps = np.array([[2.006250e+10, 2.025000e+10, 2.043750e+10, 2.062500e+10],
-                                    [2.084375e+10, 2.109375e+10, 2.128125e+10, 2.146875e+10],
-                                    [2.165625e+10, 2.187500e+10, 2.206250e+10, 2.225000e+10],
-                                    [2.243750e+10, 2.262500e+10, 2.284375e+10, 2.309375e+10],
-                                    [2.328125e+10, 2.346875e+10, 2.365625e+10, 2.387500e+10]])
-    # fmt: on
+    reference_timestamps = np.array(
+        [
+            [20062500000, 20812500000, 22187500000, 23562500000, 24937500000],
+            [20250000000, 21625000000, 22375000000, 23750000000, 25125000000],
+            [20437500000, 21812500000, 23187500000, 23937500000, 25312500000],
+            [20625000000, 22000000000, 23375000000, 24750000000, 25500000000],
+        ]
+    ).T
 
     np.testing.assert_allclose(scan.timestamps, np.transpose(reference_timestamps))
     assert scan.num_frames == 1
     assert scan.pixels_per_line == 4
     assert scan.lines_per_frame == 5
-    assert len(scan.infowave) == 64
+    assert len(scan.infowave) == 90
     assert scan.get_image("rgb").shape == (4, 5, 3)
     assert scan.get_image("red").shape == (4, 5)
     assert scan.get_image("blue").shape == (4, 5)
@@ -45,7 +47,7 @@ def test_scan_attrs(test_scans):
     assert scan.num_frames == 2
     assert scan.pixels_per_line == 4
     assert scan.lines_per_frame == 3
-    assert len(scan.infowave) == 64
+    assert len(scan.infowave) == 90
     assert scan.get_image("rgb").shape == (2, 4, 3, 3)
     assert scan.get_image("red").shape == (2, 4, 3)
     assert scan.get_image("blue").shape == (2, 4, 3)
@@ -67,7 +69,7 @@ def test_scan_attrs(test_scans):
     assert scan.num_frames == 2
     assert scan.pixels_per_line == 4
     assert scan.lines_per_frame == 3
-    assert len(scan.infowave) == 64
+    assert len(scan.infowave) == 90
     assert scan.get_image("rgb").shape == (2, 3, 4, 3)
     assert scan.get_image("red").shape == (2, 3, 4)
     assert scan.get_image("blue").shape == (2, 3, 4)
@@ -89,7 +91,7 @@ def test_scan_attrs(test_scans):
     assert scan.num_frames == 2
     assert scan.pixels_per_line == 4
     assert scan.lines_per_frame == 3
-    assert len(scan.infowave) == 64
+    assert len(scan.infowave) == 90
     assert scan.get_image("rgb").shape == (2, 3, 4, 3)
     assert scan.get_image("red").shape == (2, 3, 4)
     assert scan.get_image("blue").shape == (2, 3, 4)


### PR DESCRIPTION
**Why this PR?**
Currently, we reconstruct the entire timestamp array to obtain the pixel and line time. Considering that this is something we do often, while we rarely need the full matrix of per-pixel timestamps, we may want a fast path here. Loading 30 kymographs and obtaining the line and pixel times goes from `4.1 +- 0.5` seconds to `0.5 +- 0.14` seconds on my machine.

I recommend to go commit by commit.

**Old tests**
To make sure this change doesn't fire up a bunch of the very old tests, I had to update the test data to some degree. I decided to go with minimal changes on that front, since it is not the focus of this PR. You can check out that commit and all tests should be green at that particular commit.

Note that the affected tests are all in the old test folder (and thankfully there were far fewer than last time I had to make a change to this file already).

**Caching**
While doing this, I noticed that while this calculation is faster, it still takes a little bit of time. Given that the `timestamps` were cached in the old setup, many requests for the line or pixel time would be slower than what we had before. We can simply do the same thing here and just cache the result. In this case, the result is even very small.

Timestamps were cached using `cachetools.cachedmethod`, I decided to go over a similar route. However, what I didn't like was that it stores exclusively by arguments. This is also the reason we had a dummy argument on `_timestamps` that had to be `"timestamps"`. What I'd rather do is have the actual function appear in the key used for hashing.

I did consider some other options as well:
- `cached_property` looked nice, but since it effectively replaces the property with its result (it puts the result in the object's `__dict__`), it removes the docstring after accessing it and leaves the attribute it makes write-able, which is not desirable.
- Using a regular `cache` in combination with a `property` is not desirable, since the `cache` does not get stored in the instance and holds a reference to the `instance` in the hash key (through the `self` argument). This would preclude garbage collection. Of course, one could mess with it a bit to try and store a weak reference, or some `id()` instead, but it still feels odd to not store the cache in the instance itself.
- So that leads us back to `cached_method`. I had a look at what it does for the key when using a [method key](https://github.com/tkem/cachetools/blob/master/src/cachetools/keys.py#L46) and it basically just amounts to ignoring the self part. It's therefore pretty easy to just write a little function that returns a `cached_method` where the key has a string inserted as a first argument. That way we don't pollute our argument list of the function we are trying to cache, and still get method specific caching.

Overall, option 3 (the utility decorator) seemed like a decent, low code tradeoff to me to me, but if better alternatives or strong objections exist, I'd be happy to switch.

Note: if we want another factor two in performance for a particular use case where we need both, we can shave off another 40% of the time if we compute both at once (since both grab the `infowave`). I didn't do that yet, because the function seems fast enough.