### PR TITLE
docs: fix import issue and add `id` field to notebook export

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx_lfs_content==1.0.0
 matplotlib
+nbclient>=0.5.0
 nbconvert
 nbformat
 numpy


### PR DESCRIPTION
**Why this PR?**
Our docs stopped building.

One is an import issue (they removed an import from `nbexport` [here](https://github.com/jupyter/nbconvert/commit/a7df9afbf165e397c31d6b79c66cff8288e4a42e)). Second was just a warning (but one that will become an error in the future) which is that an `id` field is missing from our exported notebooks.