### PR TITLE
Consolidate plotting documentation

### DIFF
--- a/docs/tutorial/figures/imagestack/imagestack_adjust_absolute.png
+++ b/docs/tutorial/figures/imagestack/imagestack_adjust_absolute.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c658081cb6203e2c9967ff45c44782320d2186688f3ebbe16bdbbb7ff19b11c8
-size 191274

--- a/docs/tutorial/figures/imagestack/imagestack_adjust_percentile.png
+++ b/docs/tutorial/figures/imagestack/imagestack_adjust_percentile.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e5be253eeaedbea615911e835d6390b632f83a771c71f365b0f4d094ce07ea3
-size 219595

--- a/docs/tutorial/figures/imagestack/imagestack_cropped.png
+++ b/docs/tutorial/figures/imagestack/imagestack_cropped.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7bc6de4bfb1def7dc1a1ca0eb8f1df4dab52eff266bc655c6d7275b91dc30e0b
-size 141047

--- a/docs/tutorial/figures/imagestack/imagestack_red.png
+++ b/docs/tutorial/figures/imagestack/imagestack_red.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b8faa91e7f1d3d45f669d417103fed5d60a0585bcf80db44f5b987b8f034878
-size 132313

--- a/docs/tutorial/figures/kymographs/kymo_blue.png
+++ b/docs/tutorial/figures/kymographs/kymo_blue.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ff64fa52f206c0236d54f5ba89de62bccd30b399d9da9d61566a11859fc04f0
-size 21650

--- a/docs/tutorial/figures/kymographs/kymo_intro.png
+++ b/docs/tutorial/figures/kymographs/kymo_intro.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d0a26d11446fb849d05a6363d3b1b703c18b37fc99f88cf4121da5f914515130
-size 208563

--- a/docs/tutorial/figures/kymographs/kymo_wavelength_cmap.png
+++ b/docs/tutorial/figures/kymographs/kymo_wavelength_cmap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:28f6bac24fe809a7a9107aa1c721975dffcd4816e3621e4874a4c3d5e5d5ee96
-size 936194

--- a/docs/tutorial/figures/plotting_images/adjustment_options.png
+++ b/docs/tutorial/figures/plotting_images/adjustment_options.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a778fa8dcc3876ecae3e6821c1658b506039b86cb9dea44f25414b56250a05a
+size 1607429

--- a/docs/tutorial/figures/plotting_images/colormaps.png
+++ b/docs/tutorial/figures/plotting_images/colormaps.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8267ac2cfd6655bb6940c424f508d22cad72f46e7ff7d4df56ec8a897c9b1e16
+size 1640987

--- a/docs/tutorial/figures/plotting_images/gamma.png
+++ b/docs/tutorial/figures/plotting_images/gamma.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08de065d1acf98d88dae9649e89dd74bb79d8418376964b0f052ff994fa01242
+size 1396023

--- a/docs/tutorial/figures/plotting_images/plot_intro.png
+++ b/docs/tutorial/figures/plotting_images/plot_intro.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:940677c153e5454e59bb6f9dad49453119947a47045c59a7fb085630305c0f59
+size 1831604

--- a/docs/tutorial/figures/plotting_images/scalebar.png
+++ b/docs/tutorial/figures/plotting_images/scalebar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b452927bf29d9fce2895f862ecbcbaa77a12debeca77f174aa5d838ad3020eb
+size 1612897

