### PR TITLE
kymo: crop beads out of kymograph

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,8 @@
 #### New features
 
 * Added [`lk.HiddenMarkovModel`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.HiddenMarkovModel.html#lumicks.pylake.HiddenMarkovModel) for classifying data traces exhibiting transitions between discrete states. For more information, see the tutorials section on [Population Dynamics](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/population_dynamics.html#hidden-markov-models).
-* Added API to determine bead edges in a kymograph using [`Kymo.bead_roi()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.bead_roi).
+* Added option to crop beads out of a kymograph using [`Kymo.crop_beads()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.crop_beads).
+* Added API to determine bead edges in a kymograph using [`Kymo.estimate_bead_edges()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.estimate_bead_edges).
 * Added `emission_path()` and `plot_path()` methods to [`lk.GaussianMixtureModel`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.GaussianMixtureModel.html)
 * Added option to [`File`](https://lumicks-pylake.readthedocs.io/en/stable/_api/lumicks.pylake.File.html) to pass a custom mapping from Photon count detector to RGB colors colors. This is useful to reconstruct images on systems with non-standard imaging modules.
 * Added option to customize the filter width of the Gaussian filter that is applied prior to spot detection in [`lk.track_greedy()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.track_greedy.html#). Increasing this value results in fewer false detections at the cost of resolution. Note that the current default is set to half a pixel to preserve the old behavior.

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### New features
 
 * Added [`lk.HiddenMarkovModel`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.HiddenMarkovModel.html#lumicks.pylake.HiddenMarkovModel) for classifying data traces exhibiting transitions between discrete states. For more information, see the tutorials section on [Population Dynamics](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/population_dynamics.html#hidden-markov-models).
+* Added API to determine bead edges in a kymograph using [`Kymo.bead_roi()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.bead_roi).
 * Added `emission_path()` and `plot_path()` methods to [`lk.GaussianMixtureModel`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.GaussianMixtureModel.html)
 * Added option to [`File`](https://lumicks-pylake.readthedocs.io/en/stable/_api/lumicks.pylake.File.html) to pass a custom mapping from Photon count detector to RGB colors colors. This is useful to reconstruct images on systems with non-standard imaging modules.
 * Added option to customize the filter width of the Gaussian filter that is applied prior to spot detection in [`lk.track_greedy()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.track_greedy.html#). Increasing this value results in fewer false detections at the cost of resolution. Note that the current default is set to half a pixel to preserve the old behavior.

--- a/lumicks/pylake/detail/bead_cropping.py
+++ b/lumicks/pylake/detail/bead_cropping.py
@@ -1,0 +1,101 @@
+import numpy as np
+
+
+def find_beads(
+    summed_kymo,
+    bead_diameter_pixels,
+    plot=False,
+    threshold_percentile=70,
+    allow_negative_beads=True,
+):
+    """Find bead edges in kymograph image sum
+
+    Attempts to search for the bead edges by checking where the fluorescence drops below a
+    threshold. Only intended for stationary beads.
+
+    Parameters
+    ----------
+    summed_kymo : np.ndarray
+        Kymograph image data (single channel summed along the time axis).
+    bead_diameter_pixels : float
+        Estimate for the bead size in pixels.
+    plot : bool
+        Plot result
+    threshold_percentile : int
+        Percentile below which to drop.
+    allow_negative_beads : bool
+        Tries to estimate a background from the dominant mode of the photon counts. This estimate
+        is subtracted from the raw counts prior to analysis.
+
+    Returns
+    -------
+    list of int
+       List of the two edge positions in pixels.
+
+    Raises
+    ------
+    RuntimeError
+        When the algorithm fails to locate two edges during the bead finding stage.
+    """
+    import scipy.ndimage
+    import matplotlib.pyplot as plt
+
+    data = summed_kymo.astype(float)
+
+    # Makes sure we can handle dark beads
+    if allow_negative_beads:
+        # Try to guess the background by finding the most prominent mode
+        kde_estimate = scipy.stats.gaussian_kde(data, 0.02)
+        interpolated_kde = np.arange(min(data), np.max(data))
+        baseline = interpolated_kde[np.argmax(kde_estimate.pdf(interpolated_kde))]
+        data = np.abs(data - baseline)
+    else:
+        baseline = 0
+
+    # Get rid of small fluorescence peaks.
+    only_beads = scipy.ndimage.grey_opening(data, int(bead_diameter_pixels / 4) * 2 + 1)
+
+    # Get rough estimate of where the beads are.
+    blurred, blurred_derivative = (
+        scipy.ndimage.gaussian_filter(
+            only_beads, bead_diameter_pixels, mode="constant", cval=0, order=order
+        )
+        for order in (0, 1)
+    )
+
+    # Find negative zero crossings.
+    bead_edges = np.where(np.diff(np.sign(blurred_derivative)) == -2)[0]
+
+    if plot:
+        plt.plot(summed_kymo, label="input data")
+        plt.axhline(baseline, label="baseline")
+        plt.plot(data, label="transformed data")
+        plt.plot(only_beads, label="only beads")
+        plt.plot(blurred, label="Gaussian filtered")
+
+        for be in bead_edges:
+            plt.axvline(be, label="center guess", color="k", linestyle="--", alpha=0.5)
+
+        plt.legend()  # In case we don't make it past the exception
+
+    if len(bead_edges) != 2:
+        raise RuntimeError("Did not find two beads")
+
+    # We move inwards until the opened trace drops below the Gaussian blurred trace. This will be
+    # roughly halfway on the slope.
+    bead_edges[0] += np.where(only_beads[bead_edges[0] :] < blurred[bead_edges[0] :])[0][0]
+    bead_edges[1] -= np.where(
+        np.flip(only_beads[: bead_edges[1]]) < np.flip(blurred[: bead_edges[1]])
+    )[0][0]
+
+    # We then keep moving until we've hit a low enough signal level that we are confident we
+    # have reached the tether.
+    final_cutoff = np.percentile(data[bead_edges[0] : bead_edges[1]], threshold_percentile)
+    bead_edges[0] += np.where(data[bead_edges[0] :] <= final_cutoff)[0][0]
+    bead_edges[1] -= np.where(np.flip(data[: bead_edges[1]]) <= final_cutoff)[0][0]
+
+    if plot:
+        [plt.axvline(be, label="edge", color="k", linestyle="--") for be in bead_edges]
+        plt.legend()
+
+    return bead_edges

--- a/lumicks/pylake/detail/tests/data/kymo_sum0.npz
+++ b/lumicks/pylake/detail/tests/data/kymo_sum0.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf54abbb423f13ea30d8cfeff293dc346ec0084f29da675f8613b5016f1b96c2
+size 14480

--- a/lumicks/pylake/detail/tests/data/kymo_sum1.npz
+++ b/lumicks/pylake/detail/tests/data/kymo_sum1.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80734a53d1e10e005147c0d269ac8e18306b498424605436f64e35f07d683568
+size 14480

--- a/lumicks/pylake/detail/tests/data/kymo_sum2.npz
+++ b/lumicks/pylake/detail/tests/data/kymo_sum2.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f4b4cdc55a823562f0cbdf11b74843523a53f8d054ed7118034bc74af58d56d
+size 13712

--- a/lumicks/pylake/detail/tests/data/kymo_sum3.npz
+++ b/lumicks/pylake/detail/tests/data/kymo_sum3.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06a9152ce4797f40bdb0e8caf7f345f196b5ad44ae786d268a8088691f466963
+size 18368

--- a/lumicks/pylake/detail/tests/data/kymo_sum4.npz
+++ b/lumicks/pylake/detail/tests/data/kymo_sum4.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a21674d35fc553722c328f05b46ba6edccf25a393b9b127b5e7bc9eee1fa6755
+size 18368

--- a/lumicks/pylake/detail/tests/data/kymo_sum5.npz
+++ b/lumicks/pylake/detail/tests/data/kymo_sum5.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8eb53ceec6b6782f5f5ca4f736fcc5378e478e11e00607f646b0c8174735ef26
+size 9536

--- a/lumicks/pylake/detail/tests/data/kymo_sum6.npz
+++ b/lumicks/pylake/detail/tests/data/kymo_sum6.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d560b04bafeed5702a73ef011d99060887519a35991e097ff33854d82df4b5f
+size 18272

--- a/lumicks/pylake/detail/tests/data/kymo_sum7.npz
+++ b/lumicks/pylake/detail/tests/data/kymo_sum7.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a761a2ab6cb6e3e1810787d8a58212fbcbafca8a1ba4eefbdf7cda767baab3b4
+size 18272

--- a/lumicks/pylake/detail/tests/test_bead_crop.py
+++ b/lumicks/pylake/detail/tests/test_bead_crop.py
@@ -1,0 +1,60 @@
+import pathlib
+from contextlib import nullcontext
+
+import numpy as np
+import pytest
+import matplotlib.pyplot as plt
+
+from lumicks.pylake.detail.bead_cropping import find_beads
+
+
+@pytest.mark.parametrize(
+    "filename, ref_edges, ref_edges_no_negative",
+    [
+        ("kymo_sum0", [148, 354], [148, 354]),
+        ("kymo_sum1", [144, 323], [144, 323]),
+        ("kymo_sum2", [161, 349], [161, 349]),
+        ("kymo_sum3", [181, 491], []),  # Negative beads
+        ("kymo_sum4", [209, 489], []),  # Negative beads
+        ("kymo_sum5", [56, 266], []),  # Negative beads
+        ("kymo_sum6", [185, 519], []),  # Crowded kymo (dark beads)
+        ("kymo_sum7", [188, 523], []),  # Crowded kymo (dark beads)
+    ],
+)
+def test_bead_cropping_allow_negative_beads(filename, ref_edges, ref_edges_no_negative):
+    data = np.load(pathlib.Path(__file__).parent / "data" / f"{filename}.npz")
+
+    edges = find_beads(data["green"], bead_diameter_pixels=4.84 / data["pixelsize"], plot=False)
+    # Asserting equal to pin behavior, but I wouldn't expect more accuracy than half a micron
+    # because the fluorescence typically tails out wide.
+    np.testing.assert_equal(edges, ref_edges)
+
+    with nullcontext() if ref_edges_no_negative else pytest.raises(
+        RuntimeError, match="Did not find two beads"
+    ):
+        edges = find_beads(
+            data["green"], bead_diameter_pixels=4.84 / data["pixelsize"], allow_negative_beads=False
+        )
+        np.testing.assert_equal(edges, ref_edges_no_negative)
+
+
+def test_bead_cropping_failure():
+    mock = np.zeros((100,))
+    mock[50] = 1  # Standard deviation of the data should not be zero or the KDE estimate fails.
+    with pytest.raises(RuntimeError, match="Did not find two beads"):
+        find_beads(mock, bead_diameter_pixels=1, plot=True)
+
+
+def test_plotting():
+    data = np.load(pathlib.Path(__file__).parent / "data" / f"kymo_sum0.npz")
+    for allow_negative in (False, True):
+        edges = find_beads(
+            data["green"],
+            bead_diameter_pixels=4.84 / data["pixelsize"],
+            plot=True,
+            allow_negative_beads=allow_negative,
+        )
+
+        np.testing.assert_equal(plt.gca().lines[0].get_data()[1], data["green"])
+        np.testing.assert_equal(plt.gca().lines[-2].get_data()[0], [edges[0], edges[0]])
+        np.testing.assert_equal(plt.gca().lines[-1].get_data()[0], [edges[1], edges[1]])

--- a/lumicks/pylake/tests/test_imaging_confocal/conftest.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/conftest.py
@@ -1,8 +1,10 @@
+import pathlib
 from itertools import permutations
 
 import numpy as np
 import pytest
 
+from lumicks.pylake.kymo import _kymo_from_array
 from lumicks.pylake.channel import Slice, Continuous
 from lumicks.pylake.point_scan import PointScan
 from lumicks.pylake.detail.imaging_mixins import _FIRST_TIMESTAMP
@@ -132,6 +134,19 @@ def cropping_kymo():
     )
 
     return kymo, ref
+
+
+@pytest.fixture(scope="module")
+def bead_kymo():
+    data = np.load(pathlib.Path(__file__).parent / "data" / "bead_kymo.npz")
+
+    return _kymo_from_array(
+        data["rgb"],
+        color_format="rgb",
+        line_time_seconds=data["line_time_seconds"],
+        exposure_time_seconds=0,
+        pixel_size_um=data["pixelsize_um"],
+    )
 
 
 @pytest.fixture(scope="module")

--- a/lumicks/pylake/tests/test_imaging_confocal/data/bead_kymo.npz
+++ b/lumicks/pylake/tests/test_imaging_confocal/data/bead_kymo.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74e7d8d00335af26e37f0118b37a2cf7bc59ad9626dde715179971229fea02c2
+size 221862

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_slice_crop.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_slice_crop.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import numpy as np
 import pytest
 
@@ -275,3 +277,24 @@ def test_incremental_offset(cropping_kymo):
     np.testing.assert_allclose(twice_cropped.line_time_seconds, kymo.line_time_seconds)
     np.testing.assert_allclose(twice_cropped.pixels_per_line, 2)
     np.testing.assert_allclose(twice_cropped._position_offset, 2 * px_size)
+
+
+@pytest.mark.parametrize(
+    "color, ref_locations, percentile",
+    [
+        ("red", (7.65, 17.7), 70),
+        ("green", (7.65, 17.65), 70),
+        ("blue", (7.25, 20.9), 70),
+        ("blue", (7.25, 20.45), 20),
+    ],
+)
+def test_bead_crop(bead_kymo, color, ref_locations, percentile):
+    np.testing.assert_allclose(
+        bead_kymo.estimate_bead_edges(4.89, channel=color, threshold_percentile=percentile),
+        ref_locations,
+    )
+    np.testing.assert_allclose(
+        bead_kymo.crop_beads(4.89, channel=color, threshold_percentile=percentile).size_um,
+        np.diff(ref_locations),
+        atol=bead_kymo.pixelsize_um[0],
+    )


### PR DESCRIPTION
**Why this PR?**
Selecting ROIs by hand can be cumbersome. This function provides approximate bead edges that can be used for setting the kymotracking ROI (or directly crop the kymograph).

Might be a good initial approach until we find something better. Marked as beta because while tested on a fair number of kymographs, we might still find a better algorithm in the future.

<img width="565" alt="Screenshot 2024-02-13 at 10 33 17" src="https://github.com/lumicks/pylake/assets/19836026/77072f6d-1954-4264-8238-6461d9351f31">

<img width="356" alt="Screenshot 2024-02-13 at 10 34 21" src="https://github.com/lumicks/pylake/assets/19836026/a60343ee-ff95-427c-9c7d-4245a0d02f67">

<img width="569" alt="Screenshot 2024-02-13 at 10 35 31" src="https://github.com/lumicks/pylake/assets/19836026/54246dfe-273b-4088-a229-7ad0238951d4">

API docs [here](https://lumicks-pylake.readthedocs.io/en/find_beads/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.bead_roi) and [here](https://lumicks-pylake.readthedocs.io/en/find_beads/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.crop_beads)