### PR TITLE
release: release pylake `1.3.1`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.3.1 | 2023-12-07
+
+#### Bug fixes
+
+* Fixed a bug in [`Scan.export_video()`](https://lumicks-pylake.readthedocs.io/en/v1.3.1/_api/lumicks.pylake.scan.Scan.html#lumicks.pylake.scan.Scan.export_video) and [`ImageStack.export_video()`](https://lumicks-pylake.readthedocs.io/en/v1.3.1/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.export_video) which resulted in empty frames being written when exporting with channel data.
+
 ## v1.3.0 | 2023-12-07
 
 #### New features

--- a/lumicks/pylake/__about__.py
+++ b/lumicks/pylake/__about__.py
@@ -1,5 +1,5 @@
 __title__ = "lumicks.pylake"
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __summary__ = "Bluelake data analysis tools"
 __url__ = "https://github.com/lumicks/pylake"
 

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -239,8 +239,6 @@ class VideoExport:
                 )
                 return plt.gca().get_children()
 
-        fig = plt.figure()
-        fig.patch.set_alpha(1.0)
         # Don't store the FuncAnimation in a variable as this leads to mpl attempting to remove
         # a callback that doesn't exist on plt.close(fig) when using the jupyter notebook backend.
         animation.FuncAnimation(fig, plot, stop_frame - start_frame, interval=1, blit=True).save(


### PR DESCRIPTION
Unfortunately, an error snuck in merging back bugfixes from `main`, which resulted in a new figure being opened before setting up the class that renders to the file. This resulted in blank figures being exported.