--- a/docs/tutorial/imagestack.rst
+++ b/docs/tutorial/imagestack.rst
@@ -76,58 +76,34 @@ You can also obtain the image stack data as a :class:`numpy array <numpy.ndarray
 Plotting and exporting
 ----------------------
 
-You can quickly plot an individual frame using the :meth:`~lumicks.pylake.ImageStack.plot()` method::
+Pylake provides a convenience :meth:`plot()<lumicks.ImageStack.plot>` method to quickly
+visualize your data. For details and examples see the :doc:`plotting_images` section.
 
-    plt.figure()
-    stack_roi.plot("rgb")
-    plt.show()
+The stack can also be exported to TIFF format::
 
-.. image:: figures/imagestack/imagestack_cropped.png
+    stack_roi.export_tiff("aligned_stack.tiff")
+    stack_roi[3:7].export_tiff("aligned_short_stack.tiff")  # export a slice of the ImageStack
 
-The first argument is the color channel that you wish to plot. All additional arguments must be supplied as keyword arguments.
+Image stacks can also be exported to video formats. Exporting the red channel as a GIF can be
+done as follows::
 
-You can also plot only a single color channel. Note that you can also pass additional formatting
-arguments (here, the `"magma"` colormap), which are forwarded to :func:`plt.imshow() <matplotlib.pyplot.imshow()>`::
-
-    plt.figure()
-    stack_roi.plot(channel="red", cmap="magma")
-    plt.show()
-
-.. image:: figures/imagestack/imagestack_red.png
-
-There are also a number of custom colormaps for plotting single channel images. These are available from :data:`~lumicks.pylake.colormaps`;
-the available colormaps are: `.red`, `.green`, `.blue`, `.magenta`, `.yellow`, and `.cyan`.
-
-If the `channel` argument is not provided, the default behavior is `"rgb"` for 3-color images. For single-color
-images, this argument is ignored as there is only one channel available.
-
-Sometimes a few bright pixels can dominate the image. When this is the case, it may be beneficial to manually set the color limits
-for each of the channels. This can be accomplished by providing a :class:`~lumicks.pylake.ColorAdjustment` to plotting or export functions::
-
-    plt.figure()
-    stack_roi.plot("rgb", adjustment=lk.ColorAdjustment([100, 100, 100], [185, 200, 200]))
-    plt.show()
-
-.. image:: figures/imagestack/imagestack_adjust_absolute.png
-
-Similarly, you can add a scale bar to your plots by providing a :class:`~lumicks.pylake.ScaleBar` to plotting or export functions.
-
-By default the limits should be provided in absolute values, although percentiles can be used instead for convenience::
-
-    plt.figure()
-    stack_roi.plot(
-        "rgb",
-        adjustment=lk.ColorAdjustment(20, 99, mode="percentile"),
-        scale_bar=lk.ScaleBar(),  # Adds a scale bar to the plot
+    stack_roi.export_video(
+        "red",
+        "test_red.gif",
+        adjustment=lk.ColorAdjustment(20, 99, mode="percentile")
     )
-    plt.show()
 
-.. image:: figures/imagestack/imagestack_adjust_percentile.png
+Or if we want to export a subset of frames (the first frame being 2, and the last frame being 7)
+of all three channels at a frame rate of 2 frames per second, we can do this::
 
-Finally, the aligned image stack can also be exported to TIFF format::
-
-    stack.export_tiff("aligned_stack.tiff")
-    stack[5:20].export_tiff("aligned_short_stack.tiff")  # export a slice of the ImageStack
+    stack_roi.export_video(
+        "rgb",
+        "test_rgb.gif",
+        start_frame=2,
+        stop_frame=7, f
+        ps=2,
+        adjustment=lk.ColorAdjustment(20, 99, mode="percentile")
+    )
 
 Defining a tether
 -----------------

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -27,6 +27,7 @@ These import conventions are used consistently in the tutorial.
     scans
     kymographs
     imagestack
+    plotting_images
     fdfitting
     nbwidgets
     kymotracking

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -33,60 +33,8 @@ Or access a particular `Kymo` object directly to work with::
 Plotting and exporting
 ----------------------
 
-We can use the :meth:`~lumicks.pylake.kymo.Kymo.plot()` convenience function to plot individual color channels and the full RGB image::
-
-    plt.figure()
-
-    # plot just the green channel
-    plt.subplot(2, 1, 1)
-    kymo.plot("green", adjustment=lk.ColorAdjustment(0, 15, mode="absolute"))
-
-    # plot full color
-    plt.subplot(2, 1, 2)
-    kymo.plot(channel="rgb", adjustment=lk.ColorAdjustment(0, 99, mode="percentile"))
-
-    plt.show()
-
-.. image:: figures/kymographs/kymo_intro.png
-
-Note that the axes are labeled with the appropriate time and position units.
-
-The first argument `channel` accepts the strings "red", "green", "blue", or "rgb". We also see that the color limits can be set easily using
-the :class:`~lumicks.pylake.ColorAdjustment` class. The first two arguments act like the `vmin` and `vmax` arguments used with
-:func:`plt.imshow() <matplotlib.pyplot.imshow()>` if `mode="absolute"`. In the second plot, we use `mode=percentile` to automatically calculate
-the limits at the 0th and 99th percentile of all of the pixel values.
-Similarly, you can add a scale bar to your plots by providing a :class:`~lumicks.pylake.ScaleBar` to plotting or export functions.
-In addition, this method also accepts keyword arguments that are passed to :func:`plt.imshow() <matplotlib.pyplot.imshow()>` internally.
-
-There are also a number of custom colormaps for plotting single channel images. These are available from :data:`~lumicks.pylake.colormaps`;
-the available colormaps are: `.red`, `.green`, `.blue`, `.magenta`, `.yellow`, and `.cyan`. For example, we can plot the blue channel image
-with the cyan colormap::
-
-    plt.figure()
-    kymo.plot(channel="blue", cmap=lk.colormaps.cyan)
-    plt.show()
-
-.. image:: figures/kymographs/kymo_blue.png
-
-We can also use the `lk.colormaps.from_wavelength()` method to generate a color map approximating the color of a particular wavelength::
-
-    adjustment = lk.ColorAdjustment(0, 99, mode="percentile")
-
-    plt.figure()
-    plt.subplot(2, 1, 1)
-    kymo.plot(channel="green", adjustment=adjustment)
-    plt.title("default 'green' colormap")
-    plt.subplot(2, 1, 2)
-    kymo.plot(
-        channel="green",
-        adjustment=adjustment,
-        cmap=lk.colormaps.from_wavelength(590)
-    )
-    plt.title("emission @ 590 nm")
-    plt.tight_layout()
-    plt.show()
-
-.. image:: figures/kymographs/kymo_wavelength_cmap.png
+Pylake provides a convenience :meth:`plot()<lumicks.pylake.kymo.Kymo.plot>` method to quickly
+visualize your data. For details and examples see the :doc:`plotting_images` section.
 
 The kymograph can also be exported to TIFF format::
 

--- a/docs/tutorial/plotting_images.rst
+++ b/docs/tutorial/plotting_images.rst
@@ -1,0 +1,189 @@
+Plotting Images
+===============
+
+.. only:: html
+
+    :nbexport:`Download this page as a Jupyter notebook <self>`
+
+This tutorial covers the built-in plotting functionality for images in Pylake. While most of the
+examples shown use kymographs, the details described here are valid for
+:meth:`Kymo.plot()<lumicks.pylake.kymo.Kymo.plot>`, :meth:`Scan.plot()<lumicks.pylake.scan.Scan.plot>`
+and :meth:`ImageStack.plot()<lumicks.pylake.ImageStack.plot>`.
+
+First, we load a data file::
+
+    filenames = lk.download_from_doi("10.5281/zenodo.7729525", "test_data")
+
+    file = lk.File("test_data/kymo.h5")
+    kymo = file.kymos["16"]
+
+We can use the :meth:`~lumicks.pylake.kymo.Kymo.plot()` function to plot individual
+color channels and the full RGB image::
+
+    plt.figure(figsize=(6.4, 7))
+
+    # plot just the green channel
+    plt.subplot(3, 1, 1)
+    kymo.plot("green", adjustment=lk.ColorAdjustment(0, 15), aspect="auto")
+
+    #plot just the red and green channels
+    plt.subplot(3, 1, 2)
+    kymo.plot("rg", adjustment=lk.ColorAdjustment(0, 99, mode="percentile"), aspect="auto")
+    plt.title("just red & green")
+
+    # full color is default
+    plt.subplot(3, 1, 3)
+    kymo.plot(adjustment=lk.ColorAdjustment(0, 99, mode="percentile"), aspect="auto")
+    plt.title("full RGB")
+
+    plt.tight_layout()
+    plt.show()
+
+.. image:: figures/plotting_images/plot_intro.png
+
+Note that the axes are labeled with the appropriate time and position units. For confocal scans,
+both axes are labeled with the appropiate spatial units. For camera-based images, this behavior
+is also true if the camera has been calibrated (with the corresponding metadata stored in the TIF
+file).
+
+In addition, this method also accepts keyword arguments that are passed to
+:func:`plt.imshow() <matplotlib.pyplot.imshow()>` internally. We see this with the `aspect`
+argument above. The default aspect ratio Pylake uses for kymographs is such that pixels end up
+visualized as square. However, for long kymographs like this one, the data is difficult to see
+for such a narrow image; therefore we use `aspect="auto"` to just fill the available space in
+the figure.
+
+.. note::
+
+    This method accepts an additional keyword argument `frame` for both :class:`~lumicks.pylake.scan.Scan`
+    and :class:`~lumicks.pylake.ImageStack` instances to specify the frame that is to be plotted.
+
+Choosing color channels
+-----------------------
+
+The first argument `channel` accepts a string specifying the color channels to plot.
+
+The default behavior is to plot all available color channels, which in most cases is an RGB image.
+This is seen in the bottom panel of the figure above. This can also be specified using `channel="rgb"`.
+
+To plot just a single color channel (top panel of the figure above) use `"red"`, `"green"`, or
+`"blue"` or their abbreviations `"r"`, `"g"` or `"b"`, respectively.
+
+You can also plot a subset of channels (middle panel of the figure above) using combinations of
+`"r"`, `"g"`, and/or `"b"`. Note that these must be specified in RGB order (eg, to plot red and
+green use `"rg"`; using `"gr"` will result in an error).
+
+Adjusting color limits
+----------------------
+
+We also see that the color limits can be set easily using the :class:`~lumicks.pylake.ColorAdjustment` class.
+This class takes two arguments representing the minimum and maximum desired color limits and an
+optional `mode` keyword argument, which can be either `"absolute"` or `"percentile"`.
+
+If `mode="absolute"`, the first two arguments act like the `vmin` and `vmax` arguments used with
+:func:`plt.imshow() <matplotlib.pyplot.imshow()>`. This is the default behavior,
+as demonstrated in the top panel of the figure above.
+
+For multichannel images, it can be especially convenient to specify the limits from percentiles of
+the pixel values::
+
+    plt.figure()
+
+    plt.subplot(2, 1, 1)
+    kymo.plot("rgb", adjustment=lk.ColorAdjustment(0, 99.9, mode="percentile"))
+
+    plt.subplot(2, 1, 2)
+    kymo.plot("rgb", adjustment=lk.ColorAdjustment(0, [50, 99, 10], mode="percentile"))
+
+    plt.tight_layout()
+    plt.show()
+
+.. image:: figures/plotting_images/adjustment_options.png
+
+The color scale is linear by default, but `Gamma correction <https://en.wikipedia.org/wiki/Gamma_correction>`_
+can be applied in addition to the bounds by supplying an extra argument named `gamma`.
+For example, a gamma adjustment of `0.1` to the red channel can be applied as follows::
+::
+
+    plt.figure()
+
+    plt.subplot(2, 1, 1)
+    kymo.plot("rgb", adjustment=lk.ColorAdjustment(0, 99.9, mode="percentile"))
+    plt.title("default")
+
+    plt.subplot(2, 1, 2)
+    kymo.plot("rgb", adjustment=lk.ColorAdjustment(0, 99.9, gamma=[0.1, 1.0, 1.0], mode="percentile"))
+    plt.title("red gamma = 0.1")
+
+    plt.tight_layout()
+    plt.show()
+
+.. image:: figures/plotting_images/gamma.png
+
+In the first plot, the limits are automatically calculated as the 0th and 99.9th percentile of all
+of the pixel values. In the bottom panel, we see that different values can be defined for each channel
+individually.
+
+.. note::
+    When specifying values for each channel, a list of three values in RGB order must be supplied,
+    even if only one or two channels are plotted (ie, using `channel="rg"`).
+
+
+Scale bars
+----------
+
+Similarly, you can easily add a scale bar to your plots simply by providing a
+:class:`~lumicks.pylake.ScaleBar` with the `scalebar` keyword argument::
+
+    plt.figure()
+
+    kymo.plot(
+        "rg",
+        scale_bar=lk.ScaleBar(15, 2.5),
+        adjustment=lk.ColorAdjustment(0, 99, mode="percentile"),
+        aspect="auto",
+    )
+    plt.show()
+
+.. image:: figures/plotting_images/scalebar.png
+
+
+Pylake custom colormaps
+-----------------------
+
+We can use the standard `cmap` argument to control the visualization for single-channel images easily.
+In addition to the colormaps provided by matplotlib, there are also a number of Pylake custom
+colormaps for plotting single channel images. These are available from :data:`~lumicks.pylake.colormaps`.
+The available colormaps are: `.red`, `.green`, `.blue`, `.magenta`, `.yellow`, and `.cyan`, with the
+first three being the default colormaps used by Pylake for plotting their respective channels.
+
+We can also use the `lk.colormaps.from_wavelength()` method to generate a color map approximating
+the color of a particular wavelength. This can be useful to visualize fluorophores closer to the
+color of their actual emission wavelength.
+
+These various options are demonstrated in the figure below::
+
+    kwargs = dict(adjustment=lk.ColorAdjustment(0, 99, mode="percentile"), aspect="auto")
+
+    plt.figure(figsize=(6.4, 8))
+
+    plt.subplot(4, 1, 1)
+    kymo.plot("g", **kwargs)
+    plt.title("default Pylake colormap")
+
+    plt.subplot(4, 1, 2)
+    kymo.plot("g", cmap="viridis", **kwargs)
+    plt.title("matplotlib viridis colormap")
+
+    plt.subplot(4, 1, 3)
+    kymo.plot("g", cmap=lk.colormaps.cyan, **kwargs)
+    plt.title("Pylake cyan colormap")
+
+    plt.subplot(4, 1, 4)
+    kymo.plot("g", cmap=lk.colormaps.from_wavelength(590), **kwargs)
+    plt.title("emission @ 590 nm")
+
+    plt.tight_layout()
+    plt.show()
+
+.. image:: figures/plotting_images/colormaps.png

