### PR TITLE
More options of image plotting `channel` argument

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.3.0 | t.b.d.
+
+#### New features
+
+* Added more options for plotting color channels for images:
+  * Shortcuts `"r"`, `"g"`, and `"b"` can now be used for plotting single color channels in addition to `"red"`, `"green"`, and `"blue"`.
+  * Two-channel visualizations can be plotted using `"rg"`, `"gb"`, or `"rb"`.
+
 ## v1.2.1 | t.b.d.
 
 #### Bug fixes

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -5,6 +5,7 @@ import numpy as np
 import tifffile
 import numpy.typing as npt
 
+from .plotting import parse_color_channel
 from .timeindex import to_timestamp
 from ..adjustments import no_adjustment
 
@@ -138,9 +139,7 @@ class VideoExport:
         import matplotlib.pyplot as plt
         from matplotlib import animation
 
-        channels = ("red", "green", "blue", "rgb")
-        if channel not in channels:
-            raise ValueError(f"Channel should be {', '.join(channels[:-1])} or {channels[-1]}")
+        channel = parse_color_channel(channel)
 
         metadata = dict(title=self.name)
         if "ffmpeg" in animation.writers:

--- a/lumicks/pylake/detail/plotting.py
+++ b/lumicks/pylake/detail/plotting.py
@@ -14,6 +14,26 @@ def get_axes(axes=None, image_handle=None):
     return axes
 
 
+def parse_color_channel(channel):
+    """Parse user supplied color channel specification to rgb-like format."""
+
+    if channel in (full_colors := {"red": "r", "green": "g", "blue": "b"}):
+        channel = full_colors[channel]
+
+    # check all specified components in 'rgb'
+    if not set(channel).issubset(set("rgb")):
+        raise ValueError(
+            "channel must be 'red', 'green', 'blue' or a combination of 'r', 'g', and/or 'b', "
+            f"got '{channel}'."
+        )
+
+    # check rgb order
+    if channel != "".join(sorted(channel)[::-1]):
+        raise ValueError(f"color channel must be in 'rgb' order, got '{channel}'.")
+
+    return channel
+
+
 def show_image(
     image,
     adjustment=no_adjustment,

--- a/lumicks/pylake/detail/plotting.py
+++ b/lumicks/pylake/detail/plotting.py
@@ -1,3 +1,5 @@
+import warnings
+
 from ..adjustments import no_adjustment
 
 
@@ -20,6 +22,9 @@ def parse_color_channel(channel):
     if channel in (full_colors := {"red": "r", "green": "g", "blue": "b"}):
         channel = full_colors[channel]
 
+    input_channel = channel
+    channel = channel.lower()
+
     # check all specified components in 'rgb'
     if not set(channel).issubset(set("rgb")):
         raise ValueError(
@@ -27,9 +32,19 @@ def parse_color_channel(channel):
             f"got '{channel}'."
         )
 
+    if input_channel != channel:
+        warnings.warn(
+            DeprecationWarning(
+                "In future versions, the `channel` argument will be restricted to lowercase "
+                f"letters only. Use '{channel}' instead of '{input_channel}'."
+            )
+        )
+
     # check rgb order
-    if channel != "".join(sorted(channel)[::-1]):
-        raise ValueError(f"color channel must be in 'rgb' order, got '{channel}'.")
+    if channel != (correct_order := "".join(sorted(channel)[::-1])):
+        raise ValueError(
+            f"color channel must be in 'rgb' order; got '{channel}', expected '{correct_order}'."
+        )
 
     return channel
 

--- a/lumicks/pylake/detail/tests/test_plotting.py
+++ b/lumicks/pylake/detail/tests/test_plotting.py
@@ -5,7 +5,7 @@ import pytest
 from matplotlib import pyplot as plt
 
 from lumicks.pylake.adjustments import ColorAdjustment
-from lumicks.pylake.detail.plotting import get_axes, parse_color_channel, show_image
+from lumicks.pylake.detail.plotting import get_axes, show_image, parse_color_channel
 
 
 def test_get_axes():
@@ -47,8 +47,19 @@ def test_parse_color_channel():
     for channel in ("r", "g", "b", "rg", "rb", "gb", "rgb"):
         assert parse_color_channel(channel) == channel, f"failed on {channel}"
 
-    with pytest.raises(ValueError, match="color channel must be in 'rgb' order, got 'bg'."):
+    with pytest.raises(
+        ValueError, match="color channel must be in 'rgb' order; got 'bg', expected 'gb'."
+    ):
         parse_color_channel("bg")
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            "In future versions, the `channel` argument will be restricted to lowercase "
+            "letters only. Use 'rgb' instead of 'RGB'."
+        ),
+    ):
+        parse_color_channel("RGB")
 
 
 def test_show_image():
@@ -90,7 +101,7 @@ def test_show_image():
     assert ih.get_url() == "FORWARDED_KWARG"
 
     # Test if ColorAdjustment is applied to image_handle
-    ih = show_image(im2, axes=ax1, adjustment=ColorAdjustment(1.5, 2, mode="absolute"))
+    ih = show_image(im2, axes=ax1, adjustment=ColorAdjustment(1.5, 2, mode="absolute"), channel="g")
     assert ih.norm.vmin == 1.5
     assert ih.norm.vmax == 2
 

