### PR TITLE
tracking: add `min_duration` argument to `lk.filter_tracks`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
   * Shortcuts `"r"`, `"g"`, and `"b"` can now be used for plotting single color channels in addition to `"red"`, `"green"`, and `"blue"`.
   * Two-channel visualizations can be plotted using `"rg"`, `"gb"`, or `"rb"`.
 * Added `duration` property to `KymoTrack` which returns the duration (in seconds) that the track was observed.
+* Added option to filter tracks by duration in seconds using `lk.filter_tracks(tracks, minimum_duration=duration_in_seconds)`.
 
 #### Improvements
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Added more options for plotting color channels for images:
   * Shortcuts `"r"`, `"g"`, and `"b"` can now be used for plotting single color channels in addition to `"red"`, `"green"`, and `"blue"`.
   * Two-channel visualizations can be plotted using `"rg"`, `"gb"`, or `"rb"`.
+* Added `duration` property to `KymoTrack` which returns the duration (in seconds) that the track was observed.
 
 #### Improvements
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
   * Two-channel visualizations can be plotted using `"rg"`, `"gb"`, or `"rb"`.
 * Added `duration` property to `KymoTrack` which returns the duration (in seconds) that the track was observed.
 * Added option to filter tracks by duration in seconds using `lk.filter_tracks(tracks, minimum_duration=duration_in_seconds)`.
+* Added `KymoTrackGroup.filter()` to filter tracks in-place. `tracks.filter(minimum_duration=2)` is equivalent to `tracks = lk.filter_tracks(tracks, minimum_duration=2)`.
 
 #### Improvements
 

