### PR TITLE
plot_correlated: fix off by one error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.3.2 | t.b.d.
+
+#### Bug fixes
+
+* Fixed a bug where the time indicator was off by one frame in [`ImageStack.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.plot_correlated) and [`ImageStack.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.export_video).
+
 ## v1.3.1 | 2023-12-07
 
 #### Bug fixes

--- a/lumicks/pylake/nb_widgets/correlated_plot.py
+++ b/lumicks/pylake/nb_widgets/correlated_plot.py
@@ -70,7 +70,21 @@ def plot_correlated(
 
     t0 = downsampled.timestamps[0]
     t, y = downsampled.seconds, downsampled.data
-    ax_channel.step(t, y, where="pre")
+
+    # We explicitly append the last frame time to make sure that it still shows up
+    last_dt = np.diff(
+        [
+            frame_range
+            for frame_range in frame_timestamps
+            if frame_range[0] >= channel_slice.start and frame_range[1] <= channel_slice.stop
+        ][-1]
+    )
+    t = np.hstack((t, t[-1] + last_dt * 1e-9))
+    y = np.hstack((y, y[-1]))
+
+    # We want a constant line from the start of the first frame, to the end. So we plot up to
+    # the second point.
+    ax_channel.step(t, y, where="post")
     ax_img.tick_params(
         axis="both", which="both", bottom=False, left=False, labelbottom=False, labelleft=False
     )


### PR DESCRIPTION
**Why this PR?**
It fixes a bug that leads to an off-by-one error in the correlated plot.

- We downsample over the frame.
- The downsampled time axis uses the minimum timestamp of each frame as its timestamp.
- We subtract the first downsampled timestamp such that the origin starts at zero.
- We want to hold this first sample over the entire frame, as it corresponds to that frame. In other words, up to the next frame/time point. Therefore we should be using "post", not "pre" when setting up the step plot.
- To make sure we get an additional stick for the last frame, we must also hold the last value for the frame time.

Note:
I will defer the regression test (for now) as I plan to add an additional test that will cover this once we correctly handle the exposure time for `ImageStack`. Basically this means making sure that we integrate the channel data over the exposure time rather than the frame time when that option is selected.

With the bug:
![bug_real_data_bead](https://github.com/lumicks/pylake/assets/19836026/fff29685-5dbe-4a9a-8d0a-b3c60432e281)
![bug_real_data_trap](https://github.com/lumicks/pylake/assets/19836026/9b3d3983-0fe9-4a7e-965a-f4ab3fe68dbd)
Real data with the bug, trap and bead position

![bug_simulated](https://github.com/lumicks/pylake/assets/19836026/0901aa70-44d3-43c3-b19a-9d23398c8230)
Simulated data. There should be four frames, with the noise shown when the signal value is high.

Without the bug:
![fixed_real_data_bead](https://github.com/lumicks/pylake/assets/19836026/988db207-4131-42c4-ab54-f6cb126b1129)
![fixed_real_data_trap](https://github.com/lumicks/pylake/assets/19836026/0f2db7e3-ed0c-4e7e-8506-0becad85c388)

![fixed_simulated_data](https://github.com/lumicks/pylake/assets/19836026/05de59fd-f1db-47fb-8fe6-7b34b1dc66f7)
Simulated data. There should be four frames, with the noise shown when the signal value is high.

If you want to simulate the test data yourself:
```
from lumicks.pylake.tests.data.mock_widefield import make_frame_times, MockTiffFile
from lumicks.pylake.image_stack import TiffStack, ImageStack
from lumicks.pylake import channel
import numpy as np

a1 = np.random.normal(size=(4, 4))
a2 = np.zeros((4, 4))
make_frame_times(3)

fake_tiff = TiffStack(
    [
        MockTiffFile(
            data=[a2, a1, a2, a2],
            times=make_frame_times(4),
            description="stack",
            bit_depth=16,
        )
    ],
    align_requested=False,
)

stack = ImageStack.from_dataset(fake_tiff)
d = [0] * 5 + [2] * 5 + [0] * 10

s = channel.Slice(channel.Continuous(d, stack.start, 2), labels={"y": "test", "title": "y"})
stack.plot_correlated(s, frame=1)
```