### PR TITLE
deps: update `pylake` dependencies

### DIFF
--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -4,7 +4,6 @@ from functools import partial
 from dataclasses import dataclass
 
 import numpy as np
-import scipy
 
 from .detail.drag_models import faxen_factor, brenner_axial
 from .detail.power_models import (
@@ -524,6 +523,8 @@ class PassiveCalibrationModel:
         filter_params_err : list of float
             Standard errors for the filter model
         """
+        import scipy.constants
+
         # diameter [um] -> [m]
         temperature_k = scipy.constants.convert_temperature(self.temperature, "C", "K")
 
@@ -793,6 +794,8 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
         filter_params_err : list of float
             Standard errors for the filter model
         """
+        import scipy.constants
+
         reference_peak = self(self.driving_frequency, fc, diffusion_constant_volts, *filter_params)
 
         # Equation 14 from [6]

--- a/lumicks/pylake/force_calibration/tests/data/simulate_calibration_data.py
+++ b/lumicks/pylake/force_calibration/tests/data/simulate_calibration_data.py
@@ -1,7 +1,6 @@
 from functools import partial
 
 import numpy as np
-import scipy
 
 from lumicks.pylake.force_calibration.detail.power_models import (
     g_diode,
@@ -100,6 +99,8 @@ def generate_active_calibration_test_data(
         Distance from bead center to the surface. Only used when using hydrodynamically correct
         model. None uses the approximation valid for deep in bulk.
     """
+    import scipy.constants
+
     pos_response_m_volt = pos_response_um_volt / 1e6
     gamma_0 = sphere_friction_coefficient(viscosity, bead_diameter * 1e-6)  # Ns/m
     diffusion_physical = scipy.constants.k * (temperature + 273.15) / gamma_0  # m^2/s

--- a/lumicks/pylake/force_calibration/tests/data/simulate_ideal.py
+++ b/lumicks/pylake/force_calibration/tests/data/simulate_ideal.py
@@ -146,9 +146,10 @@ def simulate_calibration_data(
     stage_pos : np.ndarray
         Stage position in microns.
     """
-    boltzmann_const = scipy.constants.k
+    import scipy.constants
+
     gamma = 3.0 * np.pi * viscosity * bead_diameter * 1e-6  # friction coefficient [Ns/m]
-    diffusion_const = (boltzmann_const * (temperature + 273.15)) / gamma  # diffusion [m^2/s]
+    diffusion_const = (scipy.constants.k * (temperature + 273.15)) / gamma  # diffusion [m^2/s]
     dt = 1 / sample_rate
     stiffness_si = stiffness * 1e-3  # Trap stiffness [N/m]
 

--- a/lumicks/pylake/force_calibration/tests/test_active_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_active_calibration.py
@@ -32,6 +32,8 @@ def test_integration_active_calibration(
     power_density,
     response_power,
 ):
+    import scipy.constants
+
     """Functional end to end test for active calibration"""
     sample_rate, bead_diameter = 78125, 1.03
     np.random.seed(0)

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setup(
     ],
     extras_require={
         "notebook": [
-            "notebook>=4.4.1",
+            # Notebook upper limit is a workaround for issues with IPython not being defined.
+            "notebook>=4.4.1,<7",
             "ipywidgets>=7.0.0",
             "jupyter_client<8",  # https://github.com/jupyter/notebook/issues/6748
             "pyzmq<25",  # https://github.com/jupyter/notebook/issues/6748

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ setup(
     install_requires=[
         "pytest>=3.5",
         "h5py>=3.4, <4",
-        "numpy>=1.20, <2",
-        "scipy>=1.1, <2",
+        "numpy>=1.24, <2",  # 1.24 is needed for dtype in vstack/hstack (Dec 18th, 2022)
+        "scipy>=1.9, <2",  # 1.9.0 needed for lazy imports (July 29th, 2022)
         "matplotlib>=3.5",
         "tifffile>=2020.9.30",
         "tabulate>=0.8.8, <0.9",


### PR DESCRIPTION
**Why this PR?**
We rely on some functionalities that depend on newer versions of `numpy` (`dtype` argument for hvstack) and lazy imports for `scipy`.

The lazy import ensures that this works:
```python
import scipy

scipy.optimize.curve_fit  # Prior to 1.9.0 this would fail.
```

Note that `scipy.optimize.constants` seems to have been forgotten in the initial release for lazy imports, but is added in [`1.11.1`](https://github.com/scipy/scipy/commit/855bc76864ea1e577bedb854a5d9aef97a149a86). The latter is probably still a bit too new.

The last thing is a temporary upper limit for the version of `jupyter notebook`. The reason we are introducing this is because we've been seeing issues with the `%matplotlib notebook` not working on several computers (resulting in an error that `IPython is not defined`) and with `%matplotlib ipympl` the kymotracker widget doesn't show up properly (needs further investigation).