### PR TITLE
Fix fetching files from zenodo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.2 | t.b.d.
+
+#### Bug fixes
+
+* Fixed `lk.download_from_doi()` to align with new Zenodo REST API.
+
 ## v1.2.1 | 2023-10-17
 
 #### Bug fixes

--- a/lumicks/pylake/file_download.py
+++ b/lumicks/pylake/file_download.py
@@ -120,10 +120,7 @@ def download_from_doi(doi, target_path="", force_download=False, show_progress=T
     file_names = []
     for file in record_metadata["files"]:
         file_name = file["filename"]
-        url = (
-            f"https://zenodo.org/api/records/{record_metadata['record_id']}"
-            f"/files/{file_name}/content"
-        )
+        url = f"https://zenodo.org/api/records/{record_metadata['id']}/files/{file_name}/content"
 
         full_path = os.path.join(target_path, file_name)
 


### PR DESCRIPTION
The API changed the record lookup from using `record_id` to `id`