### PR TITLE
export_movie: add the option to correlate a channel slice when exporting to a movie

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,3 +24,4 @@
 *.npz filter=lfs diff=lfs merge=lfs -text
 *.ico filter=lfs diff=lfs merge=lfs -text
 *.gb filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * Added `duration` property to `KymoTrack` which returns the duration (in seconds) that the track was observed.
 * Added option to filter tracks by duration in seconds using `lk.filter_tracks(tracks, minimum_duration=duration_in_seconds)`.
 * Added `KymoTrackGroup.filter()` to filter tracks in-place. `tracks.filter(minimum_duration=2)` is equivalent to `tracks = lk.filter_tracks(tracks, minimum_duration=2)`.
+* Added option to align plots vertically by passing `vertical=True` to `Scan.plot_correlated` and `ImageStack.plot_correlated()`.
 
 #### Bug fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,13 +4,14 @@
 
 #### New features
 
+* Added option to export [`ImageStack`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack) and [`Scan`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.scan.Scan.html) stacks to movies correlated with channel data. Simply pass a [`Slice`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.channel.Slice.html) to the `channel_slice` parameter of [`Scan.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.scan.Scan.html#lumicks.pylake.scan.Scan.export_video) or [`ImageStack.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.export_video).
 * Added more options for plotting color channels for images:
   * Shortcuts `"r"`, `"g"`, and `"b"` can now be used for plotting single color channels in addition to `"red"`, `"green"`, and `"blue"`.
   * Two-channel visualizations can be plotted using `"rg"`, `"gb"`, or `"rb"`.
 * Added `duration` property to `KymoTrack` which returns the duration (in seconds) that the track was observed.
 * Added option to filter tracks by duration in seconds using `lk.filter_tracks(tracks, minimum_duration=duration_in_seconds)`.
 * Added `KymoTrackGroup.filter()` to filter tracks in-place. `tracks.filter(minimum_duration=2)` is equivalent to `tracks = lk.filter_tracks(tracks, minimum_duration=2)`.
