### PR TITLE
Rework confocal tests: kymo basics

### DIFF
--- a/lumicks/pylake/tests/data/test_mock_confocal.py
+++ b/lumicks/pylake/tests/data/test_mock_confocal.py
@@ -47,7 +47,7 @@ def test_generate_timestamps(
     scan,
     x_axis_fast,
 ):
-    timestamps, ranges = generate_timestamps(
+    timestamps, ranges, ranges_deadtime = generate_timestamps(
         number_of_frames,
         lines_per_frame,
         pixels_per_line,
@@ -70,6 +70,8 @@ def test_generate_timestamps(
     assert timestamps.shape == shape_ref
     assert ranges.dtype == np.int64
     assert ranges.shape == (number_of_frames if scan else lines_per_frame, 2)
+    assert ranges_deadtime.dtype == np.int64
+    assert ranges_deadtime.shape == (number_of_frames if scan else lines_per_frame, 2)
 
     # Test crucial timestamp values (i.e. the first timestamp and increments in all dimensions)
     pixel_time = dt * samples_per_pixel
@@ -92,10 +94,13 @@ def test_generate_timestamps(
 
     # Test crucial ranges timestamp values
     assert ranges[0, 0] == start + padding_time
+    assert ranges_deadtime[0, 0] == start + padding_time
     np.testing.assert_equal(np.diff(ranges, axis=0), frame_time if scan else line_time)
     np.testing.assert_equal(
         np.diff(ranges, axis=1), (frame_time if scan else line_time) - 2 * padding_time
     )
+    np.testing.assert_equal(np.diff(ranges_deadtime, axis=0), frame_time if scan else line_time)
+    np.testing.assert_equal(np.diff(ranges_deadtime, axis=1), frame_time if scan else line_time)
 
 
 @pytest.mark.parametrize(

--- a/lumicks/pylake/tests/test_imaging_confocal/conftest.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/conftest.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+
+from ..data.mock_confocal import generate_kymo_with_ref
+
+start = np.int64(20e9)
+dt = np.int64(62.5e6)
+
+
+@pytest.fixture(scope="module")
+def test_kymo():
+    # RGB Kymo with infowave as expected from BL
+    image = np.random.poisson(5, size=(5, 10, 3))
+
+    kymo, ref = generate_kymo_with_ref(
+        "tester",
+        image,
+        pixel_size_nm=100,
+        start=start,
+        dt=dt,
+        samples_per_pixel=4,
+        line_padding=50,
+    )
+
+    return kymo, ref
+
+
+@pytest.fixture(scope="module")
+def truncated_kymo():
+    image = np.random.poisson(5, size=(5, 4, 3))
+
+    kymo, ref = generate_kymo_with_ref(
+        "truncated",
+        image,
+        pixel_size_nm=100,
+        start=start,
+        dt=dt,
+        samples_per_pixel=4,
+        line_padding=50,
+    )
+    kymo.start = start - 62500000
+    return kymo, ref

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -1,0 +1,146 @@
+import pytest
+import numpy as np
+from lumicks.pylake.channel import Slice, Continuous
+from lumicks.pylake.kymo import _default_line_time_factory
+from ..data.mock_confocal import generate_kymo
+
+
+def test_kymo_properties(test_kymo):
+    kymo, ref = test_kymo
+
+    assert repr(kymo) == f"Kymo(pixels={ref.metadata.pixels_per_line})"
+    assert kymo.pixels_per_line == ref.metadata.pixels_per_line
+    assert len(kymo.infowave) == len(ref.infowave.data)
+
+    np.testing.assert_equal(kymo.get_image("rgb"), ref.image)
+    assert kymo.shape == ref.image.shape
+    assert kymo.get_image("rgb").shape == ref.image.shape
+    assert kymo.get_image("red").shape == ref.image[:, :, 0].shape
+    assert kymo.get_image("blue").shape == ref.image[:, :, 1].shape
+    assert kymo.get_image("green").shape == ref.image[:, :, 2].shape
+
+    np.testing.assert_equal(kymo.timestamps, ref.timestamps.data)
+    assert kymo.start == ref.start
+    assert kymo.stop == ref.stop
+
+    assert kymo.fast_axis == ref.metadata.fast_axis
+    np.testing.assert_equal(kymo.pixelsize_um, ref.metadata.pixelsize_um)
+    np.testing.assert_allclose(kymo.line_time_seconds, ref.timestamps.line_time_seconds)
+    np.testing.assert_allclose(
+        kymo.duration, ref.timestamps.line_time_seconds * ref.metadata.lines_per_frame
+    )
+    np.testing.assert_equal(kymo.center_point_um, ref.metadata.center_point_um)
+    np.testing.assert_allclose(
+        kymo.size_um, [ref.metadata.pixels_per_line * ref.metadata.pixelsize_um[0]]
+    )
+    np.testing.assert_allclose(kymo.pixel_time_seconds, ref.timestamps.pixel_time_seconds)
+    np.testing.assert_allclose(kymo.motion_blur_constant, 0)  # We neglect motion blur for confocal
+
+
+def test_empty_kymo_properties(test_kymo):
+    kymo, ref = test_kymo
+    empty_kymo = kymo["3s":"2s"]
+
+    assert empty_kymo.fast_axis == ref.metadata.fast_axis
+    np.testing.assert_equal(empty_kymo.pixelsize_um, ref.metadata.pixelsize_um)
+    np.testing.assert_equal(empty_kymo.duration, 0)
+    np.testing.assert_equal(empty_kymo.center_point_um, ref.metadata.center_point_um)
+    np.testing.assert_allclose(
+        empty_kymo.size_um, [ref.metadata.pixels_per_line * ref.metadata.pixelsize_um[0]]
+    )
+
+    with pytest.raises(RuntimeError, match="Can't get pixel timestamps if there are no pixels"):
+        empty_kymo.line_time_seconds
+
+    with pytest.raises(RuntimeError, match="Can't get pixel timestamps if there are no pixels"):
+        empty_kymo.pixel_time_seconds
+
+
+def test_damaged_kymo(truncated_kymo):
+    # Assume the user incorrectly exported only a partial Kymo
+    kymo, ref = truncated_kymo
+
+    with pytest.warns(RuntimeWarning):
+        assert kymo.get_image("red").shape == (5, 3)
+    np.testing.assert_allclose(kymo.get_image("red"), ref.image[:, 1:, 0])
+
+
+def test_regression_unequal_timestamp_spacing():
+    """This particular set of initial timestamp and sampler per pixel led to unequal timestamp
+    spacing in an actual dataset."""
+    kymo = generate_kymo(
+        "Mock",
+        np.array([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]]),
+        pixel_size_nm=100,
+        start=1536582124217030400,
+        dt=int(1e9 / 78125),
+        samples_per_pixel=47,
+        line_padding=0,
+    )
+    assert len(np.unique(np.diff(kymo.timestamps))) == 1
+
+
+def test_partial_pixel_kymo():
+    """This function tests whether a partial pixel at the end is fully dropped. This is important,
+    since in the timestamp reconstruction, we subtract the minimum value from a row prior to
+    averaging (to allow taking averages of larger chunks). Without this functionality, the lowest
+    pixel to be reconstructed can be smaller than the first timestamp, which means the subtraction
+    of the minimum is rendered less effective (leading to unnecessarily long reconstruction
+    times)."""
+    kymo = generate_kymo(
+        "Mock",
+        np.ones((5, 5)),
+        pixel_size_nm=100,
+        start=1536582124217030400,
+        dt=int(1e9 / 78125),
+        samples_per_pixel=47,
+        line_padding=0,
+    )
+
+    kymo.infowave.data[-60:] = 0  # Remove the last pixel entirely, and a partial pixel before that
+    np.testing.assert_equal(kymo.timestamps[-1, -1], 0)
+    np.testing.assert_equal(kymo.timestamps[-2, -1], 0)
+    np.testing.assert_equal(kymo.get_image("red")[-1, -1], 0)
+    np.testing.assert_equal(kymo.get_image("red")[-2, -1], 0)
+
+
+@pytest.mark.parametrize(
+    "data, ref_line_time, pixels_per_line, bad",
+    [
+        ([1, 1, 2, 1, 1, 2, 0, 0, 1, 1, 2, 1, 1, 2], 8 * 2, 2, False),
+        ([1, 1, 2, 1, 1, 2, 0, 1], 7 * 2, 2, False),
+        ([0, 0, 1, 1, 2, 1, 1, 2, 0, 1], 7 * 2, 2, False),
+        ([1, 1, 2, 1, 1, 2, 1, 1, 2, 0, 1], 10 * 2, 3, False),
+        ([1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2], 9 * 2, 3, False),  # No dead time
+        ([2, 2, 2, 0, 1], 4 * 2, 3, False),  # Three pixels and a one sample dead time
+        ([2, 2], 2 * 2, 3, True),  # Expected 3 pixels per line, but got partial line
+        ([2, 2, 2], 3 * 2, 3, True),  # A single line without dead time (can't be sure)
+        ([2, 2, 2, 0], 4 * 2, 3, True),  # 3 pixels, 1 sample dead time, but deadtime undefined
+        ([2, 2, 2, 2], 3 * 2, 3, False),  # Three pixels, a line and a little, without dead-time
+        ([0, 2, 2], 2 * 2, 3, True),  # Expected 3 pixels per line, but partial line
+        ([0, 2, 2, 2], 3 * 2, 3, True),  # A single line, but can't be sure
+        ([0, 2, 2, 2, 0], 4 * 2, 3, True),  # 3 pixels, 1 sample dead time, but deadtime undefined
+        ([0, 2, 2, 2, 2], 3 * 2, 3, False),  # Three pixels, a line and a little, without dead-time
+        ([0, 0, 2, 2, 2, 0, 1], 4 * 2, 3, False),  # Three pixels and a pixel dead time
+        ([1, 1], 2 * 2, 2, True),  # No full pixel available at all
+        ([1, 1, 2, 1, 1], 5 * 2, 2, True),  # No full line available
+        ([0, 0, 1, 1, 2, 1, 1], 5 * 2, 2, True),  # No full line available but padded
+        ([0, 0, 1, 1, 2, 1, 1, 2], 6 * 2, 2, True),  # Exactly a full line, w/o dead time
+        ([0, 0, 1, 1, 2, 1, 1, 2, 0], 7 * 2, 2, True),  # Full line, dead time not yet defined
+        ([0, 0, 1, 1, 2, 1, 1, 2, 0, 0], 8 * 2, 2, True),  # Full line, dead time not yet defined
+        ([0, 0, 1, 1, 2, 1, 1, 2, 0, 0, 1], 8 * 2, 2, False),  # Well defined
+        ([0, 0, 1, 1, 2, 1, 1, 2, 0, 0, 1, 1], 8 * 2, 2, False),  # Well defined
+    ],
+)
+def test_direct_infowave_linetime(data, ref_line_time, pixels_per_line, bad):
+    class KymoWave:
+        def __init__(self):
+            self.infowave = Slice(Continuous(data, int(100e9), int(2e9)))
+            self._has_default_factories = lambda: True
+            self.pixels_per_line = pixels_per_line
+
+    if not bad:
+        assert _default_line_time_factory(KymoWave()) == ref_line_time
+    else:
+        with pytest.raises(RuntimeError, match=r"This kymograph consists of only a single line"):
+            _default_line_time_factory(KymoWave())


### PR DESCRIPTION
**Why this PR?**
We've had a longstanding ticket to rework and reorganize the confocal imaging tests. The main point is to remove hardcoded reference values for comparisons. Preparatory work was done in #413 where you can now generate reference data when creating mock kymos and scans.

The strategy in this PR was to, one-by-one, copy relevant tests from `test_imaging_confocal_old/test_kymo.py` to the new `test_imaging_confocal/test_kymo.py` and replace all hardcoded reference values with values from the reference data objects. Fixtures also added to `conftest.py` as needed. I also ended up needing to add some extra data to the timestamps reference object for completeness. Finally, I removed all of the old tests that had been reworked (keeping that in a separate commit)

Right now, I've copied in functions that test the very basic kymo functionality. Next PRs will rework tests for other subsets (eg, slicing, cropping, downsampling, plotting, etc...) with each set in their own file so we can hopefully keep things more organized moving forward. 