### PR TITLE
powerspectrum: add bin width number of samples used to compute the power spectrum.

### DIFF
--- a/lumicks/pylake/force_calibration/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/power_spectrum.py
@@ -70,6 +70,12 @@ class PowerSpectrum:
         self.sample_rate = sample_rate
         self.total_duration = data.size / sample_rate
         self.num_points_per_block = len(squared_fft_chunks)
+        self.total_sampled_used = num_points_per_window * self.num_points_per_block
+
+    @property
+    def frequency_bin_width(self):
+        """Returns the frequency bin width of the spectrum"""
+        return self.sample_rate / self.total_sampled_used * self.num_points_per_block
 
     def downsampled_by(self, factor, reduce=np.mean) -> "PowerSpectrum":
         """Returns a spectrum downsampled by a given factor."""


### PR DESCRIPTION
**Why this PR?**
I find myself frequently adding this same calculation to notebooks.

When using `window_seconds`, it is not immediately apparent how many of the raw data points actually get used and what frequency bin width that leads to. You could compute the bin width from `ps.frequency[1] - ps.frequency[0]` but that comes with the caveat that someone could have chopped parts of the spectrum out giving you an incorrect value.

We know what the native bin width will be, so let's add it as a property.