### PR TITLE
Hidden Markov models

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -126,6 +126,7 @@ Population Dynamics
     :toctree: _api
     :template: class.rst
 
+    HiddenMarkovModel
     GaussianMixtureModel
     DwelltimeModel
     population.dwelltime.DwelltimeBootstrap

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ release = pylake.__version__
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.5.0"
+needs_sphinx = "5.0.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -123,7 +123,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -445,3 +445,14 @@ publisher = {Biophysical Society}
   year={2020},
   publisher={AIP Publishing LLC}
 }
+
+@article{Rabiner1989HMM,
+  title={A Tutorial on Hidden Markov Models and Selected Applications in Speech Rrecognition},
+  author={Rabiner, Lawrence R.},
+  journal={Proceedings of the IEEE},
+  volume={77},
+  number={2},
+  pages={257-289},
+  year={1989},
+  publisher={IEEE}
+}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,8 +5,8 @@ nbconvert
 nbformat
 numpy
 scipy
-sphinx==4.5.0
-sphinx_rtd_theme==1.0.0
+sphinx==5.0.0
+sphinx_rtd_theme==2.0.0
 sphinxcontrib-bibtex==2.5.0
-docutils<0.18
+docutils
 myst-parser

--- a/docs/tutorial/figures/population_dynamics/hmm_hist.png
+++ b/docs/tutorial/figures/population_dynamics/hmm_hist.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34b10f33a142f06058c9e92bd48d7d3beee46162c40549f93ec22121a5861d2d
+size 105557

--- a/docs/tutorial/figures/population_dynamics/hmm_labeled_trace.png
+++ b/docs/tutorial/figures/population_dynamics/hmm_labeled_trace.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a645fdc013f1ef9477644ec1cc47068bb436b8b93092d5f6ce20fc83940e7cc8
+size 272346

--- a/lumicks/pylake/population/__init__.py
+++ b/lumicks/pylake/population/__init__.py
@@ -1,2 +1,3 @@
+from .hmm import HiddenMarkovModel
 from .mixture import GaussianMixtureModel
 from .dwelltime import DwelltimeModel

--- a/lumicks/pylake/population/detail/fit_info.py
+++ b/lumicks/pylake/population/detail/fit_info.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FitInfo:
+    converged: bool
+    n_iter: int
+    bic: float
+    aic: float
+
+
+@dataclass(frozen=True)
+class HmmFitInfo(FitInfo):
+    """
+    Fitting information for a HiddenMarkovModel
+
+    Parameters
+    ----------
+    converged: bool
+        Whether the model converged
+    n_iter: int
+        Number of iterations during the fit
+    bic: float
+        Bayesian Information Criterion on fitted data
+    aic: float
+        Akaike Information Criterion on fitted data
+    log_likelihood: float
+        Log Likelihood of the fitted data
+    """
+
+    log_likelihood: float

