### PR TITLE
Start using `isort` to complement `black` with import sorting/formatting

### DIFF
--- a/.github/workflows/pylake_test.py
+++ b/.github/workflows/pylake_test.py
@@ -1,7 +1,8 @@
-import lumicks.pylake as lk
-import sys
 import os
+import sys
 import pathlib
+
+import lumicks.pylake as lk
 
 os.chdir(str(pathlib.Path(lk.__file__).parent))
 sys.exit(lk.pytest(args=["--runslow", "--strict_reference_data", "--color=yes", "-Werror"]))

--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -36,7 +36,7 @@ jobs:
       run: python -c "import lumicks.pylake as lk; lk.benchmark(repeat=1)"
     - name: Black
       run: |
-        pip install black==22.3.0 isort==5.12.0
+        pip install black==23.7.0 isort==5.12.0
         black --check --diff --color .
         isort --check-only --diff .
     - name: flake8

--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -36,8 +36,9 @@ jobs:
       run: python -c "import lumicks.pylake as lk; lk.benchmark(repeat=1)"
     - name: Black
       run: |
-        pip install black==22.3.0
+        pip install black==22.3.0 isort==5.12.0
         black --check --diff --color .
+        isort --check-only --diff .
     - name: flake8
       run: |
         pip install flake8 flake8-bugbear

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-import sys
 import os
+import sys
 
 sys.path.append(os.path.dirname(__file__))

--- a/docs/_ext/nbexport.py
+++ b/docs/_ext/nbexport.py
@@ -1,15 +1,15 @@
+import os
 import itertools
 import mimetypes
-import os
 import posixpath
 from base64 import b64encode
 
 import nbformat
+from sphinx import roles, addnodes
 from docutils import nodes, writers
 from docutils.parsers.rst import directives
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError
-from sphinx import addnodes, roles
 
 
 def _finalize_markdown_cells(nb):

--- a/docs/_static/pylake_syntax_theme.py
+++ b/docs/_static/pylake_syntax_theme.py
@@ -1,15 +1,15 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment,
-    Error,
-    Generic,
     Name,
-    Number,
-    Operator,
-    String,
     Text,
-    Whitespace,
+    Error,
+    Number,
+    String,
+    Comment,
+    Generic,
     Keyword,
+    Operator,
+    Whitespace,
 )
 
 colors = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,10 +10,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-import sys
 import os
+import sys
 import shutil
 import filecmp
+
 import sphinx_rtd_theme
 
 sys.path.insert(0, os.path.abspath("./_ext"))
@@ -21,7 +22,6 @@ sys.path.insert(0, os.path.abspath("./_static"))
 sys.path.insert(0, os.path.abspath(".."))
 
 from lumicks import pylake  # noqa: E402
-
 
 # -- Project information -----------------------------------------------------
 

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -1,42 +1,41 @@
+from . import simulation
+from .file import *
+from .scalebar import ScaleBar
 from .__about__ import (
-    __author__,
-    __copyright__,
     __doc__,
+    __url__,
     __email__,
+    __title__,
+    __author__,
     __license__,
     __summary__,
-    __title__,
-    __url__,
     __version__,
+    __copyright__,
 )
-
-from .file_download import *
 from .benchmark import benchmark
-from .adjustments import ColorAdjustment, colormaps
-from .scalebar import ScaleBar
-from .image_stack import ImageStack, CorrelatedStack
-from .piezo_tracking.piezo_tracking import *
-from .piezo_tracking.baseline import *
-from .file import *
-from .fitting.models import *
-from .fitting.fit import FdFit
-from .fitting.parameter_trace import parameter_trace
-from .nb_widgets.range_selector import FdRangeSelector, FdDistanceRangeSelector
-from .kymotracker.kymotracker import *
-from .nb_widgets.kymotracker_widgets import KymoWidgetGreedy
 from .fdensemble import FdEnsemble
 from .population import *
+from .adjustments import ColorAdjustment, colormaps
+from .fitting.fit import FdFit
+from .image_stack import ImageStack, CorrelatedStack
+from .file_download import *
+from .fitting.models import *
+from .fitting.parameter_trace import parameter_trace
+from .kymotracker.kymotracker import *
+from .piezo_tracking.baseline import *
+from .nb_widgets.range_selector import FdRangeSelector, FdDistanceRangeSelector
 from .force_calibration.convenience import calibrate_force
+from .piezo_tracking.piezo_tracking import *
+from .nb_widgets.kymotracker_widgets import KymoWidgetGreedy
 from .force_calibration.calibration_models import (
-    PassiveCalibrationModel,
     ActiveCalibrationModel,
+    PassiveCalibrationModel,
     viscosity_of_water,
 )
 from .force_calibration.power_spectrum_calibration import (
-    calculate_power_spectrum,
     fit_power_spectrum,
+    calculate_power_spectrum,
 )
-from . import simulation
 
 
 def pytest(args=None, plugins=None):
@@ -49,8 +48,9 @@ def pytest(args=None, plugins=None):
     plugins : list
         Plugin objects to be auto-registered during initialization.
     """
-    import pytest
     import pathlib
+
+    import pytest
 
     args = args or []
     module_path = str(pathlib.Path(__file__).parent)

--- a/lumicks/pylake/adjustments.py
+++ b/lumicks/pylake/adjustments.py
@@ -1,8 +1,9 @@
+from dataclasses import make_dataclass
+
 import numpy as np
 import matplotlib as mpl
-from matplotlib.colors import LinearSegmentedColormap
 from skimage.color import xyz2rgb
-from dataclasses import make_dataclass
+from matplotlib.colors import LinearSegmentedColormap
 
 
 class ColorAdjustment:

--- a/lumicks/pylake/benchmark.py
+++ b/lumicks/pylake/benchmark.py
@@ -2,7 +2,9 @@ import os
 import timeit
 import tempfile
 import contextlib
+
 import numpy as np
+
 import lumicks.pylake as lk
 
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import numpy as np
-import numpy.typing as npt
 import numbers
 from typing import Union
 
-from .detail.utilities import downsample
+import numpy as np
+import numpy.typing as npt
+
 from .detail.timeindex import to_timestamp
+from .detail.utilities import downsample
 from .nb_widgets.range_selector import SliceRangeSelectorWidget
 
 

--- a/lumicks/pylake/conftest.py
+++ b/lumicks/pylake/conftest.py
@@ -1,8 +1,9 @@
-import importlib
-import warnings
-import pytest
 import os.path
+import warnings
+import importlib
+
 import numpy as np
+import pytest
 import matplotlib.pyplot as plt
 
 

--- a/lumicks/pylake/detail/alignment.py
+++ b/lumicks/pylake/detail/alignment.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from lumicks.pylake.detail.utilities import first
 
 

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -1,16 +1,16 @@
 import json
 import warnings
-from dataclasses import dataclass
 from typing import List
+from dataclasses import dataclass
 
 import numpy as np
 from numpy import typing as npt
 
-from ..adjustments import no_adjustment
 from .image import reconstruct_image, reconstruct_image_sum
+from .mixin import PhotonCounts, ExcitationLaserPower
+from .utilities import method_cache, could_sum_overflow
+from ..adjustments import no_adjustment
 from .imaging_mixins import TiffExport
-from .mixin import ExcitationLaserPower, PhotonCounts
-from .utilities import could_sum_overflow, method_cache
 
 
 def _int_mean(a, total_size, axis):

--- a/lumicks/pylake/detail/h5_helper.py
+++ b/lumicks/pylake/detail/h5_helper.py
@@ -1,6 +1,7 @@
-import h5py
 import warnings
 from fnmatch import fnmatch
+
+import h5py
 
 
 def _write_numerical_data(

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -1,7 +1,8 @@
 import enum
 import math
-import numpy as np
 import warnings
+
+import numpy as np
 
 
 class InfowaveCode(enum.IntEnum):

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -1,11 +1,12 @@
 import json
-import numpy as np
-import numpy.typing as npt
-import tifffile
-from typing import Iterator, Union
+from typing import Union, Iterator
 
-from ..adjustments import no_adjustment
+import numpy as np
+import tifffile
+import numpy.typing as npt
+
 from .timeindex import to_timestamp
+from ..adjustments import no_adjustment
 
 _FIRST_TIMESTAMP = 1388534400
 
@@ -134,8 +135,8 @@ class VideoExport:
             Scale bar to add to the figure.
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`."""
-        from matplotlib import animation
         import matplotlib.pyplot as plt
+        from matplotlib import animation
 
         channels = ("red", "green", "blue", "rgb")
         if channel not in channels:

--- a/lumicks/pylake/detail/tests/test_plotting.py
+++ b/lumicks/pylake/detail/tests/test_plotting.py
@@ -143,8 +143,8 @@ def implements_plot_interface(cls, image=False, stack=False):
 def test_plot_interface_implementations():
     from lumicks.pylake import ImageStack
     from lumicks.pylake.kymo import Kymo
-    from lumicks.pylake.point_scan import PointScan
     from lumicks.pylake.scan import Scan
+    from lumicks.pylake.point_scan import PointScan
 
     # Check if classes properly implement the "plotting" interface
     assert implements_plot_interface(ImageStack, image=True, stack=True)

--- a/lumicks/pylake/detail/tests/test_widefield.py
+++ b/lumicks/pylake/detail/tests/test_widefield.py
@@ -1,5 +1,6 @@
-import pytest
 import numpy as np
+import pytest
+
 from lumicks.pylake.detail import widefield
 
 

--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -1,9 +1,10 @@
-import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib as mpl
-import cachetools
 import math
 import contextlib
+
+import numpy as np
+import cachetools
+import matplotlib as mpl
+import matplotlib.pyplot as plt
 
 
 def method_cache(name):

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -1,11 +1,13 @@
-import numpy as np
 import re
-import json
-import tifffile
-import warnings
 import enum
+import json
+import warnings
 from copy import copy
 from dataclasses import dataclass
+
+import numpy as np
+import tifffile
+
 from ..adjustments import no_adjustment
 
 

--- a/lumicks/pylake/fdcurve.py
+++ b/lumicks/pylake/fdcurve.py
@@ -1,12 +1,13 @@
-import deprecated
-import numpy as np
 from copy import copy, deepcopy
+from collections import namedtuple
+
+import numpy as np
+import deprecated
+
 from .channel import Slice, TimeSeries
 from .detail.mixin import DownsampledFD
 from .detail.utilities import find_contiguous
 from .nb_widgets.range_selector import FdTimeRangeSelectorWidget, FdDistanceRangeSelectorWidget
-from collections import namedtuple
-
 
 FdSlice = namedtuple("FdSlice", "f d")
 

--- a/lumicks/pylake/fdensemble.py
+++ b/lumicks/pylake/fdensemble.py
@@ -1,5 +1,6 @@
-from lumicks.pylake.detail.alignment import align_fd_simple
 import numpy as np
+
+from lumicks.pylake.detail.alignment import align_fd_simple
 
 
 class FdEnsemble:

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -1,19 +1,20 @@
-import h5py
 import warnings
-import numpy as np
 from typing import Dict
 
-from .calibration import ForceCalibration
-from .channel import Slice, Continuous, TimeSeries, TimeTags
-from .detail.mixin import Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, PhotonTimeTags
-from .detail.h5_helper import write_h5
-from .fdcurve import FdCurve
-from .group import Group
+import h5py
+import numpy as np
+
 from .kymo import Kymo
-from .point_scan import PointScan
-from .scan import Scan
-from .marker import Marker
 from .note import Note
