### PR TITLE
`ImageStack`: Make `include_dead_time=False` actually exclude the dead time.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,3 +25,4 @@
 *.ico filter=lfs diff=lfs merge=lfs -text
 *.gb filter=lfs diff=lfs merge=lfs -text
 *.gif filter=lfs diff=lfs merge=lfs -text
+*.tiff filter=lfs diff=lfs merge=lfs -text

--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,15 @@
 
 ## v1.3.2 | t.b.d.
 
+#### New features
+
+* Add option to `include_dead_time` to [`ImageStack.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/v1.3.0/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.plot_correlated) for `Scan` and `ImageStack`. This parameter defaults to `True`. 
+
 #### Bug fixes
 
 * Fixed a bug where the time indicator was off by one frame in [`ImageStack.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.plot_correlated) and [`ImageStack.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.export_video).
 * Fixed a bug where the time between frames was incorrectly not excluded when calling [`ImageStack.frame_timestamp_ranges()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.frame_timestamp_ranges) with `include_dead_time=False`. Note that `Scan` and `Kymo` are not affected.
+* Fixed a bug where [`ImageStack.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/v1.3.0/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.plot_correlated) was not excluding the dead time between frames.
 * Changed the `DateTime` tag on TIFFs exported with Pylake from `Scan` and `Kymo` objects. Before the change, the start and end of the scanning period in nanoseconds was stored. After the change, we store the starting timestamp of the frame, followed by the starting timestamp of the next frame to be consistent with data exported from Bluelake. The scanning time is stored in the field `Exposure time (ms)` on the Description tag.
 
 ## v1.3.1 | 2023-12-07

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Fixed a bug where the time indicator was off by one frame in [`ImageStack.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.plot_correlated) and [`ImageStack.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.export_video).
 * Fixed a bug where the time between frames was incorrectly not excluded when calling [`ImageStack.frame_timestamp_ranges()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.frame_timestamp_ranges) with `include_dead_time=False`. Note that `Scan` and `Kymo` are not affected.
+* Changed the `DateTime` tag on TIFFs exported with Pylake from `Scan` and `Kymo` objects. Before the change, the start and end of the scanning period in nanoseconds was stored. After the change, we store the starting timestamp of the frame, followed by the starting timestamp of the next frame to be consistent with data exported from Bluelake. The scanning time is stored in the field `Exposure time (ms)` on the Description tag.
 
 ## v1.3.1 | 2023-12-07
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### Bug fixes
 
 * Fixed a bug where the time indicator was off by one frame in [`ImageStack.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.plot_correlated) and [`ImageStack.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.export_video).
