### PR TITLE
Merge bug fixes from `1.3` back into `main`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -36,8 +36,14 @@
 * Fixed a bug where the time indicator was off by one frame in [`ImageStack.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.plot_correlated) and [`ImageStack.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.export_video).
 * Fixed a bug where the time between frames was incorrectly not excluded when calling [`ImageStack.frame_timestamp_ranges()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.frame_timestamp_ranges) with `include_dead_time=False`. Note that `Scan` and `Kymo` are not affected.
 * Fixed a bug where [`ImageStack.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/v1.3.0/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.plot_correlated) was not excluding the dead time between frames.
+* Fixed a bug where color adjustments on a single channel [`ImageStack`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack) would not be applied unless a channel was provided as argument. This bug was introduced in `v1.3.0`.
 * Changed the `DateTime` tag on TIFFs exported with Pylake from `Scan` and `Kymo` objects. Before the change, the start and end of the scanning period in nanoseconds was stored. After the change, we store the starting timestamp of the frame, followed by the starting timestamp of the next frame to be consistent with data exported from Bluelake. The scanning time is stored in the field `Exposure time (ms)` on the Description tag.
 * Fixed tests to be compatible with `pytest>=8.0.0`.
+* Ensure `in` returns `True` for a valid data path (e.g. `"Force HF/Force 1x" in file` should return `True`).
+
+#### Other changes
+
+* Bump `tifffile` dependency to `>=2022.7.28`.
 
 ## v1.3.1 | 2023-12-07
 

--- a/lumicks/pylake/adjustments.py
+++ b/lumicks/pylake/adjustments.py
@@ -74,7 +74,6 @@ class ColorAdjustment:
         image : array_like
             Raw image data.
         """
-
         if len(channel) == 2:
             missing_channel = set("rgb") - set(channel)
             missing_channel_index = "rgb".index(missing_channel.pop())
@@ -114,10 +113,13 @@ class ColorAdjustment:
         if not self.mode:
             return
 
-        if channel in ("rgb", "rg", "gb", "rb"):
+        # Single channel images can come in any of the channel parameters but should be treated
+        # as though a single channel was sliced.
+        if channel in ("rgb", "rg", "gb", "rb") and image.ndim == 3:
             return
 
-        idx = ({"red": 0, "green": 1, "blue": 2, "r": 0, "g": 1, "b": 2})[channel]
+        color_mapping = {"red": 0, "green": 1, "blue": 2, "r": 0, "g": 1, "b": 2}
+        idx = color_mapping.get(channel, 0)  # The default of zero is for monochrome images
         limits = (self.minimum[idx], self.maximum[idx])
         if self.mode == "percentile":
             limits = np.percentile(image, limits)

--- a/lumicks/pylake/detail/confocal.py
+++ b/lumicks/pylake/detail/confocal.py
@@ -389,7 +389,8 @@ class ConfocalImage(BaseScan, TiffExport):
             pixel_sizes_um[1] if len(pixel_sizes_um) == 2 else pixel_sizes_um[0],
         )
         if pixel_size_x:
-            write_kwargs["resolution"] = (1e4 / pixel_size_x, 1e4 / pixel_size_y, "CENTIMETER")
+            write_kwargs["resolution"] = (1e4 / pixel_size_x, 1e4 / pixel_size_y)
+            write_kwargs["resolutionunit"] = "CENTIMETER"
 
         return write_kwargs
 

--- a/lumicks/pylake/group.py
+++ b/lumicks/pylake/group.py
@@ -55,6 +55,9 @@ class Group:
     def __next__(self):
         return self.h5.__next__()
 
+    def __contains__(self, name):
+        return self.h5.__contains__(name)
+
     def __repr__(self):
         """Return formatted representation of group keys"""
         group_keys = ", ".join(f"'{k}'" for k in self.h5)

--- a/lumicks/pylake/tests/test_file/test_file.py
+++ b/lumicks/pylake/tests/test_file/test_file.py
@@ -54,6 +54,14 @@ def test_groups(h5_file):
             assert set(t) == set(["Force 1x", "Force 1y", "Force 1z"])
 
 
+def test_contains(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+    assert "Force HF" in f
+    assert "Force 1x" in f["Force HF"]
+    assert "Force HF/Force 1x" in f
+    assert "Force HF" not in f["Force HF"]
+
+
 def test_redirect_list(h5_file):
     f = pylake.File.from_h5py(h5_file)
     if f.format_version == 2:

--- a/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
@@ -844,6 +844,41 @@ def test_image_stack_plot_single_channel_percentile_color_adjustment(rgb_alignme
         plt.close(fig)
 
 
+def test_single_channel_image_adjustment(gray_alignment_image_data):
+    """Tests whether we can set color ranges for single channel images."""
+    reference_image, warped_image, description, bit_depth = gray_alignment_image_data
+    fake_tiff = TiffStack(
+        [
+            MockTiffFile(
+                data=[warped_image] * 2,
+                times=make_frame_times(2),
+                description=description,
+            )
+        ],
+        align_requested=True,
+    )
+    stack = ImageStack.from_dataset(fake_tiff)
+
+    lbs, ubs = np.array([94, 93, 95]), np.array([95, 98, 97])
+    lbs_ref, ubs_ref = [*lbs, 94], [*ubs, 95]
+    for lb, ub, channel in zip(lbs_ref, ubs_ref, ("red", "green", "blue", "rgb")):
+        # Test whether setting RGB values and then sampling one of them works correctly.
+        fig = plt.figure()
+        stack.plot(channel=channel, adjustment=ColorAdjustment(lbs, ubs, mode="absolute"))
+        image = plt.gca().get_images()[0]
+        np.testing.assert_allclose(image.get_array(), stack[0].get_image(channel=channel))
+        np.testing.assert_allclose(image.get_clim(), [lb, ub])
+        plt.close(fig)
+
+        # Test whether setting a single color value correctly
+        fig = plt.figure()
+        stack.plot(channel=channel, adjustment=ColorAdjustment(lb, ub, mode="absolute"))
+        image = plt.gca().get_images()[0]
+        np.testing.assert_allclose(image.get_array(), stack[0].get_image(channel=channel))
+        np.testing.assert_allclose(image.get_clim(), [lb, ub])
+        plt.close(fig)
+
+
 def test_invalid_slicing():
     n_frames = 3
     data = [np.random.rand(5, 4) for j in range(n_frames)]

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "numpy>=1.24, <2",  # 1.24 is needed for dtype in vstack/hstack (Dec 18th, 2022)
         "scipy>=1.9, <2",  # 1.9.0 needed for lazy imports (July 29th, 2022)
         "matplotlib>=3.5",
-        "tifffile>=2020.9.30",
+        "tifffile>=2022.7.28",
         "tabulate>=0.8.8, <0.9",
         "cachetools>=3.1",
         "deprecated>=1.2.8",


### PR DESCRIPTION
**Why this PR?**
Tests are failing on `main` because of one of the missing `tifffile` deprecation fix.

If we're gonna be merging some things back, might as well merge back all the bug fixes as there are no conflicts.