### PR TITLE
group: forward `__contains__` dunder to `h5py`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 * Fixed a bug where color adjustments on a single channel [`ImageStack`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack) would not be applied unless a channel was provided as argument. This bug was introduced in `v1.3.0`.
 * Changed the `DateTime` tag on TIFFs exported with Pylake from `Scan` and `Kymo` objects. Before the change, the start and end of the scanning period in nanoseconds was stored. After the change, we store the starting timestamp of the frame, followed by the starting timestamp of the next frame to be consistent with data exported from Bluelake. The scanning time is stored in the field `Exposure time (ms)` on the Description tag.
 * Fixed tests to be compatible with `pytest>=8.0.0`.
+* Ensure `in` returns `True` for a valid data path (e.g. `"Force HF/Force 1x" in file` should return `True`).
 
 #### Other changes
 

--- a/lumicks/pylake/group.py
+++ b/lumicks/pylake/group.py
@@ -55,6 +55,9 @@ class Group:
     def __next__(self):
         return self.h5.__next__()
 
+    def __contains__(self, name):
+        return self.h5.__contains__(name)
+
     def __repr__(self):
         """Return formatted representation of group keys"""
         group_keys = ", ".join(f"'{k}'" for k in self.h5)

--- a/lumicks/pylake/tests/test_file/test_file.py
+++ b/lumicks/pylake/tests/test_file/test_file.py
@@ -54,6 +54,14 @@ def test_groups(h5_file):
             assert set(t) == set(["Force 1x", "Force 1y", "Force 1z"])
 
 
+def test_contains(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+    assert "Force HF" in f
+    assert "Force 1x" in f["Force HF"]
+    assert "Force HF/Force 1x" in f
+    assert "Force HF" not in f["Force HF"]
+
+
 def test_redirect_list(h5_file):
     f = pylake.File.from_h5py(h5_file)
     if f.format_version == 2:


### PR DESCRIPTION
**Why this PR?**
Noticed this while working on a small data analysis script. Sometimes, it can be quite useful to grab by full paths, but once you start relying on that, you start noticing that some things are inconsistent with `h5py`.

This makes our API consistent with `h5py`.

Before:
```python
file = lk.File("test.h5")
"Force HF/Force 1x" in file  # => False
"Force HF/Force 1x" in file.h5  # => True
```

After:
```python
file = lk.File("test.h5")
"Force HF/Force 1x" in file  # => True
"Force HF/Force 1x" in file.h5  # => True
```