### PR TITLE
kymo: make single line scan return a valid `line_time_seconds`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 #### Improvements
 
 * Kymographs consisting of a single scan line now return a valid `line_time_seconds`. This allows certain downstream functionality, such as `Kymo.plot()`.
+* Issue a more descriptive error when attempting to compute a diffusion constant of a track with no points.
 
 ## v1.2.1 | 2023-10-17
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@
   * Shortcuts `"r"`, `"g"`, and `"b"` can now be used for plotting single color channels in addition to `"red"`, `"green"`, and `"blue"`.
   * Two-channel visualizations can be plotted using `"rg"`, `"gb"`, or `"rb"`.
 
+#### Improvements
+
+* Kymographs consisting of a single scan line now return a valid `line_time_seconds`. This allows certain downstream functionality, such as `Kymo.plot()`.
+
 ## v1.2.1 | 2023-10-17
 
 #### Bug fixes

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 
 * Kymographs consisting of a single scan line now return a valid `line_time_seconds`. This allows certain downstream functionality, such as `Kymo.plot()`.
 * Issue a more descriptive error when attempting to compute a diffusion constant of a track with no points.
+* Pylake can now handle kymographs that were erroneously stored in the `Scan` field. Kymographs with a pre-specified number of lines to record were incorrectly being marked on the timeline and exported as 'Scan' instead of 'Kymograph' in versions of Bluelake prior to `2.5.0`.
 
 ## v1.2.1 | 2023-10-17
 

--- a/lumicks/pylake/detail/image.py
+++ b/lumicks/pylake/detail/image.py
@@ -180,9 +180,11 @@ def first_pixel_sample_indices(infowave):
     if infowave.size == 0:
         return 0, 0
 
-    return np.argmax(infowave != InfowaveCode.discard), np.argmax(
-        infowave == InfowaveCode.pixel_boundary
-    )
+    pixel_boundary = np.argmax(infowave == InfowaveCode.pixel_boundary)
+    if infowave[pixel_boundary] != InfowaveCode.pixel_boundary:
+        raise RuntimeError("No completed pixel found in image")
+
+    return np.argmax(infowave != InfowaveCode.discard), pixel_boundary
 
 
 def histogram_rows(image, pixels_per_bin, pixel_width):

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -275,7 +275,16 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
     @property
     def kymos(self) -> Dict[str, Kymo]:
         """Kymos stored in the file"""
-        return self._get_object_dictionary("Kymograph", Kymo)
+
+        # Due to an error in an earlier version of Bluelake, some Kymographs were stored in the
+        # `Scan` field. This reads those using a fallback mechanism.
+        scan_kymos = {
+            key: item
+            for key, item in self._get_object_dictionary("Scan", Kymo).items()
+            if item._metadata.num_axes == 1
+        }
+
+        return scan_kymos | self._get_object_dictionary("Kymograph", Kymo)
 
     @property
     def point_scans(self) -> Dict[str, Scan]:

--- a/lumicks/pylake/kymotracker/detail/msd_estimation.py
+++ b/lumicks/pylake/kymotracker/detail/msd_estimation.py
@@ -735,6 +735,12 @@ def determine_optimal_points(frame_idx, coordinate, max_iterations=100):
 
         num_slopes.add(num_slope)
 
+        if len(coordinate) <= 4:
+            raise RuntimeError(
+                "You need at least 5 time points to estimate the number of points to include in "
+                "the fit."
+            )
+
         # Determine the number of points to include in the next fit
         num_slope, num_intercept = optimal_points(
             calculate_localization_error(frame_lags[:num_slope], msd[:num_slope]), len(coordinate)

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -1211,6 +1211,18 @@ def test_kymotrack_group_diffusion_filter():
         d = tracks.estimate_diffusion("ols", min_length=2)
 
 
+@pytest.mark.parametrize("data", [[], [1, 2, 3, 4]])
+def test_ols_empty_kymotrack(blank_kymo, data):
+    track = KymoTrack(data, data, blank_kymo, "red", 0)
+
+    with pytest.raises(
+        RuntimeError,
+        match="You need at least 5 time points to estimate the number of points to include in the "
+        "fit.",
+    ):
+        track.estimate_diffusion("ols")
+
+
 @pytest.mark.parametrize("kbp_calibration, line_width", [(None, 7), (4, 7), (None, 8)])
 def test_ensemble_msd_calibration_from_kymo(blank_kymo, kbp_calibration, line_width):
     """Checks whether all the properties are correctly forwarded from the Kymo"""

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -30,6 +30,8 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
 
     def __init__(self, name, file, start, stop, metadata):
         super().__init__(name, file, start, stop, metadata)
+        if self._metadata.num_axes == 1:
+            raise RuntimeError("1D scans are not supported")
         if self._metadata.num_axes > 2:
             raise RuntimeError("3D scans are not supported")
 

--- a/lumicks/pylake/tests/test_file/conftest.py
+++ b/lumicks/pylake/tests/test_file/conftest.py
@@ -191,3 +191,19 @@ def h5_file_invalid_version(tmpdir_factory):
     mock_file.attrs["File format version"] = 254
 
     return mock_file
+
+
+@pytest.fixture(scope="module", params=[MockDataFile_v2])
+def h5_kymo_as_scan(tmpdir_factory, request):
+    mock_class = request.param
+
+    tmpdir = tmpdir_factory.mktemp("pylake")
+    mock_file = mock_class(tmpdir.join("%s.h5" % mock_class.__class__.__name__))
+    mock_file.write_metadata()
+
+    json_kymo = generate_scan_json([{"axis": 1, "num of pixels": 4, "pixel size (nm)": 191.0}])
+    ds = mock_file.make_json_data("Scan", "Kymo1", json_kymo)
+    ds.attrs["Start time (ns)"] = np.int64(20e9)
+    ds.attrs["Stop time (ns)"] = np.int64(100e9)
+
+    return mock_file.file

--- a/lumicks/pylake/tests/test_file/test_file_items.py
+++ b/lumicks/pylake/tests/test_file/test_file_items.py
@@ -117,3 +117,15 @@ def test_notes(h5_file):
         assert note.text == "Note content"
         assert note.start == 100
         assert note.stop == 100
+
+
+def test_kymos_in_scans(h5_kymo_as_scan):
+    """Tests whether Kymos accidentally put in Scan are loaded correctly"""
+    f = pylake.File.from_h5py(h5_kymo_as_scan)
+
+    assert len(f.kymos) == 1
+    assert f.kymos["Kymo1"].name == "Kymo1"
+
+    with pytest.warns():
+        scan_dict = f.scans
+        assert not scan_dict


### PR DESCRIPTION
**Why this PR?**
Prior to this change, `Kymo`s consisting of a single or partial scan line provide no `line_time_seconds` which prevents plotting and other functionality. Now they provide the line time of what is actually shown in the plot (e.g. a full line, without deadtime if the line time is smaller or equal than a single line).

The second issue is that for a few Bluelake versions, Bluelake put some kymographs that were taken with a fixed line count in the `Scan` field. The last commit contains a fallback method so that they will not be loaded as corrupted `Scan` items, but end up in the `kymos` field.