### PR TITLE
kymotrackgroup: test round trip from old csv

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.1 | t.b.d.
+
+#### Bug fixes
+
+* Fixed a bug that prevented resaving a `KymoTrackGroup` loaded from an older version of Pylake.
+
 ## v1.2.0 | 2023-08-15
 
 #### New features

--- a/docs/tutorial/nbwidgets.rst
+++ b/docs/tutorial/nbwidgets.rst
@@ -298,3 +298,18 @@ Detected tracks are accessible through the :attr:`~lumicks.pylake.KymoWidgetGree
     KymoTrackGroup(N=132)
 
 For more information on its use, please see the example :ref:`cas9_kymotracking`.
+
+.. _track_migration:
+
+Migrating old track files
+-------------------------
+
+Prior to pylake `1.2.0`, tracks saved from the widget or API did not store the minimum length in the CSV file.
+This means that certain downstream analyses are not possible.
+To update a file with tracks to the new format, load the file in the widget, then filter the tracks by length using the largest minimum length you have used while tracking.
+You can do this as follows::
+
+    filtered_tracks = lk.filter_tracks(widget.tracks, minimum_length=4)
+    filtered_tracks.save("fixed_file.csv")
+
+where `4` should be replaced with a length relevant for your tracking settings.

--- a/docs/whatsnew/1.2.0/1_2_0.rst
+++ b/docs/whatsnew/1.2.0/1_2_0.rst
@@ -26,7 +26,7 @@ times will be underestimated. For more information see the :doc:`changelog</chan
     Note that CSVs exported from the kymotracker widget  before `v1.2.0` will contain insufficient metadata
     to make use of the improved analysis. To create this metadata, use :func:`~lumicks.pylake.filter_tracks()` on the group with a specified
     `min_length` before further analysis. CSVs exported starting from `v1.2.0` contain an additional data column with this data
-    under the header `"minimum_length (-)"`.
+    under the header `"minimum_length (-)"`. For more information, see :ref:`tutorial<track_migration>`.
 
 Correct for discretization in binding lifetime analysis
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -139,7 +139,21 @@ def export_kymotrackgroup_to_csv(
             ),
         )
 
-    store_column("minimum_length (-)", "%d", minimum_length)
+    if None not in minimum_length:
+        store_column("minimum_length (-)", "%d", minimum_length)
+    else:
+        warnings.warn(
+            RuntimeWarning(
+                "Loaded tracks have no minimum length metadata defined (CSV exported with "
+                "pylake <  1.2.0) therefore some analyses may not be possible with this file. To "
+                "remedy this error and add the required metadata, use `lk.filter_tracks()` on the "
+                "tracks from the widget with the desired minimum track length and resave "
+                "using the `KymoTrackGroup.save()` method. Note that the minimum length should be "
+                "greater or equal to the minimum length used for the original tracking. For more "
+                "information refer to "
+                "https://lumicks-pylake.readthedocs.io/en/latest/tutorial/nbwidgets.html#migrating-old-track-files "
+            )
+        )
 
     version_header = f"Exported with pylake v{__version__} | track coordinates v3\n"
     header = version_header + delimiter.join(column_titles)

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -1739,7 +1739,6 @@ class KymoTrackGroup:
             max_position = n_rows * _kymo.pixelsize[0]
         else:
             (min_time, min_position), (max_time, max_position) = roi
-            n_rows = np.ceil((max_position - min_position) / _kymo.pixelsize[0])
             n_frames = np.ceil((max_time - min_time) / _kymo.line_time_seconds)
             start_frame = min_time // _kymo.line_time_seconds
 

--- a/lumicks/pylake/kymotracker/tests/test_io.py
+++ b/lumicks/pylake/kymotracker/tests/test_io.py
@@ -215,3 +215,18 @@ def test_bad_csv(filename, blank_kymo):
     with pytest.raises(IOError, match="Invalid file format!"):
         file = Path(__file__).parent / "data" / filename
         import_kymotrackgroup_from_csv(file, blank_kymo, "red", delimiter=";")
+
+
+def test_min_obs_csv_regression(tmpdir_factory, blank_kymo):
+    """This tests a regression where saving a freshly imported older file does not function"""
+    testfile = Path(__file__).parent / f"./data/tracks_v0.csv"
+    imported_tracks = import_kymotrackgroup_from_csv(testfile, blank_kymo, "red", delimiter=";")
+    out_file = f"{tmpdir_factory.mktemp('pylake')}/no_min_lengths.csv"
+
+    err_msg = "Loaded tracks have no minimum length metadata defined"
+    with pytest.warns(RuntimeWarning, match=err_msg):
+        imported_tracks.save(out_file, ";", None, correct_origin=True)
+
+    out_file2 = f"{tmpdir_factory.mktemp('pylake')}/no_min_lengths2.csv"
+    with pytest.warns(RuntimeWarning, match=err_msg):
+        import_kymotrackgroup_from_csv(out_file, blank_kymo, "red", delimiter=";").save(out_file2)

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -352,7 +352,12 @@ class KymoWidget:
                 "help(lk.KymoWidgetGreedy) for more info.",
             )
 
-        self.tracks.save(filename, delimiter, sampling_width, correct_origin=correct_origin)
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            self.tracks.save(filename, delimiter, sampling_width, correct_origin=correct_origin)
+
+            if caught_warnings:
+                warning_string = "\n".join(str(warning.message) for warning in caught_warnings)
+                self._set_label("warning", warning_string)
 
     def _load_from_ui(self):
         try:


### PR DESCRIPTION
**Why this PR?**
Turns out that you can't resave a `csv` file when it's been opened until you call `lk.filter_tracks()` because of the `None` entries.