### PR TITLE
touchdown: use nonzero initial guess for decay

### DIFF
--- a/lumicks/pylake/force_calibration/touchdown.py
+++ b/lumicks/pylake/force_calibration/touchdown.py
@@ -199,7 +199,7 @@ def fit_damped_sine_with_polynomial(
         exp_sine_with_polynomial,
         independent,
         dependent,
-        [result, 0],
+        [result, 1e-8],
         bounds=((0, 0), (2 * result, np.inf)),
     )
 


### PR DESCRIPTION
Use non-zero initial guess for the decay parameter so it isn't exactly at the bound. `scipy=1.11.2` issues a `DivisionByZero` warning when the initial guess is exactly at the bound, but the solution is outside of the bounds.

Since in our case, it is better to provide a nonzero initial guess for the decay anyhow, this seems like the best solution.