--- a/lumicks/pylake/population/detail/hmm.py
+++ b/lumicks/pylake/population/detail/hmm.py
@@ -1,0 +1,313 @@
+"""
+Parameters for internal API here conform to notation in Rabiner
+
+References
+----------
+.. [1] Rabiner, L. A Tutorial on Hidden Markov Models and Selected Applications in Speech
+        Recognition. Proceedings of IEEE. 77, 257-286 (1989).
+"""
+
+import warnings
+from dataclasses import dataclass
+
+import numpy as np
+
+from ..mixture import GaussianMixtureModel
+from .fit_info import HmmFitInfo
+from ...channel import Slice, Continuous
+from .validators import col, row
+
+
+def normalize_rows(matrix):
+    return matrix / col(np.sum(matrix, axis=1))
+
+
+@dataclass(frozen=True)
+class ClassicHmm:
+    """Model parameters for classic Hidden Markov Model.
+
+    Parameters
+    ----------
+    K : int
+        number of states
+    pi : np.ndarray
+        initial state probabilities, shape [K, ]
+    A : np.ndarray
+        state transition probability matrix, shape [K, K]
+    mu : np.ndarray
+        state means, shape [K, ]
+    tau : np.ndarray
+        state precision (1 / variance), shape [K, ]
+    """
+
+    K: int
+    pi: np.ndarray
+    A: np.ndarray
+    mu: np.ndarray
+    tau: np.ndarray
+
+    @classmethod
+    def guess(cls, data, n_states, gmm=None):
+        """Calculate an initial guess for the model from a GMM.
+
+        Parameters
+        ----------
+        data : np.ndarray
+            Training data
+        n_states : int
+            Number of hidden states
+        gmm : GaussianMixtureModel
+            Pre-trained GMM
+        """
+        data = Slice(Continuous(data, 0, 1))
+        if gmm is None:
+            gmm = GaussianMixtureModel.from_channel(data, n_states)
+        statepath = gmm.label(data)
+        A = normalize_rows(
+            np.vstack(
+                [
+                    [
+                        np.logical_and(statepath[:-1] == j, statepath[1:] == k).sum()
+                        for k in range(n_states)
+                    ]
+                    for j in range(n_states)
+                ]
+            )
+        )
+        pi = np.ones(n_states) / n_states
+
+        return cls(n_states, pi, A, gmm.means, 1 / gmm.variances)
+
+    def state_log_likelihood(self, x):
+        """Calculate the state likelihood of the observation data `x`. Work in log space to avoid
+        underflow.
+        """
+        x2 = (row(x) - col(self.mu)) ** 2
+        tau = col(self.tau)
+        return -0.5 * (np.log(2 * np.pi) - np.log(tau) + x2 * tau)
+
+    def update(self, data, gamma, xi):
+        """Update model parameters from the temporary variables of the Baum Welch algorithm.
+
+        Parameters
+        ----------
+        data : np.ndarray
+            observed data, shape [T, ]
+        gamma : np.ndarray
+            probability of being in state i at time t, shape [T, K]
+        xi : np.ndarray
+            probability of being in state i at time t and state j at time t + 1, shape [T, K, K]
+        """
+        pi = gamma[0]  # Eq 40a
+        A = xi.sum(axis=0) / col(gamma[:-1].sum(axis=0))  # Eq 40b
+        x_bar = np.sum(gamma * col(data), axis=0) / gamma.sum(axis=0)  # Eq 53
+        variance = np.sum(gamma * (col(data) - row(x_bar)) ** 2, axis=0) / gamma.sum(axis=0)  # Eq54
+
+        return ClassicHmm(self.K, pi, A, x_bar, 1 / variance)
+
+
+def baum_welch(data, model, tol, max_iter):
+    """Specialized form of the expectation maximization algorithm to train HMMs.
+
+    Described in detail in Section I in Rabiner (specific discussion on the full Baul-Welch procedure
+    given on page 265).
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Observation data, shape [T, ]
+    model : ClassicHmm
+        Model parameters with K states
+    tol : float
+        The tolerance for training convergence
+    max_iter : int
+        The maximum number of iterations to perform
+
+    Returns
+    -------
+    model : ClassicHmm
+        Optimized model instance
+    """
+    # initial E-step
+    converged = False
+    gamma, xi, previous_log_likelihood = calculate_temporary_variables(
+        model, *forward_backward(data, model)
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        for _itr in range(1, max_iter + 1):
+            # M-step
+            model = model.update(data, gamma, xi)
+
+            # E-step
+            gamma, xi, current_log_likelihood = calculate_temporary_variables(
+                model, *forward_backward(data, model)
+            )
+
+            # check for convergence
+            delta = current_log_likelihood - previous_log_likelihood
+            if np.abs(delta) < tol:
+                converged = True
+                break
+            previous_log_likelihood = current_log_likelihood
+
+        if not converged:
+            warnings.warn(
+                f"Model has not converged after {_itr} iterations. Last log likelihood step "
+                f"was {delta:0.4e}."
+            )
+
+    # free parameters; pi and each row of A constrained to sum to 1
+    # (K - 1) + (K**2 - K) + K + K
+    #   pi          A        mu  tau
+    k = model.K**2 + 2 * model.K - 1
+    bic = k * np.log(len(data)) - 2 * current_log_likelihood
+    aic = 2 * k - 2 * current_log_likelihood
+
+    fit_info = HmmFitInfo(converged, _itr, bic, aic, current_log_likelihood)
+
+    return model, fit_info
+
+
+def forward_backward(data, model):
+    """Recursive algorithm to calculate state path probabilities from observations.
+
+    Use scaled version to avoid underflow (Section V-A in Rabiner; the unscaled versions fournd in
+    Equations 18-21 and 24-25 in Section I).
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Observation data, shape [T, ]
+    model : ClassicHmm
+        Model parameters with K states
+
+    Returns
+    -------
+    alpha : np.ndarray
+        probability of the sequence y[0]...y[t] and being in state i at time t; shape [T, K]
+    beta : np.ndarray
+        probability of the ending partial sequence y[t+1]...y[T] given starting state i at time t;
+        shape [T, K]
+    c : np.ndarray
+        scaling factors; shape [T, ]
+    B : np.ndarray
+        state likelihoods; shape[T, K]
+    """
+    # for here, simpler if states as columns, observations as rows
+    B = np.exp(model.state_log_likelihood(data)).T
+    T = data.size
+    K = model.K
+
+    alpha = np.zeros((T, K))
+    beta = np.ones((T, K))
+    c = np.zeros(T)
+
+    # forward loop, initialize
+    alpha[0] = model.pi * B[0]
+    c[0] = np.sum(alpha[0])
+    alpha[0] = alpha[0] / c[0]
+
+    # forward loop, induction
+    for t in range(1, T):
+        tmp = col(alpha[t - 1]) * model.A
+        alpha[t] = np.sum(tmp, axis=0) * B[t]
+        c[t] = np.sum(alpha[t])
+        alpha[t] = alpha[t] / c[t]
+
+    # backward loop
+    for t in range(1, T):
+        beta[-(t + 1)] = np.sum(model.A * row(B[-t]) * row(beta[-t]), axis=1) / c[-t]
+
+    return alpha, beta, c, B
+
+
+def calculate_temporary_variables(model, alpha, beta, c, B):
+    """Calculate temporary variables for model update and log likelihood of current model.
+
+    Parameters
+    ----------
+    model : ClassicHmm
+        Current model parameters with K states
+    alpha : np.ndarray
+        probability of the sequence y[0]...y[t] and being in state i at time t; shape [T, K]
+    beta : np.ndarray
+        probability of the ending partial sequence y[t+1]...y[T] given starting state i at time t;
+        shape [T, K]
+    c : np.ndarray
+        scaling factors (to avoid underflow); shape [T, ]
+    B : np.ndarray
+        state likelihoods; shape[T, K]
+
+    Returns
+    -------
+    gamma : np.ndarray
+        Probability of being in state i at time t; shape [T, K]
+    xi : np.ndarray
+        Probability of being in state i at time t and transitioning to state j at time t + 1;
+        shape [T, K, K]
+    log_likelihood : float
+    """
+    gamma = alpha * beta  # Eq 27
+
+    # Eq 37
+    xi = (
+        alpha[:-1][:, :, np.newaxis]
+        * model.A
+        * B[1:][:, np.newaxis, :]
+        * beta[1:][:, np.newaxis, :]
+    ) / c[1:][:, np.newaxis, np.newaxis]
+
+    # Eq 103
+    log_likelihood = np.sum(np.log(c))
+
+    return gamma, xi, log_likelihood
+
+
+def viterbi(data, model):
+    """The Viterbi algorithm to assign most probable hidden state path based on observation
+    sequence.
+
+    Details in Equations 29-35.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Observation data, shape [T, ]
+    model : ClassicHmm
+        Model parameters with K states
+
+    Returns
+    -------
+    statepath : np.ndarray
+        Hidden state path, shape [T, ]
+    """
+    T = data.size
+    B = model.state_log_likelihood(data).T
+    psi = np.zeros(B.shape, dtype=int)
+    statepath = np.zeros(T, dtype=int)
+
+    # - for models trained on a single trace you can end up with zeros
+    #   if states are well separated or observations have very low noise
+    # - you can also end up with zeros in the transition matrix for states
+    #   which are not connected to each other
+    with np.errstate(divide="ignore"):
+        log_pi = np.log(model.pi)
+        log_A = np.log(model.A)
+
+    # initialization
+    delta = col(log_pi + B[0])
+    # recursion
+    for t in range(1, T):
+        R = delta + log_A
+        psi[t] = np.argmax(R, axis=0)
+        delta = col(np.max(R, axis=0) + B[t])
+
+    # termination
+    statepath[-1] = np.argmax(delta)
+    # path backtracking
+    for t in range(1, T):
+        statepath[-(t + 1)] = psi[-t, statepath[-t]]
+
+    return statepath

--- a/lumicks/pylake/population/detail/validators.py
+++ b/lumicks/pylake/population/detail/validators.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+
+def row(x):
+    """Return x as row vector."""
+    return np.reshape(x, (1, -1))
+
+
+def col(x):
+    """Return x as column vector."""
+    return np.reshape(x, (-1, 1))

--- a/lumicks/pylake/population/hmm.py
+++ b/lumicks/pylake/population/hmm.py
@@ -1,0 +1,223 @@
+import numpy as np
+
+from .mixture import GaussianMixtureModel
+from ..channel import Slice
+from .dwelltime import _dwellcounts_from_statepath
+from .detail.hmm import ClassicHmm, viterbi, baum_welch
+from .detail.validators import col
+
+
+class HiddenMarkovModel:
+    """A Hidden Markov Model describing hidden state occupancy and state transitions of observed
+    time series data (force, fluorescence, etc.)
+
+    A detailed description of the model properties and training algorithms can be found in [1]_.
+
+    .. warning::
+
+        This is early access alpha functionality. While usable, this has not yet been tested in a
+        large number of different scenarios. The API can still be subject to change without any
+        prior deprecation notice! If you use this functionality keep a close eye on the changelog
+        for any changes that may affect your analysis.
+
+    Parameters
+    ----------
+    data : numpy.ndarray | Slice
+        Data array used for model training.
+    n_states : int
+        The number of hidden states in the model.
+    tol : float
+        The tolerance for training convergence.
+    max_iter : int
+        The maximum number of iterations to perform.
+    initial_guess : HiddenMarkovModel | GaussianMixtureModel | None
+        Initial guess for the observation model parameters.
+
+    References
+    ----------
+    .. [1] Rabiner, L. A Tutorial on Hidden Markov Models and Selected Applications in Speech
+           Recognition. Proceedings of IEEE. 77, 257-286 (1989).
+    """
+
+    def __init__(self, data, n_states, *, tol=1e-3, max_iter=250, initial_guess=None):
+        if isinstance(data, Slice):
+            data = data.data
+
+        if (
+            isinstance(initial_guess, (GaussianMixtureModel, HiddenMarkovModel))
+            and initial_guess.n_states != n_states
+        ):
+            raise ValueError(
+                "Initial guess must have the same number of states as requested "
+                f"for the current model; expected {n_states} got {initial_guess.n_states}."
+            )
+        self.n_states = n_states
+
+        if isinstance(initial_guess, GaussianMixtureModel) or initial_guess is None:
+            initial_guess = ClassicHmm.guess(data, n_states, gmm=initial_guess)
+        elif isinstance(initial_guess, HiddenMarkovModel):
+            initial_guess = initial_guess._model
+        else:
+            raise TypeError(
+                f"if provided, `initial_guess` must be either GaussianMixtureModel or "
+                f"HiddenMarkovModel, got `{type(initial_guess).__name__}`."
+            )
+
+        self._model, self._fit_info = baum_welch(data, initial_guess, tol=tol, max_iter=max_iter)
+
+    @property
+    def fit_info(self):
+        """Information about the model training exit conditions.
+
+        Returns
+        -------
+        HmmFitInfo
+            Fitting information for the model.
+        """
+        return self._fit_info
+
+    @property
+    def initial_state_probability(self):
+        """Model initial state probability."""
+        return self._model.pi
+
+    @property
+    def transition_matrix(self):
+        """Model state transition matrix.
+
+        Element `i, j` gives the probability of transitioning from state `i` at time point `t`
+        to state `j` at time point `t+1`.
+        """
+        return self._model.A
+
+    @property
+    def means(self):
+        """Model state means."""
+        return self._model.mu
+
+    @property
+    def variances(self):
+        """Model state variances."""
+        return 1 / self._model.tau
+
+    @property
+    def std(self):
+        """Model state standard deviations."""
+        return np.sqrt(self.variances)
+
+    def state_path(self, trace):
+        """Calculate the state emission path for a given data trace.
+
+        Parameters
+        ----------
+        trace : Slice
+            Channel data to determine path.
+
+        Returns
+        -------
+        state_path : Slice
+            Estimated state path
+        """
+        state_path = viterbi(trace.data, self._model)
+        src = trace._src._with_data(state_path)
+        labels = trace.labels.copy()
+        labels["y"] = "state"
+        return Slice(src, labels=labels)
+
+    def emission_path(self, trace):
+        """Calculate the emission path for a given data trace.
+
+        Parameters
+        ----------
+        trace : Slice
+            Channel data to determine path.
+
+        Returns
+        -------
+        emission_path : Slice
+            Estimated emission path
+        """
+        emission_path = self.means[self.state_path(trace).data]
+        return Slice(trace._src._with_data(emission_path), labels=trace.labels.copy())
+
+    def extract_dwell_times(self, trace, *, exclude_ambiguous_dwells=True):
+        """Calculate lists of dwelltimes for each state in a time-ordered statepath array.
+
+        Parameters
+        ----------
+        trace : Slice
+            Channel data to be analyzed.
+        exclude_ambiguous_dwells : bool
+            Determines whether to exclude dwelltimes which are not exactly determined. If `True`, the first
+            and last dwells are not used in the analysis, since the exact start/stop times of these events are
+            not definitively known.
+
+        Returns
+        -------
+        dict:
+            Dictionary of all dwell times (in seconds) for each state. Keys are state labels.
+        """
+        state_path = self.state_path(trace).data
+        dt_seconds = 1.0 / trace.sample_rate
+
+        dwell_counts, _ = _dwellcounts_from_statepath(
+            state_path, exclude_ambiguous_dwells=exclude_ambiguous_dwells
+        )
+        dwell_times = {key: counts * dt_seconds for key, counts in dwell_counts.items()}
+        return dwell_times
+
+    def hist(self, trace, n_bins=100, plot_kwargs=None, hist_kwargs=None):
+        """Plot a histogram of the data overlaid with the model PDF.
+
+        Parameters
+        ----------
+        trace : Slice
+            Data object to histogram.
+        n_bins : int
+            Number of histogram bins.
+        plot_kwargs : Optional[dict]
+            Plotting keyword arguments passed to the PDF line plot.
+        hist_kwargs : Optional[dict]
+            Plotting keyword arguments passed to the histogram plot.
+        """
+        import matplotlib.pyplot as plt
+
+        hist_kwargs = {"facecolor": "#c5c5c5", **(hist_kwargs or {})}
+
+        lims = (np.min(trace.data), np.max(trace.data))
+        bins = np.linspace(*lims, num=n_bins)
+        x = np.linspace(*lims, num=(n_bins * 5))
+
+        state_path = self.state_path(trace)
+        fractions = col(
+            [np.sum(state_path.data == j) / len(state_path) for j in np.unique(state_path.data)]
+        )
+        pdf = np.exp(self._model.state_log_likelihood(x))
+        g_components = pdf * fractions
+
+        plt.hist(trace.data, bins=bins, density=True, **hist_kwargs)
+        # reset color cycle
+        plt.gca().set_prop_cycle(None)
+        plt.plot(x, g_components.T, **(plot_kwargs or {}))
+        plt.ylabel("density")
+        plt.xlabel(trace.labels.get("y", "signal"))
+
+    def plot(self, trace, *, trace_kwargs=None, path_kwargs=None):
+        """Plot a time trace with each data point labeled with the state assignment.
+
+        Parameters
+        ----------
+        trace : Slice
+            Data object to histogram.
+        trace_kwargs : Optional[dict]
+            Plotting keyword arguments passed to the data line plot.
+        path_kwargs : Optional[dict]
+            Plotting keyword arguments passed to the state path line plot.
+        """
+
+        trace_kwargs = {"c": "#c5c5c5", **(trace_kwargs or {})}
+        path_kwargs = {"c": "tab:blue", "lw": 2, **(path_kwargs or {})}
+
+        trace.plot(**trace_kwargs)
+        emission_path = self.emission_path(trace)
+        emission_path.plot(**path_kwargs)

--- a/lumicks/pylake/population/tests/test_hmm.py
+++ b/lumicks/pylake/population/tests/test_hmm.py
@@ -1,0 +1,184 @@
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from lumicks.pylake import HiddenMarkovModel, GaussianMixtureModel
+from lumicks.pylake.channel import Slice, Continuous
+from lumicks.pylake.population.detail.hmm import ClassicHmm
+from lumicks.pylake.population.detail.fit_info import HmmFitInfo
+
+
+def make_channel(data):
+    return Slice(Continuous(data, np.int64(20e9), np.int64(1 / 78125 * 1e9)))
+
+
+def test_hmm(trace_lownoise):
+    data, statepath, params = trace_lownoise
+    n_states = params["n_states"]
+
+    # fmt: off
+    ref_transition_matrices = {
+        2: [
+            [0.9375, 0.0625],
+            [0.05882353, 0.94117647],
+        ],
+        3: [
+            [0.85714286, 0.07142857, 0.07142857],
+            [0.04545455, 0.90909091, 0.04545455],
+            [0.07407407, 0.11111111, 0.81481481],
+        ],
+        4: [
+            [0.86363636, 0.0, 0.04545455, 0.09090909],
+            [0.0, 0.85185185, 0.14814815, 0.0],
+            [0.03448276, 0.06896552, 0.79310345, 0.10344828],
+            [0.0952381, 0.14285714, 0.0, 0.76190476],
+        ],
+    }
+    # fmt: on
+
+    for data in (data, make_channel(data)):
+        model = HiddenMarkovModel(data, n_states)
+
+        # test model emission parameters converge to model used to generate test data
+        np.testing.assert_allclose(model.means, params["means"], atol=0.032)
+        np.testing.assert_allclose(model.std, params["st_devs"], atol=0.02)
+
+        # there are too few transitions in the trace for the model to converge to the transition
+        # matrix used to generate the data; would need to use an atol on the order of 0.1
+        # test against hard-coded values instead to guard against unintended changes to algo
+        np.testing.assert_allclose(model.transition_matrix, ref_transition_matrices[n_states])
+
+        # because only one trace is fit, the initial state proability collapses to the
+        # actual observed first state
+        ref_pi = np.zeros(n_states)
+        ref_pi[statepath[0]] = 1
+        np.testing.assert_allclose(model.initial_state_probability, ref_pi, atol=1e-10)
+
+
+def test_initial_guess(trace_simple):
+    data, statepath, params = trace_simple
+    n_states = params["n_states"]
+    trace = make_channel(data)
+
+    # no initial guess
+    model = HiddenMarkovModel(trace, n_states)
+
+    # GMM initial guess
+    gmm_guess = GaussianMixtureModel.from_channel(trace, n_states)
+    model = HiddenMarkovModel(trace, n_states, initial_guess=gmm_guess)
+
+    # HMM initial guess
+    model._model = ClassicHmm.guess(trace.data, n_states, gmm=gmm_guess)
+    model = HiddenMarkovModel(trace, n_states, initial_guess=model)
+
+    # anything else raises
+    with pytest.raises(
+        TypeError,
+        match=(
+            "if provided, `initial_guess` must be either GaussianMixtureModel or "
+            "HiddenMarkovModel, got `str`."
+        ),
+    ):
+        model = HiddenMarkovModel(trace, n_states, initial_guess="hello")
+
+    # initial guess must have correct number of states
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Initial guess must have the same number of states as requested for the current model; "
+            f"expected {n_states} got {n_states + 1}."
+        ),
+    ):
+        bad_gmm_guess = GaussianMixtureModel.from_channel(trace, n_states + 1)
+        model = HiddenMarkovModel(trace, n_states, initial_guess=bad_gmm_guess)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Initial guess must have the same number of states as requested for the current model; "
+            f"expected {n_states} got {n_states+1}."
+        ),
+    ):
+        bad_hmm_guess = HiddenMarkovModel(trace, n_states + 1)
+        model = HiddenMarkovModel(trace, n_states, initial_guess=bad_hmm_guess)
+
+
+def test_state_path(trace_simple):
+    data, ref_statepath, params = trace_simple
+    trace = make_channel(data)
+    trace.labels = {"title": "mock", "y": "Force (pN)"}
+    original_labels = trace.labels.copy()
+
+    model = HiddenMarkovModel(trace, params["n_states"])
+    state_path = model.state_path(trace)
+    np.testing.assert_equal(state_path.data, ref_statepath)
+
+    # no changes to original channel instance
+    np.testing.assert_equal(trace.data, data)
+    assert id(trace.labels) != id(state_path.labels)
+    for key, original_value in original_labels.items():
+        if key == "y":
+            assert original_value == "Force (pN)"
+            assert state_path.labels[key] == "state"
+        else:
+            assert state_path.labels[key] == original_value
+
+
+def test_emission_path(trace_simple):
+    data, statepath, params = trace_simple
+    trace = make_channel(data)
+    trace.labels = {"title": "mock", "y": "Force (pN)"}
+    original_labels = trace.labels.copy()
+
+    model = HiddenMarkovModel(trace, params["n_states"])
+    emission_path = model.emission_path(trace)
+    np.testing.assert_equal(emission_path.data, model.means[statepath])
+
+    # no changes to original channel instance
+    np.testing.assert_equal(trace.data, data)
+    assert id(trace.labels) != id(emission_path.labels)
+    for key, original_value in original_labels.items():
+        assert emission_path.labels[key] == original_value
+
+
+def test_dwelltimes(trace_simple):
+    data, _, params = trace_simple
+    trace = make_channel(data)
+
+    model = HiddenMarkovModel(trace, params["n_states"])
+
+    dwell_times = model.extract_dwell_times(trace, exclude_ambiguous_dwells=False)
+    np.testing.assert_allclose(dwell_times[0], [3.200e-04, 2.432e-04, 5.120e-05])
+    np.testing.assert_allclose(dwell_times[1], [1.664e-04, 3.456e-04, 3.840e-05, 1.152e-04])
+
+    dwell_times = model.extract_dwell_times(trace, exclude_ambiguous_dwells=True)
+    np.testing.assert_allclose(dwell_times[0], [3.200e-04, 2.432e-04, 5.120e-05])
+    np.testing.assert_allclose(dwell_times[1], [3.456e-04, 3.840e-05])
+
+
+def test_fit_info(trace_simple):
+    data, _, params = trace_simple
+
+    model = HiddenMarkovModel(data, params["n_states"])
+
+    assert isinstance(model.fit_info, HmmFitInfo)
+    assert model.fit_info.converged
+    assert model.fit_info.n_iter == 2
+    np.testing.assert_allclose(model.fit_info.bic, -104.03696527084878)
+    np.testing.assert_allclose(model.fit_info.aic, -122.27315657276543)
+    np.testing.assert_allclose(model.fit_info.log_likelihood, 68.13657828638271)
+
+
+def test_plots(trace_simple):
+    import matplotlib.pyplot as plt
+
+    data, _, params = trace_simple
+    trace = make_channel(data)
+    model = HiddenMarkovModel(trace, params["n_states"])
+
+    model.hist(trace)
+    plt.close()
+
+    model.plot(trace)
+    plt.close()