--- a/lumicks/pylake/detail/tests/test_plotting.py
+++ b/lumicks/pylake/detail/tests/test_plotting.py
@@ -5,7 +5,7 @@ import pytest
 from matplotlib import pyplot as plt
 
 from lumicks.pylake.adjustments import ColorAdjustment
-from lumicks.pylake.detail.plotting import get_axes, show_image
+from lumicks.pylake.detail.plotting import get_axes, parse_color_channel, show_image
 
 
 def test_get_axes():
@@ -29,6 +29,26 @@ def test_get_axes():
         ax = get_axes(axes=ax1, image_handle=ih2)
 
     plt.close(fig)
+
+
+def test_parse_color_channel():
+    for name, result in zip(("red", "green", "blue"), ("r", "g", "b")):
+        assert parse_color_channel(name) == result, f"failed on {name}"
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "channel must be 'red', 'green', 'blue' or a combination "
+            "of 'r', 'g', and/or 'b', got 'violet'."
+        ),
+    ):
+        parse_color_channel("violet")
+
+    for channel in ("r", "g", "b", "rg", "rb", "gb", "rgb"):
+        assert parse_color_channel(channel) == channel, f"failed on {channel}"
+
+    with pytest.raises(ValueError, match="color channel must be in 'rgb' order, got 'bg'."):
+        parse_color_channel("bg")
 
 
 def test_show_image():

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 import numpy as np
 import tifffile
 
+from .plotting import parse_color_channel
 from ..adjustments import no_adjustment
 
 
@@ -99,14 +100,14 @@ class TiffFrame:
         if not self.is_rgb:
             return self.data
 
-        if channel.lower() == "rgb":
-            data = self.data.astype(float)
-            return adjustment._get_data_rgb(data)
-        else:
-            try:
-                return self.data[:, :, ("red", "green", "blue").index(channel.lower())]
-            except ValueError:
-                raise ValueError(f"'{channel}' is not a recognized channel")
+        channel = parse_color_channel(channel)
+
+        if channel in ("r", "g", "b"):
+            return self.data[:, :, "rgb".index(channel)]
+
+        data = self.data.astype(float)
+
+        return adjustment._get_data_rgb(data, channel=channel)
 
     @property
     def start(self):

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -408,7 +408,7 @@ class Kymo(ConfocalImage):
                 -0.5 * self.pixelsize[0],
             ],
             aspect=(image.shape[0] / image.shape[1]) * (self.duration / size_calibrated),
-            cmap=getattr(colormaps, channel),
+            cmap=colormaps._get_default_colormap(channel),
         )
 
         image_handle = show_image(

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -334,9 +334,9 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         from lumicks.pylake.nb_widgets.correlated_plot import plot_correlated
 
         def plot_channel(frame):
-            if channel in ("red", "green", "blue", "rgb"):
+            try:
                 return self._get_plot_data(channel, frame=frame, adjustment=adjustment)
-            else:
+            except ValueError:
                 raise RuntimeError("Invalid channel selected")
 
         def post_update(image_handle, image):
@@ -354,7 +354,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             title_factory,
             frame,
             reduce,
-            colormap=getattr(colormaps, channel),
+            colormap=colormaps._get_default_colormap(channel),
             figure_scale=figure_scale,
             post_update=post_update,
         )
@@ -464,7 +464,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             # With origin set to upper (default) bounds should be given as (0, n, n, 0)
             extent=[0, x_um, y_um, 0],
             aspect=(image.shape[0] / image.shape[1]) * (x_um / y_um),
-            cmap=getattr(colormaps, channel),
+            cmap=colormaps._get_default_colormap(channel),
         )
 
         image_handle = show_image(

--- a/lumicks/pylake/tests/test_imaging_camera/test_export.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_export.py
@@ -69,7 +69,13 @@ def test_stack_movie_export(
         stack.export_video("red", fn, start_frame=0, stop_frame=2)
         assert stat(fn).st_size > 0
 
-        with pytest.raises(ValueError, match="Channel should be red, green, blue or rgb"):
+        with pytest.raises(
+            ValueError,
+            match=(
+                "channel must be 'red', 'green', 'blue' or a combination of 'r', 'g', "
+                "and/or 'b', got 'gray'."
+            ),
+        ):
             stack.export_video("gray", "dummy.gif")  # Gray is not a color!
 
         stack._src.close()

--- a/lumicks/pylake/tests/test_imaging_confocal_old/test_scan.py
+++ b/lumicks/pylake/tests/test_imaging_confocal_old/test_scan.py
@@ -294,7 +294,13 @@ def test_movie_export(tmpdir_factory, test_scans):
     with pytest.raises(IndexError):
         scan.export_video("rgb", f"{tmpdir}/rgb.gif", start_frame=0, stop_frame=4)
 
-    with pytest.raises(ValueError, match="Channel should be red, green, blue or rgb"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "channel must be 'red', 'green', 'blue' or a combination of 'r', 'g', "
+            "and/or 'b', got 'gray'."
+        ),
+    ):
         scan.export_video("gray", "dummy.gif")  # Gray is not a color!
 
 


### PR DESCRIPTION
**Why this PR?**
Enable some extra conveniences:
- alias single-channel plotting (eg, `kymo.plot("r")` instead of `kymo.plot("red")`
- enable 2-channel plotting (eg, `kymo.plot("rg")` and ignore the blue channel)

*note: I had to change the error message thrown if an invalid channel argument is supplied to `export_video`. There was no way to get around this as we hard-coded in the previous choices. However the type `ValueError` remains the same