+from .scan import Scan
+from .group import Group
+from .marker import Marker
+from .channel import Slice, TimeTags, Continuous, TimeSeries
+from .fdcurve import FdCurve
+from .point_scan import PointScan
+from .calibration import ForceCalibration
+from .detail.mixin import Force, PhotonCounts, DownsampledFD, PhotonTimeTags, BaselineCorrectedForce
+from .detail.h5_helper import write_h5
 
 __all__ = ["File"]
 

--- a/lumicks/pylake/file_download.py
+++ b/lumicks/pylake/file_download.py
@@ -1,11 +1,11 @@
 import os
-import hashlib
 import json
+import hashlib
 import urllib.error
 from urllib.parse import urljoin
 from urllib.request import urlopen
-from tqdm.auto import tqdm
 
+from tqdm.auto import tqdm
 
 __all__ = ["download_from_doi"]
 

--- a/lumicks/pylake/fitting/datasets.py
+++ b/lumicks/pylake/fitting/datasets.py
@@ -1,9 +1,11 @@
-from .detail.link_functions import generate_conditions
-from .detail.utilities import parse_transformation
-from .fitdata import FitData
 from copy import deepcopy
 from collections import OrderedDict
+
 import numpy as np
+
+from .fitdata import FitData
+from .detail.utilities import parse_transformation
+from .detail.link_functions import generate_conditions
 
 
 class Datasets:

--- a/lumicks/pylake/fitting/detail/derivative_manipulation.py
+++ b/lumicks/pylake/fitting/detail/derivative_manipulation.py
@@ -1,4 +1,5 @@
 import warnings
+
 import numpy as np
 import scipy.optimize as optim
 from scipy.interpolate import InterpolatedUnivariateSpline

--- a/lumicks/pylake/fitting/detail/link_functions.py
+++ b/lumicks/pylake/fitting/detail/link_functions.py
@@ -1,6 +1,7 @@
+import numpy as np
+
 from ..fitdata import Condition
 from .utilities import unique_idx
-import numpy as np
 
 
 def generate_conditions(data_sets, parameter_lookup, model_params):

--- a/lumicks/pylake/fitting/detail/model_implementation.py
+++ b/lumicks/pylake/fitting/detail/model_implementation.py
@@ -1,8 +1,10 @@
+import warnings
+
+import numpy as np
+
+from .utilities import latex_frac, latex_sqrt, solve_formatter, solve_formatter_tex
 from ..parameters import Parameter
 from .derivative_manipulation import invert_function, invert_jacobian, invert_function_interpolation
-from .utilities import latex_sqrt, latex_frac, solve_formatter, solve_formatter_tex
-import numpy as np
-import warnings
 
 
 class Defaults:

--- a/lumicks/pylake/fitting/detail/utilities.py
+++ b/lumicks/pylake/fitting/detail/utilities.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+
 import numpy as np
 
 

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -1,14 +1,16 @@
-from .parameters import Params
-from .datasets import Datasets, FdDatasets
-from .model import Model
 from collections import OrderedDict
-from ..detail.utilities import unique, lighten_color
-from .detail.derivative_manipulation import numerical_jacobian
-from .detail.utilities import print_styled, optimal_plot_layout
-from .profile_likelihood import ProfileLikelihood1D
+
 import numpy as np
 import scipy.optimize as optim
 import matplotlib.pyplot as plt
+
+from .model import Model
+from .datasets import Datasets, FdDatasets
+from .parameters import Params
+from .detail.utilities import print_styled, optimal_plot_layout
+from ..detail.utilities import unique, lighten_color
+from .profile_likelihood import ProfileLikelihood1D
+from .detail.derivative_manipulation import numerical_jacobian
 
 
 def front(x):

--- a/lumicks/pylake/fitting/fitdata.py
+++ b/lumicks/pylake/fitting/fitdata.py
@@ -1,7 +1,9 @@
-import numpy as np
-from .parameters import Params
 from collections import OrderedDict
+
+import numpy as np
 import matplotlib.pyplot as plt
+
+from .parameters import Params
 
 
 class FitData:

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -1,26 +1,27 @@
-from .parameters import Parameter, Params
+import uuid
+import inspect
+from copy import deepcopy
+from collections import OrderedDict
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from .parameters import Params, Parameter
 from .detail.utilities import (
-    optimal_plot_layout,
-    print_styled,
-    solve_formatter_tex,
     escape_tex,
+    print_styled,
     solve_formatter,
+    optimal_plot_layout,
+    solve_formatter_tex,
 )
 from .detail.derivative_manipulation import (
-    numerical_jacobian,
     numerical_diff,
     invert_function,
     invert_jacobian,
     invert_derivative,
+    numerical_jacobian,
     invert_function_interpolation,
 )
-from collections import OrderedDict
-from copy import deepcopy
-
-import uuid
-import inspect
-import numpy as np
-import matplotlib.pyplot as plt
 
 
 class Model:

