### PR TITLE
caching: backward compatibility for `cachetools<5`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### Bug fixes
 
 * Fixed a bug that prevented resaving a `KymoTrackGroup` loaded from an older version of Pylake.
+* Fixed a bug that inadvertently made us rely on `cachetools>=5.x`. Older versions of `cachetools` did not pass the instance to the key function resulting in a `TypeError: key() missing 1 required positional argument: '_'` error when accessing cached properties or methods.
 
 ## v1.2.0 | 2023-08-15
 


### PR DESCRIPTION
**Why this PR?**
In [this PR](https://github.com/lumicks/pylake/pull/544), a dependency on `cachetools>=5` was inadvertently introduced.

`cachetools>=5.0.0` started passing `self` as first argument. The previous PR had been made under the assumption that this was always the case. Since we don't want to bump the reference count by including a reference to the object we're about to store the cache into, so we explicitly drop the first argument. For `cachetools<5` this then results in an error since we're assuming the `self` argument is there, while it is not.

Note that for the default key, they also cut off the first argument in the package, but we can't use the default key, since it doesn't hash in the method name to prevent clashes when we use more than one cached method in an instance.