--- a/lumicks/pylake/population/tests/test_hmm_algos.py
+++ b/lumicks/pylake/population/tests/test_hmm_algos.py
@@ -1,0 +1,137 @@
+import numpy as np
+import pytest
+
+from lumicks.pylake import HiddenMarkovModel, GaussianMixtureModel
+from lumicks.pylake.population.detail.hmm import (
+    ClassicHmm,
+    viterbi,
+    normalize_rows,
+    forward_backward,
+    calculate_temporary_variables,
+)
+
+
+@pytest.fixture(scope="module")
+def test_data():
+    return np.array([1, 1, 1, 2, 2, 1, 1, 1]) + np.random.normal(0, scale=0.01, size=8)
+
+
+def test_classic_hmm(trace_simple):
+    data, _, params = trace_simple
+
+    for gmm in (
+        None,
+        GaussianMixtureModel(
+            data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
+        ),
+    ):
+        guess = ClassicHmm.guess(data, params["n_states"], gmm=gmm)
+
+        assert guess.K == params["n_states"]
+        np.testing.assert_allclose(guess.mu, [9.99752139, 11.00902636])
+        np.testing.assert_allclose(guess.tau, [94.173207, 115.911592])
+        np.testing.assert_allclose(guess.pi, [0.5, 0.5])
+        np.testing.assert_allclose(guess.A, [[0.9375, 0.0625], [0.05882353, 0.94117647]])
+
+        np.testing.assert_allclose(
+            guess.state_log_likelihood([10, 11]),
+            [[1.35334005, -45.96668197], [-57.54930288, 1.45275339]],
+        )
+
+
+def test_forward_backward_vectorization(test_data):
+    model = ClassicHmm.guess(test_data, 2)
+    alpha, beta, c, B = forward_backward(test_data, model)
+
+    # B comes from the internal model instance, needs to be exponentiated for this algo
+    np.testing.assert_allclose(B, np.exp(model.state_log_likelihood(test_data).T))
+
+    # alpha is row-wise normalized for scaling
+    np.testing.assert_equal(alpha.sum(axis=1), 1)
+
+    # beta is initialized (from the end) to 1
+    # Rabiner Eqn 24
+    np.testing.assert_equal(beta[-1], 1)
+
+    # test against non-vectorized equation for initialization, first observation (t=0)
+    # Rabiner Eqn 18 (unscaled)
+    fwd_init = np.array([model.pi[i] * B[0, i] for i in range(model.K)])
+    fwd_init = fwd_init / fwd_init.sum()
+    np.testing.assert_allclose(alpha[0], fwd_init)
+
+    # test against non-vectorized equation for induction, first time step (t=1)
+    # Rabiner Eqn 19 (unscaled)
+    fwd_ind = np.array(
+        [
+            np.sum([alpha[0, j] * model.A[j, i] for j in range(model.K)]) * B[1, i]
+            for i in range(model.K)
+        ]
+    )
+    fwd_ind = fwd_ind / fwd_ind.sum()
+    np.testing.assert_allclose(alpha[1], fwd_ind)
+
+    # test against non-vectorized equation for backward induction (t=T-1)
+    # Rabiner Eqn 25 (unscaled)
+    back_ind = [
+        np.sum([model.A[i, j] * 1 * B[-1, j] for j in range(model.K)]) / c[-1]
+        for i in range(model.K)
+    ]
+    np.testing.assert_allclose(beta[-2], back_ind)
+
+
+def test_temp_variables(test_data):
+    model = ClassicHmm.guess(test_data, 2)
+    alpha, beta, c, B = forward_backward(test_data, model)
+    gamma, xi, log_likelihood = calculate_temporary_variables(model, alpha, beta, c, B)
+
+    np.testing.assert_equal(gamma.sum(axis=1), 1)
+
+    # test again non-vectorized equation
+    # Rabiner Eqn 37 (unscaled)
+    xi_ref = np.stack(
+        [
+            np.vstack(
+                [
+                    [
+                        alpha[t, i] * model.A[i, j] * B[t + 1, j] * beta[t + 1, j] / c[t + 1]
+                        for j in range(model.K)
+                    ]
+                    for i in range(model.K)
+                ]
+            )
+            for t in range(len(test_data) - 1)
+        ],
+        axis=0,
+    )
+    np.testing.assert_allclose(xi, xi_ref)
+
+    # Rabiner Eqn 38
+    np.testing.assert_allclose(gamma[:-1], np.sum(xi, axis=2))
+
+    # Rabiner Eqn 103
+    np.testing.assert_allclose(log_likelihood, np.sum(np.log(c)))
+
+
+def test_viterbi_with_zeros(trace_simple):
+    """test viterbi algorithm with zeros in initial state probability or transition matrix.
+    Should not warn (invalid divide from log(0))"""
+    data, _, params = trace_simple
+    model = ClassicHmm(
+        params["n_states"],
+        [1, 0],
+        normalize_rows(params["transition_prob"]),
+        params["means"],
+        params["st_devs"],
+    )
+
+    viterbi(data, model)
+
+    model = ClassicHmm(
+        params["n_states"],
+        params["initial_state_prob"],
+        [[1, 0], [0.1, 0.9]],
+        params["means"],
+        params["st_devs"],
+    )
+
+    viterbi(data, model)

