### PR TITLE
Speed up `import lumicks.pylake` by streamlining `scipy` imports

### DIFF
--- a/lumicks/pylake/adjustments.py
+++ b/lumicks/pylake/adjustments.py
@@ -1,8 +1,8 @@
 from dataclasses import make_dataclass
 
 import numpy as np
+import skimage
 import matplotlib as mpl
-from skimage.color import xyz2rgb
 from matplotlib.colors import LinearSegmentedColormap
 
 
@@ -232,7 +232,7 @@ class _ColorMaps(
 
     def from_wavelength(self, wavelength):
         xyz = wavelength_to_xyz(wavelength)
-        rgb = xyz2rgb(xyz.reshape([1, 1, 3])).squeeze()
+        rgb = skimage.color.xyz2rgb(xyz.reshape([1, 1, 3])).squeeze()
         return _make_cmap(f"{wavelength}nm", rgb)
 
 

--- a/lumicks/pylake/fitting/detail/derivative_manipulation.py
+++ b/lumicks/pylake/fitting/detail/derivative_manipulation.py
@@ -1,8 +1,7 @@
 import warnings
 
 import numpy as np
-import scipy.optimize as optim
-from scipy.interpolate import InterpolatedUnivariateSpline
+import scipy
 
 
 def numerical_diff(fn, x, dx=1e-6):
@@ -29,7 +28,7 @@ def inversion_functions(model_function, f_min, f_max, derivative_function, tol):
     def fit_single(single_distance, initial_guess):
         """Invert a single independent / dependent data point"""
         jac = derivative_function if derivative_function else "2-point"
-        single_estimate = optim.least_squares(
+        single_estimate = scipy.optimize.least_squares(
             lambda f: model_function(f) - single_distance,
             initial_guess,
             jac=jac,
@@ -122,7 +121,7 @@ def invert_function_interpolation(
     result = np.zeros(d.shape)
     if np.sum(interpolated_idx) > 3 and len(f_range) > 3:
         try:
-            interp = InterpolatedUnivariateSpline(d_range, f_range, k=3)
+            interp = scipy.interpolate.InterpolatedUnivariateSpline(d_range, f_range, k=3)
             result[interpolated_idx] = interp(d[interpolated_idx])
         except Exception as e:
             warnings.warn(

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 import numpy as np
-import scipy.optimize as optim
+import scipy
 import matplotlib.pyplot as plt
 
 from .model import Model
@@ -217,7 +217,7 @@ class Fit:
             parameter_vector[fitted] = params
             return self._calculate_jacobian(parameter_vector)[:, fitted]
 
-        result = optim.least_squares(
+        result = scipy.optimize.least_squares(
             residual,
             parameter_vector[fitted],
             jac=jacobian if self.has_jacobian else "2-point",

--- a/lumicks/pylake/fitting/parameter_trace.py
+++ b/lumicks/pylake/fitting/parameter_trace.py
@@ -1,5 +1,5 @@
 import numpy as np
-import scipy.optimize as optim
+import scipy
 
 
 def parameter_trace(model, params, inverted_parameter, independent, dependent, **kwargs):
@@ -82,7 +82,7 @@ def parameter_trace(model, params, inverted_parameter, independent, dependent, *
             return -model.jacobian(x, param_vector)[inverted_parameter_index]
 
         jac = jacobian if model.has_jacobian else "2-point"
-        result = optim.least_squares(
+        result = scipy.optimize.least_squares(
             residual,
             param_vector[inverted_parameter_index],
             jac=jac,

--- a/lumicks/pylake/fitting/profile_likelihood.py
+++ b/lumicks/pylake/fitting/profile_likelihood.py
@@ -4,8 +4,8 @@ from warnings import warn
 from dataclasses import dataclass
 
 import numpy as np
+import scipy
 import matplotlib.pyplot as plt
-from scipy.stats import chi2
 
 
 def _validate_in_bound(error_description, params, lower_bounds, upper_bounds, bound_tolerance):
@@ -472,7 +472,7 @@ class ProfileLikelihood1D:
         self.profile_info = ProfileInfo(
             minimum_chi2=chi2_function(parameters.values),
             profiled_parameter_index=list(parameters.keys()).index(parameter_name),
-            delta_chi2=chi2.ppf(options["confidence_level"], options["num_dof"]),
+            delta_chi2=scipy.stats.chi2.ppf(options["confidence_level"], options["num_dof"]),
             confidence_level=options["confidence_level"],
             parameter_names=list(parameters.keys()),
         )
@@ -514,7 +514,7 @@ class ProfileLikelihood1D:
             fitted=fitted,
             step_function=step_function,
             termination_level=self.profile_info.minimum_chi2
-            + chi2.ppf(options["termination_significance"], options["num_dof"]),
+            + scipy.stats.chi2.ppf(options["termination_significance"], options["num_dof"]),
             bound_tolerance=options["bound_tolerance"],
         )
 
@@ -603,7 +603,7 @@ class ProfileLikelihood1D:
                 f"the minimum profiled level ({profiled_level:.2f})."
             )
 
-        cutoff = self.profile_info.minimum_chi2 + chi2.ppf(
+        cutoff = self.profile_info.minimum_chi2 + scipy.stats.chi2.ppf(
             1.0 - significance_level, self.options["num_dof"]
         )
 
@@ -642,7 +642,7 @@ class ProfileLikelihood1D:
             if significance_level is not None
             else self.profile_info.confidence_level
         )
-        delta_chi2 = chi2.ppf(confidence_coefficient, self.options["num_dof"])
+        delta_chi2 = scipy.stats.chi2.ppf(confidence_coefficient, self.options["num_dof"])
         confidence_chi2 = self.profile_info.minimum_chi2 + delta_chi2
         plt.axhline(y=confidence_chi2, linewidth=1, color="k", dashes=[dash_length, dash_length])
 

--- a/lumicks/pylake/force_calibration/detail/driving_input.py
+++ b/lumicks/pylake/force_calibration/detail/driving_input.py
@@ -1,5 +1,5 @@
 import numpy as np
-import scipy.signal.windows
+import scipy
 
 from lumicks.pylake.force_calibration.power_spectrum import PowerSpectrum
 

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -33,8 +33,6 @@ from collections import namedtuple
 
 import numpy as np
 import scipy
-import scipy.optimize
-import scipy.constants
 import matplotlib.pyplot as plt
 from tabulate import tabulate
 

--- a/lumicks/pylake/force_calibration/tests/data/simulate_calibration_data.py
+++ b/lumicks/pylake/force_calibration/tests/data/simulate_calibration_data.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 import numpy as np
-import scipy.constants
+import scipy
 
 from lumicks.pylake.force_calibration.detail.power_models import (
     g_diode,

--- a/lumicks/pylake/force_calibration/tests/data/simulate_ideal.py
+++ b/lumicks/pylake/force_calibration/tests/data/simulate_ideal.py
@@ -1,6 +1,5 @@
 import numpy as np
-import scipy.signal
-import scipy.constants
+import scipy
 
 
 def calculate_active_term(time, driving_sinusoid, stiffness, gamma):

--- a/lumicks/pylake/force_calibration/tests/test_active_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_active_calibration.py
@@ -1,6 +1,6 @@
 import numpy as np
+import scipy
 import pytest
-import scipy.constants
 
 from lumicks.pylake.force_calibration.calibration_models import ActiveCalibrationModel
 from lumicks.pylake.force_calibration.detail.power_models import sphere_friction_coefficient

--- a/lumicks/pylake/force_calibration/touchdown.py
+++ b/lumicks/pylake/force_calibration/touchdown.py
@@ -2,9 +2,8 @@ import warnings
 from dataclasses import dataclass
 
 import numpy as np
+import scipy
 import matplotlib.pyplot as plt
-from scipy import stats
-from scipy.optimize import curve_fit, minimize_scalar
 
 from lumicks.pylake.detail.utilities import downsample
 
@@ -89,7 +88,7 @@ def f_test(sse_restricted, sse_unrestricted, num_data, num_pars_difference, num_
         return 0.0
     else:
         f_statistic = nominator / denominator
-        p_value = 1.0 - stats.f.cdf(f_statistic, num_pars_difference, num_pars_unrestricted)
+        p_value = 1.0 - scipy.stats.f.cdf(f_statistic, num_pars_difference, num_pars_unrestricted)
         return p_value
 
 
@@ -115,7 +114,7 @@ def fit_piecewise_linear(x, y):
     slope1_est = (y_mid - y_start) / (x_mid - x_start)
     slope2_est = (y_end - y_mid) / (x_end - x_mid)
     initial_guess = [x_mid, y_mid, slope1_est, slope2_est]
-    pars, _ = curve_fit(piecewise_linear, x, y, initial_guess)
+    pars, _ = scipy.optimize.curve_fit(piecewise_linear, x, y, initial_guess)
 
     single_pars = np.polyfit(x, y, 1)
     sse_restricted = np.sum((np.polyval(single_pars, x) - y) ** 2)
@@ -194,10 +193,10 @@ def fit_damped_sine_with_polynomial(
         guesses[max(0, min_error_index - 1)],
         guesses[min(min_error_index + 1, guesses.size - 1)],
     ]
-    result = minimize_scalar(cost, method="bounded", bounds=search_range).x
+    result = scipy.optimize.minimize_scalar(cost, method="bounded", bounds=search_range).x
 
     # After obtaining the amplitude, we can fit the decay parameter reliably
-    result, _ = curve_fit(
+    result, _ = scipy.optimize.curve_fit(
         exp_sine_with_polynomial,
         independent,
         dependent,

--- a/lumicks/pylake/kymotracker/detail/denoising.py
+++ b/lumicks/pylake/kymotracker/detail/denoising.py
@@ -1,6 +1,5 @@
 import numpy as np
-import scipy.signal
-from scipy.ndimage import convolve
+import scipy
 
 
 def equal_length(kernels):
@@ -242,7 +241,7 @@ class MultiScaleVarianceStabilizingTransform:
         remainder : np.ndarray
             Image containing the remainder (what's left after adding the detail layers).
         """
-        filtered_imgs = [convolve(image, kernel) for kernel in self._full_kernels]
+        filtered_imgs = [scipy.ndimage.convolve(image, kernel) for kernel in self._full_kernels]
 
         # Stabilize variance
         if stabilize:

--- a/lumicks/pylake/kymotracker/detail/gaussian_mle.py
+++ b/lumicks/pylake/kymotracker/detail/gaussian_mle.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 import numpy as np
-from scipy.optimize import minimize
+import scipy
 
 
 def overlapping_pixels(coordinates, width):
@@ -83,7 +83,7 @@ def _mle_optimize(initial_guess, expectation_fun, derivatives_fun, photon_count,
         photon_count=photon_count,
     )
 
-    return minimize(
+    return scipy.optimize.minimize(
         optimization_fun,
         initial_guess,
         jac=jac_fun,

--- a/lumicks/pylake/kymotracker/detail/geometry_2d.py
+++ b/lumicks/pylake/kymotracker/detail/geometry_2d.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.ndimage import gaussian_filter
+import scipy
 
 from .linalg_2d import eigenvalues_2d_symmetric, eigenvector_2d_symmetric
 
@@ -112,11 +112,11 @@ def calculate_image_geometry(data, sig_x, sig_y):
     inside: np_array
         2D image mask whether it is a potential line center or not.
     """
-    gx = gaussian_filter(data, [sig_x, sig_y], order=[1, 0])
-    gy = gaussian_filter(data, [sig_x, sig_y], order=[0, 1])
-    gxx = gaussian_filter(data, [sig_x, sig_y], order=[2, 0])
-    gyy = gaussian_filter(data, [sig_x, sig_y], order=[0, 2])
-    gxy = gaussian_filter(data, [sig_x, sig_y], order=[1, 1])
+    gx = scipy.ndimage.gaussian_filter(data, [sig_x, sig_y], order=[1, 0])
+    gy = scipy.ndimage.gaussian_filter(data, [sig_x, sig_y], order=[0, 1])
+    gxx = scipy.ndimage.gaussian_filter(data, [sig_x, sig_y], order=[2, 0])
+    gyy = scipy.ndimage.gaussian_filter(data, [sig_x, sig_y], order=[0, 2])
+    gxy = scipy.ndimage.gaussian_filter(data, [sig_x, sig_y], order=[1, 1])
 
     nx, ny, largest_eig = largest_second_derivative_2d(gxx, gxy, gyy)
     px, py, inside = find_subpixel_location(gx, gy, largest_eig, nx, ny)

--- a/lumicks/pylake/kymotracker/detail/peakfinding.py
+++ b/lumicks/pylake/kymotracker/detail/peakfinding.py
@@ -1,8 +1,7 @@
 import math
 
 import numpy as np
-from scipy.signal import convolve2d
-from scipy.ndimage import grey_dilation, gaussian_filter
+import scipy
 
 
 def peak_estimate(data, half_width, thresh):
@@ -23,8 +22,8 @@ def peak_estimate(data, half_width, thresh):
         Threshold for accepting something as a peak.
     """
     dilation_factor = int(math.ceil(half_width)) * 2 + 1
-    data = gaussian_filter(data, [0.5, 0])
-    dilated = grey_dilation(data, (dilation_factor, 0))
+    data = scipy.ndimage.gaussian_filter(data, [0.5, 0])
+    dilated = scipy.ndimage.grey_dilation(data, (dilation_factor, 0))
     dilated[dilated < thresh] = -1
     coordinates, time_points = np.where(data == dilated)
     return coordinates, time_points
@@ -298,8 +297,8 @@ def refine_peak_based_on_moment(
     mean_kernel = np.ones((2 * half_kernel_size + 1, 1))
     coordinates = np.copy(coordinates)
 
-    m0 = convolve2d(data, mean_kernel, "same")
-    subpixel_offset = convolve2d(data, dir_kernel, "same") / (m0 + eps)
+    m0 = scipy.signal.convolve2d(data, mean_kernel, "same")
+    subpixel_offset = scipy.signal.convolve2d(data, dir_kernel, "same") / (m0 + eps)
 
     max_coordinates = subpixel_offset.shape[0]
     for _ in range(max_iter):

--- a/lumicks/pylake/kymotracker/tests/test_geometry_2d.py
+++ b/lumicks/pylake/kymotracker/tests/test_geometry_2d.py
@@ -1,6 +1,6 @@
 import numpy as np
+import scipy
 import pytest
-from scipy.stats import norm
 
 from lumicks.pylake.kymotracker.detail.linalg_2d import (
     eigenvalues_2d_symmetric,
@@ -110,7 +110,7 @@ def test_eigen_2d():
     ],
 )
 def test_position_determination(loc, scale, sig_x, sig_y, transpose, tol=1e-2):
-    data = np.tile(0.0001 + norm.pdf(np.arange(0, 50, 1), loc=loc, scale=scale), (5, 1))
+    data = np.tile(0.0001 + scipy.stats.norm.pdf(np.arange(0, 50, 1), loc=loc, scale=scale), (5, 1))
     if transpose:
         data = data.transpose()
     max_derivative, normals, positions, inside = calculate_image_geometry(data, sig_x, sig_y)

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -1,8 +1,8 @@
 import re
 
 import numpy as np
+import scipy
 import pytest
-from scipy.stats import norm
 
 from lumicks.pylake.kymo import _kymo_from_array
 from lumicks.pylake.kymotracker.kymotrack import KymoTrack, KymoTrackGroup
@@ -243,7 +243,7 @@ def test_no_swap_gaussian_refinement():
     def gen_gaussians(locs):
         x = np.arange(0, 20, 1)
         return np.random.poisson(
-            200 * np.sum(np.vstack([norm.pdf(x, loc=loc) for loc in locs]), axis=0) + 10
+            200 * np.sum(np.vstack([scipy.stats.norm.pdf(x, loc=loc) for loc in locs]), axis=0) + 10
         )
 
     np.random.seed(31415)

--- a/lumicks/pylake/population/mixture.py
+++ b/lumicks/pylake/population/mixture.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy import stats
+import scipy
 
 from .dwelltime import _dwellcounts_from_statepath
 
@@ -206,7 +206,9 @@ class GaussianMixtureModel:
             PDF array split into components for each state with shape (n_states, x.size).
             The full normalized PDF can be calculated by summing across rows.
         """
-        components = np.vstack([stats.norm(m, s).pdf(x) for m, s in zip(self.means, self.std)])
+        components = np.vstack(
+            [scipy.stats.norm(m, s).pdf(x) for m, s in zip(self.means, self.std)]
+        )
         return self.weights.reshape((-1, 1)) * components
 
     def hist(self, trace, n_bins=100, plot_kwargs=None, hist_kwargs=None):

--- a/lumicks/pylake/population/tests/test_dwelltimes.py
+++ b/lumicks/pylake/population/tests/test_dwelltimes.py
@@ -607,7 +607,7 @@ def test_dwelltime_exponential_no_free_params(monkeypatch):
         raise StopIteration
 
     with monkeypatch.context() as m:
-        m.setattr("lumicks.pylake.population.dwelltime.minimize", stop)
+        m.setattr("scipy.optimize.minimize", stop)
 
         def quick_fit(fixed_params):
             return _exponential_mle_optimize(


### PR DESCRIPTION
This follows one simple rule: At module scope, always use `import scipy`, never `imports scipy.<foo>` nor `from scipy import <foo>`.

Why: `scipy.<foo>` works anyway following `import scipy` and it will lazily import heavy submodules. Using `imports scipy.<foo>` forces the submodules to be imported eagerly.

Results: On my machine, cold import (first import following installation) goes down from 11.4 seconds to 3.9 seconds. Hot import goes down from 0.7 to 0.4 seconds.

Measuring: I followed the import time profiling method [described here](https://stackoverflow.com/a/51300944) plus a `pipenv` for reproducible cold import measurements:
```
mkdir tmp && cd tmp
pipenv --rm && pipenv shell
pip install <path/to/pylake>
python -X importtime -c "import lumicks.pylake" 2> pylake-cold.log
python -X importtime -c "import lumicks.pylake" 2> pylake-hot.log
tuna pylake-cold.log
tuna pylake-hot.log
```

#### Cold import: BEFORE

<img width="1112" alt="Screenshot 2023-08-08 at 10 02 59" src="https://github.com/lumicks/pylake/assets/4831417/15ff5d7d-7ebd-4350-8ad4-e00ffe10e999">

#### Cold import: AFTER

<img width="1115" alt="Screenshot 2023-08-08 at 10 03 14" src="https://github.com/lumicks/pylake/assets/4831417/3c264dca-cca4-4905-83d4-d9e82784209e">


#### Hot import: BEFORE

<img width="1115" alt="Screenshot 2023-08-08 at 10 03 56" src="https://github.com/lumicks/pylake/assets/4831417/15895a44-de53-4e5a-9305-6ef83ff027d5">

#### Hot import: AFTER

<img width="1115" alt="Screenshot 2023-08-08 at 10 04 08" src="https://github.com/lumicks/pylake/assets/4831417/1b0ca3c9-8796-4c96-b3e1-e095495d5b46">
