### PR TITLE
tiff: don't rely on deprecated API for resolution unit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,10 @@
 * Changed the `DateTime` tag on TIFFs exported with Pylake from `Scan` and `Kymo` objects. Before the change, the start and end of the scanning period in nanoseconds was stored. After the change, we store the starting timestamp of the frame, followed by the starting timestamp of the next frame to be consistent with data exported from Bluelake. The scanning time is stored in the field `Exposure time (ms)` on the Description tag.
 * Fixed tests to be compatible with `pytest>=8.0.0`.
 
+#### Other changes
+
+* Bump `tifffile` dependency to `>=2022.7.28`.
+
 ## v1.3.1 | 2023-12-07
 
 #### Bug fixes

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -389,7 +389,8 @@ class ConfocalImage(BaseScan, TiffExport):
             pixel_sizes_um[1] if len(pixel_sizes_um) == 2 else pixel_sizes_um[0],
         )
         if pixel_size_x:
-            write_kwargs["resolution"] = (1e4 / pixel_size_x, 1e4 / pixel_size_y, "CENTIMETER")
+            write_kwargs["resolution"] = (1e4 / pixel_size_x, 1e4 / pixel_size_y)
+            write_kwargs["resolutionunit"] = "CENTIMETER"
 
         return write_kwargs
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "numpy>=1.24, <2",  # 1.24 is needed for dtype in vstack/hstack (Dec 18th, 2022)
         "scipy>=1.9, <2",  # 1.9.0 needed for lazy imports (July 29th, 2022)
         "matplotlib>=3.5",
-        "tifffile>=2020.9.30",
+        "tifffile>=2022.7.28",
         "tabulate>=0.8.8, <0.9",
         "cachetools>=3.1",
         "deprecated>=1.2.8",


### PR DESCRIPTION
**Why this PR?**
`tifffile` deprecated the way we pass the resolution unit a while ago. This PR gets rid of the old way of passing it.

I did have to bump the dependency to where the parameter was first introduced.