### PR TITLE
Fix scan aspect ratio

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### Bug fixes
 
 * Fixed `lk.download_from_doi()` to align with new Zenodo REST API.
+* Fixed a bug in `Scan.plot()` in which the default aspect ratio was calculated such that pixels always appeared square. For scans with non-square pixel sizes, this would result in distortion of the image.
 
 ## v1.2.1 | 2023-10-17
 

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -463,7 +463,6 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         default_kwargs = dict(
             # With origin set to upper (default) bounds should be given as (0, n, n, 0)
             extent=[0, x_um, y_um, 0],
-            aspect=(image.shape[0] / image.shape[1]) * (x_um / y_um),
             cmap=getattr(colormaps, channel),
         )
 


### PR DESCRIPTION
**Why this PR?**
We currently calculate a default aspect ratio which results in square pixels. For scans acquired with non-square pixels, this results in distortion of the image

Current:
<img width="752" alt="Screenshot 2023-10-31 at 15 05 56" src="https://github.com/lumicks/pylake/assets/61475504/3f79906e-4998-4914-a459-b28fa751752c">

Fixed:
<img width="752" alt="Screenshot 2023-10-31 at 15 06 38" src="https://github.com/lumicks/pylake/assets/61475504/dbd15383-3286-4fa0-a96b-db656dddee26">
