### PR TITLE
Move duplicated GMM/HMM properties to mixin

### DIFF
--- a/lumicks/pylake/population/detail/mixin.py
+++ b/lumicks/pylake/population/detail/mixin.py
@@ -1,10 +1,33 @@
+from dataclasses import dataclass
+
 import numpy as np
 
+from .fit_info import PopulationFitInfo
 from ...channel import Slice
 from ..dwelltime import _dwellcounts_from_statepath
 
 
 class TimeSeriesMixin:
+    @property
+    def fit_info(self) -> PopulationFitInfo:
+        """Information about the model training exit conditions."""
+        return self._fit_info
+
+    @property
+    def means(self) -> np.ndarray:
+        """Model state means."""
+        return self._model.mu
+
+    @property
+    def variances(self) -> np.ndarray:
+        """Model state variances."""
+        return 1 / self._model.tau
+
+    @property
+    def std(self) -> np.ndarray:
+        """Model state standard deviations."""
+        return np.sqrt(self.variances)
+
     def extract_dwell_times(self, trace, *, exclude_ambiguous_dwells=True):
         """Calculate lists of dwelltimes for each state in a time-ordered state path array.
 
@@ -151,3 +174,10 @@ class TimeSeriesMixin:
         path_kwargs = {"c": "tab:blue", "lw": 2, **(path_kwargs or {})}
         emission_path = self.emission_path(trace)
         emission_path.plot(**path_kwargs)
+
+
+@dataclass(frozen=True)
+class LatentVariableModel:
+    K: int
+    mu: np.ndarray
+    tau: np.ndarray

--- a/lumicks/pylake/population/hmm.py
+++ b/lumicks/pylake/population/hmm.py
@@ -4,7 +4,6 @@ from .mixture import GaussianMixtureModel
 from ..channel import Slice
 from .detail.hmm import ClassicHmm, viterbi, baum_welch
 from .detail.mixin import TimeSeriesMixin
-from .detail.fit_info import PopulationFitInfo
 from .detail.validators import col
 
 
@@ -67,11 +66,6 @@ class HiddenMarkovModel(TimeSeriesMixin):
         self._model, self._fit_info = baum_welch(data, initial_guess, tol=tol, max_iter=max_iter)
 
     @property
-    def fit_info(self) -> PopulationFitInfo:
-        """Information about the model training exit conditions."""
-        return self._fit_info
-
-    @property
     def initial_state_probability(self) -> np.ndarray:
         """Model initial state probability."""
         return self._model.pi
@@ -84,21 +78,6 @@ class HiddenMarkovModel(TimeSeriesMixin):
         to state `j` at time point `t+1`.
         """
         return self._model.A
-
-    @property
-    def means(self) -> np.ndarray:
-        """Model state means."""
-        return self._model.mu
-
-    @property
-    def variances(self) -> np.ndarray:
-        """Model state variances."""
-        return 1 / self._model.tau
-
-    @property
-    def std(self) -> np.ndarray:
-        """Model state standard deviations."""
-        return np.sqrt(self.variances)
 
     def _calculate_state_path(self, trace):
         return viterbi(trace.data, self._model)

--- a/lumicks/pylake/population/tests/test_hmm_algos.py
+++ b/lumicks/pylake/population/tests/test_hmm_algos.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from lumicks.pylake import HiddenMarkovModel, GaussianMixtureModel
+from lumicks.pylake import GaussianMixtureModel
 from lumicks.pylake.population.detail.hmm import (
     ClassicHmm,
     viterbi,
@@ -118,20 +118,20 @@ def test_viterbi_with_zeros(trace_simple):
     data, _, params = trace_simple
     model = ClassicHmm(
         params["n_states"],
-        [1, 0],
-        normalize_rows(params["transition_prob"]),
         params["means"],
         params["st_devs"],
+        [1, 0],
+        normalize_rows(params["transition_prob"]),
     )
 
     viterbi(data, model)
 
     model = ClassicHmm(
         params["n_states"],
-        params["initial_state_prob"],
-        [[1, 0], [0.1, 0.9]],
         params["means"],
         params["st_devs"],
+        params["initial_state_prob"],
+        [[1, 0], [0.1, 0.9]],
     )
 
     viterbi(data, model)


### PR DESCRIPTION
**Why this PR?**
After adding HMMs and re-aligning the GMM API, I realized that we could de-duplicate a bit more code using the mixin if we implement a simple data structure for the GMM rather than just storing the `sklearn` model. This has the added benefit in that we can get rid of the `as_sorted` decorator and the private `_map` property.

All changes are to private API

Two tiny extras that I had to do, but I think it's worth it:
- store the `lower_bound` as a private attribute, but this can be removed when we remove `exit_flag`
- change the implementation of the deprecated `label()` method, but I realized we can do it even easier with other stuff we already had