-* Added option to align plots vertically by passing `vertical=True` to `Scan.plot_correlated` and `ImageStack.plot_correlated()`.
+* Added option to align plots vertically by passing `vertical=True` to [`Scan.plot_correlated`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.scan.Scan.html#lumicks.pylake.scan.Scan.plot_correlated) and [`ImageStack.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.plot_correlated).
 
 #### Bug fixes
 

--- a/docs/tutorial/imagestack.rst
+++ b/docs/tutorial/imagestack.rst
@@ -73,6 +73,8 @@ You can also obtain the image stack data as a :class:`numpy array <numpy.ndarray
     red_data = stack.get_image(channel="red") # shape = [n_frames, y_pixels, x_pixels]
     rgb_data = stack.get_image(channel="rgb") # shape = [n_frames, y_pixels, x_pixels, 3 channels]
 
+.. _stack_plotting:
+
 Plotting and exporting
 ----------------------
 
@@ -100,10 +102,25 @@ of all three channels at a frame rate of 2 frames per second, we can do this::
         "rgb",
         "test_rgb.gif",
         start_frame=2,
-        stop_frame=7, f
-        ps=2,
+        stop_frame=7,
+        fps=2,
         adjustment=lk.ColorAdjustment(20, 99, mode="percentile")
     )
+
+You can also export a video including correlated channel data by providing :meth:`~lumicks.pylake.ImageStack.export_video` with a :class:`~lumicks.pylake.channel.Slice`::
+
+    file = lk.File("test_data/stack.h5")  # Loading a stack.
+    stack_roi.export_video(
+        "rgb",
+        "with_channel.gif",
+        fps=2,
+        adjustment=lk.ColorAdjustment(20, 99, mode="percentile"),
+        channel_slice=file.force1x
+    )
+
+.. note::
+
+    To export to an `mp4` file, you will need to install `ffmpeg`. See :ref:`ffmpeg_installation` for more information.
 
 Defining a tether
 -----------------

--- a/docs/tutorial/scans.rst
+++ b/docs/tutorial/scans.rst
@@ -51,6 +51,9 @@ The scan can also be exported to TIFF format::
 Scans can also be exported to video formats. Exporting the red channel of a multi-scan GIF can be
 done as follows::
 
+    multiframe_file = lk.File("test_data/scan_stack.h5")
+    multiframe_scan = multiframe_file.scans["46"]
+
     multiframe_scan.export_video(
         "red",
         "test_red.gif",
@@ -72,6 +75,25 @@ at a frame rate of 2 frames per second, we can do this::
 For other video formats such as `.mp4` or `.avi`, ffmpeg must be installed. See
 :ref:`installation instructions <ffmpeg_installation>` for more information on this.
 
+You can also export the scan stack as a video including correlated channel data by providing :meth:`~lumicks.pylake.scan.Scan.export_video` with a :class:`~lumicks.pylake.channel.Slice`::
+
+    multiframe_scan.export_video(
+        "rgb",
+        "test_rgb.gif",
+        start_frame=2,
+        stop_frame=15,
+        fps=2,
+        adjustment=lk.ColorAdjustment(20, 99, mode="percentile"),
+        channel_slice=multiframe_file.force1x
+    )
+
+.. note::
+
+    To export to an `mp4` file, you will need to install `ffmpeg`. See :ref:`ffmpeg_installation` for more information.
+
+Photon counts
+-------------
+
 The images contain pixel data where each pixel represents summed photon counts.
 The photon count per pixel can be accessed as follows::
 
@@ -81,7 +103,7 @@ The photon count per pixel can be accessed as follows::
     plt.show()
 
 Scan metadeta
---------------
+-------------
 There are several properties available for convenient access to the scan metadata:
 
 * :attr:`scan.center_point_um <lumicks.pylake.scan.Scan.center_point_um>` provides a dictionary of

--- a/docs/whatsnew/1.3.0/1_3_0.rst
+++ b/docs/whatsnew/1.3.0/1_3_0.rst
@@ -5,6 +5,15 @@ Pylake 1.3.0
 
 Here's a sneak peek at the new features coming in Pylake `v1.3.0`:
 
+Export correlated movies
+------------------------
+
+Movies exported with Pylake can now optionally show a correlated data slice by simply providing a :class:`~lumicks.pylake.channel.Slice` to the :meth:`~lumicks.pylake.scan.Scan.export_video` function.
+
+.. figure:: export_correlated.gif
+
+Check out the exporting section in :ref:`ImageStack<stack_plotting>` and :ref:`Scan<confocal_plotting>` tutorial for more information.
+
 More options for plotting images
 --------------------------------
 

--- a/docs/whatsnew/1.3.0/export_correlated.gif
+++ b/docs/whatsnew/1.3.0/export_correlated.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0e0acc1c8cdf46cbd43141be35ec719552ae269b765877ec7d88a25cda759d6
+size 1796824

--- a/lumicks/pylake/image_stack.py
+++ b/lumicks/pylake/image_stack.py
@@ -481,6 +481,7 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
         channel="rgb",
         figure_scale=0.75,
         adjustment=no_adjustment,
+        vertical=False,
     ):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling
         function (e.g. `np.mean`) is evaluated for the time between a start and end time of a
@@ -509,6 +510,8 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
             figure.
         adjustment : lk.ColorAdjustment
             Color adjustments to apply to the output image.
+        vertical : bool
+            Align plots vertically.
 
         Note
         ----
@@ -542,6 +545,7 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
             reduce=reduce,
             figure_scale=figure_scale,
             post_update=post_update,
+            vertical=vertical,
         )
 
     @property

--- a/lumicks/pylake/image_stack.py
+++ b/lumicks/pylake/image_stack.py
@@ -481,7 +481,9 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
         channel="rgb",
         figure_scale=0.75,
         adjustment=no_adjustment,
+        *,
         vertical=False,
+        return_frame_setter=False,
     ):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling
         function (e.g. `np.mean`) is evaluated for the time between a start and end time of a
@@ -512,6 +514,8 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
             Color adjustments to apply to the output image.
         vertical : bool
             Align plots vertically.
+        return_frame_setter : bool
+            Whether to return a handle that allows updating the plotted frame.
 
         Note
         ----
@@ -536,7 +540,7 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
         def post_update(image_handle, image):
             return adjustment._update_limits(image_handle, image, channel)
 
-        plot_correlated(
+        frame_setter = plot_correlated(
             channel_slice=channel_slice,
             frame_timestamps=self.frame_timestamp_ranges(),
             get_plot_data=frame_grabber,
@@ -547,6 +551,9 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
             post_update=post_update,
             vertical=vertical,
         )
+
+        if return_frame_setter:
+            return frame_setter
 
     @property
     def size_um(self) -> Optional[list]:

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -292,7 +292,9 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         channel="rgb",
         figure_scale=0.75,
         adjustment=no_adjustment,
+        *,
         vertical=False,
+        return_frame_setter=False,
     ):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling
         function (e.g. np.mean) is evaluated for the time between a start and end time of a frame.
@@ -324,6 +326,8 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             Color adjustments to apply to the output image.
         vertical : bool
             Align plots vertically.
+        return_frame_setter : bool
+            Whether to return a handle that allows updating the plotted frame.
 
         Examples
         --------
@@ -351,7 +355,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
 
         frame_timestamps = self.frame_timestamp_ranges()
 
-        plot_correlated(
+        frame_setter = plot_correlated(
             channel_slice,
             frame_timestamps,
             plot_channel,
@@ -363,6 +367,8 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             post_update=post_update,
             vertical=vertical,
         )
+        if return_frame_setter:
+            return frame_setter
 
     @property
     def lines_per_frame(self):

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -292,6 +292,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         channel="rgb",
         figure_scale=0.75,
         adjustment=no_adjustment,
+        vertical=False,
     ):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling
         function (e.g. np.mean) is evaluated for the time between a start and end time of a frame.
@@ -321,7 +322,8 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             figure.
         adjustment : lk.ColorAdjustment
             Color adjustments to apply to the output image.
-
+        vertical : bool
+            Align plots vertically.
 
         Examples
         --------
@@ -359,6 +361,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             colormap=colormaps._get_default_colormap(channel),
             figure_scale=figure_scale,
             post_update=post_update,
+            vertical=vertical,
         )
 
     @property

--- a/lumicks/pylake/tests/test_imaging_confocal/test_export.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_export.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from lumicks.pylake.channel import Slice, Continuous
+
 
 def test_export_tiff(tmp_path, test_kymo, grab_tiff_tags):
     from os import stat
@@ -92,3 +94,24 @@ def test_movie_export(tmpdir_factory, test_scans_multiframe):
         ),
     ):
         scan.export_video("gray", "dummy.gif")  # Gray is not a color!
+
+
+@pytest.mark.parametrize("vertical, channel", [(False, "red"), (True, "red"), (False, "rgb")])
+def test_correlated_movie_export(tmpdir_factory, test_scans_multiframe, vertical, channel):
+    from os import stat
+
+    tmpdir = tmpdir_factory.mktemp("pylake")
+    scan, _ = test_scans_multiframe["fast Y slow X multiframe"]
+    corr_data = Slice(
+        Continuous(np.arange(1000), scan.start, int(1e9)), labels={"title": "title", "y": "y"}
+    )
+
+    scan.export_video(
+        channel,
+        f"{tmpdir}/{channel}_corr.gif",
+        start_frame=0,
+        stop_frame=0,
+        channel_slice=corr_data,
+        vertical=vertical,
+    )
+    assert stat(f"{tmpdir}/{channel}_corr.gif").st_size > 0


### PR DESCRIPTION
**Why this PR?**
Highly requested feature. This feature allows you to export channel data alongside a movie. Users want these kind of movies in talks and whatnot.

I've manually tested all permutations I could think of (cropping by time, pixels, including color adjustments for both scans and image stacks). I tested on jupyter notebook (with `notebook` backend), jupyter lab (with `widget` backend) and on the non-interactive backend.

![test_scan](https://github.com/lumicks/pylake/assets/19836026/5953d4dd-d2da-4ff0-91bb-76de8018a8e2)
![with_channel](https://github.com/lumicks/pylake/assets/19836026/a69206aa-49d1-4048-b5fb-ab039e69b621)

Docs [here](https://lumicks-pylake.readthedocs.io/en/correlated_movie/whatsnew/1.3.0/1_3_0.html), [here](https://lumicks-pylake.readthedocs.io/en/correlated_movie/tutorial/imagestack.html#stack-plotting) and [here](https://lumicks-pylake.readthedocs.io/en/correlated_movie/tutorial/scans.html#confocal-plotting). API docs [here](https://lumicks-pylake.readthedocs.io/en/correlated_movie/_api/lumicks.pylake.scan.Scan.html#lumicks.pylake.scan.Scan.export_video) and [here](https://lumicks-pylake.readthedocs.io/en/correlated_movie/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.export_video). 