### PR TITLE
docs: fix some small oversights in the documentation

### DIFF
--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -326,7 +326,7 @@ Let's have a look to see if this peak indeed appears in our power spectrum.
 To see it clearly, we reduce the blocking amount and show the spectrum all the way up to a frequency of 10 Hz::
 
     show_peak = lk.calculate_power_spectrum(
-        volts.data, sample_rate=78125, num_points_per_block=5, fit_range=(10, 23000)
+        volts.data, sample_rate=volts.sample_rate, num_points_per_block=5, fit_range=(10, 23000)
     )
 
     plt.figure()
@@ -339,7 +339,7 @@ The driving peak is clearly visible in the spectrum.
 Next let's calculate the power spectrum we'll use for fitting.
 It is important to *not* include the driving peak when doing this (the default will only go up to 100 Hz)::
 
-    power_spectrum = lk.calculate_power_spectrum(volts.data, sample_rate=78125)
+    power_spectrum = lk.calculate_power_spectrum(volts.data, sample_rate=volts.sample_rate)
 
 We can now use this to fit our data::
 

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -376,7 +376,7 @@ class PassiveCalibrationModel:
 
         power_spectrum = lk.calculate_power_spectrum(
             volts.data,
-            sample_rate=78125,
+            sample_rate=volts.sample_rate,
             excluded_ranges=[[4400, 4500]],  # Exclude a noise peak
             num_points_per_block=350,
         )
@@ -754,7 +754,7 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
 
         power_spectrum = lk.calculate_power_spectrum(
             volts.data,
-            sample_rate=78125,
+            sample_rate=volts.sample_rate,
             excluded_ranges=[[4400, 4500]],  # Exclude a noise peak
             num_points_per_block=350,
         )
@@ -763,7 +763,7 @@ class ActiveCalibrationModel(PassiveCalibrationModel):
             f["Nanostage position"]["X"].data,  # Driving data
             volts.data,  # Position sensitive detector data
             temperature=25,
-            sample_rate=78125,
+            sample_rate=volts.sample_rate,
             bead_diameter=4.89,
             driving_frequency_guess=37,  # Have to provide a guess for the frequency
             hydrodynamically_correct=True,  # Big bead, so use hydrodynamic model

--- a/lumicks/pylake/force_calibration/convenience.py
+++ b/lumicks/pylake/force_calibration/convenience.py
@@ -150,14 +150,16 @@ def calibrate_force(
         volts = force_slice / force_slice.calibration[0]["Response (pN/V)"]
 
         # Determine calibration factors using the viscosity of water at T=25 C.
-        lk.calibrate_force(volts.data, bead_diameter=0.58, temperature=25, sample_rate=78125)
+        lk.calibrate_force(
+            volts.data, bead_diameter=0.58, temperature=25, sample_rate=volts.sample_rate
+        )
 
         # Determine calibration factors using the hydrodynamically correct model
         lk.calibrate_force(
             volts.data,
             bead_diameter=4.89,
             temperature=25,
-            sample_rate=78125,
+            sample_rate=volts.sample_rate,
             hydrodynamically_correct=True
         )
 
@@ -168,7 +170,7 @@ def calibrate_force(
             volts.data,
             bead_diameter=4.89,
             temperature=25,
-            sample_rate=78125,
+            sample_rate=volts.sample_rate,
             hydrodynamically_correct=True,
             distance_to_surface=7,
             driving_data=driving_data.data,

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -417,6 +417,7 @@ class KymoTrack:
 
     @property
     def time_idx(self):
+        """Return temporal coordinates in units of pixels."""
         return self._time_idx
 
     @property


### PR DESCRIPTION
**Why this PR?**
- We have systems out in the field with `100` kHz sampling rate. We should ideally not hardcode the `78125` Hz in our docs examples, because people may end up copying these and getting invalid results.
- We forgot to provide the public function `time_idx` with a docstring which makes it not show up as an API endpoint in the documentation.