--- a/docs/tutorial/scans.rst
+++ b/docs/tutorial/scans.rst
@@ -41,72 +41,33 @@ Or just pick a single one by providing the name of the scan as ``scan=file.scans
 Plotting and Exporting
 ----------------------
 
-As shown above, there are convenience functions for plotting either the full RGB image or a single
-color channel::
+Pylake provides a convenience :meth:`plot()<lumicks.pylake.scan.Scan.plot>` method to quickly
+visualize your data. For details and examples see the :doc:`plotting_images` section.
 
-    plt.figure()
-    scan.plot(channel="rgb")
-    plt.show()
-
-The `channel` argument accepts the strings `“red”`, `“green”`, `“blue”`, or `“rgb”`. Multi-frame scans are also supported::
-
-    multiframe_file = lk.File("test_data/scan_stack.h5")
-    multiframe_scan = multiframe_file.scans["46"]
-
-    print(multiframe_scan.num_frames)
-    print(multiframe_scan.get_image("blue").shape)  # (self.num_frames, h, w) -> single color channel
-    print(multiframe_scan.get_image("rgb").shape)  # (self.num_frames, h, w, 3) -> three color channels
-
-    # plot frame at index 3 (first frame is index 0)
-    # defaults to the first frame if no argument is given
-    plt.figure()
-    multiframe_scan.plot("green", frame=3)
-    plt.show()
-
-Sometimes a few bright pixels can dominate the colormap of a scan.
-When this is the case, it may be beneficial to manually set the color limits for each of the channels.
-This can be accomplished by providing a :class:`~lumicks.pylake.ColorAdjustment` to plotting or export functions::
-
-    plt.figure()
-    scan.plot(channel="rgb", adjustment=lk.ColorAdjustment([0, 0, 0], [4, 4, 4]))
-    plt.show()
-
-Similarly, you can add a scale bar to your plots by providing a :class:`~lumicks.pylake.ScaleBar` to plotting or export functions.
-
-There are also a number of custom colormaps for plotting single channel images. These are available from :data:`~lumicks.pylake.colormaps`; the available colormaps are:
-`.red`, `.green`, `.blue`, `.magenta`, `.yellow`, and `.cyan`. For example, we can plot the blue channel image with the cyan colormap::
-
-    plt.figure()
-    scan.plot(channel="blue", cmap=lk.colormaps.cyan)
-    plt.show()
-
-Here the first array gives the minimal values for the color scale of red, green and blue respectively (here `[0, 0, 0]`) and the second array gives the maximum values for the color scales.
-The color scale is linear by default, but `Gamma correction <https://en.wikipedia.org/wiki/Gamma_correction>`_ can be applied in addition to the bounds by supplying an extra argument named `gamma`.
-For example, a gamma adjustment of `0.1` to the green channel can be applied as follows::
-
-    plt.figure()
-    scan.plot(channel="rgb", adjustment=lk.ColorAdjustment([0, 0, 0], [4, 4, 4], gamma=[1, 0.1, 1]))
-    plt.show()
-
-The limits can also be specified in percentiles::
-
-    plt.figure()
-    scan.plot(channel="rgb", adjustment=lk.ColorAdjustment([5, 5, 5], [95, 95, 95], mode="percentile"))
-    plt.show()
-
-Export an image in the TIFF format as follows::
+The scan can also be exported to TIFF format::
 
     scan.export_tiff("image.tiff")
 
