### PR TITLE
kymo: finding bead edges part 2

### DIFF
--- a/lumicks/pylake/detail/bead_cropping.py
+++ b/lumicks/pylake/detail/bead_cropping.py
@@ -21,7 +21,7 @@ def _move_inward_percentile(data, bead_edges, threshold_percentile):
 
 
 def find_beads_brightness(
-    summed_kymo,
+    kymograph_image,
     bead_diameter_pixels,
     plot=False,
     threshold_percentile=70,
@@ -34,8 +34,8 @@ def find_beads_brightness(
 
     Parameters
     ----------
-    summed_kymo : np.ndarray
-        Kymograph image data (single channel summed along the time axis).
+    kymograph_image : np.ndarray
+        2D kymograph image
     bead_diameter_pixels : float
         Estimate for the bead size in pixels.
     plot : bool
@@ -59,6 +59,7 @@ def find_beads_brightness(
     import scipy.ndimage
     import matplotlib.pyplot as plt
 
+    summed_kymo = kymograph_image.sum(axis=1)
     data = summed_kymo.astype(float)
 
     # Makes sure we can handle dark beads

--- a/lumicks/pylake/detail/bead_cropping.py
+++ b/lumicks/pylake/detail/bead_cropping.py
@@ -1,7 +1,26 @@
 import numpy as np
 
 
-def find_beads(
+def _guess_background(data):
+    """Determine background level by determining most prominent mode"""
+    import scipy.stats
+
+    kde_estimate = scipy.stats.gaussian_kde(data, 0.02)
+    interpolated_kde = np.arange(min(data), np.max(data))
+    return interpolated_kde[np.argmax(kde_estimate.pdf(interpolated_kde))]
+
+
+def _move_inward_percentile(data, bead_edges, threshold_percentile):
+    """Move inward until a specific percentile is reached"""
+
+    final_cutoff = np.percentile(data[slice(*bead_edges)], threshold_percentile)
+    return [
+        bead_edges[0] + np.where(data[bead_edges[0] :] <= final_cutoff)[0][0],
+        bead_edges[1] - np.where(np.flip(data[: bead_edges[1]]) <= final_cutoff)[0][0],
+    ]
+
+
+def find_beads_brightness(
     summed_kymo,
     bead_diameter_pixels,
     plot=False,
@@ -29,7 +48,7 @@ def find_beads(
 
     Returns
     -------
-    list of int
+    bead_edges : list[int]
        List of the two edge positions in pixels.
 
     Raises
@@ -45,9 +64,7 @@ def find_beads(
     # Makes sure we can handle dark beads
     if allow_negative_beads:
         # Try to guess the background by finding the most prominent mode
-        kde_estimate = scipy.stats.gaussian_kde(data, 0.02)
-        interpolated_kde = np.arange(min(data), np.max(data))
-        baseline = interpolated_kde[np.argmax(kde_estimate.pdf(interpolated_kde))]
+        baseline = _guess_background(data)
         data = np.abs(data - baseline)
     else:
         baseline = 0
@@ -88,14 +105,201 @@ def find_beads(
         np.flip(only_beads[: bead_edges[1]]) < np.flip(blurred[: bead_edges[1]])
     )[0][0]
 
-    # We then keep moving until we've hit a low enough signal level that we are confident we
-    # have reached the tether.
-    final_cutoff = np.percentile(data[bead_edges[0] : bead_edges[1]], threshold_percentile)
-    bead_edges[0] += np.where(data[bead_edges[0] :] <= final_cutoff)[0][0]
-    bead_edges[1] -= np.where(np.flip(data[: bead_edges[1]]) <= final_cutoff)[0][0]
+    bead_edges = _move_inward_percentile(data, bead_edges, threshold_percentile)
 
     if plot:
         [plt.axvline(be, label="edge", color="k", linestyle="--") for be in bead_edges]
         plt.legend()
+
+    return bead_edges
+
+
+def find_beads_template(
+    kymograph_image,
+    bead_diameter_pixels,
+    downsample_num_frames=5,
+    plot=False,
+    allow_movement=False,
+    threshold_percentile=70,
+):
+    """Determine bead edges using a cross correlation procedure
+
+    This function seeks a bead-sized template that appears in subsequent frames.
+    It then moves inward by half the template size to provide bead edges.
+
+    Parameters
+    ----------
+    kymograph_image : np.ndarray
+        2D kymograph image
+    bead_diameter_pixels : int
+        Template size in pixels (will be rounded up to an odd number). Note that
+        the template size should be equal or larger than the bead size. It should
+        capture as much of the bead (including the fluorescent side lobe if present)
+        as possible.
+    downsample_num_frames : int
+        Number of time frames to downsample to (must be larger than 3).
+    plot : bool
+        Plots results that can be used for debugging why it has failed.
+    allow_movement : bool
+        Allow movement of the template between frames?
+    threshold_percentile : int
+        Percentile below which to drop.
+
+    Returns
+    -------
+    bead_edges : list[int]
+       List of the two edge positions in pixels.
+
+    Raises
+    ------
+    ValueError
+        If downsample_num_frames is set to a value lower than 3.
+    ValueError
+        If the kymograph image is shorter than 3 frames or has incorrect dimensions.
+    """
+    import scipy.ndimage
+    import matplotlib.pyplot as plt
+    from skimage.measure import block_reduce
+
+    if downsample_num_frames < 3:
+        raise ValueError(
+            f"Time axis needs to be divided in at least 3 sections, provided {downsample_num_frames}"
+        )
+
+    if kymograph_image.ndim != 2:
+        raise ValueError(
+            f"Kymograph image must be two dimensional. Provided {kymograph_image.ndim} dimensional "
+            "image"
+        )
+
+    if kymograph_image.shape[1] < 3:
+        raise ValueError(
+            "Kymograph is too short to apply this method. This method requires at least 3 scan "
+            f"lines while this kymograph has {kymograph_image.shape[1]} scan lines."
+        )
+
+    half_width = int(bead_diameter_pixels // 2)
+    template_size_pixels = half_width * 2 + 1
+
+    ds_factor = kymograph_image.shape[1] // downsample_num_frames
+    img = (
+        block_reduce(kymograph_image, (1, ds_factor), func=np.sum)[
+            :, : kymograph_image.shape[1] // ds_factor
+        ]
+        if ds_factor > 1
+        else kymograph_image
+    )
+
+    # Try to guess the background by finding the most prominent mode
+    baseline = _guess_background(img.flatten())
+
+    # Flip dark beads into having positive signal that we can template match on
+    img = np.abs(img - baseline)
+
+    # Pad so that we don't get boundary effects from our filtering
+    padding = np.zeros((half_width * 2, img.shape[1]))
+    padded_img = np.vstack((padding, img, padding))
+
+    # Set up the correlation matrix. For each frame, we apply a sliding window.
+    # for each window we look into the subsequent frames whether we see the window there
+    # using cross correlation.
+    if allow_movement:
+
+        def normalized_cross_correlation(template_origin, t):
+            template = padded_img[template_origin : template_origin + template_size_pixels, t]
+            normalization_factor = 1.0 + np.std(padded_img[:, t + 1]) * np.std(template)
+
+            return (
+                np.max(scipy.signal.correlate(padded_img[:, t + 1], template, mode="same"))
+                / normalization_factor
+            )
+
+        correlation_stack = np.stack(
+            [
+                [
+                    normalized_cross_correlation(template_origin, t)
+                    for t in range(padded_img.shape[1] - 1)
+                ]
+                for template_origin in range(padded_img.shape[0])
+            ]
+        )
+    else:
+
+        def normalized_cross_correlation_row(current, subsequent, row_std):
+            mul = current * subsequent
+            template_mean = scipy.ndimage.uniform_filter(current, template_size_pixels)
+            template_sq = scipy.ndimage.uniform_filter(current**2, template_size_pixels)
+            # Sometimes this nets tiny negative values, hence the absolute value
+            template_std = np.sqrt(np.abs(template_sq - template_mean**2))
+
+            normalization = 1.0 + template_std * row_std
+            return scipy.ndimage.uniform_filter(mul, template_size_pixels) / normalization
+
+        row_stds = np.std(padded_img, axis=0)
+        correlation_stack = np.stack(
+            [
+                normalized_cross_correlation_row(current, subsequent, row_std)
+                for (current, subsequent, row_std) in zip(
+                    padded_img[:, :-1].T, padded_img[:, 1:].T, row_stds[1:]
+                )
+            ]
+        )[
+            :, template_size_pixels // 2 : -template_size_pixels // 2
+        ].T  # remove overhangs
+
+    # Only use positive correlation
+    positive_correlation = correlation_stack * (correlation_stack > 0)
+
+    # Sum over time
+    aggregate = positive_correlation.sum(axis=1)
+
+    # If the feature we are looking for is smaller than the template, the feature position with
+    # respect to the template becomes arbitrary.
+    #
+    #  ___/\__ will have just as good a score as /\_____
+    #
+    # To instill a preference for centering the template, we blur the match score such that this
+    # flat match score now features a peak in the middle that we can find.
+    aggregate = scipy.ndimage.gaussian_filter(aggregate, half_width // 4)
+    aggregate = aggregate[half_width:-half_width]  # Remove the padding
+
+    # Find local positive non-zero maxima
+    peaks = (
+        scipy.ndimage.grey_dilation([aggregate], (0, 2 * template_size_pixels)) == aggregate
+    ).flatten()
+    peaks *= aggregate > 0
+    peak_centers = np.where(peaks)[0]
+
+    if plot:
+        # Show the correlation map
+        plt.figure()
+        plt.imshow(positive_correlation, aspect="auto")
+
+        for m in peak_centers:
+            plt.axhline(m + half_width, color="k", linestyle="--")
+
+        plt.figure()
+        plt.plot(np.arange(len(aggregate)), aggregate, label="correlation score")
+        plt.twinx()
+        plt.plot(img[:, 0], "k", alpha=0.5, label="intensities")
+        plt.plot(img[:, 1:], "k", alpha=0.5, label="_")
+
+        if np.any(peak_centers):
+            plt.axvline(peak_centers[0], label="center")
+            if len(peak_centers) > 0:
+                for m in peak_centers[1:]:
+                    plt.axvline(m, label="_")
+
+    if len(peak_centers) < 2:
+        raise RuntimeError("Did not find two beads")
+
+    # Seek inward until we cross the baseline.
+    bead_edges = [peak_centers[0] + half_width, peak_centers[-1] - half_width]
+    data = np.sum(img, axis=1)
+    bead_edges = _move_inward_percentile(data, bead_edges, threshold_percentile)
+
+    if plot:
+        plt.axvline(bead_edges[0], label="edge", color="k")
+        plt.axvline(bead_edges[1], label="_edge", color="k")
 
     return bead_edges

--- a/lumicks/pylake/detail/tests/test_bead_crop.py
+++ b/lumicks/pylake/detail/tests/test_bead_crop.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import matplotlib.pyplot as plt
 
-from lumicks.pylake.detail.bead_cropping import find_beads
+from lumicks.pylake.detail.bead_cropping import find_beads_brightness, find_beads_template
 
 
 @pytest.mark.parametrize(
@@ -24,7 +24,7 @@ from lumicks.pylake.detail.bead_cropping import find_beads
 def test_bead_cropping_allow_negative_beads(filename, ref_edges, ref_edges_no_negative):
     data = np.load(pathlib.Path(__file__).parent / "data" / f"{filename}.npz")
 
-    edges = find_beads(data["green"], bead_diameter_pixels=4.84 / data["pixelsize"], plot=False)
+    edges = find_beads_brightness(data["green"], bead_diameter_pixels=4.84 / data["pixelsize"], plot=False)
     # Asserting equal to pin behavior, but I wouldn't expect more accuracy than half a micron
     # because the fluorescence typically tails out wide.
     np.testing.assert_equal(edges, ref_edges)
@@ -32,7 +32,7 @@ def test_bead_cropping_allow_negative_beads(filename, ref_edges, ref_edges_no_ne
     with nullcontext() if ref_edges_no_negative else pytest.raises(
         RuntimeError, match="Did not find two beads"
     ):
-        edges = find_beads(
+        edges = find_beads_brightness(
             data["green"], bead_diameter_pixels=4.84 / data["pixelsize"], allow_negative_beads=False
         )
         np.testing.assert_equal(edges, ref_edges_no_negative)
@@ -42,13 +42,13 @@ def test_bead_cropping_failure():
     mock = np.zeros((100,))
     mock[50] = 1  # Standard deviation of the data should not be zero or the KDE estimate fails.
     with pytest.raises(RuntimeError, match="Did not find two beads"):
-        find_beads(mock, bead_diameter_pixels=1, plot=True)
+        find_beads_brightness(mock, bead_diameter_pixels=1, plot=True)
 
 
 def test_plotting():
     data = np.load(pathlib.Path(__file__).parent / "data" / f"kymo_sum0.npz")
     for allow_negative in (False, True):
-        edges = find_beads(
+        edges = find_beads_brightness(
             data["green"],
             bead_diameter_pixels=4.84 / data["pixelsize"],
             plot=True,
@@ -58,3 +58,52 @@ def test_plotting():
         np.testing.assert_equal(plt.gca().lines[0].get_data()[1], data["green"])
         np.testing.assert_equal(plt.gca().lines[-2].get_data()[0], [edges[0], edges[0]])
         np.testing.assert_equal(plt.gca().lines[-1].get_data()[0], [edges[1], edges[1]])
+
+
+@pytest.mark.parametrize(
+    "bead_size_pixels, ref_values",
+    [
+        (5, (17, 37)),
+        (7, (17, 37)),
+        (8, (17, 36)),
+        (10, (18, 35)),
+        (11, (18, 35)),
+        (12, (19, 34)),
+    ],
+)
+def test_template_crop(bead_size_pixels, ref_values):
+    peak1 = [6, 2, 3, 2, 3, 6, 9]
+    peak2 = [5, 2, 3, 2, 12, 8, 2]
+    image_line = [0] * 10 + peak1 + [0] * 20 + peak2 + [0] * 10
+    im = np.tile(image_line, (3, 1)).T
+
+    maxima = find_beads_template(im, bead_size_pixels, downsample_num_frames=10)
+    np.testing.assert_equal(maxima, ref_values)
+
+
+def test_template_crop_plot():
+    peak1 = [6, 2, 3, 2, 3, 6, 9]
+    peak2 = [5, 2, 3, 2, 12, 8, 2]
+    image_line = [0] * 10 + peak1 + [0] * 20 + peak2 + [0] * 10
+    im = np.tile(image_line, (3, 1)).T
+    find_beads_template(im, 10, downsample_num_frames=10, plot=True, allow_movement=True)
+    find_beads_template(im, 10, downsample_num_frames=10, plot=True, allow_movement=False)
+
+
+def test_template_crop_errors():
+    peak = [6, 2, 3, 2, 3, 6, 9]
+    image_line = [0] * 10 + peak + [0] * 20
+
+    with pytest.raises(RuntimeError, match="Did not find two beads"):
+        find_beads_template(np.tile(image_line, (3, 1)).T, bead_diameter_pixels=5)
+
+    with pytest.raises(ValueError, match="Kymograph image must be two dimensional"):
+        find_beads_template(np.array([1, 2, 3]), bead_diameter_pixels=5)
+
+    with pytest.raises(ValueError, match="Kymograph is too short to apply this method"):
+        find_beads_template(np.tile(image_line, (2, 1)).T, bead_diameter_pixels=5)
+
+    with pytest.raises(ValueError, match="Time axis needs to be divided in at least 3 sections"):
+        find_beads_template(
+            np.tile(image_line, (2, 1)).T, bead_diameter_pixels=5, downsample_num_frames=2
+        )

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -16,7 +16,7 @@ from .detail.confocal import ScanAxis, ScanMetaData, ConfocalImage
 from .detail.plotting import get_axes, show_image
 from .detail.timeindex import to_timestamp
 from .detail.utilities import method_cache
-from .detail.bead_cropping import find_beads
+from .detail.bead_cropping import find_beads_brightness
 
 
 def _default_line_time_factory(self: "Kymo"):
@@ -592,7 +592,7 @@ class Kymo(ConfocalImage):
             Rough estimate for the bead size (microns).
         channel : 'red', 'green', 'blue', optional
             Channel to use for bead detection.
-        plot : bool, optional
+        plot : optional[bool]
             Plot result
         threshold_percentile : int
             Percentile to drop down to before accepting that we have left the bead area. Higher
@@ -603,7 +603,7 @@ class Kymo(ConfocalImage):
 
         Returns
         -------
-        list of float
+        bead_edges : list[float]
             List of the two edge positions in microns.
 
         Raises
@@ -619,7 +619,7 @@ class Kymo(ConfocalImage):
             )
 
         return (
-            find_beads(
+            find_beads_brightness(
                 self.get_image(channel).sum(axis=1),
                 bead_diameter_pixels=bead_diameter / self.pixelsize_um[0],
                 plot=plot,

--- a/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
+++ b/lumicks/pylake/kymotracker/tests/test_greedy_algorithm.py
@@ -156,7 +156,7 @@ def test_default_parameters(kymo_pixel_calibrations):
         tracks = track_greedy(
             kymo, "red", track_width=None, pixel_threshold=default_threshold * 0.7
         )
-        with pytest.raises(AssertionError):
+        with np.testing.assert_raises(AssertionError):
             for ref, track in zip(ref_tracks, tracks):
                 np.testing.assert_allclose(ref.position, track.position)
 
@@ -168,6 +168,6 @@ def test_default_parameters(kymo_pixel_calibrations):
             pixel_threshold=None,
             bias_correction=False,
         )
-        with pytest.raises(AssertionError):
+        with np.testing.assert_raises(AssertionError):
             for ref, track in zip(ref_tracks, tracks):
                 np.testing.assert_allclose(ref.position, track.position)

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_slice_crop.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_slice_crop.py
@@ -280,21 +280,31 @@ def test_incremental_offset(cropping_kymo):
 
 
 @pytest.mark.parametrize(
-    "color, ref_locations, percentile",
+    "color, ref_locations, algorithm, kwargs",
     [
-        ("red", (7.65, 17.7), 70),
-        ("green", (7.65, 17.65), 70),
-        ("blue", (7.25, 20.9), 70),
-        ("blue", (7.25, 20.45), 20),
+        ("red", (7.65, 17.7), "brightness", {"threshold_percentile": 70}),
+        ("green", (7.65, 17.65), "brightness", {"threshold_percentile": 70}),
+        ("blue", (7.25, 20.9), "brightness", {"threshold_percentile": 70}),
+        ("blue", (7.25, 20.45), "brightness", {"threshold_percentile": 20}),
+        ("red", (7.4, 17.7), "template", {}),
+        ("green", (7.35, 17.75), "template", {}),
+        ("blue", (7.05, 18.45), "template", {}),
+        ("blue", (7.2, 18.3), "template", {"threshold_percentile": 20}),
+        ("blue", (6.9, 18.45), "template", {"allow_movement": True}),
     ],
 )
-def test_bead_crop(bead_kymo, color, ref_locations, percentile):
+def test_bead_crop(bead_kymo, color, ref_locations, algorithm, kwargs):
     np.testing.assert_allclose(
-        bead_kymo.estimate_bead_edges(4.89, channel=color, threshold_percentile=percentile),
+        bead_kymo.estimate_bead_edges(4.89, algorithm=algorithm, channel=color, **kwargs),
         ref_locations,
     )
     np.testing.assert_allclose(
-        bead_kymo.crop_beads(4.89, channel=color, threshold_percentile=percentile).size_um,
+        bead_kymo.crop_beads(4.89, algorithm=algorithm, channel=color, **kwargs).size_um,
         np.diff(ref_locations),
         atol=bead_kymo.pixelsize_um[0],
     )
+
+
+def test_bead_crop_invalid_algorithm(bead_kymo):
+    with pytest.raises(ValueError, match="Unrecognized algorithm godot"):
+        bead_kymo.crop_beads(4.89, algorithm="godot", channel="green")


### PR DESCRIPTION
**Why this PR?**
The algorithm added in https://github.com/lumicks/pylake/pull/623 works fairly robustly, but can fail occasionally for narrow beads. The algorithm in this PR is a bit more general and can be used as fallback.

It makes use of cross correlation to determine features that recur in each frame. Basically, for each window, it attempts to use a series of all possible templates of a given size, which it then cross correlates with the next frame (taking the maximum found cross correlation). This is repeated for each frame. After this, we take the average along the positional axis which gives you a score for how "templatey" that bit is. 

There is a parameter (which is not explicitly documented in the function on kymo), which relaxes the requirement of the template to stay in the same place. I have seen this help when considering experiments where people are pulling on beads; though in most cases, it does result in some more failures (hence it is not the default).

I think initially, on the public side of the API, we should expose as little as possible. I would like to see how users get on with this functionality. If we find out that they do need the customizability that the arguments offer, then we can expose them when needed, but I would initially like to try it with the defaults first.

API doc [here](https://lumicks-pylake.readthedocs.io/en/option_2/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.estimate_bead_edges).