### PR TITLE
black: enable `black` formatting for tests

### DIFF
--- a/lumicks/pylake/force_calibration/tests/data/simulate_calibration_data.py
+++ b/lumicks/pylake/force_calibration/tests/data/simulate_calibration_data.py
@@ -44,7 +44,7 @@ def response_peak_ideal(corner_frequency, driving_frequency, driving_amplitude):
     Flyvbjerg, H. (2006). Calibration of optical tweezers with positional detection in the back
     focal plane. Review of scientific instruments, 77(10), 103101.
     """
-    return driving_amplitude ** 2 / (2 * (1 + (corner_frequency / driving_frequency) ** 2))
+    return driving_amplitude**2 / (2 * (1 + (corner_frequency / driving_frequency) ** 2))
 
 
 def generate_active_calibration_test_data(

--- a/lumicks/pylake/kymotracker/tests/data/generate_gaussian_data.py
+++ b/lumicks/pylake/kymotracker/tests/data/generate_gaussian_data.py
@@ -17,7 +17,7 @@ class GaussianParameters1D:
 
     @property
     def amplitude(self):
-        return self.total_photons * self.pixel_size * 1 / np.sqrt(2 * np.pi * self.width ** 2)
+        return self.total_photons * self.pixel_size * 1 / np.sqrt(2 * np.pi * self.width**2)
 
     def generate_coordinates(self, n_pixels):
         return np.arange(n_pixels) * self.pixel_size

--- a/lumicks/pylake/kymotracker/tests/test_algorithm_scaling.py
+++ b/lumicks/pylake/kymotracker/tests/test_algorithm_scaling.py
@@ -38,11 +38,15 @@ def test_kymotracker_positional_scaling(vel, dt, dx):
     np.testing.assert_allclose(traces[0].position, ref_positions, rtol=1e-2)
 
     # Check whether a wrong velocity also fails to track the line
-    traces = track_greedy(kymo, "red", pixel_threshold=3, track_width=1, sigma=0.01, velocity=2 * vel)
+    traces = track_greedy(
+        kymo, "red", pixel_threshold=3, track_width=1, sigma=0.01, velocity=2 * vel
+    )
     np.testing.assert_equal(len(traces[0].seconds), 1)
     np.testing.assert_equal(len(traces[0].position), 1)
 
     # When sigma is large, we expect the line to be strung together despite the velocity being zero
-    traces = track_greedy(kymo, "red", pixel_threshold=3, track_width=1, sigma=0.5 * vel * dx, velocity=0)
+    traces = track_greedy(
+        kymo, "red", pixel_threshold=3, track_width=1, sigma=0.5 * vel * dx, velocity=0
+    )
     np.testing.assert_allclose(traces[0].seconds, ref_seconds)
     np.testing.assert_allclose(traces[0].position, ref_positions, rtol=1e-2)

--- a/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
+++ b/lumicks/pylake/kymotracker/tests/test_derived_quantities/test_msd.py
@@ -243,10 +243,18 @@ def test_diffusion_estimate_ols(
         (2.0, 1000, 5, 0.01, 0.5, 2.0191353993755534, 0.2691422691544549, 2, False),
         (2.0, 1000, 3, 0.01, 0.5, 1.5714322945079129, 0.8912916583320089, 2, True),
         (2.0, 5000, 5, 0.01, 0.5, 1.9352306588121024, 0.23809537086111288, 2, True),
-    ]
+    ],
 )
 def test_regression_ols_with_skipped_frames(
-    diffusion, num_points, max_lag, time_step, obs_noise, diff_est, std_err_est, skip, shuffle,
+    diffusion,
+    num_points,
+    max_lag,
+    time_step,
+    obs_noise,
+    diff_est,
+    std_err_est,
+    skip,
+    shuffle,
 ):
     with temp_seed(0):
         trace = _simulate_diffusion_1d(diffusion, num_points, time_step, obs_noise)
@@ -426,7 +434,7 @@ def test_cve_skipped_samples(
             time_step,
             blur_constant,
             localization_var,
-            var_of_localization_var
+            var_of_localization_var,
         )
         np.testing.assert_allclose(diffusion_est, diffusion_ref)
         np.testing.assert_allclose(diffusion_var_est, diffusion_var_ref)

--- a/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
@@ -39,7 +39,9 @@ def test_kymotracker_subset_test_greedy(kymo_integration_test_data):
     pixel_size = kymo_integration_test_data.pixelsize_um[0]
     rect = [[0.0 * line_time, 15.0 * pixel_size], [30 * line_time, 30.0 * pixel_size]]
 
-    tracks = track_greedy(kymo_integration_test_data, "red", track_width=3 * pixel_size, pixel_threshold=4, rect=rect)
+    tracks = track_greedy(
+        kymo_integration_test_data, "red", track_width=3 * pixel_size, pixel_threshold=4, rect=rect
+    )
     np.testing.assert_allclose(
         tracks[0].sample_from_image(1, correct_origin=True), [40] * np.ones(10)
     )
@@ -81,7 +83,9 @@ def test_kymotracker_greedy_algorithm_integration_tests(kymo_integration_test_da
     np.testing.assert_allclose(tracks[1].photon_counts, np.full((10,), 42))
 
     rect = [[0.0 * line_time, 15.0 * pixel_size], [30 * line_time, 30.0 * pixel_size]]
-    tracks = track_greedy(test_data, "red", track_width=3 * pixel_size, pixel_threshold=4, rect=rect)
+    tracks = track_greedy(
+        test_data, "red", track_width=3 * pixel_size, pixel_threshold=4, rect=rect
+    )
     np.testing.assert_allclose(tracks[0].coordinate_idx, [21] * np.ones(10))
     np.testing.assert_allclose(tracks[0].time_idx, np.arange(15, 25))
 
@@ -128,10 +132,11 @@ def test_greedy_algorithm_input_validation(kymo_integration_test_data):
 def test_default_parameters(kymo_pixel_calibrations):
     # calibrated in microns, kilobase pairs, pixels
     for kymo, default_width in zip(kymo_pixel_calibrations, [0.35, 0.35 / 0.34, 4]):
-
         # test that default values are used when `None` is supplied
         default_threshold = np.percentile(kymo.get_image("red"), 98)
-        ref_tracks = track_greedy(kymo, "red", track_width=default_width, pixel_threshold=default_threshold)
+        ref_tracks = track_greedy(
+            kymo, "red", track_width=default_width, pixel_threshold=default_threshold
+        )
 
         tracks = track_greedy(kymo, "red", track_width=None, pixel_threshold=default_threshold)
         for ref, track in zip(ref_tracks, tracks):
@@ -157,7 +162,8 @@ def test_default_parameters(kymo_pixel_calibrations):
 
         # To verify this for the width, we have to make sure we go to the next odd window size.
         tracks = track_greedy(
-            kymo, "red",
+            kymo,
+            "red",
             track_width=default_width / kymo.pixelsize[0] + 2,
             pixel_threshold=None,
             bias_correction=False,
@@ -165,4 +171,3 @@ def test_default_parameters(kymo_pixel_calibrations):
         with pytest.raises(AssertionError):
             for ref, track in zip(ref_tracks, tracks):
                 np.testing.assert_allclose(ref.position, track.position)
-

--- a/lumicks/pylake/kymotracker/tests/test_image_sampling.py
+++ b/lumicks/pylake/kymotracker/tests/test_image_sampling.py
@@ -27,13 +27,13 @@ def test_sampling():
         start=np.int64(20e9),
         dt=np.int64(1e9),
         samples_per_pixel=1,
-        line_padding=0
+        line_padding=0,
     )
 
     # Tests the bound handling
     kymotrack = KymoTrack([0, 1, 2, 3, 4], [0, 1, 2, 3, 4], test_img, "red", 0)
-    np.testing.assert_allclose(kymotrack.sample_from_image(
-        50, correct_origin=True), [0, 2, 3, 2, 0]
+    np.testing.assert_allclose(
+        kymotrack.sample_from_image(50, correct_origin=True), [0, 2, 3, 2, 0]
     )
     np.testing.assert_allclose(kymotrack.sample_from_image(2, correct_origin=True), [0, 2, 3, 2, 0])
     np.testing.assert_allclose(kymotrack.sample_from_image(1, correct_origin=True), [0, 2, 2, 2, 0])
@@ -46,8 +46,8 @@ def test_sampling():
     )
 
     kymotrack = KymoTrack([0, 1, 2, 3, 4], [0.1, 1.1, 2.1, 3.1, 4.1], test_img, "red", 0)
-    np.testing.assert_allclose(kymotrack.sample_from_image(
-        50, correct_origin=True), [0, 2, 3, 2, 0]
+    np.testing.assert_allclose(
+        kymotrack.sample_from_image(50, correct_origin=True), [0, 2, 3, 2, 0]
     )
     np.testing.assert_allclose(kymotrack.sample_from_image(2, correct_origin=True), [0, 2, 3, 2, 0])
     np.testing.assert_allclose(kymotrack.sample_from_image(1, correct_origin=True), [0, 2, 2, 2, 0])
@@ -71,10 +71,10 @@ def test_kymotrack_regression_sample_from_image_clamp():
         start=np.int64(20e9),
         dt=np.int64(1e9),
         samples_per_pixel=1,
-        line_padding=0
+        line_padding=0,
     )
-    assert np.array_equal(KymoTrack([0, 1], [2, 2], img, "red", 0).sample_from_image(
-        0, correct_origin=True), [1, 3]
+    assert np.array_equal(
+        KymoTrack([0, 1], [2, 2], img, "red", 0).sample_from_image(0, correct_origin=True), [1, 3]
     )
 
 
@@ -111,6 +111,6 @@ def test_origin_warning_sample_from_image():
             "the correct behavior and silence this warning, specify `correct_origin=True`. "
             "The old (incorrect) behavior is maintained until the next major release to "
             "ensure backward compatibility. To silence this warning use `correct_origin=False`"
-        )
+        ),
     ):
         tracks[0].sample_from_image(0)

--- a/lumicks/pylake/kymotracker/tests/test_io.py
+++ b/lumicks/pylake/kymotracker/tests/test_io.py
@@ -20,7 +20,11 @@ from lumicks.pylake.tests.data.mock_confocal import generate_kymo
 def compare_kymotrack_group(group1, group2):
     assert len(group1) == len(group2)
     attributes = (
-        "coordinate_idx", "time_idx", "position", "seconds", "_minimum_observable_duration"
+        "coordinate_idx",
+        "time_idx",
+        "position",
+        "seconds",
+        "_minimum_observable_duration",
     )
     for track1, track2 in zip(group1, group2):
         for attr in attributes:

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -592,7 +592,7 @@ def test_kymotrack_split(blank_kymo):
         np.array([1, 3, 4]),
         blank_kymo,
         "red",
-        2 * blank_kymo.line_time_seconds
+        2 * blank_kymo.line_time_seconds,
     )
     k2, k3 = k1._split(1)
     np.testing.assert_allclose(k2.position, [1])
@@ -716,9 +716,9 @@ def test_kymotrackgroup_flip():
     for track, flipped_track in zip(tracks, flipped_tracks):
         np.testing.assert_allclose(track._flip(kymo.flip()).position, flipped_track.position)
 
-    tracks2 = tracks + KymoTrackGroup([
-        KymoTrack([], [], copy(kymo), "red", kymo.line_time_seconds)
-    ])
+    tracks2 = tracks + KymoTrackGroup(
+        [KymoTrack([], [], copy(kymo), "red", kymo.line_time_seconds)]
+    )
     with pytest.raises(
         NotImplementedError,
         match=re.escape(
@@ -813,12 +813,15 @@ def test_binding_profile_histogram():
         KymoTrackGroup([])._histogram_binding_profile(3, 0.2, 4)
 
 
-@pytest.mark.parametrize("discrete, exclude_ambiguous_dwells, ref_value", [
-    (False, True, 1.002547),
-    (False, False, 1.25710457),
-    (True, True, 1.46272938),
-    (True, False, 1.73359969),
-])
+@pytest.mark.parametrize(
+    "discrete, exclude_ambiguous_dwells, ref_value",
+    [
+        (False, True, 1.002547),
+        (False, False, 1.25710457),
+        (True, True, 1.46272938),
+        (True, False, 1.73359969),
+    ],
+)
 def test_fit_binding_times(
     blank_kymo, blank_kymo_track_args, discrete, exclude_ambiguous_dwells, ref_value
 ):
@@ -875,10 +878,13 @@ def test_fit_binding_times_warning(blank_kymo_track_args):
         ktg.fit_binding_times(1, observed_minimum=False)
 
 
-@pytest.mark.parametrize("observed_minimum, ref_minima", [
-    (False, [10e-4, 10e-4, 10e-3, 10e-3]),
-    (True, [0.002, 0.002, 0.02, 0.02]),
-])
+@pytest.mark.parametrize(
+    "observed_minimum, ref_minima",
+    [
+        (False, [10e-4, 10e-4, 10e-3, 10e-3]),
+        (True, [0.002, 0.002, 0.02, 0.02]),
+    ],
+)
 def test_multi_kymo_dwell(observed_minimum, ref_minima):
     kymos = [
         _kymo_from_array(np.zeros((10, 10, 3)), "rgb", line_time_seconds=time, pixel_size_um=size)
@@ -894,7 +900,9 @@ def test_multi_kymo_dwell(observed_minimum, ref_minima):
 
     # Normal use case
     dwell, obs_min, obs_max, removed, dt = KymoTrackGroup._extract_dwelltime_data_from_groups(
-        [KymoTrackGroup([k1, k2]), KymoTrackGroup([k3, k4])], False, observed_minimum=observed_minimum,
+        [KymoTrackGroup([k1, k2]), KymoTrackGroup([k3, k4])],
+        False,
+        observed_minimum=observed_minimum,
     )
     assert removed is False
     np.testing.assert_allclose(dwell, [0.002, 0.003, 0.02, 0.02])
@@ -904,7 +912,9 @@ def test_multi_kymo_dwell(observed_minimum, ref_minima):
 
     # Drop one "empty" dwell
     dwell, obs_min, obs_max, removed, dt = KymoTrackGroup._extract_dwelltime_data_from_groups(
-        [KymoTrackGroup([k1, k2]), KymoTrackGroup([k3, k4, k5])], False, observed_minimum=observed_minimum
+        [KymoTrackGroup([k1, k2]), KymoTrackGroup([k3, k4, k5])],
+        False,
+        observed_minimum=observed_minimum,
     )
     np.testing.assert_allclose(dwell, [0.002, 0.003, 0.02, 0.02])
     np.testing.assert_allclose(obs_min, ref_minima)
@@ -968,7 +978,8 @@ def test_missing_minimum_time(blank_kymo):
             (1.90610454, 5.84528685),
             (0.45196325, 0.54803675),
             (1.90610454, 5.84528685),
-        ), (
+        ),
+        (
             20,
             (0.65421428, 0.34578572),
             (2.08205178, 10.81570587),

--- a/lumicks/pylake/kymotracker/tests/test_peakfinding.py
+++ b/lumicks/pylake/kymotracker/tests/test_peakfinding.py
@@ -141,9 +141,7 @@ def test_bounds_to_centroid_data(bounds, selection_ref, center_ref, weights_ref)
     # fmt:on
 )
 def test_unbiased_centroid_estimator(data, ref_estimate):
-    np.testing.assert_allclose(
-        unbiased_centroid(np.array((3.5, 3.5)), data), ref_estimate
-    )
+    np.testing.assert_allclose(unbiased_centroid(np.array((3.5, 3.5)), data), ref_estimate)
 
 
 @pytest.mark.parametrize(

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -107,7 +107,11 @@ def test_refinement_with_background(loc, ref_count):
 
 def test_refinement_error(kymo_integration_test_data):
     args = [
-        [0], [25], kymo_integration_test_data, "red", kymo_integration_test_data.line_time_seconds
+        [0],
+        [25],
+        kymo_integration_test_data,
+        "red",
+        kymo_integration_test_data.line_time_seconds,
     ]
     with pytest.raises(
         ValueError, match=re.escape("track_width must at least be 3 pixels (0.150 [um])")
@@ -255,9 +259,7 @@ def test_no_swap_gaussian_refinement():
     )
     group = KymoTrackGroup(
         [
-            KymoTrack(
-                np.array([0, 1]), np.array([loc, loc]), kymo, "red", kymo.line_time_seconds
-            )
+            KymoTrack(np.array([0, 1]), np.array([loc, loc]), kymo, "red", kymo.line_time_seconds)
             for loc in locations
         ]
     )
@@ -406,7 +408,9 @@ def test_gaussian_refinement_plotting():
     group = KymoTrackGroup(
         [
             KymoTrack(np.array([0, 2]), np.array([2, 2]), kymo, "red", kymo.line_time_seconds),
-            KymoTrack(np.array([0, 1, 2]), np.array([4, 4, 4]), kymo, "red", kymo.line_time_seconds),
+            KymoTrack(
+                np.array([0, 1, 2]), np.array([4, 4, 4]), kymo, "red", kymo.line_time_seconds
+            ),
         ]
     )
 

--- a/lumicks/pylake/kymotracker/tests/test_sequence.py
+++ b/lumicks/pylake/kymotracker/tests/test_sequence.py
@@ -52,4 +52,4 @@ def test_read_genbank_corrupted():
     with pytest.raises(
         AttributeError, match="There is no feature table in this file; the format may be corrupted."
     ):
-        features = read_genbank(filename)
+        read_genbank(filename)

--- a/lumicks/pylake/kymotracker/tests/test_stitching.py
+++ b/lumicks/pylake/kymotracker/tests/test_stitching.py
@@ -16,7 +16,6 @@ def test_distance_line_to_point():
 
 
 def test_stitching(blank_kymo, blank_kymo_track_args):
-
     segment_1 = KymoTrack([0, 1], [0, 1], *blank_kymo_track_args)
     segment_2 = KymoTrack([2, 3], [2, 3], *blank_kymo_track_args)
     segment_3 = KymoTrack([2, 3], [0, 0], *blank_kymo_track_args)
@@ -52,14 +51,16 @@ def test_stitching(blank_kymo, blank_kymo_track_args):
 
     # Check whether the alignment has to work in both directions
     # - and - should connect
-    track1, track2 = KymoTrack(
-        [0, 1], [0, 0], *blank_kymo_track_args), KymoTrack([2, 3], [0, 0], *blank_kymo_track_args
+    track1, track2 = (
+        KymoTrack([0, 1], [0, 0], *blank_kymo_track_args),
+        KymoTrack([2, 3], [0, 0], *blank_kymo_track_args),
     )
     assert len(stitch_kymo_lines([track1, track2], radius, 1, 2)) == 1
 
     # - and | should not connect.
-    track1, track2 = KymoTrack(
-        [0, 1], [0, 0], *blank_kymo_track_args), KymoTrack([2, 3], [0, 1], *blank_kymo_track_args
+    track1, track2 = (
+        KymoTrack([0, 1], [0, 0], *blank_kymo_track_args),
+        KymoTrack([2, 3], [0, 1], *blank_kymo_track_args),
     )
     assert len(stitch_kymo_lines([track1, track2], radius, 1, 2)) == 2
 

--- a/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
+++ b/lumicks/pylake/nb_widgets/tests/test_kymotracker_widget.py
@@ -16,6 +16,7 @@ class MockLabel:
     def __init__(self):
         self.value = ""
 
+
 def calibrate_to_kymo(kymo):
     return (
         lambda coord_idx: kymo.pixelsize_um[0] * coord_idx,
@@ -29,7 +30,8 @@ def test_widget_open(kymograph):
 
 def test_parameters_kymo(kymograph):
     """Test whether the parameter setting is passed correctly to the algorithm. By setting the threshold to different
