### PR TITLE
deps: enforce upper limit `jupyter_client` and `pyzmq`

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -51,12 +51,7 @@ The easiest way to install Python and SciPy is with `Anaconda`_, a free scientif
 
     .. code-block::
 
-        conda install lumicks.pylake "jupyter_client<8"
-
-    .. note::
-
-        There is currently an `open issue <https://github.com/jupyter/notebook/issues/6748>`_ with Jupyter that results in communication problems between Jupyter notebooks and the Jupyter kernel.
-        As a workaround, we temporarily suggest adding the constraint `jupyter_client<8` to install an older version of this kernel.
+        conda install lumicks.pylake
 
 #. It should be possible to open a jupyter notebook in this environment by calling::
 
@@ -103,12 +98,7 @@ This concludes the Pylake installation procedure. Check out the :doc:`Tutorial <
 
     .. code-block::
 
-        conda install lumicks.pylake "jupyter_client<8"
-
-    .. note::
-
-        There is currently an `open issue <https://github.com/jupyter/notebook/issues/6748>`_ with Jupyter that results in communication problems between Jupyter notebooks and the Jupyter kernel.
-        As a workaround, we temporarily suggest adding the constraint `jupyter_client<8` to install an older version of this kernel.
+        conda install lumicks.pylake
 
 #. You can open a Jupyter notebook in this environment by calling `jupyter notebook` from the terminal.
 
@@ -142,12 +132,7 @@ This concludes the Pylake installation procedure. Check out the :doc:`Tutorial <
 
     .. code-block::
 
-        conda install lumicks.pylake "jupyter_client<8"
-
-    .. note::
-
-        There is currently an `open issue <https://github.com/jupyter/notebook/issues/6748>`_ with Jupyter that results in communication problems between Jupyter notebooks and the Jupyter kernel.
-        As a workaround, we temporarily suggest adding the constraint `jupyter_client<8` to install an older version of this kernel.
+        conda install lumicks.pylake
 
 #. You can open a jupyter notebook in this environment by calling::
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,12 @@ setup(
         "tqdm>=4.27.0",  # 4.27.0 introduced tqdm.auto which auto-selects notebook or console
     ],
     extras_require={
-        "notebook": ["notebook>=4.4.1", "ipywidgets>=7.0.0"],
+        "notebook": [
+            "notebook>=4.4.1",
+            "ipywidgets>=7.0.0",
+            "jupyter_client<8",  # https://github.com/jupyter/notebook/issues/6748
+            "pyzmq<25",  # https://github.com/jupyter/notebook/issues/6748
+        ],
     },
     zip_safe=False,
 )


### PR DESCRIPTION
**Why this PR?**
To work around a bug in `notebook` we need to pin the upper limit of `jupyter_client` and `zeromq` (see https://github.com/jupyter/notebook/issues/6748).

Until now, we've been asking users to add these extra constraints manually, but forgetting it can lead to broken interactive notebook functionality. It's unnecessary friction when it comes to installing `pylake`. Instead of adding these lines to the pip [installation instructions](https://github.com/lumicks/pylake/pull/538), it's better to just add it to the requirements for the time being.

When we release on `conda`, we should also pin the upper limit in the recipe there.