### PR TITLE
tracking widget: fix width of kymograph part of the widget layout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Fixed a bug that prevented resaving a `KymoTrackGroup` loaded from an older version of Pylake.
 * Fixed a bug that inadvertently made us rely on `cachetools>=5.x`. Older versions of `cachetools` did not pass the instance to the key function resulting in a `TypeError: key() missing 1 required positional argument: '_'` error when accessing cached properties or methods.
 * Fixed a bug that could cause a division by zero while fitting power spectra with `f_diode`. The lower bound of `f_diode` was changed from 0 to 1.0 Hz. This change should not impact results unless users were getting failed calibrations with this error.
+* Fixed a layout issue that made the sliders appear so narrow in `jupyterlab` that they were not visible.
 
 ## v1.2.0 | 2023-08-15
 

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -500,6 +500,7 @@ class KymoWidget:
             # Without this, HBox fails to align horizontally.
             self._fig.canvas.show()
 
+        output.layout.width = "68%"  # by default, the output box leaves no room for the sliders
         ui = ipywidgets.HBox(
             [
                 output,


### PR DESCRIPTION
**Why this PR?**
Workaround for https://github.com/jupyter-widgets/ipywidgets/issues/3822

Without this PR, the slider part of the widget ends up so narrow that it is invisible. Initially I thought `ipywidgets` was not installed correctly, but it turned out that the `output` widget was just eating up all the screen space.