### PR TITLE
docs: update install instruction with latest conda

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -29,7 +29,7 @@ The easiest way to install Python and SciPy is with `Anaconda`_, a free scientif
 
     .. code-block:: python
 
-        conda create -n pylake conda=4.9
+        conda create -n pylake conda=23.7.2
 
     .. note::
 
@@ -304,12 +304,12 @@ The full error message is::
 
 This issue has to be solved by conda. Until that happens, a possible solution is to use an older conda version::
 
-    conda create -n pylake conda=4.9
+    conda create -n pylake conda=23.7.2
 
 And then follow the rest of the installation instructions.
 If you already have an environment named pylake, you can remove this environment, before creating it again with an older conda version. Another option is to create an environment with a different name, eg::
 
-    conda create -n pylake2 conda=4.9
+    conda create -n pylake2 conda=23.7.2
     conda activate pylake2
 
 **I tried the installation instructions, but I cannot import Pylake inside a Jupyter notebook**
@@ -450,7 +450,7 @@ If you use Anaconda, then it is best to create a new environment for this instal
 
 And on Windows an environment is created as::
 
-    conda create -n pylake_pip conda=4.9
+    conda create -n pylake_pip conda=23.7.2
 
 Activate the environment as follows::
 


### PR DESCRIPTION
**Why this PR?**
We pinned `conda` to an older version [earlier](https://github.com/lumicks/pylake/commit/11d383378bdbeea49c7ae61c4614668bafbc563b) to work around an OpenSSL issue. It seems that on newer `conda` versions, this issue is fixed. However, when creating a new conda environment from an older version _without_ specifying a version, it typically still installs an older version that does have the OpenSSL issue. The newer versions however, do download and extract packages in parallel which is much faster, so I would suggest keeping the explicit version in the installation instructions, but bumping it to the latest one.