### PR TITLE
export_movie: force showing the figure

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Fixed `lk.download_from_doi()` to align with new Zenodo REST API.
 * Fixed a bug in `Scan.plot()` in which the default aspect ratio was calculated such that pixels always appeared square. For scans with non-square pixel sizes, this would result in distortion of the image.
+* Don't store animation writer in a temporary variable as this results in a `matplotlib` error when attempting to export a movie on jupyter notebook. 
 
 ## v1.2.1 | 2023-10-17
 

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -172,10 +172,12 @@ class VideoExport:
 
         fig = plt.figure()
         fig.patch.set_alpha(1.0)
-        line_ani = animation.FuncAnimation(
-            fig, plot, stop_frame - start_frame, interval=1, blit=True
+        # Don't store the FuncAnimation in a variable as this leads to mpl attempting to remove
+        # a callback that doesn't exist on plt.close(fig) when using the jupyter notebook backend.
+        animation.FuncAnimation(fig, plot, stop_frame - start_frame, interval=1, blit=True).save(
+            file_name,
+            writer=writer,
         )
-        line_ani.save(file_name, writer=writer)
         plt.close(fig)
 
 


### PR DESCRIPTION
**Why this PR?**
It seems that on jupyter notebook, when you export a movie, keeping a handle to `FuncAnimation` results in `matplotlib` attempting to disconnect a callback that no longer exists when you call `plt.close()`. This change mitigates that by not storing the variable.