-Scans can also be exported to video formats.
-Exporting the red channel of a multi-scan GIF can be done as follows::
+Scans can also be exported to video formats. Exporting the red channel of a multi-scan GIF can be
+done as follows::
 
-    multiframe_scan.export_video("red", "test_red.gif", adjustment=lk.ColorAdjustment([0], [4]))
+    multiframe_scan.export_video(
+        "red",
+        "test_red.gif",
+        adjustment=lk.ColorAdjustment([0], [4])
+    )
 
 Or if we want to export a subset of frames (the first frame being 2, and the last frame being 15) of all three channels
 at a frame rate of 2 frames per second, we can do this::
 
-    multiframe_scan.export_video("rgb", "test_rgb.gif", start_frame=2, stop_frame=15, fps=2,adjustment=lk.ColorAdjustment([0, 0, 0], [4, 4, 4]))
+    multiframe_scan.export_video(
+        "rgb",
+        "test_rgb.gif",
+        start_frame=2,
+        stop_frame=15,
+        fps=2,
+        adjustment=lk.ColorAdjustment([0, 0, 0], [4, 4, 4])
+    )
 
 For other video formats such as `.mp4` or `.avi`, ffmpeg must be installed. See
 :ref:`installation instructions <ffmpeg_installation>` for more information on this.

