### PR TITLE
force_calibration: fix small mistake in the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ release = pylake.__version__
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.5.0"
+needs_sphinx = "5.0.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -123,7 +123,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,8 +5,8 @@ nbconvert
 nbformat
 numpy
 scipy
-sphinx==4.5.0
-sphinx_rtd_theme==1.0.0
+sphinx==5.0.0
+sphinx_rtd_theme==2.0.0
 sphinxcontrib-bibtex==2.5.0
-docutils<0.18
+docutils
 myst-parser

--- a/docs/theory/force_calibration/force_calibration.rst
+++ b/docs/theory/force_calibration/force_calibration.rst
@@ -76,7 +76,7 @@ We can plot this spectrum for different diffusion constants::
 
     f = np.arange(100, 23000)
     for diffusion in 10**np.arange(1, 4):
-        plt.loglog(f, diffusion / (np.pi * f**2), label=f"D={diffusion} $\mu m^2/s$")
+        plt.loglog(f, diffusion / (np.pi**2 * f**2), label=f"D={diffusion} $\mu m^2/s$")
 
     plt.xlabel("Frequency [Hz]")
     plt.ylabel("Amplitude [$\mu m^2$/Hz]");
@@ -113,7 +113,7 @@ When plotting this equation for various values of the corner frequency, we see t
     plt.subplot(1, 2, 1)
     diffusion, corner_freq = 1000, 1000
     for diffusion in 10**np.arange(1, 4):
-        plt.loglog(f, diffusion / (np.pi * (f**2 + corner_freq**2)), label=f"D={diffusion} $\mu m^2/s$")
+        plt.loglog(f, diffusion / (np.pi**2 * (f**2 + corner_freq**2)), label=f"D={diffusion} $\mu m^2/s$")
 
     plt.xlabel("Frequency [Hz]")
     plt.ylabel("Amplitude [$\mu m^2$/Hz]");
@@ -123,7 +123,7 @@ When plotting this equation for various values of the corner frequency, we see t
     diffusion, corner_freq = 1000, 1000
     for corner_freq in [1000, 5000, 10000]:
         line, = plt.loglog(
-            f, diffusion / (np.pi * (f**2 + corner_freq**2)), label=f"$f_c$={corner_freq} Hz"
+            f, diffusion / (np.pi**2 * (f**2 + corner_freq**2)), label=f"$f_c$={corner_freq} Hz"
         )
         plt.axvline(corner_freq, color=line.get_color(), linestyle="--")
 


### PR DESCRIPTION
**Why this PR?**
Normalization constant is missing a factor `pi` in the theory code.

Note: Had to cherrypick the docs fixup from `main` to get the docs to build.