--- a/lumicks/pylake/population/tests/test_mixture.py
+++ b/lumicks/pylake/population/tests/test_mixture.py
@@ -1,6 +1,4 @@
 import numpy as np
-import pytest
-import matplotlib.pyplot as plt
 
 from lumicks.pylake import GaussianMixtureModel
 from lumicks.pylake.channel import Slice, Continuous
@@ -14,14 +12,13 @@ def test_gmm(trace_lownoise):
     weights = np.array([np.sum(statepath == j) for j in np.arange(params["n_states"])])
     weights = weights / weights.sum()
 
-    # assert np.all(np.equal(m.label(trace), statepath))
     np.testing.assert_allclose(m.means, params["means"], atol=0.05)
     np.testing.assert_allclose(m.std, params["st_devs"], atol=0.02)
     np.testing.assert_allclose(m.weights, weights)
 
 
 def test_gmm_from_slice(trace_simple):
-    data, statepath, params = trace_simple
+    data, _, params = trace_simple
     trace = Slice(Continuous(data, 20000, 12800))
     m = GaussianMixtureModel.from_channel(trace, params["n_states"])
     np.testing.assert_allclose(m.means, params["means"], atol=0.05)
@@ -37,7 +34,7 @@ def test_labels(trace_simple):
 
 
 def test_dwelltimes(trace_simple):
