### PR TITLE
ci: convert convertible list of lists to `ndarray`

### DIFF
--- a/lumicks/pylake/conftest.py
+++ b/lumicks/pylake/conftest.py
@@ -198,7 +198,9 @@ def reference_data(request):
 
             reference_data_path.mkdir(parents=True, exist_ok=True)
 
-            if not isinstance(reference_data, np.ndarray):
+            try:
+                reference_data = np.asarray(reference_data)
+            except ValueError:
                 reference_data = np.asarray(reference_data, dtype=object)
 
             np.savez(reference_file_path, reference_data)

--- a/lumicks/pylake/tests/reference_data/freezing/non_ndarray_matrix[1].npz
+++ b/lumicks/pylake/tests/reference_data/freezing/non_ndarray_matrix[1].npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9eb818375fc21a953fff4142349cad4ed1fa77abb5bf82edbb02ddcc04130c16
+size 312

--- a/lumicks/pylake/tests/reference_data/freezing/non_ndarray_matrix[2].npz
+++ b/lumicks/pylake/tests/reference_data/freezing/non_ndarray_matrix[2].npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9eb818375fc21a953fff4142349cad4ed1fa77abb5bf82edbb02ddcc04130c16
+size 312

--- a/lumicks/pylake/tests/test_utilities.py
+++ b/lumicks/pylake/tests/test_utilities.py
@@ -224,6 +224,9 @@ def test_freezing(reference_data, tst):
     for test, ref in zip(test_data, ref_data):
         np.testing.assert_allclose(test, ref)
 
+    test_data = [[1, 2, 3], [1, 2, 3]]
+    np.testing.assert_allclose(test_data, reference_data(test_data, test_name="non_ndarray_matrix"))
+
 
 def test_cache_method():
     calls = 0


### PR DESCRIPTION
**Why this PR?**
Non-ragged lists should just be converted to `ndarray`, since it facilitates convenient testing. If you don't do this, then you can't really use `np.testing.assert_allclose` conveniently, since you'll always explicitly have to do this step.