--- a/docs/whatsnew/1.3.0/1_3_0.rst
+++ b/docs/whatsnew/1.3.0/1_3_0.rst
@@ -1,0 +1,16 @@
+Pylake 1.3.0
+============
+
+.. only:: html
+
+Here's a sneak peek at the new features coming in Pylake `v1.3.0`:
+
+More options for plotting images
+--------------------------------
+
+Now there's more flexibility with which color channels to plot for images, including shorthand
+values for the red/green/blue channels and plotting only two colors:
+
+.. figure:: plot_channel_options.png
+
+Check out :doc:`../../tutorial/plotting_images` for more information.

--- a/docs/whatsnew/1.3.0/plot_channel_options.png
+++ b/docs/whatsnew/1.3.0/plot_channel_options.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d07819d3350181442b49b90752250b2759c4be6ce2f680147db2c51506b6ee2
+size 1062967

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -8,6 +8,7 @@ For a full list of new features and changes, please refer to the :doc:`changelog
     :caption: Contents
     :maxdepth: 1
 
+    1.3.0/1_3_0
     1.2.0/1_2_0
     1.1.0/1_1_0
     1.0.0/1_0_0


### PR DESCRIPTION
**Why this PR?**
Now that our image plotting API is consistent across all of our image classes, it makes sense to have a single page explaining the shared plotting functionality rather than duplicating it in each tutorial.

[Build here](https://lumicks-pylake.readthedocs.io/en/all_the_plot_docs/tutorial/plotting_images.html)