### PR TITLE
force_calibration: coupling model for active calibration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 #### New features
 
+* Added model to correct for bead-bead coupling when using active calibration deep in bulk with two beads. See [`tutorial`](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/force_calibration.html#active-calibration-with-two-beads-far-away-from-the-surface) and [`theory`](https://lumicks-pylake.readthedocs.io/en/latest/theory/force_calibration/active.html#bead-bead-coupling) for more information.
 * Added option to highlight a region on a time plot using [`Slice.highlight_time_range()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.channel.Slice.html#lumicks.pylake.channel.Slice.highlight_time_range). For more information see the [`tutorial`](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#highlight-time-range).
 * Added parameter `allow_overwrite` to [`lk.download_from_doi()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.download_from_doi.html#lumicks.pylake.download_from_doi) to allow re-downloading only those files where the checksum does not match.
 * Added force calibration information to channels accessed directly via the square bracket notation (e.g. `file["Force HF"]["Force 1x"].calibration`).

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -49,6 +49,7 @@ Force calibration
     fit_power_spectrum
     viscosity_of_water
     density_of_water
+    coupling_correction_2d
 
 
 FD Fitting

--- a/docs/examples/bead_coupling/corrected_dataset_0.png
+++ b/docs/examples/bead_coupling/corrected_dataset_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:841386636a9c199546141c66c7fb57c8f8f77a90d56be5492493b1099ac28964
+size 162014

--- a/docs/examples/bead_coupling/corrected_dataset_1.png
+++ b/docs/examples/bead_coupling/corrected_dataset_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04dbcbd6aebc3fe0f7bed9ba033fb3e38bda48b8455a2300867312964afc3a39
+size 159792

--- a/docs/examples/bead_coupling/corrected_dataset_2.png
+++ b/docs/examples/bead_coupling/corrected_dataset_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:512a53b8f08c97bf9bf834f5d544c1be0124a9a55b747995f47c34822eac0b42
+size 156818

--- a/docs/examples/bead_coupling/corrected_dataset_3.png
+++ b/docs/examples/bead_coupling/corrected_dataset_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4abd91d9502dc104a11095a4436e65c3d76b15033d140e8864c9230d8f1df8ed
+size 150777

--- a/docs/examples/bead_coupling/corrected_dataset_4.png
+++ b/docs/examples/bead_coupling/corrected_dataset_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31a862a79614dcef42e08a606abd0d9893b8b5ed1dc0cad241a5cd75343bda4c
+size 173525

--- a/docs/examples/bead_coupling/corrected_dataset_5.png
+++ b/docs/examples/bead_coupling/corrected_dataset_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5022f3801448ad8947257cb5eac75fb24a23ea0acd2a627f4ade0b191e26c5f
+size 153844

--- a/docs/examples/bead_coupling/coupling.rst
+++ b/docs/examples/bead_coupling/coupling.rst
@@ -1,0 +1,493 @@
+.. warning::
+
+    This is alpha functionality. While usable, this has not yet been tested in a large
+    number of different scenarios.
+
+Active calibration for two beads
+================================
+
+.. only:: html
+
+    :nbexport:`Download this page as a Jupyter notebook <self>`
+
+When performing active calibration, the nanostage (whose motion is calibrated in microns) is oscillated sinusoidally.
+In turn, this results in fluid motion, which displaces the beads from the trap centers.
+We can detect this sinusoidal displacement on the force detectors and use it to calibrate the displacement sensitivity.
+For the theory on how this works, please refer to the :doc:`theory section on active calibration</theory/force_calibration/active>`.
+
+When using two beads, the flow field around the beads is reduced (because the presence of the additional bead slows down the fluid).
+The magnitude of this effect depends on the bead diameter, distance between the beads and their orientation with respect to the fluid flow.
+Streamlines for some bead configurations are shown below (simulated using FEniCSx :cite:`the_fenics_project_developers_2023_10432590`).
+
+.. image:: coupling_overview.png
+  :nbattach:
+
+In this notebook, we will show this effect on some C-Trap data and apply a correction for it.
+
+.. note::
+
+    In practice, correcting data for this effect is straightforward and most of this notebook is not required.
+    Considering the correction factor is a single factor that only depends on the bead to bead distance and bead radius, it can be applied as a correction factor to already calibrated data.
+    See :ref:`tutorial<bead_bead_tutorial>` for more information on how to correct an experiment.
+
+Loading the data
+----------------
+
+First, we need to download the necessary data. Note that this cell downloads 7.4 GB of data (it may take a while)::
+
+    lk.download_from_doi("10.5281/zenodo.11105579", "coupling_data")
+
+We can get a list of filenames for the files we need for each experiment using `glob.glob()`::
+
+    import glob
+    from tqdm.auto import tqdm
+
+    # Grab calibration data for different beads
+    calibration_data = [glob.glob(f"coupling_data/bead{bead}_*.h5") for bead in ("1", "2", "3", "4", "4b", "4c")]
+
+To perform active calibration for two beads, we will need the following:
+
+    - Nanostage signals
+    - The uncalibrated force signal in volts
+    - Bead positions (if there is more than one bead).
+
+Let's plot a typical active calibration dataset::
+
+    dataset = lk.File(calibration_data[0][0])
+
+    plt.figure()
+    plt.subplot(4, 1, 1)
+    dataset["Nanostage position"]["X"].plot()
+    plt.subplot(4, 1, 2)
+    dataset["Nanostage position"]["Y"].plot()
+    plt.subplot(4, 1, 3)
+    dataset.force1x.plot()
+    plt.subplot(4, 1, 4)
+    dataset.force1y.plot()
+    plt.tight_layout()
+
+.. image:: show_dataset.png
+
+Let's write a function that grabs the timestamp range of each oscillatory segment.
+Since the nanostage position shows a transient settling behavior when starting and stopping its motion, we trim a little extra time at the edges::
+
+    def find_oscillation_timestamp_range(slc, thresh=0.1, offset=0.5):
+        """Search for oscillation timestamp range by thresholding signal power.
+
+        Note: This function assumes that there is only one oscillation period in the slice.
+
+        Parameters
+        ----------
+        slc : Slice
+            Slice of channel data
+        thresh : float
+            Threshold
+        offset : float
+            How many seconds to trim at each edge.
+
+        Returns
+        -------
+        Tuple(int64, int64)
+            Returns a tuple of integer timestamps in nanoseconds.
+        """
+
+        # Calculate a downsampled mean signal power.
+        zero_mean = slc - np.mean(slc.data)
+        squared = (zero_mean * zero_mean).downsampled_by(100)
+        start_idx = np.where(squared.data > thresh)[0][0]
+        stop_idx = len(squared.data) - np.where(np.flip(squared.data) > thresh)[0][0]
+        start, stop = (squared.timestamps[idx] for idx in (start_idx, stop_idx))
+
+        # How much data do we cut at the edges? Convert the time in seconds to nanoseconds.
+        trim_nanoseconds = int(offset * 1e9)
+
+        return start + trim_nanoseconds, stop - trim_nanoseconds
+
+Let's plot some results and see if it identifies the regions correctly::
+
+    plt.figure()
+    plt.subplot(2, 1, 1)
+    dataset["Nanostage position"]["X"].plot()
+    plt.subplot(2, 1, 2)
+    dataset["Nanostage position"]["Y"].plot()
+    plt.subplot(2, 1, 1)
+    x_start, x_stop = find_oscillation_timestamp_range(dataset["Nanostage position"]["X"])
+    nano_x = dataset["Nanostage position"]["X"][x_start:x_stop]
+    nano_x.plot(start=dataset["Nanostage position"]["X"].start)
+    plt.subplot(2, 1, 2)
+    y_start, y_stop = find_oscillation_timestamp_range(dataset["Nanostage position"]["Y"])
+    nano_y = dataset["Nanostage position"]["Y"][y_start:y_stop]
+    nano_y.plot(start=dataset["Nanostage position"]["Y"].start)
+    plt.tight_layout()
+
+.. image:: show_selection.png
+
+To do active calibration correctly, we will need a slice containing *only* those chunks of data where the nanostage is oscillating.
+We need to de-calibrate the force (since we intend to do the calibration ourselves).
+And finally, we need the bead-to-bead distances.
+We can make a little helper function to extract these::
+
+    def read_calibration_data(h5_file, driving_axis):
+        """Read active calibration data for a single axis
+
+        h5_file : lumicks.pylake.File
+            Opened h5 file with a single active calibration.
+        driving_axis : str
+            Which driving axis to extract data for ("x" or "y")
+        """
+        # Grab our driving data
+        driving_channel = h5_file["Nanostage position"][driving_axis.upper()]
+        start, stop = find_oscillation_timestamp_range(driving_channel)
+
+        # Slice the data we need (data during the oscillation phase)
+        driving_data = driving_channel[start:stop]
+
+        volt_slices = {}
+        for trap in ("1", "2"):
+            force_data = getattr(h5_file, f"force{trap}{driving_axis}")
+            force_data = force_data[start:stop]
+
+            # To recalibrate, we need the signal in volts. If the force was calibrated prior to
+            # acquisition, we need to de-calibrate it first. We use `get` on the calibration
+            # dictionary here so that we can revert to a default of `1`, if the last calibration
+            # does not have a force sensitivity (meaning the signal was already in volts).
+            force_calibration = force_data.calibration[0].get("Rf (pN/V)", 1)
+
+            # We can divide directly on the slice.
+            volt_slices[f"{trap}{driving_axis}"] = force_data / force_calibration
+
+        # Grab the average bead positions
+        b1x = np.mean(h5_file["Bead position"]["Bead 1 X"][start:stop].data)
+        b2x = np.mean(h5_file["Bead position"]["Bead 2 X"][start:stop].data)
+        b1y = np.mean(h5_file["Bead position"]["Bead 1 Y"][start:stop].data)
+        b2y = np.mean(h5_file["Bead position"]["Bead 2 Y"][start:stop].data)
+
+        return b2x - b1x, b2y - b1y, driving_data, volt_slices
+
+
+    # Test our experiment reading function by looking at the first second of data
+    dx, dy, stage, volts = read_calibration_data(dataset, driving_axis="x")
+
+    plt.figure()
+    plt.subplot(2, 1, 1)
+    stage.plot()
+    plt.xlim([0, 1])
+    plt.subplot(2, 1, 2)
+    volts["1x"].plot()
+    volts["2x"].plot()
+    plt.xlim([0, 1])
+    plt.tight_layout()
+
+.. image:: show_sliced.png
+
+Performing the calibrations
+---------------------------
+
+We define a calibration helper function to make our code more succinct::
+
+    def calibrate(psd, nano=None, *, bead_diameter, temperature, excluded_ranges):
+        """Perform passive or active calibration
+
+        Parameters
+        ----------
+        psd : Slice
+            Slice of raw voltage data from the force detector
+        nano : Slice, optional
+            Slice of nanostage data. When omitted, passive calibration is performed.
+        bead_diameter : float
+            Bead diameter in microns
+        temperature : float
+            Calibration temperature
+        excluded_ranges : list
+            List of exclusion ranges
+        """
+        return lk.calibrate_force(
+            force_voltage_data=psd.data,
+            sample_rate=psd.sample_rate,
+            bead_diameter=bead_diameter,
+            temperature=temperature,
+            driving_data=nano.data if nano else None,
+            driving_frequency_guess=17,  # This is the default driving frequency in Bluelake
+            num_points_per_block=350,
+            hydrodynamically_correct=True,  # The hydrodynamically correct provides more accurate calibration
+            active_calibration=True if nano else False,
+            excluded_ranges=excluded_ranges,
+        )
+
+Most systems have a few exclusion ranges defined to reject narrow noise peaks.
+These are system-specific ranges that are not used in the fitting procedure when calibrating.
+You can find these in any calibration item obtained from Bluelake (listed as `Exclusion range ## (min.) (Hz)` and `Exclusion range ## (max.) (Hz)` for each range).
+For this system, we'll define them here::
+
+    excluded_ranges = {
+        "1x": [[12, 22], [205, 265]],
+        "1y": [[12, 22]],
+        "2x": [[12, 22], [205, 265]],
+        "2y": [[12, 22], [19505, 19565]],
+    }
+
+Let's do a passive and active calibration now.
+We can plot the thermal part of the fit by calling `.plot()` on the calibration result::
+
+    dx, dy, stage, volts = read_calibration_data(dataset, driving_axis="x")
+    passive = calibrate(
+        volts["1x"], bead_diameter=2.1, temperature=26.6, excluded_ranges=excluded_ranges["1x"]
+    )
+    active = calibrate(
+        volts["1x"], stage, bead_diameter=2.1, temperature=26.6, excluded_ranges=excluded_ranges["1x"]
+    )
+
+    passive.plot()
+    active.plot()
+
+.. image:: spectra.png
+
+Note that the spectral fit is exactly the same for passive and active calibration.
+In active calibration, the peak resulting from the sinusoidal stage motion is used to directly calibrate the displacement sensitivity.
+As a result, active calibration does not rely on an estimate of the diffusion constant to perform the displacement sensitivity calibration, thereby reducing its reliance on assumed parameters such as viscosity, bead radius and temperature.
+
+We can see this by changing the temperature in our calibration procedure.
+The result for passive calibration changes a lot, while the result for active calibration changes very little.
+The reason for this is that active calibration does not rely on the viscosity estimate as much (which depends strongly on temperature)::
+
+    # Put some of the parameters that will be the same in a dictionary so we don't have to repeat them.
+    shared_pars = {"bead_diameter": 2.1, "excluded_ranges": excluded_ranges["1x"]}
+
+    print("Passive")
+    print(calibrate(volts["1x"], temperature=25, **shared_pars)["kappa"])
+    print(calibrate(volts["1x"], temperature=30, **shared_pars)["kappa"])
+    print("Active")
+    print(calibrate(volts["1x"], stage, temperature=25, **shared_pars)["kappa"])
+    print(calibrate(volts["1x"], stage, temperature=30, **shared_pars)["kappa"])
+
+Analyzing the coupling dataset
+------------------------------
+
+Next, we define a function that calibrates all axes with both passive and active calibration for a dataset::
+
+    def calculate_calibrations(h5_file, bead_diameter, temperature):
+        passive = {}
+        active = {}
+
+        for axis in ("x", "y"):
+            dx, dy, stage, volts = read_calibration_data(h5_file, driving_axis=axis)
+            for trap in ("1", "2"):
+                shared_parameters = {
+                    "bead_diameter": bead_diameter,
+                    "temperature": temperature,
+                    "excluded_ranges": excluded_ranges[f"{trap}{axis}"],
+                }
+
+                passive[f"{trap}{axis}"] = calibrate(
+                    volts[f"{trap}{axis}"],
+                    **shared_parameters,  # This unpacks the dictionary into keyword arguments
+                )
+
+                active[f"{trap}{axis}"] = calibrate(
+                    volts[f"{trap}{axis}"],
+                    stage,
+                    **shared_parameters,  # This unpacks the dictionary into keyword arguments
+                )
+
+        return {"dx": dx, "dy": dy, "passive": passive, "active": active}
+
+`calculate_calibrations` now returns the distances between the beads and all the calibration factors obtained with passive and active calibration.
+
+    >>> calculate_calibrations(lk.File(calibration_data[0][0]), bead_diameter=2.1, temperature=25)
+    {'dx': 22.107661709308474,
+     'dy': -0.07111526715106109,
+     'passive': {'1x': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d024aaa0>,
+      '2x': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d06df130>,
+      '1y': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d0297010>,
+      '2y': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d04992d0>},
+     'active': {'1x': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d056fe80>,
+      '2x': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d053b370>,
+      '1y': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d04992a0>,
+      '2y': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d049cfd0>}}
+
+Let's calculate calibration factors for all the data in this dataset.
+Note that this cell may take a while to execute as it is performing `240` calibrations::
+
+    # Determine the force calibration factors for all the bead pairs in the dataset.
+    experiment = []
+    for bead_pair_files in calibration_data:
+        # Determine results for a single bead pair
+        bead_pair_results = []
+        for calibration_file in tqdm(bead_pair_files):  # tqdm shows a progress bar
+            file = lk.File(calibration_file)
+            calibration = calculate_calibrations(file, bead_diameter=2.1, temperature=26.6)
+            bead_pair_results.append(calibration)
+
+        experiment.append(bead_pair_results)
+
+Now that we have those results, let's define some functions to conveniently extract the calibration parameters::
+
+    def extract_parameter(calibrations, calibration_type, axis, parameter):
+        """Extract particular parameter for a particular experiment
+
+        Parameters
+        ----------
+        calibrations : dict
+            Dictionary of calibration results
+        calibration_type : "active" or "passive"
+            Calibration type
+        axis : str
+            Calibration axis (e.g. "1x")
+        parameter : str
+            Which parameter to extract (e.g. "kappa")
+        """
+        values = [cal[calibration_type][axis][parameter].value for cal in calibrations]
+        return np.array(values)
+
+
+    def extract_distances(calibrations):
+        """Extract bead distances"""
+        return (np.array(s) for s in zip(*[(cal["dx"], cal["dy"]) for cal in calibrations]))
+
+We can now show the effect of coupling on active calibration in practice using the analyzed data::
+
+    parameters = {
+        "Rd": "Displacement sensitivity [$\mu$m/V]",
+        "Rf": "Force sensitivity [pN/V]",
+        "kappa": "Stiffness [pN/nm]",
+    }
+
+    plt.figure(figsize=(10, 3))
+    for ix, (param, param_description) in enumerate(parameters.items()):
+        plt.subplot(1, 3, ix + 1)
+        dx, dy = extract_distances(experiment[0])
+        plt.plot(dx, extract_parameter(experiment[0], "active", "2x", param), ".", label="active")
+        plt.plot(dx, extract_parameter(experiment[0], "passive", "2x", param), "x", label="passive")
+        plt.xlabel("Bead-Bead Distance [$\mu$m]")
+        plt.ylabel(param_description)
+
+    plt.tight_layout()
+    plt.legend()
+
+.. image:: coupling_effect.png
+
+Note how the active calibration result strongly depends on the distance between the bead centers.
+This is due to the reduced flow due to the presence of a second bead.
+Pylake contains a model that calculates a correction factor that can be used to correct for this.
+The correction factor can be obtained using :func:`~lumicks.pylake.coupling_correction_2d()` and applied as follows:
+
+.. math::
+
+    \begin{align}
+        R_{d, corrected} &= c R_d\\
+        R_{f, corrected} &= \frac{R_f}{c}\\
+        \kappa_{corrected} &= \frac{\kappa}{c^2}
+    \end{align}
+
+For more information on this, please refer to the :ref:`theory<bead_bead_theory>` or :ref:`tutorial<bead_bead_tutorial>`.
+To show how well this model fits the data, we can plot it alongside the ratio of active to passive calibration::
+
+    for exp in experiment:
+        plt.figure(figsize=(10, 6))
+        dx, dy = extract_distances(exp)
+
+        for trap in (1, 2):
+            for ix, axis in enumerate(("x", "y")):
+                plt.subplot(2, 3, 1 + 3 * ix)
+
+                # Note that y-oscillations have a different coupling correction than x-oscillations!
+                bead_diameter = 2.1
+                dx_c = np.arange(3, 25, 0.1)
+                c = lk.coupling_correction_2d(
+                    dx_c,
+                    np.zeros(dx_c.shape),
+                    bead_diameter=bead_diameter,
+                    is_y_oscillation=True if axis == "y" else False,
+                )
+
+                ac = extract_parameter(exp, "active", f"{trap}{axis}", "Rd")
+                pc = extract_parameter(exp, "passive", f"{trap}{axis}", "Rd")
+                plt.plot(dx, ac / pc, f"C{trap}.")
+                plt.plot(dx_c, 1 / c, "k--")
+                plt.axvline(bead_diameter, color="lightgray", linestyle="--")
+                plt.xlabel("Bead-Bead Distance [$\mu$m]")
+                plt.ylabel("$R_{d, ac} / R_{d, passive}$")
+                plt.title(f"Displacement sensitivity ratio {axis} AC/PC")
+
+                plt.subplot(2, 3, 2 + 3 * ix)
+                ac = extract_parameter(exp, "active", f"{trap}{axis}", "Rf")
+                pc = extract_parameter(exp, "passive", f"{trap}{axis}", "Rf")
+                plt.plot(dx, ac / pc, f"C{trap}.")
+                plt.plot(dx_c, c, "k--")
+                plt.axvline(bead_diameter, color="lightgray", linestyle="--")
+                plt.xlabel("Bead-Bead Distance [$\mu$m]")
+                plt.ylabel("$R_{f, ac} / R_{f, passive}$")
+                plt.title(f"Force sensitivity ratio {axis} AC/PC")
+
+                plt.subplot(2, 3, 3 + 3 * ix)
+                ac = extract_parameter(exp, "active", f"{trap}{axis}", "kappa")
+                pc = extract_parameter(exp, "passive", f"{trap}{axis}", "kappa")
+                plt.plot(dx, ac / pc, f"C{trap}.", label=f"{trap}{axis}")
+                plt.plot(dx_c, c**2, "k--")
+                plt.axvline(bead_diameter, color="lightgray", linestyle="--")
+                plt.xlabel("Bead-Bead Distance [$\mu$m]")
+                plt.ylabel("$\kappa_{ac} / \kappa_{passive}$")
+                plt.title(f"Stiffness sensitivity ratio {axis} AC/PC")
+
+                plt.tight_layout()
+                plt.legend()
+
+.. image:: dataset_0.png
+.. image:: dataset_1.png
+.. image:: dataset_2.png
+.. image:: dataset_3.png
+.. image:: dataset_4.png
+.. image:: dataset_5.png
+
+Applying the correction for coupling, we can see that the ratio between active and passive is almost constant.
+
+Some remaining variability is expected as the bead radius (which is subject to variability) and temperature (which isn't known exactly) impact passive stronger than active::
+
+    for exp in experiment:
+        dx, dy = extract_distances(exp)
+        plt.figure(figsize=(10, 6))
+
+        for trap in (1, 2):
+            for ix, axis in enumerate(("x", "y")):
+                plt.subplot(2, 3, 1 + 3 * ix)
+
+                # Note that y-oscillations have a different coupling correction than x-oscillations!
+                bead_diameter = 2.1
+                c = lk.coupling_correction_2d(
+                    dx, dy, bead_diameter=bead_diameter, is_y_oscillation=True if axis == "y" else False
+                )
+
+                ac = extract_parameter(exp, "active", f"{trap}{axis}", "Rd")
+                pc = extract_parameter(exp, "passive", f"{trap}{axis}", "Rd")
+                plt.plot(dx, ac * c / pc, f"C{trap}.")
+                plt.axvline(bead_diameter, color="lightgray", linestyle="--")
+                plt.xlabel("Bead-Bead Distance [$\mu$m]")
+                plt.ylabel("$R_{d, ac} / R_{d, passive}$")
+                plt.title(f"Displacement sensitivity ratio {axis} AC/PC")
+
+                plt.subplot(2, 3, 2 + 3 * ix)
+                ac = extract_parameter(exp, "active", f"{trap}{axis}", "Rf")
+                pc = extract_parameter(exp, "passive", f"{trap}{axis}", "Rf")
+                plt.plot(dx, ac / c / pc, f"C{trap}.")
+                plt.axvline(bead_diameter, color="lightgray", linestyle="--")
+                plt.xlabel("Bead-Bead Distance [$\mu$m]")
+                plt.ylabel("$R_{f, ac} / R_{f, passive}$")
+                plt.title(f"Force sensitivity ratio {axis} AC/PC")
+
+                plt.subplot(2, 3, 3 + 3 * ix)
+                ac = extract_parameter(exp, "active", f"{trap}{axis}", "kappa")
+                pc = extract_parameter(exp, "passive", f"{trap}{axis}", "kappa")
+                plt.plot(dx, ac / c**2 / pc, f"C{trap}.", label=f"{trap}{axis}")
+                plt.axvline(bead_diameter, color="lightgray", linestyle="--")
+                plt.xlabel("Bead-Bead Distance [$\mu$m]")
+                plt.ylabel("$\kappa_{ac} / \kappa_{passive}$")
+                plt.title(f"Stiffness sensitivity ratio {axis} AC/PC")
+
+                plt.tight_layout()
+
+.. image:: corrected_dataset_0.png
+.. image:: corrected_dataset_1.png
+.. image:: corrected_dataset_2.png
+.. image:: corrected_dataset_3.png
+.. image:: corrected_dataset_4.png
+.. image:: corrected_dataset_5.png

--- a/docs/examples/bead_coupling/coupling_effect.png
+++ b/docs/examples/bead_coupling/coupling_effect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d14a49f7fee4e5f1740cf98991ed777632d0bb85400735fc8bce35d5d9d868b3
+size 85002

--- a/docs/examples/bead_coupling/coupling_overview.png
+++ b/docs/examples/bead_coupling/coupling_overview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a57978b39aad803b60ca3b778826e3df26239f6e54ea2acdef81be712bf1d1
+size 315034

--- a/docs/examples/bead_coupling/dataset_0.png
+++ b/docs/examples/bead_coupling/dataset_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:beb23c2d882081f13fef5102afe2f9406f841ae8577df8b25f9be86754873d76
+size 209726

--- a/docs/examples/bead_coupling/dataset_1.png
+++ b/docs/examples/bead_coupling/dataset_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0a8773f07680397f7fe34250c4caca3acb18d031662c8c12197c35c22bf0776
+size 208547

--- a/docs/examples/bead_coupling/dataset_2.png
+++ b/docs/examples/bead_coupling/dataset_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bf48bf4076301670af97fa65c396867493c3d21d3581dd82e13cff505cac4b1
+size 208602

--- a/docs/examples/bead_coupling/dataset_3.png
+++ b/docs/examples/bead_coupling/dataset_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af9371832f87f5697d924bcea3fa2592e536d6a0d46b85b78dcd3f92de2f521e
+size 207157

--- a/docs/examples/bead_coupling/dataset_4.png
+++ b/docs/examples/bead_coupling/dataset_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6221e93b93e023b7587b0f68c9f057dfe6c276e13ea222e0974b6cbf511d2e28
+size 208034

--- a/docs/examples/bead_coupling/dataset_5.png
+++ b/docs/examples/bead_coupling/dataset_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:213c6289e933103d2376b9867d6a28da87985c5617e9a4ef1823709e00a934fc
+size 205683

--- a/docs/examples/bead_coupling/show_dataset.png
+++ b/docs/examples/bead_coupling/show_dataset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56816d121aef75543c051eb28c739d2460112f6f4c545020a3093ceb01b7edce
+size 117215

--- a/docs/examples/bead_coupling/show_selection.png
+++ b/docs/examples/bead_coupling/show_selection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3a3c1cdb2570e7f697aee98fd6be442086806d43c39c5992904691cf7340fc3
+size 69664

--- a/docs/examples/bead_coupling/show_sliced.png
+++ b/docs/examples/bead_coupling/show_sliced.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81ac6375be8eae6288feba7b81d7d681b5da912dd8029c591ed826a52f87e7e8
+size 141229

--- a/docs/examples/bead_coupling/spectra.png
+++ b/docs/examples/bead_coupling/spectra.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1873589738768b726477b530ea94124839cc6cc1223a41979a23c30f2cfa7291
+size 76516

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -21,3 +21,4 @@ For all of the examples, it is assumed that the following lines precede any othe
     reca_fitting/reca_fitting
     cas9_kymotracking/cas9_kymotracking
     hairpin_fitting/hairpin_unfolding
+    bead_coupling/coupling

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -456,3 +456,47 @@ publisher = {Biophysical Society}
   year={1989},
   publisher={IEEE}
 }
+
+@article{stimson1926motion,
+  title={The motion of two spheres in a viscous fluid},
+  author={Stimson, Margaret and Jeffery, George Barker},
+  journal={Proceedings of the Royal Society of London. Series A, Containing Papers of a Mathematical and Physical Character},
+  volume={111},
+  number={757},
+  pages={110--116},
+  year={1926},
+  publisher={The Royal Society London}
+}
+
+@article{goldman1966slow,
+  title={The slow motion of two identical arbitrarily oriented spheres through a viscous fluid},
+  author={Goldman, AJ and Cox, RG and Brenner, H},
+  journal={Chemical Engineering Science},
+  volume={21},
+  number={12},
+  pages={1151--1170},
+  year={1966},
+  publisher={Elsevier}
+}
+
+@misc{the_fenics_project_developers_2023_10432590,
+  author={The FEniCS Project Developers},
+  title={FEniCS/dolfinx: v0.7.3},
+  month={dec},
+  year={2023},
+  publisher={Zenodo},
+  version={v0.7.3},
+  doi={10.5281/zenodo.10432590},
+  url={https://doi.org/10.5281/zenodo.10432590}
+}
+
+@article{alinezhad2018enhancement,
+  title={Enhancement of axial force of optical tweezers by utilizing a circular stop at the back focal plane of the objective},
+  author={Alinezhad, Hossein Gorjizadeh and Meydanloo, Sajad and Reihani, S Nader S},
+  journal={JOSA B},
+  volume={35},
+  number={11},
+  pages={2654--2660},
+  year={2018},
+  publisher={Optica Publishing Group}
+}

--- a/docs/theory/force_calibration/active.rst
+++ b/docs/theory/force_calibration/active.rst
@@ -92,6 +92,8 @@ We can also include a distance to the surface like before. This results in an ex
 coefficient :math:`\gamma` that depends on the distance to the surface which is given by the same
 equations as listed in the section on the :doc:`hydrodynamically correct model<hyco>`.
 
+.. _bead_bead_theory:
+
 Bead-bead coupling
 ------------------
 

--- a/docs/theory/force_calibration/active.rst
+++ b/docs/theory/force_calibration/active.rst
@@ -95,7 +95,7 @@ equations as listed in the section on the :doc:`hydrodynamically correct model<h
 .. _bead_bead_theory:
 
 Bead-bead coupling
-------------------
+^^^^^^^^^^^^^^^^^^
 
 .. warning::
 
@@ -147,7 +147,7 @@ Filling in the maximal velocity we expect during the oscillation, we find the fo
 Here :math:`\rho` refers to the fluid density, :math:`u` the characteristic velocity, :math:`L` the characteristic length scale, :math:`\eta` the viscosity, :math:`f` the oscillation frequency, :math:`A` the oscillation amplitude and :math:`d` the bead diameter.
 For microfluidic flow, this value is typically much smaller than `1`.
 
-In this limit, the Navier-Stokes equation reduces to the following expressions:
+In this limit, the Navier-Stokes equation describing fluid flow reduces to the following expressions:
 
 .. math::
 

--- a/docs/theory/force_calibration/figures/correction_factor.png
+++ b/docs/theory/force_calibration/figures/correction_factor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2535150d4f46705200ebb2175d912f11e35b9dac0e70a3a8c93353d7eab39c1b
+size 99635

--- a/docs/theory/force_calibration/figures/errors.png
+++ b/docs/theory/force_calibration/figures/errors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c377fcf51c8eb0af99f3f2c5761b9c917fde4d0cd86983af769c92013f61545f
+size 310474

--- a/docs/theory/force_calibration/figures/streamlines.png
+++ b/docs/theory/force_calibration/figures/streamlines.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b953f15befc820933d650ab964af496a8c786ecf18c98be12e664bb3449d6a54
+size 253080

--- a/docs/theory/force_calibration/figures/temperature_dependence.png
+++ b/docs/theory/force_calibration/figures/temperature_dependence.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16c919dbd78567d8129cb22a9d6b98915b36888f5f20fbe0240b8f781a03bcf1
+size 252340

--- a/docs/theory/force_calibration/passive.rst
+++ b/docs/theory/force_calibration/passive.rst
@@ -60,6 +60,61 @@ drag coefficient of a sphere and is given by:
 
 .. math::
 
-    \gamma_0 = 3 \pi \eta d \tag{$\mathrm{kg/s}$}
+    \gamma_0 = 3 \pi \eta(T) d \tag{$\mathrm{kg/s}$}
 
-where :math:`\eta` corresponds to the dynamic viscosity [Pa*s] and :math:`d` is the bead diameter [m].
+where :math:`\eta(T)` corresponds to the dynamic viscosity [Pa*s] and :math:`d` is the bead diameter [m].
+
+.. _temperature_theory:
+
+The effect of temperature
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As we can see above, temperature enters the calibration procedure both directly, as well as through the medium viscosity.
+It is especially the latter that results in large calibration errors when mis-specified.
+
+.. math::
+
+    \begin{align}
+    \kappa = 2 \pi \gamma(T) f_c &\propto& \eta(T)\\
+    R_d = \sqrt{\frac{kT}{\gamma(T)D_{volts}}} &\propto& \sqrt{T / \eta(T)}\\
+    R_f = R_d \kappa &\propto& \sqrt{T \eta(T)}
+    \end{align}
+
+Mis-specification can lead to errors in calibration. To get a feeling for the magnitude of these errors, we can plot them::
+
+    plt.figure(figsize=(12, 3))
+    temps = np.arange(20, 35)
+    viscosity_25 = lk.viscosity_of_water(25)
+    plt.subplot(1, 4, 1)
+    plt.plot(temps, 1000 * lk.viscosity_of_water(temps))
+    plt.xlabel("Temperature ($^o$C)")
+    plt.ylabel("Viscosity of water (mPa*s)")
+
+    plt.subplot(1, 4, 2)
+    viscosities = lk.viscosity_of_water(temps)
+    kappa_err = 100 * (viscosity_25 / viscosities - 1)
+    plt.plot(temps, kappa_err)
+    plt.xlabel("Actual Temperature ($^o$C)")
+    plt.ylabel("Stiffness error (%)")
+    plt.axvline(25, linestyle="--", color="k")
+    plt.tight_layout()
+
+    plt.subplot(1, 4, 3)
+    rd_err = 100 * (np.sqrt((25 + 273.15) / viscosity_25) / np.sqrt((temps + 273.15) / viscosities) - 1)
+    plt.plot(temps, rd_err)
+    plt.xlabel("Actual Temperature ($^o$C)")
+    plt.ylabel("Displacement error (%)")
+    plt.axvline(25, linestyle="--", color="k")
+    plt.tight_layout()
+
+    plt.subplot(1, 4, 4)
+    rf_err = 100 * (np.sqrt((25 + 273.15) * viscosity_25) / np.sqrt((temps + 273.15) * viscosities) - 1)
+    plt.plot(temps, rf_err)
+    plt.xlabel("Actual Temperature ($^o$C)")
+    plt.ylabel("Force sensitivity error (%)")
+    plt.axvline(25, linestyle="--", color="k", label="Assumed temperature")
+    plt.suptitle("Effect of mis-specifying temperature")
+    plt.tight_layout()
+    plt.legend()
+
+.. image:: figures/temperature_dependence.png

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -400,6 +400,8 @@ However, if we do not provide the height above the surface, we can see that the 
     Consequently, when this model is selected, this parameter affects both passive and active calibration.
     For more information on this see the :doc:`theory section on force calibration</theory/force_calibration/force_calibration>` section.
 
+.. _bead_bead_tutorial:
+
 Active calibration with two beads far away from the surface
 -----------------------------------------------------------
 

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -263,8 +263,8 @@ Axial force calibration can be performed by specifying `axial=True`::
 
     force_model = lk.PassiveCalibrationModel(bead_diameter, distance_to_surface=5, axial=True)
 
-Active calibration
-------------------
+Active calibration with a single bead
+-------------------------------------
 
 Active calibration has a few benefits.
 When performing passive calibration, we base our calculations on a theoretical drag coefficient which depends on parameters that are only known with limited precision:
@@ -399,6 +399,49 @@ However, if we do not provide the height above the surface, we can see that the 
     When fitting with the hydrodynamically correct model, the `distance_to_surface` parameter impacts the expected shape of the power spectrum.
     Consequently, when this model is selected, this parameter affects both passive and active calibration.
     For more information on this see the :doc:`theory section on force calibration</theory/force_calibration/force_calibration>` section.
+
+Active calibration with two beads far away from the surface
+-----------------------------------------------------------
+
+.. warning::
+
+    The implementation of the coupling correction models is still alpha functionality.
+    While usable, this has not yet been tested in a large number of different scenarios.
+    The API can still be subject to change *without any prior deprecation notice*!
+    If you use this functionality keep a close eye on the changelog for any changes that may affect your analysis.
+
+When performing active calibration, we get a smaller fluid velocity around the beads than expected when calibrating with two beads in a dual trap configuration.
+This leads to a smaller voltage readout than expected if there's no coupling and therefore a higher displacement sensitivity (microns per volt).
+Failing to take this into account results in a bias.
+Pylake offers a function to calculate a correction factor to account for the lower velocity around the bead.
+Appropriate coupling correction factors for oscillation in x can be calculated as follows::
+
+    factor = lk.coupling_correction_2d(dx=5.0, dy=0, bead_diameter=bead_diameter, is_y_oscillation=False)
+
+Here `dx` and `dy` represent the horizontal and vertical distance between the beads, while the parameter `bead_diameter` refers to the bead diameter.
+Note that all three parameters have to be specified in the same spatial unit (meters or micron).
+The final parameter `is_y_oscillation` indicates whether the stage was oscillated in the y-direction.
+
+The obtained correction factor can be used to correct the calibration factors::
+
+    Rd_corrected = factor * calibration["Rd"].value
+    Rf_corrected = calibration["Rf"].value / factor
+    stiffness_corrected = calibration["kappa"].value / factor**2
+
+To correct a force trace, simply divide it by the correction factor::
+
+    corrected_force1x = f.force1x / factor
+
+.. note::
+
+    This coupling model neglects effects from the surface. It is intended for measurements performed at the center of the flowcell.
+
+.. note::
+
+    The model implemented here only supports beads that are aligned in the same plane.
+    It does not take a mismatch in the `z`-position of the beads into account.
+    In reality, the position in the focus depends on the bead radius and may be different for the two beads if they slightly differ in size :cite:`alinezhad2018enhancement` (Fig. 3).
+    At short bead-to-bead distances, such a mismatch would make the coupling less pronounced than the model predicts.
 
 Fast Sensors
 ------------

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -159,10 +159,10 @@ In literature, passive calibration is often referred to as thermal calibration.
 It involves fitting a physical model to the power spectrum obtained in the previous step.
 This physical model relies on a number of parameters that have to be specified in order to get the correct calibration factors.
 
-The most important of these is the bead diameter (in microns).
+The most important parameters are the bead diameter (in microns) and viscosity.
 Let's use the bead diameter found in the calibration performed in Bluelake.
 
-You can optionally also provide a viscosity (in Pa/s) and temperature (in degrees Celsius).
+Note that the viscosity of water strongly depends on :ref:`temperature<temperature_theory>`.
 To find the viscosity of water at a particular temperature, Pylake uses :func:`~lumicks.pylake.viscosity_of_water` which implements the model presented in :cite:`huber2009new`.
 When omitted, this function will automatically be used to look up the viscosity of water for that particular temperature
 
@@ -412,15 +412,21 @@ Active calibration with two beads far away from the surface
     The API can still be subject to change *without any prior deprecation notice*!
     If you use this functionality keep a close eye on the changelog for any changes that may affect your analysis.
 
-When performing active calibration, we get a smaller fluid velocity around the beads than expected when calibrating with two beads in a dual trap configuration.
-This leads to a smaller voltage readout than expected if there's no coupling and therefore a higher displacement sensitivity (microns per volt).
+When performing active calibration with two beads, we get a lower fluid velocity around the beads than we would with a single bead.
+This leads to a smaller voltage readout than expected and therefore a higher displacement sensitivity (microns per volt).
 Failing to take this into account results in a bias.
 Pylake offers a function to calculate a correction factor to account for the lower velocity around the bead.
-Appropriate coupling correction factors for oscillation in x can be calculated as follows::
+
+.. note::
+
+    For more information on how these factors are derived, please refer to the :ref:`theory<bead_bead_theory>` section on this topic.
+
+Appropriate correction factors for oscillation in x can be calculated as follows::
 
     factor = lk.coupling_correction_2d(dx=5.0, dy=0, bead_diameter=bead_diameter, is_y_oscillation=False)
 
-Here `dx` and `dy` represent the horizontal and vertical distance between the beads, while the parameter `bead_diameter` refers to the bead diameter.
+Here `dx` and `dy` represent the horizontal and vertical distance between the beads.
+Note that these refer to *center to center distances* (unlike the distance channel in Bluelake, which represents the bead surface to surface distance).
 Note that all three parameters have to be specified in the same spatial unit (meters or micron).
 The final parameter `is_y_oscillation` indicates whether the stage was oscillated in the y-direction.
 

--- a/docs/whatsnew/1.6.0/1_6_0.rst
+++ b/docs/whatsnew/1.6.0/1_6_0.rst
@@ -1,0 +1,15 @@
+Pylake 1.6.0
+============
+
+.. only:: html
+
+Here is a sneak preview of features that will likely be in Pylake `v1.6.0`.
+
+Bead-bead coupling correction
+-----------------------------
+
+.. figure:: correction_factor_whatsnew.png
+
+When performing active calibration with two beads coupling effects can bias the estimated calibration parameters (force and displacement sensitivity, and the stiffness).
+In Pylake 1.6.0, we include a model to account for bead-bead coupling between two beads in bulk.
+See :ref:`theory<bead_bead_theory>` and :ref:`tutorial<bead_bead_tutorial>` for more information.

--- a/docs/whatsnew/1.6.0/1_6_0.rst
+++ b/docs/whatsnew/1.6.0/1_6_0.rst
@@ -12,4 +12,4 @@ Bead-bead coupling correction
 
 When performing active calibration with two beads coupling effects can bias the estimated calibration parameters (force and displacement sensitivity, and the stiffness).
 In Pylake 1.6.0, we include a model to account for bead-bead coupling between two beads in bulk.
-See :ref:`theory<bead_bead_theory>` and :ref:`tutorial<bead_bead_tutorial>` for more information.
+See :ref:`theory<bead_bead_theory>` and :ref:`tutorial<bead_bead_tutorial>` and the :doc:`example</examples/bead_coupling/coupling>` for more information.

--- a/docs/whatsnew/1.6.0/correction_factor_whatsnew.png
+++ b/docs/whatsnew/1.6.0/correction_factor_whatsnew.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edc24cda45dfb43666c66d8fe657793c159005e772d1877d8349341b46b2b40e
+size 315043

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -8,6 +8,7 @@ For a full list of new features and changes, please refer to the :doc:`changelog
     :caption: Contents
     :maxdepth: 1
 
+    1.6.0/1_6_0
     1.5.0/1_5_0
     1.4.0/1_4_0
     1.3.0/1_3_0

--- a/docs/zrefs.rst
+++ b/docs/zrefs.rst
@@ -4,7 +4,9 @@ information on these topics.
 Force Calibration
 -----------------
 
-The passive force calibration method was based on a number of publications by the Flyvbjerg group :cite:`berg2004power,tolic2004matlab,hansen2006tweezercalib,berg2006power`.
+The passive force calibration method was based on a number of publications by the Flyvbjerg group :cite:`berg2004power,tolic2004matlab,hansen2006tweezercalib,berg2003unintended,berg2006power,norrelykke2010power`.
+Corrections for the drag coefficient of lateral and axial force when approaching the surface were based on :cite:`schaffer2007surface,brenner1961slow`.
+The active calibration method was based on :cite:`tolic2006calibration`. The corrections for dual trap calibration were based on work presented in :cite:`stimson1926motion,goldman1966slow` and numerically compared to simulations using the software :cite:`the_fenics_project_developers_2023_10432590`.
 
 F,d Fitting
 -----------
@@ -35,6 +37,7 @@ Diffusion constant estimation
 
 The unweighted ordinary least squares estimation method (including the optimal number of lag computation) is implemented from :cite:`michalet2012optimal`.
 The generalized least squares method was based on :cite:`bullerjahn2020optimal`
+The CVE method is based on :cite:`vestergaard2014optimal,vestergaard2015estimation,vestergaard2016optimizing`.
 
 References
 ----------

--- a/lumicks/pylake/__init__.py
+++ b/lumicks/pylake/__init__.py
@@ -32,6 +32,7 @@ from .force_calibration.calibration_models import (
     PassiveCalibrationModel,
     density_of_water,
     viscosity_of_water,
+    coupling_correction_2d,
 )
 from .force_calibration.power_spectrum_calibration import (
     fit_power_spectrum,

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -5,7 +5,12 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from .detail.drag_models import faxen_factor, brenner_axial
+from .detail.drag_models import (
+    faxen_factor,
+    brenner_axial,
+    coupling_correction_factor_stimson,
+    coupling_correction_factor_goldmann,
+)
 from .detail.salty_water import (
     _poly,
     pressure_factor,
@@ -173,6 +178,67 @@ def viscosity_of_water(temperature, molarity_nacl=None, pressure=None):
         ai = np.array([280.68, 511.45, 61.131, 0.45903])
         bi = np.array([-1.9, -7.7, -19.6, -40.0])
         return _poly((temperature + 273.15) / 300, bi, ai) * 1e-6
+
+
+def coupling_correction_2d(dx, dy, bead_diameter, is_y_oscillation=False, allow_rotation=True):
+    """Calculates the coupling correction factor for a 2D problem.
+
+    This function rotates the coordinate system and decomposes the fluid velocity into a component
+    perpendicular and aligned with the bead-to-bead axis. For the aligned component, we use the
+    model presented in [1]_ to determine a correction factor, while for the perpendicular axis
+    we use the model presented in [2]_, [3]_ and [4]_.
+
+    Parameters
+    ----------
+    dx, dy: array_like or float
+        X and Y distances from bead 1 to bead 2 [um].
+    bead_diameter : float
+        Bead diameter [um].
+    is_y_oscillation : bool
+        Is this a vertical oscillation?
+    allow_rotation : float
+        Provide the solution for when spheres are allowed to rotate
+
+    References
+    ----------
+    .. [1] Stimson, M., & Jeffery, G. B. (1926). The motion of two spheres in a viscous fluid.
+           Proceedings of the Royal Society of London. Series A, Containing Papers of a Mathematical
+           and Physical Character, 111(757), 110-116 (2007).
+    .. [2] Happel, J., & Brenner, H. (1983). Low Reynolds number hydrodynamics: with special
+           applications to particulate media (Vol. 1). Springer Science & Business Media.
+    .. [3] Wakiya, S. (1967). Slow motions of a viscous fluid around two spheres. Journal of the
+           Physical Society of Japan, 22(4), 1101-1109.
+    .. [4] Goldman, A. J., Cox, R. G., & Brenner, H. (1966). The slow motion of two identical
+           arbitrarily oriented spheres through a viscous fluid. Chemical Engineering Science,
+           21(12), 1151-1170.
+    """
+    dx, dy = (np.atleast_1d(arr) for arr in (dx, dy))
+    radius = bead_diameter / 2
+    distances = np.sqrt(dx**2 + dy**2)
+
+    e_osc = np.array([0, 1]) if is_y_oscillation else np.array([1, 0])
+
+    # Calculate coupling factors for on and off-axis oscillation
+    coupling_factor_aligned = np.asarray(
+        [coupling_correction_factor_stimson(radius, radius, dist)[0] for dist in distances]
+    )
+    coupling_factor_perpendicular = np.asarray(
+        [coupling_correction_factor_goldmann(radius, dist, allow_rotation) for dist in distances]
+    )
+
+    # Unit vectors defining the principal oscillation axes
+    dir_aligned = np.vstack([dx, dy]) / distances
+    dir_perp = np.vstack([dy, -dx]) / distances
+
+    # Get velocity in axes relative to the bead's principal oscillation axes
+    # and calculate the velocity in those directions
+    v_aligned = np.dot(dir_aligned.T, e_osc) * coupling_factor_aligned
+    v_perp = np.dot(dir_perp.T, e_osc) * coupling_factor_perpendicular
+
+    # Project back to regular axis
+    v_factor = v_aligned * np.dot(dir_aligned.T, e_osc) + v_perp * np.dot(dir_perp.T, e_osc)
+
+    return v_factor.squeeze()
 
 
 @dataclass

--- a/lumicks/pylake/force_calibration/detail/drag_models.py
+++ b/lumicks/pylake/force_calibration/detail/drag_models.py
@@ -299,11 +299,21 @@ def coupling_correction_factor_stimson(
 
     for n in np.arange(1, max_summands + 1):
         k = calculate_k(n, a)
-        delta = calculate_delta(n, alpha, beta)
-        an = calculate_an(n, k, alpha, beta, delta)
-        bn = calculate_bn(n, k, alpha, beta, delta)
-        cn = calculate_cn(n, k, alpha, beta, delta)
-        dn = calculate_dn(n, k, alpha, beta, delta)
+
+        # When summing for beads that are very close, the sinh and cosh functions can result in overflows for the
+        # delta constant, which forms denominator of an, bn, cn and dn. The limit of those coefficients in that case
+        # is zero, so we can safely silence this error and simply check whether delta is infinite (in which case
+        # we set the coefficients to zero).
+        with np.errstate(over="ignore"):
+            delta = calculate_delta(n, alpha, beta)
+
+        if np.isfinite(delta):
+            an = calculate_an(n, k, alpha, beta, delta)
+            bn = calculate_bn(n, k, alpha, beta, delta)
+            cn = calculate_cn(n, k, alpha, beta, delta)
+            dn = calculate_dn(n, k, alpha, beta, delta)
+        else:
+            an, bn, cn, dn = 0, 0, 0, 0
 
         d_coupling1 = (2 * n + 1) * (an + bn + cn + dn)
         d_coupling2 = (2 * n + 1) * (an - bn + cn - dn)

--- a/lumicks/pylake/force_calibration/detail/drag_models.py
+++ b/lumicks/pylake/force_calibration/detail/drag_models.py
@@ -321,3 +321,58 @@ def coupling_correction_factor_stimson(
         )
 
     return pre_factor * coupling1 / radius1, pre_factor * coupling2 / radius2
+
+
+def coupling_correction_factor_goldmann(radius, distance, allow_rotation=True):
+    r"""Calculates a coupling correction factor for oscillating perpendicular to the
+    center-to-center axes of two beads.
+
+    In the calibration of a dual-trap using active calibration, a bead is excited only by a reduced
+    driving flow field. The reason for this is that the other bead slows the fluid down. This
+    leads to a lower amplitude response than expected (and hence a lower peak power on the PSD).
+    This leads to a higher sensitivity than expected. Using the correction factor :math:`c`
+    calculated from this function, we can correct the displacement sensitivity :math:`R_d`,
+    force sensitivity :math:`R_f`, and stiffness :math:`\kappa` as follows:
+
+    .. math::
+
+        R_{d, corrected} = c R_d
+        R_{f, corrected} = \frac{R_f}{c}
+        \kappa_{corrected} = \frac{\kappa}{c^2}
+
+    Note that this function assumes the beads to be aligned along the axis perpendicular to the
+    axis in which the oscillation is taking place. Both approximation models were obtained from
+    [3]_ but were originally presented in [1]_ (spheres prevented to rotate) and [2]_ (spheres
+    allowed to rotate).
+
+    Parameters
+    ----------
+    radius : float
+        Bead radius
+    distance : float
+        Distance between the bead centers
+    allow_rotation : float
+        Provide the solution for when spheres are allowed to rotate
+
+    References
+    ----------
+    .. [1] Happel, J., & Brenner, H. (1983). Low Reynolds number hydrodynamics: with special
+           applications to particulate media (Vol. 1). Springer Science & Business Media.
+    .. [2] Wakiya, S. (1967). Slow motions of a viscous fluid around two spheres. Journal of the
+           Physical Society of Japan, 22(4), 1101-1109.
+    .. [3] Goldman, A. J., Cox, R. G., & Brenner, H. (1966). The slow motion of two identical
+           arbitrarily oriented spheres through a viscous fluid. Chemical Engineering Science,
+           21(12), 1151-1170.
+    """
+    r_over_d = radius / distance
+
+    if allow_rotation:
+        # Solution for when spheres allowed to rotate. Eqn 5.8 in [3]. Originally from [2].
+        factors = [1, -3 / 4, 9 / 16, -59 / 64, 273 / 256, -1107 / 1024, 1 / (1 + r_over_d)]
+    else:
+        # Solution for when spheres are prevented to rotate. Eqn 3.59 in [3]. Originally from [1].
+        factors = [1, -3 / 4, 9 / 16, -59 / 64, 465 / 256, -15813 / 7168, 2 / (1 + r_over_d)]
+
+    powers = np.arange(len(factors))
+
+    return np.sum(factors * r_over_d**powers)

--- a/lumicks/pylake/force_calibration/tests/test_drag.py
+++ b/lumicks/pylake/force_calibration/tests/test_drag.py
@@ -1,0 +1,116 @@
+import pytest
+
+from lumicks.pylake.force_calibration.detail.drag_models import *
+
+
+@pytest.mark.parametrize(
+    "ref_distance, ref_r1, ref_r2",
+    [
+        [3.0e-6, 0.5e-6, 0.5e-6],
+        [6.0e-6, 0.5e-6, 0.8e-6],
+        [6.0e-6, 0.9e-6, 0.8e-6],
+        [2.0e-6, 1.0e-6, 0.9999e-6],
+    ],
+)
+def test_coordinate_transform(ref_distance, ref_r1, ref_r2):
+    # Validate the transformation
+    a, alpha, beta = to_curvilinear_coordinates(ref_r1, ref_r2, ref_distance)
+    d1 = a * coth(alpha)
+    d2 = -a * coth(beta)
+    r1 = a * cosech(alpha)
+    r2 = -a * cosech(beta)
+
+    np.testing.assert_allclose(d1 + d2, ref_distance)
+    np.testing.assert_allclose(r1, ref_r1)
+    np.testing.assert_allclose(r2, ref_r2)
+
+
+def test_coordinate_transform_bad():
+    with pytest.raises(
+        ValueError, match="Distance between beads 1.9999 has to be bigger than their summed radii"
+    ):
+        to_curvilinear_coordinates(1.0, 1.0, 1.9999)
+
+
+def test_coupling_solution_coefficients():
+    """For same bead radii, the terms bn and dn should vanish"""
+    n = 2
+    a, alpha, beta = to_curvilinear_coordinates(0.5, 0.5, 6.0)
+    k = calculate_k(n, a)
+    delta = calculate_delta(n, alpha, beta)
+    np.testing.assert_allclose(calculate_bn(n, k, alpha, beta, delta), 0)
+    np.testing.assert_allclose(calculate_dn(n, k, alpha, beta, delta), 0)
+
+    a, alpha, beta = to_curvilinear_coordinates(0.5, 0.6, 6.0)
+    k = calculate_k(n, a)
+    delta = calculate_delta(n, alpha, beta)
+    assert np.abs(calculate_bn(n, k, alpha, beta, delta)) > 0
+    assert np.abs(calculate_dn(n, k, alpha, beta, delta)) > 0
+
+
+# Validate correctness
+@pytest.mark.parametrize(
+    "distance, r1, r2",
+    [
+        [3.0e-6, 0.5e-6, 0.5e-6],
+        [6.0e-6, 0.5e-6, 0.8e-6],
+        [6.0e-6, 0.9e-6, 0.8e-6],
+        [2.0e-6, 1.0e-6, 0.9999e-6],
+    ],
+)
+def test_coupling_solution(distance, r1, r2):
+    """The coefficients an, bn, cn and dn are the solution of a system of equations presented in
+    equation 26 of Stimson et al. Here we verify whether those hold."""
+    a, alpha, beta = to_curvilinear_coordinates(r1, r2, distance)
+    n = 2
+    k = calculate_k(n, a)
+    delta = calculate_delta(n, alpha, beta)
+    an = calculate_an(n, k, alpha, beta, delta)
+    bn = calculate_bn(n, k, alpha, beta, delta)
+    cn = calculate_cn(n, k, alpha, beta, delta)
+    dn = calculate_dn(n, k, alpha, beta, delta)
+
+    eq1a = (
+        an * np.cosh((n - 0.5) * alpha)
+        + bn * np.sinh((n - 0.5) * alpha)
+        + cn * np.cosh((n + 1.5) * alpha)
+        + dn * np.sinh((n + 1.5) * alpha)
+    )
+    eq1b = -k * (
+        (2 * n + 3) * np.exp(-(n - 0.5) * alpha) - (2 * n - 1) * np.exp(-(n + 1.5) * alpha)
+    )
+    eq2a = (
+        an * np.cosh((n - 0.5) * beta)
+        + bn * np.sinh((n - 0.5) * beta)
+        + cn * np.cosh((n + 1.5) * beta)
+        + dn * np.sinh((n + 1.5) * beta)
+    )
+    eq2b = -k * ((2 * n + 3) * np.exp((n - 0.5) * beta) - (2 * n - 1) * np.exp((n + 1.5) * beta))
+    eq3a = (2 * n - 1) * (an * np.sinh((n - 0.5) * alpha) + bn * np.cosh((n - 0.5) * alpha)) + (
+        2 * n + 3
+    ) * (cn * np.sinh((n + 1.5) * alpha) + dn * np.cosh((n + 1.5) * alpha))
+    eq3b = (2 * n - 1) * (2 * n + 3) * k * (np.exp(-(n - 0.5) * alpha) - np.exp(-(n + 1.5) * alpha))
+    eq4a = (2 * n - 1) * (an * np.sinh((n - 0.5) * beta) + bn * np.cosh((n - 0.5) * beta)) + (
+        2 * n + 3
+    ) * (cn * np.sinh((n + 1.5) * beta) + dn * np.cosh((n + 1.5) * beta))
+    eq4b = -(2 * n - 1) * (2 * n + 3) * k * (np.exp((n - 0.5) * beta) - np.exp((n + 1.5) * beta))
+
+    np.testing.assert_allclose(eq1a, eq1b)
+    np.testing.assert_allclose(eq2a, eq2b)
+    np.testing.assert_allclose(eq3a, eq3b)
+    np.testing.assert_allclose(eq4a, eq4b)
+
+
+@pytest.mark.parametrize(
+    "distance, radius1, radius2, ref_factor1, ref_factor2",
+    [
+        [3.0e-6, 0.5e-6, 0.5e-6, 0.8047215852074429, 0.8047215852074429],
+        [6.0e-6, 0.5e-6, 0.8e-6, 0.8224250265105119, 0.8982938795749217],
+        [6.0e-6, 0.9e-6, 0.8e-6, 0.8402922788501829, 0.8147951224475662],
+        [2.0e-6, 1.0e-6, 0.9999e-6, 0.01958146863802238, 0.019580489165418463],
+    ],
+)
+def test_coupling_factors(distance, radius1, radius2, ref_factor1, ref_factor2):
+    f1, f2 = coupling_correction_factor_stimson(radius1, radius2, distance, summands=5)
+    np.testing.assert_allclose(f1, ref_factor1)
+    np.testing.assert_allclose(f2, ref_factor2)

--- a/lumicks/pylake/force_calibration/tests/test_drag.py
+++ b/lumicks/pylake/force_calibration/tests/test_drag.py
@@ -1,5 +1,6 @@
 import pytest
 
+from lumicks.pylake.force_calibration.calibration_models import coupling_correction_2d
 from lumicks.pylake.force_calibration.detail.drag_models import *
 
 
@@ -128,4 +129,35 @@ def test_coupling_factors(distance, radius1, radius2, ref_factor1, ref_factor2):
 )
 def test_coupling_factors(distance, radius, allow_rotation, ref_factor):
     factor = coupling_correction_factor_goldmann(radius, distance, allow_rotation=allow_rotation)
+    np.testing.assert_allclose(factor, ref_factor)
+
+
+@pytest.mark.parametrize(
+    "dx, dy, radius, allow_rotation, ref_factor, vertical",
+    [
+        # First we test the same cases as above (consistency check)
+        [0.0, 3.0e-6, 0.5e-6, True, 0.8870592515374689, False],
+        [0.0, 6.0e-6, 0.5e-6, False, 0.9409521069093458, False],
+        [0.0, 1.0, 1.0e-6, True, 0.9999992500005626, False],
+        [3.0e-6, 0.0, 0.5e-6, True, 0.8870592515374689, True],
+        [6.0e-6, 0.0, 0.5e-6, False, 0.9409521069093458, True],
+        [1.0, 0.0, 1.0e-6, True, 0.9999992500005626, True],
+        [3.0e-6, 0.0e-6, 0.5e-6, True, 0.8047217606696428, False],
+        [0.0, 3.0e-6, 0.5e-6, True, 0.8047217606696428, True],
+        # When the beads are diagonal, it doesn't matter whether we oscillate vertically or
+        # horizontally.
+        [3.0e-6, 3.0e-6, 0.5e-6, True, 0.8847851093315549, True],
+        [-3.0e-6, -3.0e-6, 0.5e-6, True, 0.8847851093315549, True],
+        [3.0e-6, -3.0e-6, 0.5e-6, True, 0.8847851093315549, True],
+        [3.0e-6, 3.0e-6, 0.5e-6, True, 0.8847851093315549, True],
+        [3.0e-6, 3.0e-6, 0.5e-6, True, 0.8847851093315549, False],
+        [-3.0e-6, -3.0e-6, 0.5e-6, True, 0.8847851093315549, False],
+        [3.0e-6, -3.0e-6, 0.5e-6, True, 0.8847851093315549, False],
+        [3.0e-6, 3.0e-6, 0.5e-6, True, 0.8847851093315549, False],
+    ],
+)
+def test_2d_coupling_factors(dx, dy, radius, allow_rotation, ref_factor, vertical):
+    factor = coupling_correction_2d(
+        dx, dy, bead_diameter=2 * radius, allow_rotation=allow_rotation, is_y_oscillation=vertical
+    )
     np.testing.assert_allclose(factor, ref_factor)

--- a/lumicks/pylake/force_calibration/tests/test_drag.py
+++ b/lumicks/pylake/force_calibration/tests/test_drag.py
@@ -114,3 +114,18 @@ def test_coupling_factors(distance, radius1, radius2, ref_factor1, ref_factor2):
     f1, f2 = coupling_correction_factor_stimson(radius1, radius2, distance, summands=5)
     np.testing.assert_allclose(f1, ref_factor1)
     np.testing.assert_allclose(f2, ref_factor2)
+
+
+@pytest.mark.parametrize(
+    "distance, radius, allow_rotation, ref_factor",
+    [
+        [3.0e-6, 0.5e-6, True, 0.8870592515374689],
+        [6.0e-6, 0.5e-6, False, 0.9409521069093458],
+        [6.0e-6, 0.5e-6, True, 0.9409201499139558],
+        [6.0e-6, 0.9e-6, True, 0.8975126023400348],
+        [1.0, 1.0e-6, True, 0.9999992500005626],
+    ],
+)
+def test_coupling_factors(distance, radius, allow_rotation, ref_factor):
+    factor = coupling_correction_factor_goldmann(radius, distance, allow_rotation=allow_rotation)
+    np.testing.assert_allclose(factor, ref_factor)


### PR DESCRIPTION
**Why this PR?**
When performing active calibration, we get a smaller velocity around the beads than expected when dealing with a dual trap configuration. This can lead to biases when not taken into account in the model that predicts the oscillation amplitude of the beads:

$R_{d, corrected} = c R_d$
$R_{f, corrected} = \frac{R_f}{c}$
$\kappa_{corrected} = \frac{\kappa}{c^2}$

![correction_factor_whatsnew](https://github.com/lumicks/pylake/assets/19836026/7ca8577e-2780-4192-9e28-eaf3ef0ab703)

Various models exist to calculate the correction factor `c`. In the context of optical tweezers, I have seen Oseen (acting force being a point function) and Rotne Prager used [1]. For us, this seems to correct well for large distances, but seems to fail at short distances*. [2] seems to fare better for both regimes, but only covers oscillations parallel to the bead axes. A fraction with a reciprocal polynomial for oscillations perpendicular to the bead axes can be found in [3].

Based on these two models, we can compute a combined model (see the documentation for more information on this). If we use this to correct data over the entire trap range, we see that this corrects the calibration factors pretty nicely. See graphs below.

Docs here: [whats new](https://lumicks-pylake.readthedocs.io/en/coupling/whatsnew/index.html), [theory](https://lumicks-pylake.readthedocs.io/en/coupling/theory/force_calibration/active.html#bead-bead-coupling), [tutorial](https://lumicks-pylake.readthedocs.io/en/coupling/tutorial/force_calibration.html#active-calibration-with-two-beads-far-away-from-the-surface) and [example](https://lumicks-pylake.readthedocs.io/en/coupling/examples/bead_coupling/coupling.html#).

Note: I have marked this functionality as alpha, since testing has been somewhat limited so far. That said, for conditions where they are valid, the results obtained with these models is much more reasonable than without.

![Figure 22](https://github.com/lumicks/pylake/assets/19836026/b6f3d73d-08b3-41ce-9d3c-b4257e467f66)
_Calibrations are obtained by putting trap 2 in a static location and moving trap 1 in the x-direction. We are showing results for trap 2 here, since there is an unexplained additional dependence of the sensitivity on the x position for trap 1. Note that we have used the Stimson model for horizontal oscillations and the Wakiya approximation model as presented by Goldmann model for Y oscillation here._

![X-oscillation-XY](https://github.com/lumicks/pylake/assets/19836026/67e7134b-38ba-40de-9e0f-b3c91c7b05a9)
_Active calibration with two 4.38 um beads (X). Here we moved a second bead around in the trap range of motion and calibrating the bead that was at a fixed position._
![Y-oscillation-XY](https://github.com/lumicks/pylake/assets/19836026/e89f2f21-8c32-43a3-98ba-d59f17252e54)
_Active calibration with two 4.38 um beads (Y). Here we moved a second bead around in the trap range of motion and calibrating the bead that was at a fixed position._

[1] https://core.ac.uk/download/pdf/270293467.pdf
[2] Stimson, M., & Jeffery, G. B. (1926). The motion of two spheres in a viscous fluid. Proceedings of the Royal Society of London. Series A, Containing Papers of a Mathematical and Physical Character, 111(757), 110-116 (2007).
[3] Goldman, A. J., Cox, R. G., & Brenner, H. (1966). The slow motion of two identical arbitrarily oriented spheres through a viscous fluid. Chemical Engineering Science, 21(12), 1151-1170.

* Note that [2] contains a typographical error in equation 37, where it should read `4/3` and not `2/3`
* Note that the value reported in [2] for `alpha=0.5` should be `0.6596`.