### PR TITLE
Add custom mapping of photon counter channels to RGB colors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Added [`lk.HiddenMarkovModel`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.HiddenMarkovModel.html#lumicks.pylake.HiddenMarkovModel) for classifying data traces exhibiting transitions between discrete states. For more information, see the tutorials section on [Population Dynamics](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/population_dynamics.html#hidden-markov-models).
 * Added `emission_path()` and `plot_path()` methods to [`lk.GaussianMixtureModel`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.GaussianMixtureModel.html)
+* Added option to [`File`](https://lumicks-pylake.readthedocs.io/en/stable/_api/lumicks.pylake.File.html) to pass a custom mapping from Photon count detector to RGB colors colors. This is useful to reconstruct images on systems with non-standard imaging modules.
 
 #### Deprecations
 

--- a/lumicks/pylake/tests/test_file/conftest.py
+++ b/lumicks/pylake/tests/test_file/conftest.py
@@ -207,3 +207,19 @@ def h5_kymo_as_scan(tmpdir_factory, request):
     ds.attrs["Stop time (ns)"] = np.int64(100e9)
 
     return mock_file.file
+
+
+@pytest.fixture(scope="module", params=[MockDataFile_v2])
+def h5_custom_detectors(tmpdir_factory, request):
+    mock_class = request.param
+
+    tmpdir = tmpdir_factory.mktemp("pylake")
+    mock_file = mock_class(tmpdir.join("%s.h5" % mock_class.__class__.__name__))
+    mock_file.write_metadata()
+
+    freq = 1e9 / 16
+    mock_file.make_continuous_channel("Photon count", "Detector 1", np.int64(20e9), freq, counts)
+    mock_file.make_continuous_channel("Photon count", "Detector 2", np.int64(20e9), freq, counts)
+    mock_file.make_continuous_channel("Photon count", "Detector 3", np.int64(20e9), freq, counts)
+    mock_file.make_continuous_channel("Info wave", "Info wave", np.int64(20e9), freq, infowave)
+    return mock_file.file

--- a/lumicks/pylake/tests/test_file/test_file.py
+++ b/lumicks/pylake/tests/test_file/test_file.py
@@ -461,3 +461,13 @@ def test_h5_cropped_export_confocal(tmpdir_factory):
                 "PointScan1" not in f["Point Scan"]
                 or not f["Point Scan"]["PointScan1"].red_photon_count
             )
+
+
+def test_detector_mapping(h5_custom_detectors):
+    f = pylake.File.from_h5py(
+        h5_custom_detectors,
+        rgb_to_detectors={"Red": "Detector 1", "Green": "Detector 2", "Blue": "Detector 3"},
+    )
+    with pytest.raises(Exception):
+        f = pylake.File.from_h5py(h5_custom_detectors, match="Invalid RGB to detector mapping")
+    assert np.any(f.red_photon_count.data)


### PR DESCRIPTION
This allows reconstruction of images from systems where the photon detector channels are not named with the standard "Red, "Green", and "Blue" names.

For example, this image is reconstructed from a file where the photon count channels are named `Detector 1`, `Detector 2`, `Detector 3` and `Detector 4`. 

![output](https://github.com/lumicks/pylake/assets/17353250/20b2b47c-f578-45d5-8d65-d77f625d11a7)

Draft because needs additional tests.