### PR TITLE
ImageStack: allow closing `ImageStack` file handles

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * Added `emission_path()` and `plot_path()` methods to [`lk.GaussianMixtureModel`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.GaussianMixtureModel.html)
 * Added option to [`File`](https://lumicks-pylake.readthedocs.io/en/stable/_api/lumicks.pylake.File.html) to pass a custom mapping from Photon count detector to RGB colors colors. This is useful to reconstruct images on systems with non-standard imaging modules.
 * Added option to determine the viscosity and density of water with NaCl dissolved in it using `lk.viscosity_of_water()` and `lk.density_of_water()`.
+* Added `ImageStack.close()` to force close file handles. Note that this prohibits further access to images from the `ImageStack` it is called on, but also any `ImageStack` derived from it (i.e. through [`ImageStack.define_tether()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.define_tether) or [`ImageStack.crop_by_pixels()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.crop_by_pixels)).
 
 #### Improvements
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@
 * Added option to [`File`](https://lumicks-pylake.readthedocs.io/en/stable/_api/lumicks.pylake.File.html) to pass a custom mapping from Photon count detector to RGB colors colors. This is useful to reconstruct images on systems with non-standard imaging modules.
 * Added option to determine the viscosity and density of water with NaCl dissolved in it using `lk.viscosity_of_water()` and `lk.density_of_water()`.
 
+#### Improvements
+
+* `ImageStack` now closes any file handles it has open upon garbage collection.
+
 #### Deprecations
 
 * Deprecated `GaussianMixtureModel.from_channel()`. The class constructor now accepts `Slice` instances directly.

--- a/lumicks/pylake/image_stack.py
+++ b/lumicks/pylake/image_stack.py
@@ -663,6 +663,17 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
 
         return frame_timestamps
 
+    def close(self):
+        """Closes `ImageStack` file handle.
+
+        Note
+        ----
+        Attempting to access image data after closing the file handle will result in an `IOError` for both this
+        `ImageStack` and any `ImageStack` derived from it through e.g. `ImageStack.crop_by_pixels()` or
+        `ImageStack.define_tether()`
+        """
+        self._src.close()
+
 
 @deprecated(
     reason="`CorrelatedStack` has been renamed to `ImageStack` and will be removed in the next release.",

--- a/lumicks/pylake/tests/test_imaging_camera/test_export.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_export.py
@@ -16,7 +16,6 @@ def test_export(rgb_tiff_file, rgb_tiff_file_multi, gray_tiff_file, gray_tiff_fi
         savename = str(filename.new(purebasename=f"out_{filename.purebasename}"))
         stack = ImageStack(str(filename), align=align)
         stack.export_tiff(savename)
-        stack._src.close()
         assert stat(savename).st_size > 0
 
         with tifffile.TiffFile(str(filename)) as tif_in, tifffile.TiffFile(savename) as tif_out:
@@ -54,8 +53,6 @@ def test_export_roi(rgb_tiff_file, rgb_tiff_file_multi, gray_tiff_file, gray_tif
         with tifffile.TiffFile(savename) as tif:
             assert tif.pages[0].tags["ImageWidth"].value == 180
             assert tif.pages[0].tags["ImageLength"].value == 60
-
-        stack._src.close()
 
 
 @pytest.mark.parametrize("vertical, correlated", [(False, False), (False, True), (True, True)])
@@ -99,5 +96,3 @@ def test_stack_movie_export(
             ),
         ):
             stack.export_video("gray", "dummy.gif")  # Gray is not a color!
-
-        stack._src.close()

--- a/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
@@ -1232,3 +1232,19 @@ def test_tiffstack_automatic_cleanup(gray_tiff_file_multi):
         match=r"The file handle for this TiffStack \(gray_multi.tiff\) has already been closed.",
     ):
         im.get_frame(0)
+
+
+def test_imagestack_explicit_close(gray_tiff_file_multi):
+    im = ImageStack(gray_tiff_file_multi)
+    handle = im._src._tiff_files[0]._src.filehandle
+    derived_im = im.crop_by_pixels(1, 3, 1, 3)
+    assert not handle.closed
+    im.close()
+    assert handle.closed
+
+    for current_stack in (im, derived_im):
+        with pytest.raises(
+            IOError,
+            match=r"The file handle for this TiffStack \(gray_multi.tiff\) has already been closed.",
+        ):
+            current_stack.get_image("rgb")


### PR DESCRIPTION
**Why this PR?**
It would be nice to have `ImageStack` close the file handle when it is garbage collected. People have run into not being able to delete files on windows because the handle was still open.

In addition, a `.close()` is added for cases where it should be closed immediately.

I considered two alternatives before going for the wrapper class:
- Using `weakref.finalizer`, but this cannot pass the instance it is closing as argument (and is therefore not a solution for this).
- Adding the handling on `TiffStack`, but this is unfortunately also not an option, since the handle is actually associated with the `TiffFile` and `TiffStack` can return new `TiffStack` instances that reference the same (list of) `TiffFile`s.