--- a/lumicks/pylake/fitting/models.py
+++ b/lumicks/pylake/fitting/models.py
@@ -55,11 +55,11 @@ def force_offset(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        force_offset_model,
-        offset_model_jac,
-        offset_model_derivative,
         offset_equation,
+        offset_model_jac,
+        force_offset_model,
         offset_equation_tex,
+        offset_model_derivative,
     )
 
     return Model(
@@ -84,11 +84,11 @@ def distance_offset(name):
     """
     from .model import Model
     from .detail.model_implementation import (
-        distance_offset_model,
-        offset_model_jac,
-        offset_model_derivative,
         offset_equation,
+        offset_model_jac,
         offset_equation_tex,
+        distance_offset_model,
+        offset_model_derivative,
     )
 
     return Model(
@@ -123,12 +123,12 @@ def ewlc_marko_siggia_force(name):
     """
     from .model import Model
     from .detail.model_implementation import (
+        Defaults,
         ewlc_marko_siggia_force,
         ewlc_marko_siggia_force_jac,
-        ewlc_marko_siggia_force_derivative,
         ewlc_marko_siggia_force_equation,
+        ewlc_marko_siggia_force_derivative,
         ewlc_marko_siggia_force_equation_tex,
-        Defaults,
     )
 
     return Model(
@@ -166,12 +166,12 @@ def ewlc_marko_siggia_distance(name):
     """
     from .model import Model
     from .detail.model_implementation import (
+        Defaults,
         ewlc_marko_siggia_distance,
         ewlc_marko_siggia_distance_jac,
-        ewlc_marko_siggia_distance_derivative,
         ewlc_marko_siggia_distance_equation,
+        ewlc_marko_siggia_distance_derivative,
         ewlc_marko_siggia_distance_equation_tex,
-        Defaults,
     )
 
     return Model(
@@ -218,12 +218,12 @@ def wlc_marko_siggia_force(name):
     """
     from .model import Model
     from .detail.model_implementation import (
+        Defaults,
         wlc_marko_siggia_force,
         wlc_marko_siggia_force_jac,
-        wlc_marko_siggia_force_derivative,
         wlc_marko_siggia_force_equation,
+        wlc_marko_siggia_force_derivative,
         wlc_marko_siggia_force_equation_tex,
-        Defaults,
     )
 
     return Model(
@@ -269,12 +269,12 @@ def wlc_marko_siggia_distance(name):
     """
     from .model import Model
     from .detail.model_implementation import (
+        Defaults,
         wlc_marko_siggia_distance,
         wlc_marko_siggia_distance_jac,
-        wlc_marko_siggia_distance_derivative,
         wlc_marko_siggia_distance_equation,
+        wlc_marko_siggia_distance_derivative,
         wlc_marko_siggia_distance_equation_tex,
-        Defaults,
     )
 
     return Model(
@@ -309,12 +309,12 @@ def ewlc_odijk_distance(name):
     """
     from .model import Model
     from .detail.model_implementation import (
+        Defaults,
         ewlc_odijk_distance,
         ewlc_odijk_distance_jac,
-        ewlc_odijk_distance_derivative,
         ewlc_odijk_distance_equation,
+        ewlc_odijk_distance_derivative,
         ewlc_odijk_distance_equation_tex,
-        Defaults,
     )
 
     return Model(
@@ -401,12 +401,12 @@ def ewlc_odijk_force(name):
     """
     from .model import Model
     from .detail.model_implementation import (
+        Defaults,
         ewlc_odijk_force,
         ewlc_odijk_force_jac,
-        ewlc_odijk_force_derivative,
         ewlc_odijk_force_equation,
+        ewlc_odijk_force_derivative,
         ewlc_odijk_force_equation_tex,
-        Defaults,
     )
 
     return Model(
@@ -444,12 +444,12 @@ def efjc_distance(name):
     """
     from .model import Model
     from .detail.model_implementation import (
+        Defaults,
         efjc_distance,
         efjc_distance_jac,
-        efjc_distance_derivative,
         efjc_distance_equation,
+        efjc_distance_derivative,
         efjc_distance_equation_tex,
-        Defaults,
     )
 
     return Model(
@@ -554,12 +554,12 @@ def twlc_distance(name):
     """
     from .model import Model
     from .detail.model_implementation import (
+        Defaults,
         twlc_distance,
         twlc_distance_jac,
-        twlc_distance_derivative,
         twlc_distance_equation,
+        twlc_distance_derivative,
         twlc_distance_equation_tex,
-        Defaults,
     )
 
     return Model(
@@ -603,11 +603,11 @@ def twlc_force(name):
     """
     from .model import Model
     from .detail.model_implementation import (
+        Defaults,
         twlc_solve_force,
         twlc_solve_force_jac,
         twlc_solve_force_equation,
         twlc_solve_force_equation_tex,
-        Defaults,
     )
 
     return Model(

--- a/lumicks/pylake/fitting/parameters.py
+++ b/lumicks/pylake/fitting/parameters.py
@@ -1,5 +1,6 @@
-import numpy as np
 from collections import OrderedDict
+
+import numpy as np
 from tabulate import tabulate
 
 

--- a/lumicks/pylake/fitting/profile_likelihood.py
+++ b/lumicks/pylake/fitting/profile_likelihood.py
@@ -1,10 +1,11 @@
-from dataclasses import dataclass
-from scipy.stats import chi2
-import numpy as np
-from typing import Tuple, Optional
-import matplotlib.pyplot as plt
-from warnings import warn
 import enum
+from typing import Tuple, Optional
+from warnings import warn
+from dataclasses import dataclass
+
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.stats import chi2
 
 
 def _validate_in_bound(error_description, params, lower_bounds, upper_bounds, bound_tolerance):

--- a/lumicks/pylake/fitting/tests/test_condition_handling.py
+++ b/lumicks/pylake/fitting/tests/test_condition_handling.py
@@ -1,9 +1,11 @@
-from lumicks.pylake.fitting.detail.utilities import parse_transformation
-from lumicks.pylake.fitting.detail.link_functions import generate_conditions
-from lumicks.pylake.fitting.fitdata import Condition, FitData
 from collections import OrderedDict
+
 import numpy as np
 import pytest
+
+from lumicks.pylake.fitting.fitdata import FitData, Condition
+from lumicks.pylake.fitting.detail.utilities import parse_transformation
+from lumicks.pylake.fitting.detail.link_functions import generate_conditions
 
 
 def test_build_conditions():

--- a/lumicks/pylake/fitting/tests/test_fd_models.py
+++ b/lumicks/pylake/fitting/tests/test_fd_models.py
@@ -1,8 +1,10 @@
-from lumicks.pylake.fitting.models import *
-import lumicks.pylake.fitting.detail.model_implementation as model_impl
 from inspect import getfullargspec
+
 import numpy as np
 import pytest
+
+import lumicks.pylake.fitting.detail.model_implementation as model_impl
+from lumicks.pylake.fitting.models import *
 
 
 def test_deprecated_models():

--- a/lumicks/pylake/fitting/tests/test_fit.py
+++ b/lumicks/pylake/fitting/tests/test_fit.py
@@ -1,12 +1,14 @@
-from lumicks.pylake.fitting.models import ewlc_odijk_distance, ewlc_odijk_force
-from lumicks.pylake.fitting.model import Model
-from lumicks.pylake.fitting.fit import Fit, FdFit, Params, Datasets
-from lumicks.pylake.fitting.parameters import Parameter
 import re
-import pytest
-import numpy as np
-import matplotlib.pyplot as plt
 from collections import OrderedDict
+
+import numpy as np
+import pytest
+import matplotlib.pyplot as plt
+
+from lumicks.pylake.fitting.fit import Fit, FdFit, Params, Datasets
+from lumicks.pylake.fitting.model import Model
+from lumicks.pylake.fitting.models import ewlc_odijk_force, ewlc_odijk_distance
+from lumicks.pylake.fitting.parameters import Parameter
 
 
 def test_model_defaults():

--- a/lumicks/pylake/fitting/tests/test_model_composition.py
+++ b/lumicks/pylake/fitting/tests/test_model_composition.py
@@ -1,3 +1,6 @@
+import numpy as np
+import pytest
+
 from lumicks.pylake.fitting.model import (
     Model,
     InverseModel,
@@ -5,13 +8,11 @@ from lumicks.pylake.fitting.model import (
     SubtractIndependentOffset,
 )
 from lumicks.pylake.fitting.models import (
-    distance_offset,
     force_offset,
-    ewlc_odijk_distance,
+    distance_offset,
     ewlc_odijk_force,
+    ewlc_odijk_distance,
 )
-import pytest
-import numpy as np
 
 
 def test_model_composition():

--- a/lumicks/pylake/fitting/tests/test_model_sim.py
+++ b/lumicks/pylake/fitting/tests/test_model_sim.py
@@ -1,5 +1,6 @@
-import pytest
 import numpy as np
+import pytest
+
 from lumicks.pylake.fitting.model import Model
 from lumicks.pylake.fitting.models import ewlc_odijk_distance
 from lumicks.pylake.fitting.parameters import Params, Parameter

--- a/lumicks/pylake/fitting/tests/test_parameter_inversion.py
+++ b/lumicks/pylake/fitting/tests/test_parameter_inversion.py
@@ -1,8 +1,9 @@
+import numpy as np
+import pytest
+
 from lumicks.pylake.fitting.fit import Fit
 from lumicks.pylake.fitting.model import Model
 from lumicks.pylake.fitting.parameter_trace import parameter_trace
-import numpy as np
-import pytest
 
 
 def test_parameter_inversion():

--- a/lumicks/pylake/fitting/tests/test_parameters.py
+++ b/lumicks/pylake/fitting/tests/test_parameters.py
@@ -1,7 +1,8 @@
-from lumicks.pylake.fitting.parameters import Params, Parameter
-from lumicks.pylake.fitting.models import *
-import pytest
 import numpy as np
+import pytest
+
+from lumicks.pylake.fitting.models import *
+from lumicks.pylake.fitting.parameters import Params, Parameter
 
 
 def test_params():

--- a/lumicks/pylake/fitting/tests/test_pickling.py
+++ b/lumicks/pylake/fitting/tests/test_pickling.py
@@ -1,7 +1,9 @@
-from lumicks.pylake.fitting.models import ewlc_odijk_force
-from lumicks.pylake.fitting.fit import FdFit
-import numpy as np
 import pickle
+
+import numpy as np
+
+from lumicks.pylake.fitting.fit import FdFit
+from lumicks.pylake.fitting.models import ewlc_odijk_force
 
 
 def test_pickle(tmpdir_factory):

--- a/lumicks/pylake/fitting/tests/test_profiles.py
+++ b/lumicks/pylake/fitting/tests/test_profiles.py
@@ -1,8 +1,10 @@
-import warnings
-import pytest
 import re
-import numpy as np
+import warnings
 from textwrap import dedent
+
+import numpy as np
+import pytest
+
 from lumicks.pylake.fitting.fit import Fit
 from lumicks.pylake.fitting.model import Model
 from lumicks.pylake.fitting.parameters import Parameter

--- a/lumicks/pylake/fitting/tests/test_stderr.py
+++ b/lumicks/pylake/fitting/tests/test_stderr.py
@@ -1,7 +1,8 @@
-from lumicks.pylake.fitting.model import Model
-from lumicks.pylake.fitting.fit import Fit
-import pytest
 import numpy as np
+import pytest
+
+from lumicks.pylake.fitting.fit import Fit
+from lumicks.pylake.fitting.model import Model
 
 
 def data_for_testing():

--- a/lumicks/pylake/fitting/tests/test_stepping.py
+++ b/lumicks/pylake/fitting/tests/test_stepping.py
@@ -1,6 +1,7 @@
-import pytest
-from lumicks.pylake.fitting.profile_likelihood import clamp_step, StepConfig, do_step
 import numpy as np
+import pytest
+
+from lumicks.pylake.fitting.profile_likelihood import StepConfig, do_step, clamp_step
 
 
 @pytest.mark.parametrize(

--- a/lumicks/pylake/fitting/tests/test_utilities.py
+++ b/lumicks/pylake/fitting/tests/test_utilities.py
@@ -1,16 +1,18 @@
 from collections import OrderedDict
+
+import numpy as np
+import pytest
+
 from lumicks.pylake.fitting.detail.utilities import (
-    parse_transformation,
-    unique_idx,
     escape_tex,
     latex_sqrt,
+    unique_idx,
+    parse_transformation,
 )
 from lumicks.pylake.fitting.detail.model_implementation import (
     calc_cubic_root,
     calc_cubic_root_derivatives,
 )
-import numpy as np
-import pytest
 
 
 def test_unique_idx():

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -1,27 +1,25 @@
+from copy import copy
+from typing import Callable
+from functools import partial
+from dataclasses import dataclass
+
 import numpy as np
 import scipy
-from functools import partial
-from .detail.power_models import g_diode
-from .detail.driving_input import (
-    estimate_driving_input_parameters,
-    driving_power_peak,
-)
+
 from .detail.drag_models import faxen_factor, brenner_axial
 from .detail.power_models import (
-    passive_power_spectrum_model,
-    sphere_friction_coefficient,
-    theoretical_driving_power_lorentzian,
+    g_diode,
     alias_spectrum,
+    sphere_friction_coefficient,
+    passive_power_spectrum_model,
+    theoretical_driving_power_lorentzian,
 )
+from .detail.driving_input import driving_power_peak, estimate_driving_input_parameters
 from .detail.hydrodynamics import (
     passive_power_spectrum_model_hydro,
     theoretical_driving_power_hydrodynamics,
 )
 from .power_spectrum_calibration import CalibrationParameter
-
-from dataclasses import dataclass
-from typing import Callable
-from copy import copy
 
 
 def diode_params_from_voltage(

--- a/lumicks/pylake/force_calibration/convenience.py
+++ b/lumicks/pylake/force_calibration/convenience.py
@@ -1,12 +1,12 @@
 from lumicks.pylake.force_calibration.calibration_models import (
+    FixedDiodeModel,
     ActiveCalibrationModel,
     PassiveCalibrationModel,
-    FixedDiodeModel,
 )
 from lumicks.pylake.force_calibration.power_spectrum_calibration import (
+    CalibrationResults,
     fit_power_spectrum,
     calculate_power_spectrum,
-    CalibrationResults,
 )
 
 

--- a/lumicks/pylake/force_calibration/detail/driving_input.py
+++ b/lumicks/pylake/force_calibration/detail/driving_input.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy.signal.windows
+
 from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
 
 

--- a/lumicks/pylake/force_calibration/detail/power_models.py
+++ b/lumicks/pylake/force_calibration/detail/power_models.py
@@ -1,7 +1,8 @@
 import math
-import numpy as np
-from collections import namedtuple
 from itertools import product
+from collections import namedtuple
+
+import numpy as np
 
 
 def fit_analytical_lorentzian(ps):

--- a/lumicks/pylake/force_calibration/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/power_spectrum.py
@@ -1,8 +1,10 @@
 import warnings
-import numpy as np
-import matplotlib.pyplot as plt
 from copy import copy
 from typing import List, Tuple
+
+import numpy as np
+import matplotlib.pyplot as plt
+
 from lumicks.pylake.detail.utilities import downsample
 
 

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -28,20 +28,21 @@ References
        tweezers." Langmuir, 23(7), 3654-3665 (2007).
 """
 
-import numpy as np
 import math
+from collections import namedtuple
+
+import numpy as np
 import scipy
 import scipy.optimize
 import scipy.constants
 import matplotlib.pyplot as plt
 from tabulate import tabulate
-from collections import namedtuple
+
 from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
 from lumicks.pylake.force_calibration.detail.power_models import (
     ScaledModel,
     fit_analytical_lorentzian,
 )
-
 
 CalibrationParameter = namedtuple("CalibrationParameter", ["description", "value", "unit"])
 

--- a/lumicks/pylake/force_calibration/tests/conftest.py
+++ b/lumicks/pylake/force_calibration/tests/conftest.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 
 
 class ReferenceModels:

--- a/lumicks/pylake/force_calibration/tests/data/simulate_calibration_data.py
+++ b/lumicks/pylake/force_calibration/tests/data/simulate_calibration_data.py
@@ -1,10 +1,12 @@
-import numpy as np
 from functools import partial
+
+import numpy as np
 import scipy.constants
+
 from lumicks.pylake.force_calibration.detail.power_models import (
+    g_diode,
     sphere_friction_coefficient,
     passive_power_spectrum_model,
-    g_diode,
 )
 from lumicks.pylake.force_calibration.detail.hydrodynamics import (
     passive_power_spectrum_model_hydro,

--- a/lumicks/pylake/force_calibration/tests/data/simulate_ideal.py
+++ b/lumicks/pylake/force_calibration/tests/data/simulate_ideal.py
@@ -1,5 +1,6 @@
 import numpy as np
-import scipy.constants, scipy.signal
+import scipy.signal
+import scipy.constants
 
 
 def calculate_active_term(time, driving_sinusoid, stiffness, gamma):

--- a/lumicks/pylake/force_calibration/tests/test_active_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_active_calibration.py
@@ -1,12 +1,14 @@
 import numpy as np
-import scipy.constants
 import pytest
+import scipy.constants
+
+from lumicks.pylake.force_calibration.calibration_models import ActiveCalibrationModel
 from lumicks.pylake.force_calibration.detail.power_models import sphere_friction_coefficient
 from lumicks.pylake.force_calibration.power_spectrum_calibration import (
-    calculate_power_spectrum,
     fit_power_spectrum,
+    calculate_power_spectrum,
 )
-from lumicks.pylake.force_calibration.calibration_models import ActiveCalibrationModel
+
 from .data.simulate_calibration_data import generate_active_calibration_test_data
 
 

--- a/lumicks/pylake/force_calibration/tests/test_axial.py
+++ b/lumicks/pylake/force_calibration/tests/test_axial.py
@@ -1,17 +1,18 @@
+import numpy as np
+import pytest
+
 from lumicks.pylake.force_calibration.calibration_models import (
     ActiveCalibrationModel,
     PassiveCalibrationModel,
 )
+from lumicks.pylake.force_calibration.detail.drag_models import faxen_factor, brenner_axial
+from lumicks.pylake.force_calibration.power_spectrum_calibration import (
+    fit_power_spectrum,
+    calculate_power_spectrum,
+)
 from lumicks.pylake.force_calibration.tests.data.simulate_calibration_data import (
     generate_active_calibration_test_data,
 )
-from lumicks.pylake.force_calibration.power_spectrum_calibration import (
-    calculate_power_spectrum,
-    fit_power_spectrum,
-)
-from lumicks.pylake.force_calibration.detail.drag_models import faxen_factor, brenner_axial
-import numpy as np
-import pytest
 
 
 @pytest.mark.parametrize("hydro", [False, True])

--- a/lumicks/pylake/force_calibration/tests/test_convenience.py
+++ b/lumicks/pylake/force_calibration/tests/test_convenience.py
@@ -1,10 +1,12 @@
-import pytest
 import pickle
+
 import numpy as np
+import pytest
+
 from lumicks.pylake.force_calibration.convenience import calibrate_force
 from lumicks.pylake.force_calibration.calibration_models import (
-    PassiveCalibrationModel,
     ActiveCalibrationModel,
+    PassiveCalibrationModel,
 )
 
 

--- a/lumicks/pylake/force_calibration/tests/test_diode_models.py
+++ b/lumicks/pylake/force_calibration/tests/test_diode_models.py
@@ -1,16 +1,18 @@
 import re
-import pytest
-import numpy as np
 from copy import deepcopy
+
+import numpy as np
+import pytest
+
 from lumicks.pylake.force_calibration.calibration_models import (
     FixedDiodeModel,
-    PassiveCalibrationModel,
     ActiveCalibrationModel,
+    PassiveCalibrationModel,
     diode_params_from_voltage,
 )
 from lumicks.pylake.force_calibration.power_spectrum_calibration import (
-    calculate_power_spectrum,
     fit_power_spectrum,
+    calculate_power_spectrum,
 )
 
 

--- a/lumicks/pylake/force_calibration/tests/test_driving_input.py
+++ b/lumicks/pylake/force_calibration/tests/test_driving_input.py
@@ -1,6 +1,7 @@
-from lumicks.pylake.force_calibration.detail.driving_input import estimate_driving_input_parameters
 import numpy as np
 import pytest
+
+from lumicks.pylake.force_calibration.detail.driving_input import estimate_driving_input_parameters
 
 
 @pytest.mark.parametrize(

--- a/lumicks/pylake/force_calibration/tests/test_hydro.py
+++ b/lumicks/pylake/force_calibration/tests/test_hydro.py
@@ -1,15 +1,17 @@
 import pytest
-from lumicks.pylake.force_calibration.power_spectrum_calibration import (
-    calculate_power_spectrum,
-    fit_power_spectrum,
-)
+
 from lumicks.pylake.force_calibration.calibration_models import (
-    PassiveCalibrationModel,
     ActiveCalibrationModel,
+    PassiveCalibrationModel,
 )
+from lumicks.pylake.force_calibration.detail.drag_models import *
 from lumicks.pylake.force_calibration.detail.power_models import g_diode
 from lumicks.pylake.force_calibration.detail.hydrodynamics import *
-from lumicks.pylake.force_calibration.detail.drag_models import *
+from lumicks.pylake.force_calibration.power_spectrum_calibration import (
+    fit_power_spectrum,
+    calculate_power_spectrum,
+)
+
 from .data.simulate_calibration_data import generate_active_calibration_test_data
 
 

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -1,7 +1,10 @@
 import re
+
 import pytest
-from lumicks.pylake.force_calibration.detail.power_models import *
+
 from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
+from lumicks.pylake.force_calibration.detail.power_models import *
+
 from .data.simulate_calibration_data import power_model_to_time_series
 
 

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
@@ -1,6 +1,7 @@
-from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
 import numpy as np
 import pytest
+
+from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
 
 
 @pytest.mark.parametrize(

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -1,17 +1,20 @@
-from .data.simulate_calibration_data import generate_active_calibration_test_data
-from lumicks.pylake.force_calibration import power_spectrum_calibration as psc
-from lumicks.pylake.force_calibration.calibration_models import (
-    PassiveCalibrationModel,
-    sphere_friction_coefficient,
-    viscosity_of_water,
-    NoFilter,
-)
-from textwrap import dedent
-import numpy as np
-import scipy as sp
 import os
 import re
+from textwrap import dedent
+
+import numpy as np
+import scipy as sp
 import pytest
+
+from lumicks.pylake.force_calibration import power_spectrum_calibration as psc
+from lumicks.pylake.force_calibration.calibration_models import (
+    NoFilter,
+    PassiveCalibrationModel,
+    viscosity_of_water,
+    sphere_friction_coefficient,
+)
+
+from .data.simulate_calibration_data import generate_active_calibration_test_data
 
 
 def test_model_parameters():

--- a/lumicks/pylake/force_calibration/tests/test_simulations.py
+++ b/lumicks/pylake/force_calibration/tests/test_simulations.py
@@ -1,8 +1,10 @@
-import pytest
 import numpy as np
+import pytest
+
 from lumicks.pylake.force_calibration.power_spectrum_calibration import calculate_power_spectrum
-from .data.simulate_calibration_data import generate_active_calibration_test_data
+
 from .data.simulate_ideal import simulate_calibration_data
+from .data.simulate_calibration_data import generate_active_calibration_test_data
 
 
 @pytest.mark.slow

--- a/lumicks/pylake/force_calibration/tests/test_touchdown.py
+++ b/lumicks/pylake/force_calibration/tests/test_touchdown.py
@@ -1,11 +1,13 @@
-import pytest
 import warnings
+
 import numpy as np
+import pytest
+
 from lumicks.pylake.force_calibration.touchdown import (
-    fit_piecewise_linear,
-    fit_damped_sine_with_polynomial,
     touchdown,
     mack_model,
+    fit_piecewise_linear,
+    fit_damped_sine_with_polynomial,
 )
 
 

--- a/lumicks/pylake/force_calibration/touchdown.py
+++ b/lumicks/pylake/force_calibration/touchdown.py
@@ -1,10 +1,12 @@
-from lumicks.pylake.detail.utilities import downsample
-import numpy as np
-from scipy.optimize import curve_fit, minimize_scalar
-from scipy import stats
-from dataclasses import dataclass
-import matplotlib.pyplot as plt
 import warnings
+from dataclasses import dataclass
+
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy import stats
+from scipy.optimize import curve_fit, minimize_scalar
+
+from lumicks.pylake.detail.utilities import downsample
 
 
 def mack_model(

--- a/lumicks/pylake/group.py
+++ b/lumicks/pylake/group.py
@@ -1,5 +1,7 @@
-import h5py
 import warnings
+
+import h5py
+
 from .channel import channel_class
 
 

--- a/lumicks/pylake/image_stack.py
+++ b/lumicks/pylake/image_stack.py
@@ -1,5 +1,5 @@
 import os
-from typing import Iterator, Union, Optional
+from typing import Union, Iterator, Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -8,9 +8,9 @@ from deprecated.sphinx import deprecated
 from .kymo import Kymo, _kymo_from_image_stack
 from .adjustments import no_adjustment
 from .detail.image import make_image_title
-from .detail.imaging_mixins import FrameIndex, TiffExport, VideoExport
 from .detail.plotting import get_axes, show_image
 from .detail.widefield import TiffStack
+from .detail.imaging_mixins import FrameIndex, TiffExport, VideoExport
 
 
 class ImageStack(FrameIndex, TiffExport, VideoExport):

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -4,23 +4,18 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from .detail.utilities import method_cache
-from . import colormaps
-from .adjustments import no_adjustment
-from .detail.confocal import (
-    ConfocalImage,
-    ScanAxis,
-    ScanMetaData,
-)
+from .adjustments import colormaps, no_adjustment
 from .detail.image import (
-    histogram_rows,
-    round_down,
-    seek_timestamp_next_line,
     InfowaveCode,
+    round_down,
+    histogram_rows,
+    seek_timestamp_next_line,
     first_pixel_sample_indices,
 )
+from .detail.confocal import ScanAxis, ScanMetaData, ConfocalImage
 from .detail.plotting import get_axes, show_image
 from .detail.timeindex import to_timestamp
+from .detail.utilities import method_cache
 
 
 def _default_line_time_factory(self: "Kymo"):

--- a/lumicks/pylake/kymotracker/detail/gaussian_mle.py
+++ b/lumicks/pylake/kymotracker/detail/gaussian_mle.py
@@ -1,5 +1,6 @@
-import numpy as np
 from functools import partial
+
+import numpy as np
 from scipy.optimize import minimize
 
 

--- a/lumicks/pylake/kymotracker/detail/geometry_2d.py
+++ b/lumicks/pylake/kymotracker/detail/geometry_2d.py
@@ -1,6 +1,7 @@
-from scipy.ndimage import gaussian_filter
-from .linalg_2d import eigenvalues_2d_symmetric, eigenvector_2d_symmetric
 import numpy as np
+from scipy.ndimage import gaussian_filter
+
+from .linalg_2d import eigenvalues_2d_symmetric, eigenvector_2d_symmetric
 
 
 def find_subpixel_location(gx, gy, largest_eigenvalue, nx, ny):

--- a/lumicks/pylake/kymotracker/detail/localization_models.py
+++ b/lumicks/pylake/kymotracker/detail/localization_models.py
@@ -1,5 +1,7 @@
+from dataclasses import fields, replace, dataclass
+
 import numpy as np
-from dataclasses import dataclass, replace, fields
+
 from .gaussian_mle import normal_pdf_1d
 
 __all__ = ["LocalizationModel", "GaussianLocalizationModel"]

--- a/lumicks/pylake/kymotracker/detail/msd_estimation.py
+++ b/lumicks/pylake/kymotracker/detail/msd_estimation.py
@@ -1,9 +1,10 @@
 import warnings
+from typing import List, Tuple, Optional
+from dataclasses import field, dataclass
+
 import numpy as np
 import numpy.typing as npt
 import matplotlib.pyplot as plt
-from typing import Tuple, List, Optional
-from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)

--- a/lumicks/pylake/kymotracker/detail/peakfinding.py
+++ b/lumicks/pylake/kymotracker/detail/peakfinding.py
@@ -1,7 +1,8 @@
-import numpy as np
-from scipy.ndimage import gaussian_filter, grey_dilation
-from scipy.signal import convolve2d
 import math
+
+import numpy as np
+from scipy.signal import convolve2d
+from scipy.ndimage import grey_dilation, gaussian_filter
 
 
 def peak_estimate(data, half_width, thresh):

--- a/lumicks/pylake/kymotracker/detail/trace_line_2d.py
+++ b/lumicks/pylake/kymotracker/detail/trace_line_2d.py
@@ -1,7 +1,9 @@
 import enum
-import numpy as np
 from dataclasses import dataclass
-from .geometry_2d import is_in_2d, is_opposite, calculate_image_geometry, get_candidate_generator
+
+import numpy as np
+
+from .geometry_2d import is_in_2d, is_opposite, get_candidate_generator, calculate_image_geometry
 from .scoring_functions import build_score_matrix
 
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -1,13 +1,14 @@
-import itertools
 import re
 import pathlib
+import itertools
 from copy import copy
+
+from ..__about__ import __version__
 from ..detail.utilities import replace_key_aliases
+from .detail.peakfinding import _sum_track_signal
+from ..population.dwelltime import DwelltimeModel
 from .detail.msd_estimation import *
 from .detail.localization_models import LocalizationModel, CentroidLocalizationModel
-from .detail.peakfinding import _sum_track_signal
-from .. import __version__
-from ..population.dwelltime import DwelltimeModel
 
 
 def _read_txt(file, delimiter):
@@ -628,6 +629,7 @@ class KymoTrack:
             Forwarded to :func:`matplotlib.pyplot.plot`.
         """
         import matplotlib.patheffects as pe
+
         from ..detail.plotting import get_axes
 
         ax = get_axes(axes)

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -1,17 +1,19 @@
-from .detail.trace_line_2d import detect_lines, points_to_line_segments
-from .detail.scoring_functions import kymo_score
-from .kymotrack import KymoTrack, KymoTrackGroup
-from .detail.gaussian_mle import gaussian_mle_1d, overlapping_pixels
-from .detail.peakfinding import (
-    peak_estimate,
-    refine_peak_based_on_moment,
-    merge_close_peaks,
-    KymoPeaks,
-)
-from .detail.localization_models import GaussianLocalizationModel
-import numpy as np
 import warnings
 from itertools import chain
+
+import numpy as np
+
+from .kymotrack import KymoTrack, KymoTrackGroup
+from .detail.peakfinding import (
+    KymoPeaks,
+    peak_estimate,
+    merge_close_peaks,
+    refine_peak_based_on_moment,
+)
+from .detail.gaussian_mle import gaussian_mle_1d, overlapping_pixels
+from .detail.trace_line_2d import detect_lines, points_to_line_segments
+from .detail.scoring_functions import kymo_score
+from .detail.localization_models import GaussianLocalizationModel
 
 __all__ = [
     "track_greedy",

--- a/lumicks/pylake/kymotracker/stitching.py
+++ b/lumicks/pylake/kymotracker/stitching.py
@@ -1,5 +1,7 @@
-import numpy as np
 from copy import deepcopy
+
+import numpy as np
+
 from lumicks.pylake.kymotracker.detail.stitch import minimum_distance_extrapolants
 
 

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -1,8 +1,10 @@
-import pytest
 import numpy as np
-from lumicks.pylake.kymotracker.kymotrack import KymoTrack, KymoTrackGroup
+import pytest
+
 from lumicks.pylake.kymo import _kymo_from_array
+from lumicks.pylake.kymotracker.kymotrack import KymoTrack, KymoTrackGroup
 from lumicks.pylake.tests.data.mock_confocal import generate_kymo
+
 from .data.generate_gaussian_data import read_dataset as read_dataset_gaussian
 
 

--- a/lumicks/pylake/kymotracker/tests/data/generate_gaussian_data.py
+++ b/lumicks/pylake/kymotracker/tests/data/generate_gaussian_data.py
@@ -1,8 +1,8 @@
-import numpy as np
-from pathlib import Path
-from dataclasses import dataclass, asdict
 import json
+from pathlib import Path
+from dataclasses import asdict, dataclass
 
+import numpy as np
 
 save_path = Path(__file__).parent
 

--- a/lumicks/pylake/kymotracker/tests/test_algorithm_scaling.py
+++ b/lumicks/pylake/kymotracker/tests/test_algorithm_scaling.py
@@ -1,5 +1,6 @@
-import pytest
 import numpy as np
+import pytest
+
 from lumicks.pylake.kymotracker.kymotracker import track_greedy
 from lumicks.pylake.tests.data.mock_confocal import generate_kymo
 

--- a/lumicks/pylake/kymotracker/tests/test_denoise.py
+++ b/lumicks/pylake/kymotracker/tests/test_denoise.py
@@ -1,4 +1,5 @@
 import pytest
+
 from lumicks.pylake.kymotracker.detail.denoising import *
 
 

--- a/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
+++ b/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
@@ -1,15 +1,17 @@
-import pytest
 import re
+
+import pytest
 import matplotlib.pyplot as plt
-from lumicks.pylake.simulation.diffusion import _simulate_diffusion_1d
+
 from lumicks.pylake.detail.utilities import temp_seed
+from lumicks.pylake.simulation.diffusion import _simulate_diffusion_1d
 from lumicks.pylake.kymotracker.detail.msd_estimation import *
 from lumicks.pylake.kymotracker.detail.msd_estimation import (
+    _cve,
+    _diffusion_ols,
     _var_cve_known_var,
     _var_cve_unknown_var,
     _msd_diffusion_covariance,
-    _diffusion_ols,
-    _cve,
     _determine_optimal_points_ensemble,
 )
 

--- a/lumicks/pylake/kymotracker/tests/test_gaussian_mle.py
+++ b/lumicks/pylake/kymotracker/tests/test_gaussian_mle.py
@@ -1,12 +1,14 @@
-import pytest
-import numpy as np
 from functools import partial
 
+import numpy as np
+import pytest
+
 from lumicks.pylake.kymotracker.detail import gaussian_mle
-from lumicks.pylake.fitting.detail.derivative_manipulation import numerical_jacobian
 from lumicks.pylake.kymotracker.detail.gaussian_mle import (
-    overlapping_pixels, _estimation_parameters_simultaneous
+    overlapping_pixels,
+    _estimation_parameters_simultaneous,
 )
+from lumicks.pylake.fitting.detail.derivative_manipulation import numerical_jacobian
 
 
 @pytest.mark.parametrize(

--- a/lumicks/pylake/kymotracker/tests/test_geometry_2d.py
+++ b/lumicks/pylake/kymotracker/tests/test_geometry_2d.py
@@ -1,13 +1,14 @@
-import pytest
 import numpy as np
+import pytest
 from scipy.stats import norm
+
 from lumicks.pylake.kymotracker.detail.linalg_2d import (
     eigenvalues_2d_symmetric,
     eigenvector_2d_symmetric,
 )
 from lumicks.pylake.kymotracker.detail.geometry_2d import (
-    calculate_image_geometry,
     get_candidate_generator,
+    calculate_image_geometry,
 )
 
 

--- a/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
@@ -1,10 +1,12 @@
-import pytest
 import re
+
 import numpy as np
+import pytest
+
 from lumicks.pylake.kymo import _kymo_from_array
+from lumicks.pylake.kymotracker.kymotrack import KymoTrackGroup
 from lumicks.pylake.kymotracker.kymotracker import track_greedy
 from lumicks.pylake.tests.data.mock_confocal import generate_kymo
-from lumicks.pylake.kymotracker.kymotrack import KymoTrackGroup
 
 
 def test_kymotracker_test_bias_rect():

--- a/lumicks/pylake/kymotracker/tests/test_image_sampling.py
+++ b/lumicks/pylake/kymotracker/tests/test_image_sampling.py
@@ -1,9 +1,11 @@
-import pytest
 import re
+
 import numpy as np
+import pytest
+
 from lumicks.pylake.kymo import _kymo_from_array
-from lumicks.pylake.kymotracker.kymotracker import track_greedy
 from lumicks.pylake.kymotracker.kymotrack import KymoTrack
+from lumicks.pylake.kymotracker.kymotracker import track_greedy
 from lumicks.pylake.tests.data.mock_confocal import generate_kymo
 
 

--- a/lumicks/pylake/kymotracker/tests/test_io.py
+++ b/lumicks/pylake/kymotracker/tests/test_io.py
@@ -1,15 +1,17 @@
-import pytest
-import numpy as np
-import inspect
-import re
 import io
-from pathlib import Path
+import re
+import inspect
 from copy import copy
+from pathlib import Path
+
+import numpy as np
+import pytest
+
 from lumicks.pylake.kymo import _kymo_from_array
 from lumicks.pylake.kymotracker.kymotrack import (
-    _read_txt,
     KymoTrack,
     KymoTrackGroup,
+    _read_txt,
     import_kymotrackgroup_from_csv,
 )
 from lumicks.pylake.tests.data.mock_confocal import generate_kymo

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -1,11 +1,14 @@
 import re
+from copy import copy
+
 import pytest
 import matplotlib.pyplot as plt
-from copy import copy
+
+from lumicks.pylake.kymo import _kymo_from_array
 from lumicks.pylake.kymotracker.kymotrack import *
 from lumicks.pylake.kymotracker.kymotracker import _to_half_kernel_size
 from lumicks.pylake.kymotracker.detail.localization_models import *
-from lumicks.pylake.kymo import _kymo_from_array
+
 from ...tests.data.mock_confocal import generate_kymo
 
 

--- a/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
@@ -1,7 +1,9 @@
 import re
+
 import pytest
-from lumicks.pylake.kymotracker.kymotrack import *
+
 from lumicks.pylake.kymo import _kymo_from_array
+from lumicks.pylake.kymotracker.kymotrack import *
 
 
 @pytest.fixture(scope="module")

--- a/lumicks/pylake/kymotracker/tests/test_lines_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_lines_algorithm.py
@@ -1,11 +1,13 @@
-import pytest
-import numpy as np
 from copy import deepcopy
+
+import numpy as np
+import pytest
+
 from lumicks.pylake.kymo import _kymo_from_array
-from lumicks.pylake.kymotracker.detail.trace_line_2d import _traverse_line_direction, detect_lines
 from lumicks.pylake.kymotracker.kymotracker import track_lines, _interp_to_frame
 from lumicks.pylake.tests.data.mock_confocal import generate_kymo
 from lumicks.pylake.kymotracker.detail.geometry_2d import get_candidate_generator
+from lumicks.pylake.kymotracker.detail.trace_line_2d import detect_lines, _traverse_line_direction
 
 
 def test_tracing():

--- a/lumicks/pylake/kymotracker/tests/test_loc_models.py
+++ b/lumicks/pylake/kymotracker/tests/test_loc_models.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 from lumicks.pylake.kymotracker.detail.localization_models import *
 from lumicks.pylake.kymotracker.detail.localization_models import CentroidLocalizationModel
 

--- a/lumicks/pylake/kymotracker/tests/test_peakfinding.py
+++ b/lumicks/pylake/kymotracker/tests/test_peakfinding.py
@@ -1,14 +1,16 @@
-import pytest
 import re
+
 import numpy as np
+import pytest
+
 from lumicks.pylake.kymotracker.detail.peakfinding import (
-    peak_estimate,
-    refine_peak_based_on_moment,
     KymoPeaks,
+    peak_estimate,
     merge_close_peaks,
-    bounds_to_centroid_data,
     unbiased_centroid,
     _clip_kernel_to_edge,
+    bounds_to_centroid_data,
+    refine_peak_based_on_moment,
 )
 
 

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -1,12 +1,14 @@
-import pytest
 import re
+
 import numpy as np
-from lumicks.pylake.kymotracker.detail.localization_models import GaussianLocalizationModel
-from lumicks.pylake.kymotracker.kymotracker import *
-from lumicks.pylake.kymotracker.kymotrack import KymoTrack, KymoTrackGroup
-from lumicks.pylake.tests.data.mock_confocal import generate_kymo
-from lumicks.pylake.kymo import _kymo_from_array
+import pytest
 from scipy.stats import norm
+
+from lumicks.pylake.kymo import _kymo_from_array
+from lumicks.pylake.kymotracker.kymotrack import KymoTrack, KymoTrackGroup
+from lumicks.pylake.kymotracker.kymotracker import *
+from lumicks.pylake.tests.data.mock_confocal import generate_kymo
+from lumicks.pylake.kymotracker.detail.localization_models import GaussianLocalizationModel
 
 
 def test_kymotrack_interpolation(blank_kymo, blank_kymo_track_args):

--- a/lumicks/pylake/kymotracker/tests/test_sequence.py
+++ b/lumicks/pylake/kymotracker/tests/test_sequence.py
@@ -1,5 +1,7 @@
-import pytest
 from pathlib import Path
+
+import pytest
+
 from lumicks.pylake.kymotracker.detail.sequence import read_genbank
 
 

--- a/lumicks/pylake/kymotracker/tests/test_stitching.py
+++ b/lumicks/pylake/kymotracker/tests/test_stitching.py
@@ -1,8 +1,9 @@
-import pytest
 import numpy as np
-from lumicks.pylake.kymotracker.detail.stitch import distance_line_to_point
-from lumicks.pylake.kymotracker.stitching import stitch_kymo_lines
+import pytest
+
 from lumicks.pylake.kymotracker.kymotrack import KymoTrack
+from lumicks.pylake.kymotracker.stitching import stitch_kymo_lines
+from lumicks.pylake.kymotracker.detail.stitch import distance_line_to_point
 
 
 def test_distance_line_to_point():

--- a/lumicks/pylake/kymotracker/tests/test_tracing.py
+++ b/lumicks/pylake/kymotracker/tests/test_tracing.py
@@ -1,13 +1,14 @@
 import numpy as np
-from lumicks.pylake.kymotracker.detail.scoring_functions import build_score_matrix, kymo_score
-from lumicks.pylake.kymotracker.detail.trace_line_2d import (
-    append_next_point,
-    extend_line,
-    points_to_line_segments,
-    KymoLineData,
-)
+
 from lumicks.pylake.kymotracker.kymotrack import KymoTrack
 from lumicks.pylake.kymotracker.detail.peakfinding import KymoPeaks
+from lumicks.pylake.kymotracker.detail.trace_line_2d import (
+    KymoLineData,
+    extend_line,
+    append_next_point,
+    points_to_line_segments,
+)
+from lumicks.pylake.kymotracker.detail.scoring_functions import kymo_score, build_score_matrix
 
 
 def test_score_matrix(blank_kymo, blank_kymo_track_args):

--- a/lumicks/pylake/nb_widgets/correlated_plot.py
+++ b/lumicks/pylake/nb_widgets/correlated_plot.py
@@ -1,5 +1,6 @@
-import numpy as np
 import warnings
+
+import numpy as np
 
 
 def plot_correlated(

--- a/lumicks/pylake/nb_widgets/image_editing.py
+++ b/lumicks/pylake/nb_widgets/image_editing.py
@@ -1,10 +1,12 @@
+from dataclasses import field, dataclass
+
 import numpy as np
-from dataclasses import dataclass, field
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.widgets import RectangleSelector
-from ..image_stack import ImageStack
+
 from ..kymo import Kymo
+from ..image_stack import ImageStack
 from ..detail.image import make_image_title
 
 

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -1,16 +1,17 @@
-from dataclasses import dataclass
-from typing import Optional
 import inspect
 import warnings
+from copy import copy
+from typing import Optional
+from dataclasses import dataclass
+
 import numpy as np
 import matplotlib.pyplot as plt
-from copy import copy
 from matplotlib.widgets import RectangleSelector
-from lumicks.pylake.kymotracker.kymotracker import track_greedy
+
 from lumicks.pylake import filter_tracks, refine_tracks_centroid
-from lumicks.pylake.nb_widgets.detail.mouse import MouseDragCallback
 from lumicks.pylake.kymotracker.kymotrack import KymoTrackGroup, import_kymotrackgroup_from_csv
-from lumicks.pylake.kymotracker.kymotracker import _to_half_kernel_size
+from lumicks.pylake.kymotracker.kymotracker import track_greedy, _to_half_kernel_size
+from lumicks.pylake.nb_widgets.detail.mouse import MouseDragCallback
 from lumicks.pylake.nb_widgets.detail.undostack import UndoStack
 
 
@@ -410,8 +411,8 @@ class KymoWidget:
 
     def _create_widgets(self):
         """Create widgets for setting kymotracking settings"""
-        from IPython.display import display
         import ipywidgets
+        from IPython.display import display
 
         if not max([backend in plt.get_backend() for backend in ("nbAgg", "ipympl")]):
             raise RuntimeError(

--- a/lumicks/pylake/nb_widgets/range_selector.py
+++ b/lumicks/pylake/nb_widgets/range_selector.py
@@ -1,6 +1,7 @@
-import matplotlib.pyplot as plt
-import numpy as np
 import time
+
+import numpy as np
+import matplotlib.pyplot as plt
 
 
 class BaseRangeSelectorWidget:

--- a/lumicks/pylake/nb_widgets/tests/conftest.py
+++ b/lumicks/pylake/nb_widgets/tests/conftest.py
@@ -1,5 +1,6 @@
-import pytest
 import numpy as np
+import pytest
+
 from lumicks.pylake.tests.data.mock_confocal import generate_kymo
 
 

--- a/lumicks/pylake/nb_widgets/tests/test_correlated_plot.py
+++ b/lumicks/pylake/nb_widgets/tests/test_correlated_plot.py
@@ -1,8 +1,9 @@
-from lumicks.pylake.tests.data.mock_confocal import generate_scan
-from lumicks.pylake.channel import Slice, Continuous
-import pytest
 import numpy as np
+import pytest
 import matplotlib as mpl
+
+from lumicks.pylake.channel import Slice, Continuous
+from lumicks.pylake.tests.data.mock_confocal import generate_scan
 
 
 def test_plot_correlated():

--- a/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
+++ b/lumicks/pylake/nb_widgets/tests/test_fd_selector.py
@@ -1,13 +1,14 @@
+import numpy as np
+import pytest
+
 from lumicks.pylake import FdRangeSelector
+from lumicks.pylake.channel import Slice, TimeSeries
+from lumicks.pylake.fdcurve import FdCurve
 from lumicks.pylake.nb_widgets.range_selector import (
+    BaseRangeSelectorWidget,
     FdTimeRangeSelectorWidget,
     FdDistanceRangeSelectorWidget,
-    BaseRangeSelectorWidget,
 )
-from lumicks.pylake.fdcurve import FdCurve
-from lumicks.pylake.channel import TimeSeries, Slice
-import pytest
-import numpy as np
 
 
 def make_mock_fd(force, distance, start=0, dt=600e9):

--- a/lumicks/pylake/nb_widgets/tests/test_image_editing.py
+++ b/lumicks/pylake/nb_widgets/tests/test_image_editing.py
@@ -1,13 +1,13 @@
-import pytest
-import numpy as np
 import json
 
-from lumicks.pylake.tests.data.mock_widefield import make_alignment_image_data, MockTiffFile
-from lumicks.pylake.detail.widefield import TiffStack
-from lumicks.pylake import ImageStack
-from lumicks.pylake.nb_widgets.image_editing import ImageEditorWidget, KymoEditorWidget
-
+import numpy as np
+import pytest
 import matplotlib.pyplot as plt
+
+from lumicks.pylake import ImageStack
+from lumicks.pylake.detail.widefield import TiffStack
+from lumicks.pylake.nb_widgets.image_editing import KymoEditorWidget, ImageEditorWidget
+from lumicks.pylake.tests.data.mock_widefield import MockTiffFile, make_alignment_image_data
 
 
 def make_mock_stack():

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -1,13 +1,15 @@
+import re
+
+import numpy as np
+import pytest
+
+from lumicks.pylake.kymo import _kymo_from_array
+from lumicks.pylake.kymotracker.kymotrack import KymoTrack, KymoTrackGroup
 from lumicks.pylake.nb_widgets.kymotracker_widgets import (
     KymoWidgetGreedy,
     KymotrackerParameter,
     _get_default_parameters,
 )
-from lumicks.pylake.kymotracker.kymotrack import KymoTrack, KymoTrackGroup
-from lumicks.pylake.kymo import _kymo_from_array
-import numpy as np
-import re
-import pytest
 
 
 class MockLabel:

--- a/lumicks/pylake/nb_widgets/tests/test_mouse.py
+++ b/lumicks/pylake/nb_widgets/tests/test_mouse.py
@@ -1,5 +1,6 @@
-import matplotlib.pyplot as plt
 import numpy as np
+import matplotlib.pyplot as plt
+
 from lumicks.pylake.nb_widgets.detail.mouse import MouseDragCallback
 
 

--- a/lumicks/pylake/piezo_tracking/baseline.py
+++ b/lumicks/pylake/piezo_tracking/baseline.py
@@ -1,7 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from lumicks.pylake.channel import Slice, Continuous
 
+from lumicks.pylake.channel import Slice, Continuous
 
 __all__ = ["ForceBaseLine"]
 

--- a/lumicks/pylake/piezo_tracking/piezo_tracking.py
+++ b/lumicks/pylake/piezo_tracking/piezo_tracking.py
@@ -1,9 +1,10 @@
 import warnings
+
 import numpy as np
 import matplotlib.pyplot as plt
-from .baseline import ForceBaseLine
-from ..channel import Slice
 
+from ..channel import Slice
+from .baseline import ForceBaseLine
 
 __all__ = ["DistanceCalibration", "PiezoTrackingCalibration", "PiezoForceDistance"]
 

--- a/lumicks/pylake/piezo_tracking/tests/conftest.py
+++ b/lumicks/pylake/piezo_tracking/tests/conftest.py
@@ -1,8 +1,9 @@
-import pytest
 import numpy as np
-from lumicks.pylake.channel import Continuous, TimeSeries, Slice
-from lumicks.pylake.fitting.models import ewlc_odijk_force
+import pytest
+
+from lumicks.pylake.channel import Slice, Continuous, TimeSeries
 from lumicks.pylake.calibration import ForceCalibration
+from lumicks.pylake.fitting.models import ewlc_odijk_force
 
 
 def reference_baseline():

--- a/lumicks/pylake/piezo_tracking/tests/test_baseline.py
+++ b/lumicks/pylake/piezo_tracking/tests/test_baseline.py
@@ -1,6 +1,8 @@
+from copy import deepcopy
+
 import numpy as np
 import pytest
-from copy import deepcopy
+
 from lumicks.pylake.piezo_tracking.baseline import ForceBaseLine
 
 

--- a/lumicks/pylake/piezo_tracking/tests/test_piezo_tracking.py
+++ b/lumicks/pylake/piezo_tracking/tests/test_piezo_tracking.py
@@ -1,14 +1,15 @@
-import pytest
 import numpy as np
+import pytest
 import matplotlib.pyplot as plt
+
 from lumicks.pylake.channel import Slice, Continuous, TimeSeries
+from lumicks.pylake.detail.utilities import downsample
+from lumicks.pylake.piezo_tracking.baseline import ForceBaseLine
 from lumicks.pylake.piezo_tracking.piezo_tracking import (
+    PiezoForceDistance,
     DistanceCalibration,
     PiezoTrackingCalibration,
-    PiezoForceDistance,
 )
-from lumicks.pylake.piezo_tracking.baseline import ForceBaseLine
-from lumicks.pylake.detail.utilities import downsample
 
 
 def trap_pos_camera_distance():

--- a/lumicks/pylake/point_scan.py
+++ b/lumicks/pylake/point_scan.py
@@ -1,7 +1,8 @@
+from copy import copy
+
 from .detail.confocal import BaseScan
 from .detail.plotting import get_axes
 from .detail.timeindex import to_timestamp
-from copy import copy
 
 
 class PointScan(BaseScan):

--- a/lumicks/pylake/population/__init__.py
+++ b/lumicks/pylake/population/__init__.py
@@ -1,2 +1,2 @@
-from .dwelltime import DwelltimeModel
 from .mixture import GaussianMixtureModel
+from .dwelltime import DwelltimeModel

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -1,12 +1,14 @@
 import warnings
-import numpy as np
 from typing import Dict, Tuple, Union
+from dataclasses import field, dataclass
+
+import numpy as np
+import matplotlib.pyplot as plt
 from scipy.special import logsumexp
 from scipy.optimize import minimize
-from dataclasses import dataclass, field
-import matplotlib.pyplot as plt
 from deprecated.sphinx import deprecated
-from lumicks.pylake.fitting.parameters import Parameter, Params
+
+from lumicks.pylake.fitting.parameters import Params, Parameter
 from lumicks.pylake.fitting.profile_likelihood import ProfileLikelihood1D
 
 

--- a/lumicks/pylake/population/mixture.py
+++ b/lumicks/pylake/population/mixture.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy import stats
+
 from .dwelltime import _dwellcounts_from_statepath
 
 

--- a/lumicks/pylake/population/tests/conftest.py
+++ b/lumicks/pylake/population/tests/conftest.py
@@ -1,6 +1,8 @@
-import pytest
-import numpy as np
 from pathlib import Path
+
+import numpy as np
+import pytest
+
 from .data.generate_exponential_data import read_dataset as read_dataset_exponential
 
 

--- a/lumicks/pylake/population/tests/data/generate_exponential_data.py
+++ b/lumicks/pylake/population/tests/data/generate_exponential_data.py
@@ -1,8 +1,8 @@
-import numpy as np
-from pathlib import Path
-from dataclasses import dataclass, asdict
 import json
+from pathlib import Path
+from dataclasses import asdict, dataclass
 
+import numpy as np
 
 save_path = Path(__file__).parent
 

--- a/lumicks/pylake/population/tests/data/generate_trace_data.py
+++ b/lumicks/pylake/population/tests/data/generate_trace_data.py
@@ -1,5 +1,6 @@
-import numpy as np
 from pathlib import Path
+
+import numpy as np
 
 
 def generate_parameters(n_states):

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -1,18 +1,19 @@
-import pytest
-import numpy as np
 import re
+
+import numpy as np
+import pytest
 import matplotlib.pyplot as plt
 
 from lumicks.pylake import DwelltimeModel
-from lumicks.pylake.fitting.detail.derivative_manipulation import numerical_jacobian
 from lumicks.pylake.population.dwelltime import (
-    _dwellcounts_from_statepath,
     DwelltimeBootstrap,
-    _handle_amplitude_constraint,
     _exponential_mle_optimize,
+    _dwellcounts_from_statepath,
+    _handle_amplitude_constraint,
     _exponential_mixture_log_likelihood,
     _exponential_mixture_log_likelihood_jacobian,
 )
+from lumicks.pylake.fitting.detail.derivative_manipulation import numerical_jacobian
 
 
 def test_likelihood(exponential_data):

--- a/lumicks/pylake/population/tests/test_mixture.py
+++ b/lumicks/pylake/population/tests/test_mixture.py
@@ -1,8 +1,9 @@
-from lumicks.pylake import GaussianMixtureModel
-from lumicks.pylake.channel import Slice, Continuous
 import numpy as np
 import pytest
 import matplotlib.pyplot as plt
+
+from lumicks.pylake import GaussianMixtureModel
+from lumicks.pylake.channel import Slice, Continuous
 
 
 def test_gmm(trace_lownoise):

--- a/lumicks/pylake/scalebar.py
+++ b/lumicks/pylake/scalebar.py
@@ -1,6 +1,7 @@
-from dataclasses import dataclass, field
-from matplotlib.offsetbox import AnchoredOffsetbox, AuxTransformBox, VPacker, HPacker, TextArea
-from typing import Optional, Union
+from typing import Union, Optional
+from dataclasses import field, dataclass
+
+from matplotlib.offsetbox import HPacker, VPacker, TextArea, AuxTransformBox, AnchoredOffsetbox
 
 
 def _create_scale_legend(

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -3,13 +3,12 @@ from itertools import zip_longest
 
 import numpy as np
 
-from . import colormaps
-from .adjustments import no_adjustment
-from .detail.utilities import method_cache
-from .detail.confocal import ConfocalImage
+from .adjustments import colormaps, no_adjustment
 from .detail.image import make_image_title, reconstruct_num_frames, first_pixel_sample_indices
-from .detail.imaging_mixins import FrameIndex, VideoExport
+from .detail.confocal import ConfocalImage
 from .detail.plotting import get_axes, show_image
+from .detail.utilities import method_cache
+from .detail.imaging_mixins import FrameIndex, VideoExport
 
 
 class Scan(ConfocalImage, VideoExport, FrameIndex):

--- a/lumicks/pylake/simulation/diffusion.py
+++ b/lumicks/pylake/simulation/diffusion.py
@@ -1,5 +1,6 @@
 import numpy as np
 from cachetools import cached
+
 from lumicks.pylake.kymo import _kymo_from_array
 from lumicks.pylake.kymotracker.kymotracker import KymoTrack, KymoTrackGroup
 

--- a/lumicks/pylake/simulation/tests/test_diffusion.py
+++ b/lumicks/pylake/simulation/tests/test_diffusion.py
@@ -1,7 +1,8 @@
-from lumicks.pylake.detail.utilities import temp_seed
-from lumicks.pylake.simulation.diffusion import simulate_diffusive_tracks
 import numpy as np
 import pytest
+
+from lumicks.pylake.detail.utilities import temp_seed
+from lumicks.pylake.simulation.diffusion import simulate_diffusive_tracks
 
 
 def test_simulate_diffusive_tracks():

--- a/lumicks/pylake/tests/conftest.py
+++ b/lumicks/pylake/tests/conftest.py
@@ -1,5 +1,7 @@
-import pytest
 import json
+
+import pytest
+
 from .data.mock_file import MockDataFile_v2
 from .data.mock_fdcurve import generate_fdcurve_with_baseline_offset
 

--- a/lumicks/pylake/tests/data/mock_confocal.py
+++ b/lumicks/pylake/tests/data/mock_confocal.py
@@ -1,13 +1,14 @@
-from dataclasses import dataclass
-from numbers import Integral
 from typing import List
+from numbers import Integral
+from dataclasses import dataclass
 
 import numpy as np
-from lumicks.pylake.channel import Continuous, Slice, empty_slice
-from lumicks.pylake.detail.confocal import ConfocalImage, ScanMetaData
-from lumicks.pylake.detail.image import InfowaveCode
+
 from lumicks.pylake.kymo import Kymo
 from lumicks.pylake.scan import Scan
+from lumicks.pylake.channel import Slice, Continuous, empty_slice
+from lumicks.pylake.detail.image import InfowaveCode
+from lumicks.pylake.detail.confocal import ScanMetaData, ConfocalImage
 
 from .mock_json import mock_json
 

--- a/lumicks/pylake/tests/data/mock_fdcurve.py
+++ b/lumicks/pylake/tests/data/mock_fdcurve.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def generate_fdcurve_with_baseline_offset():
     # generate high frequency data
     distance_hf = np.linspace(1, 10, 500)                       # distance, HF

--- a/lumicks/pylake/tests/data/mock_file.py
+++ b/lumicks/pylake/tests/data/mock_file.py
@@ -1,6 +1,7 @@
-import numpy as np
-import h5py
 import json
+
+import h5py
+import numpy as np
 
 # We generate mock data files for different versions of the Bluelake HDF5 file
 # format:

--- a/lumicks/pylake/tests/data/mock_json.py
+++ b/lumicks/pylake/tests/data/mock_json.py
@@ -1,6 +1,5 @@
 import json
 
-
 force_feedback_dict = {
     "settings_at_start": {
         "enabled_status": 0,

--- a/lumicks/pylake/tests/data/mock_widefield.py
+++ b/lumicks/pylake/tests/data/mock_widefield.py
@@ -1,5 +1,6 @@
-import numpy as np
 import json
+
+import numpy as np
 import tifffile
 
 

--- a/lumicks/pylake/tests/test_channels/conftest.py
+++ b/lumicks/pylake/tests/test_channels/conftest.py
@@ -1,5 +1,6 @@
-import pytest
 import numpy as np
+import pytest
+
 from ..data.mock_file import MockDataFile_v1, MockDataFile_v2
 
 

--- a/lumicks/pylake/tests/test_channels/test_arithmetic.py
+++ b/lumicks/pylake/tests/test_channels/test_arithmetic.py
@@ -1,8 +1,8 @@
-import pytest
 import numpy as np
-from lumicks.pylake.channel import Slice, Continuous, TimeSeries, TimeTags
-from lumicks.pylake.calibration import ForceCalibration
+import pytest
 
+from lumicks.pylake.channel import Slice, TimeTags, Continuous, TimeSeries
+from lumicks.pylake.calibration import ForceCalibration
 
 start = 1 + int(1e18)
 calibration = ForceCalibration("Stop time (ns)", [{"Stop time (ns)": start, "kappa (pN/nm)": 0.45}])

--- a/lumicks/pylake/tests/test_channels/test_channels.py
+++ b/lumicks/pylake/tests/test_channels/test_channels.py
@@ -1,11 +1,13 @@
 import re
-import h5py
-import pytest
-import numpy as np
 from dataclasses import dataclass
+
+import h5py
+import numpy as np
+import pytest
+import matplotlib as mpl
+
 from lumicks.pylake import channel
 from lumicks.pylake.calibration import ForceCalibration
-import matplotlib as mpl
 
 
 def with_offset(t, start_time=1592916040906356300):

--- a/lumicks/pylake/tests/test_fdcurve.py
+++ b/lumicks/pylake/tests/test_fdcurve.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 
 from lumicks.pylake import File
-from lumicks.pylake.fdcurve import FdCurve
 from lumicks.pylake.channel import Slice, TimeSeries
+from lumicks.pylake.fdcurve import FdCurve
 
 
 def make_mock_fd(force, distance, start=0, file=None):

--- a/lumicks/pylake/tests/test_fdensemble.py
+++ b/lumicks/pylake/tests/test_fdensemble.py
@@ -1,13 +1,14 @@
-import pytest
 import numpy as np
+import pytest
+
+from lumicks.pylake.channel import Slice, TimeSeries
+from lumicks.pylake.fdcurve import FdCurve
+from lumicks.pylake.fdensemble import FdEnsemble
 from lumicks.pylake.detail.alignment import (
+    align_fd_simple,
     align_force_simple,
     align_distance_simple,
-    align_fd_simple,
 )
-from lumicks.pylake.fdcurve import FdCurve
-from lumicks.pylake.channel import Slice, TimeSeries
-from lumicks.pylake.fdensemble import FdEnsemble
 
 
 def make_mock_fd(force, distance, start=0):

--- a/lumicks/pylake/tests/test_file/conftest.py
+++ b/lumicks/pylake/tests/test_file/conftest.py
@@ -1,11 +1,12 @@
-import pytest
-import numpy as np
-import h5py
 import json
-from ..data.mock_file import MockDataFile_v1, MockDataFile_v2
-from ..data.mock_confocal import generate_scan_json
-from ..data.mock_json import mock_force_feedback_json
 
+import h5py
+import numpy as np
+import pytest
+
+from ..data.mock_file import MockDataFile_v1, MockDataFile_v2
+from ..data.mock_json import mock_force_feedback_json
+from ..data.mock_confocal import generate_scan_json
 
 # fmt: off
 counts = np.uint32([2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1, 8, 0,

--- a/lumicks/pylake/tests/test_file/test_file.py
+++ b/lumicks/pylake/tests/test_file/test_file.py
@@ -1,12 +1,15 @@
-import numpy as np
-from lumicks import pylake
-import pytest
 import time
 from textwrap import dedent
+
+import numpy as np
+import pytest
+
+from lumicks import pylake
 from lumicks.pylake.detail.h5_helper import write_h5
-from . import test_file_items
 from lumicks.pylake.tests.data.mock_file import MockDataFile_v2
 from lumicks.pylake.tests.data.mock_confocal import generate_scan_json, generate_image_data
+
+from . import test_file_items
 
 
 def test_attributes(h5_file):

--- a/lumicks/pylake/tests/test_file/test_file_items.py
+++ b/lumicks/pylake/tests/test_file/test_file_items.py
@@ -1,6 +1,8 @@
-import pytest
 import numpy as np
+import pytest
+
 from lumicks import pylake
+
 from ..data.mock_json import force_feedback_dict
 
 

--- a/lumicks/pylake/tests/test_file_download.py
+++ b/lumicks/pylake/tests/test_file_download.py
@@ -1,9 +1,10 @@
 import pytest
+
 from lumicks.pylake.file_download import (
-    get_url_from_doi,
-    download_record_metadata,
     verify_hash,
+    get_url_from_doi,
     download_from_doi,
+    download_record_metadata,
 )
 
 

--- a/lumicks/pylake/tests/test_image.py
+++ b/lumicks/pylake/tests/test_image.py
@@ -1,12 +1,14 @@
-import pytest
 import re
+
 import numpy as np
-from lumicks.pylake.adjustments import ColorAdjustment, wavelength_to_xyz, colormaps
+import pytest
+
+from lumicks.pylake.adjustments import ColorAdjustment, colormaps, wavelength_to_xyz
 from lumicks.pylake.detail.image import (
+    histogram_rows,
     reconstruct_image,
     reconstruct_image_sum,
     reconstruct_num_frames,
-    histogram_rows,
     first_pixel_sample_indices,
 )
 

--- a/lumicks/pylake/tests/test_imaging_camera/conftest.py
+++ b/lumicks/pylake/tests/test_imaging_camera/conftest.py
@@ -1,5 +1,6 @@
 import pytest
-from ..data.mock_widefield import make_alignment_image_data, write_tiff_file
+
+from ..data.mock_widefield import write_tiff_file, make_alignment_image_data
 
 
 @pytest.fixture(scope="module")

--- a/lumicks/pylake/tests/test_imaging_camera/test_export.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_export.py
@@ -1,6 +1,8 @@
+import itertools
+
 import pytest
 import tifffile
-import itertools
+
 from lumicks.pylake import ImageStack
 
 

--- a/lumicks/pylake/tests/test_imaging_camera/test_image_reconstruction.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_image_reconstruction.py
@@ -1,9 +1,12 @@
-import pytest
-import numpy as np
 import json
 from copy import deepcopy
+
+import numpy as np
+import pytest
+
 from lumicks.pylake import ImageStack
 from lumicks.pylake.detail.widefield import TiffStack
+
 from ..data.mock_widefield import MockTiffFile, make_frame_times
 
 

--- a/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
@@ -1,19 +1,20 @@
-import numpy as np
-import json
 import re
-import tifffile
+import json
 from pathlib import Path
+
+import numpy as np
 import pytest
-from lumicks.pylake.adjustments import ColorAdjustment
-from lumicks.pylake import ImageStack
-from lumicks.pylake import CorrelatedStack
-from lumicks.pylake.detail.imaging_mixins import _FIRST_TIMESTAMP
-from lumicks.pylake.detail.widefield import TiffStack
-from lumicks.pylake.kymotracker.kymotracker import track_greedy
-from lumicks.pylake import channel
+import tifffile
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-from ..data.mock_widefield import MockTiffFile, make_alignment_image_data, make_frame_times
+
+from lumicks.pylake import ImageStack, CorrelatedStack, channel
+from lumicks.pylake.adjustments import ColorAdjustment
+from lumicks.pylake.detail.widefield import TiffStack
+from lumicks.pylake.detail.imaging_mixins import _FIRST_TIMESTAMP
+from lumicks.pylake.kymotracker.kymotracker import track_greedy
+
+from ..data.mock_widefield import MockTiffFile, make_frame_times, make_alignment_image_data
 
 
 def to_tiff(image, description, bit_depth, start_time=1, num_images=2):

--- a/lumicks/pylake/tests/test_imaging_confocal/test_confocal.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_confocal.py
@@ -1,9 +1,10 @@
 import numpy as np
 import pytest
-from lumicks.pylake.detail.confocal import ScanAxis, ScanMetaData
-from lumicks.pylake.kymo import _kymo_from_array
 
-from ..data.mock_confocal import generate_scan_json, generate_scan, generate_kymo
+from lumicks.pylake.kymo import _kymo_from_array
+from lumicks.pylake.detail.confocal import ScanAxis, ScanMetaData
+
+from ..data.mock_confocal import generate_kymo, generate_scan, generate_scan_json
 
 
 @pytest.mark.parametrize(

--- a/lumicks/pylake/tests/test_imaging_confocal_old/conftest.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/conftest.py
@@ -1,11 +1,12 @@
-import pytest
 import numpy as np
-from lumicks.pylake.point_scan import PointScan
+import pytest
+
 from lumicks.pylake.kymo import Kymo
 from lumicks.pylake.scan import Scan
+from lumicks.pylake.point_scan import PointScan
+
 from ..data.mock_file import MockDataFile_v2
 from ..data.mock_confocal import MockConfocalFile, generate_scan_json, generate_image_data
-
 
 start = np.int64(20e9)
 dt = np.int64(62.5e6)

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo.py
@@ -1,11 +1,14 @@
 import re
+
 import numpy as np
-from lumicks import pylake
 import pytest
-from lumicks.pylake.channel import Slice, Continuous, TimeSeries, empty_slice
-from lumicks.pylake.kymo import EmptyKymo, _default_line_time_factory
-from lumicks.pylake.adjustments import ColorAdjustment
 import matplotlib.pyplot as plt
+
+from lumicks import pylake
+from lumicks.pylake.kymo import EmptyKymo, _default_line_time_factory
+from lumicks.pylake.channel import Slice, Continuous, TimeSeries, empty_slice
+from lumicks.pylake.adjustments import ColorAdjustment
+
 from ..data.mock_confocal import generate_kymo
 
 

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo_from_array.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo_from_array.py
@@ -1,9 +1,10 @@
-import pytest
-import numpy as np
 import itertools
-import matplotlib.pyplot as plt
-from lumicks.pylake.kymo import _kymo_from_array
 
+import numpy as np
+import pytest
+import matplotlib.pyplot as plt
+
+from lumicks.pylake.kymo import _kymo_from_array
 
 timestamp_err_msg = (
     "Per-pixel timestamps are not implemented. "

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo_from_imagestack.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_kymo_from_imagestack.py
@@ -1,9 +1,10 @@
-import pytest
 import numpy as np
-from lumicks.pylake.image_stack import ImageStack
-from lumicks.pylake.detail.widefield import TiffStack, Tether
-from lumicks.pylake.tests.data.mock_widefield import MockTiffFile
+import pytest
+
 from lumicks.pylake.kymo import _kymo_from_image_stack
+from lumicks.pylake.image_stack import ImageStack
+from lumicks.pylake.detail.widefield import Tether, TiffStack
+from lumicks.pylake.tests.data.mock_widefield import MockTiffFile
 
 
 def make_frame_times(n_frames, rate=10, step=8, start=10, framerate_jitter=0, step_jitter=0):

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_point_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_point_scan.py
@@ -1,7 +1,8 @@
+import re
+
+import numpy as np
 import pytest
 import matplotlib.pyplot as plt
-import numpy as np
-import re
 
 
 def test_point_scans_basic(test_point_scans, reference_timestamps, reference_counts):

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_scan.py
@@ -1,9 +1,12 @@
+import re
+
+import numpy as np
 import pytest
 import matplotlib.pyplot as plt
-import numpy as np
-import re
-from lumicks.pylake.detail.imaging_mixins import _FIRST_TIMESTAMP
+
 from lumicks.pylake.adjustments import ColorAdjustment
+from lumicks.pylake.detail.imaging_mixins import _FIRST_TIMESTAMP
+
 from ..data.mock_confocal import generate_scan
 
 

--- a/lumicks/pylake/tests/test_imaging_mixins.py
+++ b/lumicks/pylake/tests/test_imaging_mixins.py
@@ -1,8 +1,8 @@
-import pytest
 import numpy as np
+import pytest
+from tifffile import TiffFile
 
 from lumicks.pylake.detail.imaging_mixins import TiffExport
-from tifffile import TiffFile
 
 
 def tiffexport_factory(
@@ -184,8 +184,9 @@ def test_export_tiff_tags(tmp_path, output_dtype, number_of_bits, sampleformat):
     """
 
     def grab_tags(file):
-        import tifffile
         from ast import literal_eval
+
+        import tifffile
 
         tiff_tags = []
         with tifffile.TiffFile(file) as tif:

--- a/lumicks/pylake/tests/test_import_time.py
+++ b/lumicks/pylake/tests/test_import_time.py
@@ -1,7 +1,8 @@
-from textwrap import dedent
-import numpy as np
-import subprocess
 import sys
+import subprocess
+from textwrap import dedent
+
+import numpy as np
 import pytest
 
 

--- a/lumicks/pylake/tests/test_mixin.py
+++ b/lumicks/pylake/tests/test_mixin.py
@@ -1,5 +1,6 @@
-from lumicks.pylake.detail import mixin
 import itertools
+
+from lumicks.pylake.detail import mixin
 
 
 def test_force():

--- a/lumicks/pylake/tests/test_scalebar.py
+++ b/lumicks/pylake/tests/test_scalebar.py
@@ -1,12 +1,15 @@
 import json
+
+import numpy as np
 import pytest
 import matplotlib.pyplot as plt
-import numpy as np
+
 from lumicks.pylake.kymo import _kymo_from_array
-from lumicks.pylake.image_stack import ImageStack, TiffStack
+from lumicks.pylake.scalebar import ScaleBar, _create_scale_legend
+from lumicks.pylake.image_stack import TiffStack, ImageStack
+
 from .data.mock_confocal import generate_scan
 from .data.mock_widefield import MockTiffFile, make_frame_times
-from lumicks.pylake.scalebar import _create_scale_legend, ScaleBar
 
 
 def _validate_elements(ref_elements, item):

--- a/lumicks/pylake/tests/test_timeindex.py
+++ b/lumicks/pylake/tests/test_timeindex.py
@@ -1,7 +1,8 @@
-import pytest
 import re
 
-from lumicks.pylake.detail.timeindex import regex_template, regex, Timeindex
+import pytest
+
+from lumicks.pylake.detail.timeindex import Timeindex, regex, regex_template
 
 
 def test_regex_template():

--- a/lumicks/pylake/tests/test_utilities.py
+++ b/lumicks/pylake/tests/test_utilities.py
@@ -1,15 +1,16 @@
-from lumicks.pylake.detail.utilities import *
+import numpy as np
+import pytest
+import matplotlib as mpl
+from numpy.testing import assert_array_equal
+
 from lumicks.pylake.detail.confocal import timestamp_mean
+from lumicks.pylake.detail.utilities import *
 from lumicks.pylake.detail.utilities import (
+    method_cache,
     will_mul_overflow,
     could_sum_overflow,
     replace_key_aliases,
-    method_cache,
 )
-from numpy.testing import assert_array_equal
-import pytest
-import matplotlib as mpl
-import numpy as np
 
 
 def test_first():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,10 @@ exclude = '''
   )/
 )
 '''
+
+[tool.isort]
+profile = "black"
+line_length = 100
+py_version=39
+length_sort_sections = ["stdlib", "thirdparty", "firstparty", "localfolder"]
+lines_between_sections = 1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import sys
-from setuptools import setup, PEP420PackageFinder
+
+from setuptools import PEP420PackageFinder, setup
 from setuptools.command.egg_info import manifest_maker
 
 if sys.version_info[:2] < (3, 9):


### PR DESCRIPTION
I noticed that `pylake` wasn't using this yet and I figured you might find it useful. It's a very nice thing to complement `black` formatting.