### PR TITLE
force calibration: new lower bound for f-diode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Fixed a bug that prevented resaving a `KymoTrackGroup` loaded from an older version of Pylake.
 * Fixed a bug that inadvertently made us rely on `cachetools>=5.x`. Older versions of `cachetools` did not pass the instance to the key function resulting in a `TypeError: key() missing 1 required positional argument: '_'` error when accessing cached properties or methods.
+* Fixed a bug that could cause a division by zero while fitting power spectra with `f_diode`. The lower bound of `f_diode` was changed from 0 to 1.0 Hz. This change should not impact results unless users were getting failed calibrations with this error.
 
 ## v1.2.0 | 2023-08-15
 

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -161,7 +161,7 @@ class DiodeModel(FilterBase):
                 description="Diode low-pass filtering roll-off frequency",
                 unit="Hz",
                 initial=14000,
-                lower_bound=0.0,
+                lower_bound=1.0,
                 upper_bound=_nyquist,
             ),
             Param(


### PR DESCRIPTION
*Why*
During testing of robust fitting on axial force data I sometimes received a "division by zero" exception (or equivalent, can't fully remember). I traced it back to the lower bound of `f_diode`, which is zero. I think a still very reasonable lower bound is 1 Hz, one that is very unlikely to actually occur in practice but prevents 1/0.