### PR TITLE
Mark file APIs with `os.PathLike` type hint

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
 * [`File.save_as()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.File.html#lumicks.pylake.File.save_as) data now allows passing in a single string for the `omit_data` parameter.
 * Gracefully handle empty `Scan` after slicing. Previously, a slice operation on a `Scan` that resulted in no frames remaining raised a `NotImplementedError`. Now it returns an `EmptyScan`.
 * Improved performance of `Scan.pixel_time_seconds`, `Kymo.pixel_time_seconds` and `Kymo.line_time_seconds`.
+* Marked functions that take file paths as arguments with the `os.PathLike` type hint to idicate that `pathlib.Path` and similar types are also accepted (not just `str`).
 
 ## v1.1.1 | 2023-06-13
 

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -325,7 +325,7 @@ class ConfocalImage(BaseScan, TiffExport):
 
         Parameters
         ----------
-        filename : str
+        filename : str | os.PathLike
             The name of the TIFF file where the image will be saved.
         dtype : np.dtype
             The data type of a single color channel in the resulting image.

--- a/lumicks/pylake/detail/h5_helper.py
+++ b/lumicks/pylake/detail/h5_helper.py
@@ -70,7 +70,7 @@ def write_h5(
     ----------
     lk_file : lk.File
         pylake file handle
-    output_filename : str
+    output_filename : str | os.PathLike
         Output file name.
     compression_level : int
         Compression level for gzip compression.

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -17,7 +17,7 @@ class TiffExport:
 
         Parameters
         ----------
-        filename : str
+        filename : str | os.PathLike
             The name of the TIFF file where the image will be saved.
         dtype : np.dtype
             The data type of a single color channel in the resulting image.

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -24,7 +24,7 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
 
     Parameters
     ----------
-    filename : str
+    filename : str | os.PathLike
         The HDF5 file to open in read-only mode
 
     Examples
@@ -313,7 +313,7 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
 
         Parameters
         ----------
-        filename : str
+        filename : str | os.PathLike
             Output file name.
         compression_level : int
             Compression level for gzip compression (default: 5).

--- a/lumicks/pylake/kymotracker/detail/sequence.py
+++ b/lumicks/pylake/kymotracker/detail/sequence.py
@@ -38,7 +38,7 @@ def read_genbank(filename):
 
     Parameters
     ----------
-    filename: str
+    filename: str | os.PathLike
         Path to the file to be parsed.
     """
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -16,7 +16,7 @@ def _read_txt(file, delimiter):
 
     Parameters
     ----------
-    file : str or StringIO
+    file : str | os.PathLike | StringIO
         path to a file to read, or handle to read from directly
     delimiter : str
         Delimiter to use.
@@ -70,7 +70,7 @@ def export_kymotrackgroup_to_csv(
 
     Parameters
     ----------
-    filename : str
+    filename : str | os.PathLike
         Filename to output KymoTrackGroup to.
     kymotrack_group : KymoTrackGroup
         Kymograph tracks to export.
@@ -156,7 +156,7 @@ def import_kymotrackgroup_from_csv(filename, kymo, channel, delimiter=";"):
 
     Parameters
     ----------
-    filename : str
+    filename : str | os.PathLike
         filename to import from.
     kymo : Kymo
         kymograph instance that the CSV data was tracked from.
@@ -1377,7 +1377,7 @@ class KymoTrackGroup:
 
         Parameters
         ----------
-        filename : str
+        filename : str | os.PathLike
             Filename to output kymograph tracks to.
         delimiter : str
             Which delimiter to use in the csv file.

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -323,7 +323,7 @@ class KymoWidget:
 
         Parameters
         ----------
-        filename : str
+        filename : str | os.PathLike
             Filename to output kymograph tracks to.
         delimiter : str
             Which delimiter to use in the csv file.


### PR DESCRIPTION
This is a very minor addition. My IDE showed a warning when I was passing a `pathlib.Path` to `pylake` since the type hint was only `str`. These days, most APIs accept anything that's `PathLike` instead of strict `str`.