--- a/docs/theory/diffusion/diffusion.rst
+++ b/docs/theory/diffusion/diffusion.rst
@@ -694,12 +694,12 @@ We can filter tracks shorter than a certain length by using :func:`~lumicks.pyla
     methods = {
         "cve single": lambda list_of_tracks: [t.estimate_diffusion("cve") for tracks in list_of_tracks for t in tracks],
         "ols single": lambda list_of_tracks: [t.estimate_diffusion("ols") for tracks in list_of_tracks for t in tracks],
-        "cve (filtered)": lambda list_of_tracks: [t.estimate_diffusion("cve") for tracks in list_of_tracks for t in lk.filter_tracks(tracks, min_length)],
-        "ols (filtered)": lambda list_of_tracks: [t.estimate_diffusion("ols") for tracks in list_of_tracks for t in lk.filter_tracks(tracks, min_length)],
+        "cve (filtered)": lambda list_of_tracks: [t.estimate_diffusion("cve") for tracks in list_of_tracks for t in lk.filter_tracks(tracks, minimum_length=min_length)],
+        "ols (filtered)": lambda list_of_tracks: [t.estimate_diffusion("ols") for tracks in list_of_tracks for t in lk.filter_tracks(tracks, minimum_length=min_length)],
         "cve ensemble": lambda list_of_tracks: [t.ensemble_diffusion("cve") for t in list_of_tracks],
         "ols ensemble": lambda list_of_tracks: [t.ensemble_diffusion("ols") for t in list_of_tracks],
-        "cve ensemble (filtered)": lambda list_of_tracks: [lk.filter_tracks(t, min_length).ensemble_diffusion("cve") for t in list_of_tracks],
-        "ols ensemble (filtered)": lambda list_of_tracks: [lk.filter_tracks(t, min_length).ensemble_diffusion("ols") for t in list_of_tracks],
+        "cve ensemble (filtered)": lambda list_of_tracks: [lk.filter_tracks(t, minimum_length=min_length).ensemble_diffusion("cve") for t in list_of_tracks],
+        "ols ensemble (filtered)": lambda list_of_tracks: [lk.filter_tracks(t, minimum_length=min_length).ensemble_diffusion("ols") for t in list_of_tracks],
     }
 
     snrs = 10**np.arange(-1, 1.1, 0.125)

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -112,8 +112,13 @@ For example, to omit all tracks with fewer than 4 detected points, we can invoke
 
     print(len(tracks))  # the number of tracks originally detected -- 134
 
-    tracks = lk.filter_tracks(tracks, 4)
+    tracks = lk.filter_tracks(tracks, minimum_length=4)
     print(len(tracks))  # the number of tracks after filtering -- 35
+
+We can also filter by track duration.
+
+    >>> print(len(lk.filter_tracks(tracks, minimum_duration=1)))
+    26
 
 There are also convenience plotting functions for both :meth:`KymoTrack.plot() <lumicks.pylake.kymotracker.kymotrack.KymoTrack.plot>`
 and :meth:`KymoTrackGroup.plot() <lumicks.pylake.kymotracker.kymotrack.KymoTrackGroup.plot>`. We can see the detected tracks overlaid
@@ -162,7 +167,7 @@ Sometimes we want to track only part of a kymograph without manually slicing and
 `[[min_time, min_position], [max_time, max_position]]`. To track the same region as before, we can do::
 
     tracks = lk.track_greedy(kymo, "green", rect=[[127, 9], [162, 26]])
-    tracks = lk.filter_tracks(tracks, 4)
+    tracks = lk.filter_tracks(tracks, minimum_length=4)
 
     plt.figure()
     kymo.plot("green", aspect="auto", adjustment=adjustment)
@@ -193,7 +198,7 @@ Let's perform track refinement with two different values for `track_width` to se
 
     # re-track our kymo
     tracks = lk.track_greedy(kymo40, "green", track_width=0.3)
-    tracks = lk.filter_tracks(tracks, 4)
+    tracks = lk.filter_tracks(tracks, minimum_length=4)
 
     # refine with the same track_width
     refined = lk.refine_tracks_centroid(tracks, track_width=0.3)
@@ -398,7 +403,7 @@ We can easily plot some histograms of the binding events located with the kymotr
 
     # re-track so we have fresh data to work with
     tracks = lk.track_greedy(kymo40, "green", track_width=0.3)
-    tracks = lk.filter_tracks(tracks, 4)
+    tracks = lk.filter_tracks(tracks, minimum_length=4)
     tracks = lk.refine_tracks_centroid(tracks, track_width=0.3)
 
     plt.figure()
@@ -708,8 +713,8 @@ Sometimes, we want to combine tracking results from multiple Kymographs to deter
 We can do this, by simply adding :class:`~lumicks.pylake.kymotracker.kymotrack.KymoTrackGroup` instances together.
 We'll demonstrate this functionality using multiple sections on a single :class:`~lumicks.pylake.kymo.Kymo`, but it generalizes to tracks from different kymographs::
 
-    tracks1 = lk.filter_tracks(lk.track_greedy(kymo, "green", rect=[[127, 9], [162, 26]]), 4)
-    tracks2 = lk.filter_tracks(lk.track_greedy(kymo, "green", rect=[[175, 9], [200, 26]]), 4)
+    tracks1 = lk.filter_tracks(lk.track_greedy(kymo, "green", rect=[[127, 9], [162, 26]]), minimum_length=4)
+    tracks2 = lk.filter_tracks(lk.track_greedy(kymo, "green", rect=[[175, 9], [200, 26]]), minimum_length=4)
 
     multiple_groups = tracks1 + tracks2
     multiple_groups.plot()

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -438,6 +438,11 @@ class KymoTrack:
         return self._localization.position
 
     @property
+    def duration(self):
+        """Track duration in seconds"""
+        return self.seconds[-1] - self.seconds[0]
+
+    @property
     def _line_time_seconds(self):
         """Source kymograph line time in seconds."""
         return self._kymo.line_time_seconds
@@ -1504,7 +1509,7 @@ class KymoTrackGroup:
                 if exclude_ambiguous_dwells
                 else group
             )
-            dwelltimes_sec = np.array([track.seconds[-1] - track.seconds[0] for track in tracks])
+            dwelltimes_sec = np.array([track.duration for track in tracks])
             nonzero_dwelltimes_sec = dwelltimes_sec[dwelltimes_sec > 0]
             removed_zeros = removed_zeros or len(nonzero_dwelltimes_sec) != len(dwelltimes_sec)
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -1277,6 +1277,22 @@ class KymoTrackGroup:
 
         self._src = [track for track in self._src if not track.in_rect(rect, all_points)]
 
+    def filter(self, *, minimum_length=1, minimum_duration=0):
+        """Remove tracks shorter than specified criteria from the list.
+
+        Parameters
+        ----------
+        minimum_length : int, optional
+            Minimum number of tracked points for the track to be accepted (default: 1).
+        minimum_duration : seconds, optional
+            Minimum duration in seconds for a track to be accepted (default: 0).
+        """
+        from .kymotracker import filter_tracks  # local import to avoid circular import
+
+        self._src = filter_tracks(
+            self, minimum_length=minimum_length, minimum_duration=minimum_duration
+        )._src
+
     def __repr__(self):
         return f"{self.__class__.__name__}(N={len(self)})"
 

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -382,6 +382,7 @@ def filter_tracks(tracks, minimum_length=1, *, minimum_duration=0):
     minimum_duration : seconds, optional
         Minimum duration in seconds for a track to be accepted (default: 0).
     """
+
     def minimum_observable_time(track, min_length, min_duration):
         line_time = track._kymo.line_time_seconds
         minimum_length_based = (min_length - 1) * line_time

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -47,6 +47,16 @@ def test_kymo_track(blank_kymo, blank_kymo_track_args):
     assert str(k1) == "KymoTrack(N=3)"
 
 
+@pytest.mark.parametrize(
+    "time_idx, ref_value", [[[0, 1, 2], 2], [[0, 2], 2], [[1, 3], 2], [[1, 4, 5], 4]]
+)
+def test_kymotrack_duration(blank_kymo, time_idx, ref_value):
+    np.testing.assert_allclose(
+        KymoTrack(time_idx, time_idx, blank_kymo, "red", 0).duration,
+        blank_kymo.line_time_seconds * ref_value,
+    )
+
+
 def test_kymotrack_selection(blank_kymo, blank_kymo_track_args):
     t = np.array([4, 5, 6])
     y = np.array([7, 7, 7])

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -505,9 +505,17 @@ def test_filter_by_duration(
     tracks = KymoTrackGroup([k1, k2, k3, k4, k5])
 
     filtered = filter_tracks(tracks, minimum_length=0, minimum_duration=minimum_duration)
-    assert len(filtered) == ref_length
-    np.testing.assert_allclose(filtered[0]._minimum_observable_duration, ref_minimum)
-    np.testing.assert_allclose(filtered[-1]._minimum_observable_duration, ref_minimum_dt2)
+    assert len(tracks) == 5  # return new instance
+
+    tracks.filter(minimum_length=0, minimum_duration=minimum_duration)
+    assert len(tracks) == ref_length  # in-place modification
+
+    for filtered_tracks in (filtered, tracks):
+        assert len(filtered_tracks) == ref_length
+        np.testing.assert_allclose(filtered_tracks[0]._minimum_observable_duration, ref_minimum)
+        np.testing.assert_allclose(
+            filtered_tracks[-1]._minimum_observable_duration, ref_minimum_dt2
+        )
 
 
 def test_empty_group():

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -682,7 +682,7 @@ class KymoWidgetGreedy(KymoWidget):
         def wrapped_track_greedy(kymo, channel, min_length, **kwargs):
             return filter_tracks(
                 track_greedy(kymo, channel, **kwargs),
-                min_length,
+                minimum_length=min_length,
             )
 
         algorithm = wrapped_track_greedy


### PR DESCRIPTION
**Why this PR?**
It makes more sense for users to filter by a specific track duration, rather than a number of points in a track.

*What to look out for*
It is important to set the minimum time appropriately. If we filter by length `min_duration`, then the first length we can actually observe is the next available duration `ceil(min_duration / line_time) * line_time`.

Below are the results of running dwell time analysis on the results from two simulated kymos (line time 0.25 and line time 0.1) with 1000 lines each.

If one computes the minimally observable duration correctly, the estimates are as expected:

![Correctly taken into account](https://github.com/lumicks/pylake/assets/19836026/0b7e14b2-c196-4d8f-aeca-8af2574b705a)
_Rounded to next step (ceil)_

If not, then well, we get biased results:

![Incorrectly taken into account (round)](https://github.com/lumicks/pylake/assets/19836026/0a5855b7-597c-4494-a949-5fbcc413a47b)
_Rounded to nearest value (round)_

![Incorrectly taken into account (naive)](https://github.com/lumicks/pylake/assets/19836026/7eba14c0-cfef-42ce-8dfa-bf2eb4d4eaf3)
_Not rounded_

Note that the track durations were chosen (short compared to the line time) such that this effect would be quite prominent.