-    data, statepath, params = trace_simple
+    data, _, params = trace_simple
     m = GaussianMixtureModel(
         data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
     )
@@ -54,7 +51,7 @@ def test_dwelltimes(trace_simple):
 
 
 def test_information_criteria(trace_simple):
-    data, statepath, params = trace_simple
+    data, _, params = trace_simple
     m = GaussianMixtureModel(
         data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
     )
@@ -64,7 +61,7 @@ def test_information_criteria(trace_simple):
 
 
 def test_exit_flag(trace_simple):
-    data, statepath, params = trace_simple
+    data, _, params = trace_simple
     m = GaussianMixtureModel(
         data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
     )
@@ -76,7 +73,7 @@ def test_exit_flag(trace_simple):
 
 
 def test_pdf(trace_simple):
-    data, statepath, params = trace_simple
+    data, _, params = trace_simple
     m = GaussianMixtureModel(
         data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
     )
@@ -86,7 +83,9 @@ def test_pdf(trace_simple):
 
 
 def test_gmm_plots(trace_simple):
-    data, statepath, params = trace_simple
+    import matplotlib.pyplot as plt
+
+    data, _, params = trace_simple
     m = GaussianMixtureModel(
         data, params["n_states"], init_method="kmeans", n_init=1, tol=1e-3, max_iter=100
     )