-    values we can check which tracks are detected and use that to verify that the parameter is used."""
+    values we can check which tracks are detected and use that to verify that the parameter is used.
+    """
     kymo_widget = KymoWidgetGreedy(kymograph, "red", axis_aspect_ratio=1, use_widgets=False)
     kymo_widget._algorithm_parameters["pixel_threshold"].value = 30
     kymo_widget._track_all()

--- a/lumicks/pylake/population/tests/data/generate_trace_data.py
+++ b/lumicks/pylake/population/tests/data/generate_trace_data.py
@@ -12,7 +12,9 @@ def generate_parameters(n_states):
     }
 
 
-def generate_trace(n_states, initial_state_prob, transition_prob, means, st_devs, n_frames=100, seed=123):
+def generate_trace(
+    n_states, initial_state_prob, transition_prob, means, st_devs, n_frames=100, seed=123
+):
     """Generate a time trace from HMM parameters.
 
     Parameters

--- a/lumicks/pylake/tests/data/mock_fdcurve.py
+++ b/lumicks/pylake/tests/data/mock_fdcurve.py
@@ -3,24 +3,24 @@ import numpy as np
 
 def generate_fdcurve_with_baseline_offset():
     # generate high frequency data
-    distance_hf = np.linspace(1, 10, 500)                       # distance, HF
-    time_hf = np.arange(0, 3*distance_hf.size, 3) + 100         # timestamps, HF
-    true_f_hf = np.exp(0.5 * distance_hf)                       # true force, HF
+    distance_hf = np.linspace(1, 10, 500)  # distance, HF
+    time_hf = np.arange(0, 3 * distance_hf.size, 3) + 100  # timestamps, HF
+    true_f_hf = np.exp(0.5 * distance_hf)  # true force, HF
 
     # make baseline
-    p = [-1e-5, 1e-4, 1e-3, 0.005, 0.3, -5, 30] # baseline polynomial coefficients
-    bl = np.polyval(p, distance_hf)                             # baseline
-    obs_f_hf = true_f_hf + bl                                   # observed force, HF
+    p = [-1e-5, 1e-4, 1e-3, 0.005, 0.3, -5, 30]  # baseline polynomial coefficients
+    bl = np.polyval(p, distance_hf)  # baseline
+    obs_f_hf = true_f_hf + bl  # observed force, HF
 
     # manually downsample to low frequency like BL
     win = 5
-    rng = range(0, distance_hf.size-win, win)
-    downsample = lambda r, w, hf: np.array([np.mean(hf[start:start+w]) for start in r])
+    rng = range(0, distance_hf.size - win, win)
+    downsample = lambda r, w, hf: np.array([np.mean(hf[start : start + w]) for start in r])
 
-    time_lf = np.array([time_hf[start+win] for start in rng])   # timestamps, LF
-    distance_lf = downsample(rng, win, distance_hf)             # distance, LF
-    true_f_lf = downsample(rng, win, true_f_hf)                 # true force, LF
-    obs_f_lf = downsample(rng, win, obs_f_hf)                   # observed force, LF
+    time_lf = np.array([time_hf[start + win] for start in rng])  # timestamps, LF
+    distance_lf = downsample(rng, win, distance_hf)  # distance, LF
+    true_f_lf = downsample(rng, win, true_f_hf)  # true force, LF
+    obs_f_lf = downsample(rng, win, obs_f_hf)  # observed force, LF
 
     data = {
         "HF": {
@@ -32,8 +32,8 @@ def generate_fdcurve_with_baseline_offset():
             "time": time_lf,
             "true_force": true_f_lf,
             "obs_force": obs_f_lf,
-            "distance": distance_lf
-        }
+            "distance": distance_lf,
+        },
     }
 
     return p, data

--- a/lumicks/pylake/tests/data/mock_file.py
+++ b/lumicks/pylake/tests/data/mock_file.py
@@ -6,10 +6,10 @@ import numpy as np
 # We generate mock data files for different versions of the Bluelake HDF5 file
 # format:
 
-class MockDataFile_v1:
 
+class MockDataFile_v1:
     def __init__(self, file):
-        self.file = h5py.File(file, 'w')
+        self.file = h5py.File(file, "w")
 
     def get_file_format_version(self):
         return 1
@@ -90,16 +90,14 @@ class MockDataFile_v2(MockDataFile_v1):
 
             for i, v in attributes.items():
                 dset.attrs[i] = v
-    
+
     def make_note(self, note_name, attributes, note_text):
         if "Note" not in self.file:
             self.file.create_group("Note")
 
         if note_name not in self.file["Note"]:
             payload = {"name": note_name, "Note text": note_text}
-            dset = self.file["Note"].create_dataset(
-                note_name, data=json.dumps(payload)
-            )
+            dset = self.file["Note"].create_dataset(note_name, data=json.dumps(payload))
 
             for i, v in attributes.items():
                 dset.attrs[i] = v

--- a/lumicks/pylake/tests/data/mock_widefield.py
+++ b/lumicks/pylake/tests/data/mock_widefield.py
@@ -86,7 +86,7 @@ def make_image(spots, bit_depth):
         img += Z.reshape(X.shape)
     img = img / img.max()
 
-    return (img * (2 ** bit_depth - 1)).astype(f"uint{bit_depth}")
+    return (img * (2**bit_depth - 1)).astype(f"uint{bit_depth}")
 
 
 def _make_base_description(version, bit_depth):
@@ -155,7 +155,6 @@ def make_alignment_image_data(
     camera="wt",
     version=1,
 ):
-
     spots = np.array(spots).T  # [2 x N]
     m_red, red_spots = apply_transform(spots, offsets=offsets, **red_warp_parameters)
     m_blue, blue_spots = apply_transform(spots, offsets=offsets, **blue_warp_parameters)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ exclude = '''
     | _build
     | build
     | dist
-    | tests  # ignore test directories until we have a better solution for test datasets
   )/
 )
 '''


### PR DESCRIPTION
**Why this PR?**
If we're gonna be doing spring cleaning, might as well do all the tests now and just have `black` be active everywhere from now on. We can always selectively turn it off if we really need some bulky matrices.

I quickly went over all the changes and there was nothing particularly egregious anymore that wasn't already covered by explicitly disabling the formatter locally.