### PR TITLE
Small test improvements and bugfix on `Slice`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@
 * Added option to filter tracks by duration in seconds using `lk.filter_tracks(tracks, minimum_duration=duration_in_seconds)`.
 * Added `KymoTrackGroup.filter()` to filter tracks in-place. `tracks.filter(minimum_duration=2)` is equivalent to `tracks = lk.filter_tracks(tracks, minimum_duration=2)`.
 
+#### Bug fixes
+
+* Fixed a bug in `Slice.downsampled_like` that would fail to raise an error due to a lack of overlap between the low frequency and high frequency channel when the high frequency channel starts within the last sample of the low frequency channel.
+
 #### Improvements
 
 * Kymographs consisting of a single scan line now return a valid `line_time_seconds`. This allows certain downstream functionality, such as `Kymo.plot()`.

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -456,7 +456,7 @@ class Slice:
         timestamps = other_slice.timestamps
         delta_time = np.diff(timestamps)
 
-        if self._src.start >= timestamps[-1] or self._src.stop <= timestamps[0]:
+        if self._src.start > (timestamps[-1] - delta_time[-1]) or self._src.stop <= timestamps[0]:
             raise RuntimeError("No overlap between slices.")
 
         # When the frame rate changes, one frame is very long due to the delay of the camera. It

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -38,10 +38,6 @@ def _default_line_time_factory(self: "Kymo"):
 
         dead_time = np.argmax(beyond_first_line)
 
-        # Special case for no dead time. Is it really no deadtime, or a single line?
-        if dead_time == 0 and not np.any(beyond_first_line):
-            return scan_time * infowave._src.dt * ns_to_sec
-
         return (scan_time + dead_time) * infowave._src.dt * ns_to_sec
 
     elif self.timestamps.shape[1] > 1:

--- a/lumicks/pylake/tests/test_channels/test_channels.py
+++ b/lumicks/pylake/tests/test_channels/test_channels.py
@@ -748,10 +748,18 @@ def test_downsampling_like():
     ):
         s.downsampled_like(s)
 
-    for offset in (-4 * 4, t_downsampled[-1] + 1):
+    timestep = 4
+    for offset in (with_offset(-4 * timestep), t_downsampled[-1] - timestep + 1):
         with pytest.raises(RuntimeError, match="No overlap between slices"):
-            s = channel.Slice(channel.Continuous(np.array([1, 2, 3, 4]), with_offset(offset), 4))
+            s = channel.Slice(channel.Continuous(np.array([1, 2, 3, 4]), offset, timestep))
             s.downsampled_like(reference)
+
+    for offset, ref in [
+        (with_offset(-4 * timestep + 1), 4),
+        (t_downsampled[-1] - timestep, 1),
+    ]:
+        s = channel.Slice(channel.Continuous(np.array([1, 2, 3, 4]), offset, timestep))
+        np.testing.assert_equal(s.downsampled_like(reference)[0].data, ref)
 
 
 def test_channel_plot():


### PR DESCRIPTION
Fixes some issues that came up during mutation testing.

- Removes some unnecessary code from line time reconstruction.
- Improves tests by including more specific corner cases.
- Fixes a bug in `downsampled_like` that produced an unusable `Slice`.