--- a/lumicks/pylake/population/tests/test_validators.py
+++ b/lumicks/pylake/population/tests/test_validators.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from lumicks.pylake.population.detail.validators import col, row
+
+
+def test_row():
+    assert row(1).shape == (1, 1)
+    assert row([1, 2, 3]).shape == (1, 3)
+    assert row(np.array([1, 2, 3])).shape == (1, 3)
+
+
+def test_col():
+    assert col(1).shape == (1, 1)
+    assert col([1, 2, 3]).shape == (3, 1)
+    assert col(np.array([1, 2, 3])).shape == (3, 1)

--- a/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
@@ -478,7 +478,7 @@ def test_plot_correlated_smaller_channel():
 def test_stack_name(monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(
-            "lumicks.pylake.detail.widefield.TiffStack.from_file",
+            "lumicks.pylake.image_stack.TiffStack.from_file",
             lambda *args, **kwargs: TiffStack(
                 [MockTiffFile([np.zeros((3, 3, 3))] * 2, make_frame_times(2))],
                 align_requested=False,
@@ -707,7 +707,7 @@ def test_calibrated_tether(monkeypatch, scaling, ref_point1, ref_point2):
         return stack
 
     with monkeypatch.context() as m:
-        m.setattr("lumicks.pylake.detail.widefield.TiffStack.with_tether", check_points)
+        m.setattr("lumicks.pylake.image_stack.TiffStack.with_tether", check_points)
         m.setattr("lumicks.pylake.ImageStack.pixelsize_um", scaling)
 
         stack.define_tether([1.0, 2.0], [4.0, 5.0])


### PR DESCRIPTION
**Why this PR?**
Adds models for analyzing time series data exhibiting transitions between discrete states. This is useful for constant-extension experiments or photon count time traces (especially FRET)

This PR lays down all of the internal algorithms for model training and state labeling. A second PR will focus on building up the rest of the public API with convenience functions for plots, histograms, etc...

Notes:
- Similar to `lk.GaussianMixtureModel` that wraps `sklearn`'s GMM, I defined an internal model class to just handle the parameters and initialization/update; we can then expose what we want from the model through the public API that wraps this
- There is a lot of internal code that uses notation seemingly from nowhere, however it is pretty standard in the HMM field and derives largely from Rabiner's seminal "A tutorial on HMMs and selected applications in speech recognition". Another very useful resource is the [HMM project](https://web.ece.ucsb.edu/Faculty/Rabiner/ece259/speech%20recognition%20course/term%20projects/HMM%20Project.pdf) from his speech recognition course, although not exactly sure if we should or how we should cite this
- Mostly I did this to avoid using things like `state_transition_matrix` sprinkled in throughout the algorithm, instead using the standard `A`. Open for discussion if there are suggestions for finding a middle ground here.
- For the public properties I use more descriptive attribute names (`means` instead of `mu`)
- Much of the code is pulled from my `smtirf` repo, written during my postdoc and refactored to fit `pylake`'s API style and vectorized where possible (since we're not yet using `numba`)
- The only intended public API is the `HiddenMarkovModel` class, although I haven't made it public yet. My idea is to match the interface with that of `lk.GaussianMixtureModel`. 

A typical workflow (after completing the public API) would be something like:
```
model = lk.HiddenMarkovModel.from_channel(force1x, n_states=3)
model.plot(force1x)
```

<img width="1488" alt="image" src="https://github.com/lumicks/pylake/assets/61475504/4d84bd2f-368a-4509-92f5-f733023ede6c">
