### PR TITLE
ci: fix tests for `pytest>=8.0.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 * Fixed a bug where the time between frames was incorrectly not excluded when calling [`ImageStack.frame_timestamp_ranges()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.frame_timestamp_ranges) with `include_dead_time=False`. Note that `Scan` and `Kymo` are not affected.
 * Fixed a bug where [`ImageStack.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/v1.3.0/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.plot_correlated) was not excluding the dead time between frames.
 * Changed the `DateTime` tag on TIFFs exported with Pylake from `Scan` and `Kymo` objects. Before the change, the start and end of the scanning period in nanoseconds was stored. After the change, we store the starting timestamp of the frame, followed by the starting timestamp of the next frame to be consistent with data exported from Bluelake. The scanning time is stored in the field `Exposure time (ms)` on the Description tag.
+* Fixed tests to be compatible with `pytest>=8.0.0`.
 
 ## v1.3.1 | 2023-12-07
 

--- a/lumicks/pylake/force_calibration/tests/test_touchdown.py
+++ b/lumicks/pylake/force_calibration/tests/test_touchdown.py
@@ -145,6 +145,8 @@ def test_exp_sine_fits(decay, amplitude, frequency, phase_shift):
     np.testing.assert_allclose(par, frequency, rtol=1e-6)
 
 
+@pytest.mark.filterwarnings("ignore:Covariance of the parameters could not be estimated")
+@pytest.mark.filterwarnings("ignore:Surface detection failed")
 def test_insufficient_data(mack_parameters):
     stage_positions, simulation = simulate_touchdown(102.5, 103.5, 0.01, mack_parameters)
 

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -66,7 +66,7 @@ def two_gaussians_1d():
 
 @pytest.fixture
 def blank_kymo():
-    return generate_kymo(
+    kymo = generate_kymo(
         "",
         np.ones((1, 10)),
         pixel_size_nm=1000,
@@ -75,6 +75,8 @@ def blank_kymo():
         samples_per_pixel=1,
         line_padding=0,
     )
+    kymo._motion_blur_constant = 0
+    return kymo
 
 
 @pytest.fixture


### PR DESCRIPTION
Pytest changed its warning/exception order starting from `8.0.0` (see https://github.com/pytest-dev/pytest/issues/9036).

This updates our tests to pass under the new and old version of `pytest`.

- For kymographs, this meant explicitly passing a motion blur parameter such that we don't issue that error instead of what we are looking for.
- For the dwelltime analysis, we have to make sure we don't get any of the deprecation warnings so that we can see the warning we are testing for.
- For touchdown, we have to explicitly silence the covariance matrix is undefined error (which actually already tells us that the problem will be non-identifiable i.e. too little data, which is exactly what the test tests for).

After this gets merged, I will merge `1.3` back into `main`.