+* Fixed a bug where the time between frames was incorrectly not excluded when calling [`ImageStack.frame_timestamp_ranges()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.frame_timestamp_ranges) with `include_dead_time=False`. Note that `Scan` and `Kymo` are not affected.
 
 ## v1.3.1 | 2023-12-07
 

--- a/lumicks/pylake/detail/widefield.py
+++ b/lumicks/pylake/detail/widefield.py
@@ -115,11 +115,27 @@ class TiffFrame:
 
     @property
     def stop(self):
-        return self.frame_timestamp_range[1]
+        return self.exposure_timestamp_range[1]
 
     @property
     def frame_timestamp_range(self):
         return _get_page_timestamps(self._page)
+
+    @property
+    def exposure_timestamp_range(self):
+        try:
+            json_metadata = json.loads(self._page.description)
+        except json.decoder.JSONDecodeError:
+            json_metadata = {}
+
+        start, stop = _get_page_timestamps(self._page)
+        stop = (
+            start + int(np.round(1e6 * json_metadata["Exposure time (ms)"]))
+            if "Exposure time (ms)" in json_metadata
+            else stop
+        )
+
+        return start, stop
 
 
 class TiffStack:

--- a/lumicks/pylake/image_stack.py
+++ b/lumicks/pylake/image_stack.py
@@ -10,7 +10,7 @@ from .kymo import Kymo, _kymo_from_image_stack
 from .adjustments import no_adjustment
 from .detail.image import make_image_title
 from .detail.plotting import get_axes, show_image
-from .detail.widefield import TiffStack
+from .detail.widefield import TiffStack, _frame_timestamps_from_exposure_timestamps
 from .detail.imaging_mixins import FrameIndex, TiffExport, VideoExport
 
 
@@ -639,7 +639,12 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
             Include dead time between frames.
         """
         if include_dead_time:
-            return [frame.frame_timestamp_range for frame in self]
+            ts_ranges = [frame.frame_timestamp_range for frame in self]
+
+            if self._src._description._legacy_exposure:
+                return _frame_timestamps_from_exposure_timestamps(ts_ranges)
+
+            return ts_ranges
 
         frame_timestamps = [frame.exposure_timestamp_range for frame in self]
         if len(np.unique(np.diff(np.asarray(frame_timestamps), 1))) != 1:

--- a/lumicks/pylake/image_stack.py
+++ b/lumicks/pylake/image_stack.py
@@ -484,6 +484,7 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
         adjustment=no_adjustment,
         *,
         vertical=False,
+        include_dead_time=False,
         return_frame_setter=False,
     ):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling
@@ -513,10 +514,12 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
             figure.
         adjustment : lk.ColorAdjustment
             Color adjustments to apply to the output image.
-        vertical : bool
-            Align plots vertically.
-        return_frame_setter : bool
-            Whether to return a handle that allows updating the plotted frame.
+        vertical : bool, optional
+            Align plots vertically, default: False.
+        include_dead_time : bool, optional
+            Include dead time between frames, default: False.
+        return_frame_setter : bool, optional
+            Whether to return a handle that allows updating the plotted frame, default: False.
 
         Note
         ----
@@ -543,7 +546,7 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
 
         frame_setter = plot_correlated(
             channel_slice=channel_slice,
-            frame_timestamps=self.frame_timestamp_ranges(),
+            frame_timestamps=self.frame_timestamp_ranges(include_dead_time=include_dead_time),
             get_plot_data=frame_grabber,
             title_factory=lambda frame: make_image_title(self, frame, show_name=False),
             frame=frame,

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -266,10 +266,10 @@ class Kymo(ConfocalImage):
         metadata["Stop pixel timestamp (ns)"] = int(self.line_timestamp_ranges()[-1][1])
         return metadata
 
-    def _tiff_timestamp_ranges(self) -> list:
+    def _tiff_timestamp_ranges(self, include_dead_time) -> list:
         """Create Timestamp ranges for the DateTime field of TIFFs used by `export_tiff`."""
         # As `Kymo` has only one frame, return a list with one timestamp range
-        ts_ranges = np.array(self.line_timestamp_ranges())
+        ts_ranges = np.array(self.line_timestamp_ranges(include_dead_time=include_dead_time))
         return [(np.min(ts_ranges), np.max(ts_ranges))]
 
     def _fix_incorrect_start(self):

--- a/lumicks/pylake/nb_widgets/tests/test_image_editing.py
+++ b/lumicks/pylake/nb_widgets/tests/test_image_editing.py
@@ -23,9 +23,9 @@ def make_mock_stack():
     tiff = TiffStack(
         [
             MockTiffFile(
-                data=[image, image, image],
-                times=[["10", "18"], ["20", "28"], ["30", "38"]],
-                description=json.dumps(description),
+                data=[image] * 3,
+                times=[["10", "20", 18], ["20", "30", 28], ["30", "40", 38]],
+                description=description,
                 bit_depth=bit_depth,
             )
         ],

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -239,9 +239,9 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         metadata["Number of frames"] = self.num_frames
         return metadata
 
-    def _tiff_timestamp_ranges(self) -> list:
+    def _tiff_timestamp_ranges(self, include_dead_time) -> list:
         """Create Timestamp ranges for the DateTime field of TIFFs used by `export_tiff()`."""
-        return self.frame_timestamp_ranges()
+        return self.frame_timestamp_ranges(include_dead_time=include_dead_time)
 
     def frame_timestamp_ranges(self, *, include_dead_time=False):
         """Get start and stop timestamp of each frame in the scan.

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -294,6 +294,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         adjustment=no_adjustment,
         *,
         vertical=False,
+        include_dead_time=False,
         return_frame_setter=False,
     ):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling
@@ -324,9 +325,11 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             figure.
         adjustment : lk.ColorAdjustment
             Color adjustments to apply to the output image.
-        vertical : bool
+        vertical : bool, optional
             Align plots vertically.
-        return_frame_setter : bool
+        include_dead_time : bool, optional
+            Include dead time between scan frames.
+        return_frame_setter : bool, optional
             Whether to return a handle that allows updating the plotted frame.
 
         Examples
@@ -353,7 +356,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         def title_factory(frame):
             return make_image_title(self, frame, show_name=False)
 
-        frame_timestamps = self.frame_timestamp_ranges()
+        frame_timestamps = self.frame_timestamp_ranges(include_dead_time=include_dead_time)
 
         frame_setter = plot_correlated(
             channel_slice,

--- a/lumicks/pylake/tests/test_imaging_camera/data/tiff_from_scan_v1_3_1.tiff
+++ b/lumicks/pylake/tests/test_imaging_camera/data/tiff_from_scan_v1_3_1.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6c3e7bdcc0d32b9afe5e7affe66ef22f238eb421dbc7d4ab7e62ccbf82585dc
+size 20460

--- a/lumicks/pylake/tests/test_imaging_camera/reference_data/legacy_exposure_handling/dead_time[False].npz
+++ b/lumicks/pylake/tests/test_imaging_camera/reference_data/legacy_exposure_handling/dead_time[False].npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aebc58abb060d86a29f14f8d4be2e938ad73dea29c3b29877565dd2081cfb144
+size 552

--- a/lumicks/pylake/tests/test_imaging_camera/reference_data/legacy_exposure_handling/dead_time[True].npz
+++ b/lumicks/pylake/tests/test_imaging_camera/reference_data/legacy_exposure_handling/dead_time[True].npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dac20b74e70798551628e6b0bec7f085c21058613124faef2d6ce2f5384b68a8
+size 552

--- a/lumicks/pylake/tests/test_imaging_camera/test_image_reconstruction.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_image_reconstruction.py
@@ -17,7 +17,7 @@ def test_image_reconstruction_grayscale(gray_alignment_image_data):
             MockTiffFile(
                 data=[warped_image],
                 times=make_frame_times(1),
-                description=json.dumps(description),
+                description=description,
                 bit_depth=8,
             )
         ],
@@ -38,7 +38,7 @@ def test_image_reconstruction_rgb(rgb_alignment_image_data, rgb_alignment_image_
             MockTiffFile(
                 data=[warped_image],
                 times=make_frame_times(1),
-                description=json.dumps(description),
+                description=description,
                 bit_depth=16,
             )
         ],
@@ -79,7 +79,7 @@ def test_image_reconstruction_rgb(rgb_alignment_image_data, rgb_alignment_image_
             MockTiffFile(
                 data=[warped_image],
                 times=make_frame_times(1),
-                description=json.dumps(bad_description),
+                description=bad_description,
                 bit_depth=16,
             )
         ],
@@ -97,7 +97,7 @@ def test_image_reconstruction_rgb(rgb_alignment_image_data, rgb_alignment_image_
             MockTiffFile(
                 data=[warped_image],
                 times=make_frame_times(1),
-                description=json.dumps(description),
+                description=description,
                 bit_depth=16,
             )
         ],
@@ -117,7 +117,7 @@ def test_no_alignment_requested(rgb_alignment_image_data):
             MockTiffFile(
                 data=[warped_image],
                 times=make_frame_times(1),
-                description=json.dumps(description),
+                description=description,
                 bit_depth=16,
             )
         ],
@@ -135,7 +135,7 @@ def test_image_reconstruction_rgb_multiframe(rgb_alignment_image_data):
             MockTiffFile(
                 data=[warped_image] * 6,
                 times=make_frame_times(6, step=10),
-                description=json.dumps(description),
+                description=description,
                 bit_depth=16,
             )
         ],
@@ -158,7 +158,10 @@ def test_image_reconstruction_rgb_missing_metadata(rgb_alignment_image_data):
         fake_tiff = TiffStack(
             [
                 MockTiffFile(
-                    data=[warped_image], times=make_frame_times(1), description="", bit_depth=16
+                    data=[warped_image],
+                    times=make_frame_times(1),
+                    bit_depth=16,
+                    no_metadata=True,
                 )
             ],
             align_requested=True,
@@ -177,7 +180,7 @@ def test_image_reconstruction_rgb_missing_metadata(rgb_alignment_image_data):
                 MockTiffFile(
                     data=[warped_image],
                     times=make_frame_times(1),
-                    description=json.dumps(description),
+                    description=description,
                     bit_depth=16,
                 )
             ],

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_imagestack.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_imagestack.py
@@ -17,7 +17,8 @@ def make_frame_times(n_frames, rate=10, step=8, start=10, framerate_jitter=0, st
     return [
         [
             f"{j + noise(framerate_jitter, j)}",
-            f"{j + step + noise(framerate_jitter, j) + noise(step_jitter, j)}",
+            f"{(j + 1) + noise(framerate_jitter, (j + 1))}",
+            step + noise(step_jitter, j),
         ]
         for j in range(start, start + n_frames * rate, rate)
     ]
@@ -72,6 +73,7 @@ def test_error_frame_rate_not_constant():
         _kymo_from_image_stack(stack)
 
 
+@pytest.mark.filterwarnings("ignore:This image stack contains a non-constant exposure time")
 def test_error_exposure_time_not_constant():
     stack = create_mock_stack(3, (3, 3, 3), step_jitter=1)
     with pytest.raises(

--- a/lumicks/pylake/tests/test_imaging_mixins.py
+++ b/lumicks/pylake/tests/test_imaging_mixins.py
@@ -22,7 +22,7 @@ def tiffexport_factory(
         return {"Writing": "tests is awesome!"}
 
     def tiff_timestamp_ranges_factory(number_of_frames):
-        def tiff_timestamp_ranges():
+        def tiff_timestamp_ranges(include_dead_time):
             return [
                 np.array([i, i + exposure_time])
                 for i in range(
@@ -70,7 +70,7 @@ def test_export_tiff_insufficient_implementation(tmp_path):
     with pytest.raises(NotImplementedError, match=message_meta):
         export_bare._tiff_image_metadata()
     with pytest.raises(NotImplementedError, match=message_time):
-        export_bare._tiff_timestamp_ranges()
+        export_bare._tiff_timestamp_ranges(include_dead_time=False)
     with pytest.raises(NotImplementedError, match=message_kwargs):
         export_bare._tiff_writer_kwargs()
     # Test if `export_tiff()` requires all `_tiff_*()` methods

--- a/lumicks/pylake/tests/test_scalebar.py
+++ b/lumicks/pylake/tests/test_scalebar.py
@@ -142,7 +142,7 @@ def test_scalebar_integration(monkeypatch):
                         MockTiffFile(
                             data=[np.ones((1, 1))] * 2,
                             times=make_frame_times(2),
-                            description=json.dumps(description),
+                            description=description,
                         )
                     ],
                     align_requested=False,

--- a/setup.manifest
+++ b/setup.manifest
@@ -2,3 +2,4 @@ include license.md readme.md
 global-include *.npz
 global-include *.gb
 global-include *.csv
+global-include *.tiff


### PR DESCRIPTION
**Why this PR?**
Currently, `frame_timestamp_ranges` does not return the correct values for `include_dead_time=False` for `ImageStack` objects loaded from camera images. The reason for this was an invalid assumption on the data inside the `DateTime` tag.

Instead of `start of frame N:end of the exposure of frame N`, this metadata contains `start of frame N:start of frame N+1`. The actual exposure is stored in a field called `Exposure time (ms)` in the json field.

TIFF files written with Pylake from confocal `Scan` and `Kymo` objects were storing `start of frame N:end of the exposure of frame N` and no exposure field in the metadata. This PR also changes that to make it consistent with Bluelake files.

To recap, we have the following metadata:
1. The per-frame DateTime tag, where we have data in the format `timestamp_current_frame : timestamp_next_frame`.
2. The exposure field in the per frame `json`. This exposure is updated if acquisition parameters change during the TIFF, but may be delayed. This field is unavailable in confocal scans exported from Pylake.

If we want to fix this bug, we need to consider round trips through Pylake export as well, since we’ve been writing data with the incorrect assumption.

Let's consider what happens in all the situations and how to mitigate them:

1. TIFF File from Bluelake
Before this PR: _incorrectly_ loads the exposure time from the `DateTime` data.
However, exporting the TIFF from Pylake results in no changes to any time-related metadata. This means that fixing it, will fix it for all permutations.

2. Confocal h5 file from Bluelake, re-exported as TIFF through old Pylake.
Results in timestamps being of the form `timestamp_current_frame : end_of_exposure_timestamp` and no exposure field.
Loading this in the Pylake before this fix, attains the correct timestamps both with and without `include_dead_time`.
Loading this in Pylake after the fix also attains the correct timestamps for `include_deadtime=False`, because the exposure field is missing and in the absence of this field, we use the date time field for this (which for these Scans contains the exposure time). For `include_deadtime=True`, we need a workaround. In this case, we calculate the correct timestamps from the frame time between frames. We check whether we are dealing with this type of file by checking whether the software tag reads `Pylake` and there is no `exposure` metadata.

3. Confocal h5 file from Bluelake, re-exported as TIFF through new Pylake.
Results in timestamps being of the form `timestamp_current_frame : timestamp_next_frame` and an exposure field.
Loading this in the Pylake before this fix, attains the incorrect timestamps (but that’s OK since people should update and it is unlikely that people will load a newer Pylake file in an older Pylake). Loading this in Pylake after the fix also attains the correct timestamps, because the exposure field is present.

5. Confocal TIFF File from Bluelake
Not supported / was never supported.

**Additional considerations**
- To allow people to get the old behavior back, I added a parameter to `plot_correlated` that allows plotting *with* the dead time for `ImageStack`.
- I kept the legacy handling separate from our main code, to not clutter it up too much.