### PR TITLE
imagestack: support two-color tiff stacks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5.0 | t.b.d.
+
+* Added support for loading two-color `TIF` files with [`ImageStack`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack).
+
 ## v1.4.0 | 2024-02-28
 
 #### New features

--- a/lumicks/pylake/tests/data/mock_widefield.py
+++ b/lumicks/pylake/tests/data/mock_widefield.py
@@ -140,18 +140,22 @@ def make_irm_description(version, bit_depth):
 def make_wt_description(version, bit_depth, m_red, m_blue, offsets):
     if version == 1:
         alignment_matrices = lambda color: f"Alignment {color} channel"
+        wavelength_fields = lambda color: f"Channel {color} detection wavelength (nm)"
         channel_choices = ("red", "green", "blue")
     else:
         alignment_matrices = lambda index: f"Channel {index} alignment"
+        wavelength_fields = lambda index: f"Channel {index} detection wavelength (nm)"
         channel_choices = range(3)
 
     offsets = [0, 0] if offsets is None else offsets
     matrices = (m_red, np.eye(3), m_blue)
+    wavelengths = ("680/42", "600/50", "525/40")
 
     description = _make_base_description(version, bit_depth)
     description["Camera"] = "WT"
-    for c, mat in zip(channel_choices, matrices):
+    for c, mat, wavelength in zip(channel_choices, matrices, wavelengths):
         description[alignment_matrices(c)] = mat[:2].ravel().tolist()
+        description[wavelength_fields(c)] = wavelength
     description["Alignment region of interest (x, y, width, height)"] = [*offsets, 200, 100]
     description["TIRF"] = None
     description["TIRF angle (device units)"] = None

--- a/lumicks/pylake/tests/data/mock_widefield.py
+++ b/lumicks/pylake/tests/data/mock_widefield.py
@@ -190,9 +190,8 @@ def make_alignment_image_data(
     return reference_image, warped_image, description, bit_depth
 
 
-def write_tiff_file(image, description, n_frames, filename):
+def write_tiff_file(image, description, n_frames, filename, **kwargs):
     # We use the dimension of image data to evaluate the number of color channels
-    channels = 1 if image.ndim == 2 else 3
     movie = np.stack([image for n in range(n_frames)], axis=0)
 
     # Orientation = ORIENTATION.TOPLEFT
@@ -210,4 +209,5 @@ def write_tiff_file(image, description, n_frames, filename):
                 metadata=None,
                 contiguous=False,
                 extratags=(tag_orientation, tag_datetime),
+                **kwargs,
             )

--- a/lumicks/pylake/tests/test_imaging_camera/conftest.py
+++ b/lumicks/pylake/tests/test_imaging_camera/conftest.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from ..data.mock_widefield import write_tiff_file, make_alignment_image_data
@@ -53,6 +54,52 @@ def rgb_tiff_file(tiff_dir, rgb_alignment_image_data):
     _, warped_image, description, _ = rgb_alignment_image_data
     write_tiff_file(warped_image, description, n_frames=1, filename=str(mock_filename))
     return mock_filename
+
+
+def _create_gb_tiff(mock_filename, spot_coordinates, warp_parameters, num_frames):
+    rgb_reference_image, warped_image, description, _ = make_alignment_image_data(
+        spot_coordinates, version=2, bit_depth=16, camera="wt", **warp_parameters
+    )
+
+    # For two-color tiff files with green and blue, channel 0 refers to the green channel.
+    description = {
+        key: value for key, value in description.items() if "Red Excitation Laser" not in key
+    }
+    description["Channel 0 alignment"] = description["Channel 1 alignment"]
+    description["Channel 1 alignment"] = description["Channel 2 alignment"]
+    description.pop("Channel 2 alignment")
+
+    # RGB -> GB
+    warped_image = warped_image[:, :, 1:]
+    write_tiff_file(
+        warped_image,
+        description,
+        n_frames=num_frames,
+        filename=str(mock_filename),
+        planarconfig="contig",  # Allows storing 2-color TIFFs
+    )
+
+    reference_img = np.zeros((*rgb_reference_image.shape[:-1], 3), dtype=float)
+    reference_img[..., 1:] = rgb_reference_image[..., 1:]
+
+    # Expand reference to multiple frames
+    reference_img = np.repeat(reference_img[np.newaxis, ...], num_frames, axis=0).squeeze()
+
+    return mock_filename, reference_img
+
+
+@pytest.fixture(scope="module")
+def gb_tiff_file_single(tiff_dir, spot_coordinates, warp_parameters):
+    return _create_gb_tiff(
+        tiff_dir.join("single_two_color.tiff"), spot_coordinates, warp_parameters, 1
+    )
+
+
+@pytest.fixture(scope="module")
+def gb_tiff_file_multi(tiff_dir, spot_coordinates, warp_parameters):
+    return _create_gb_tiff(
+        tiff_dir.join("multiple_two_color.tiff"), spot_coordinates, warp_parameters, 5
+    )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
**Why this PR?**
Some systems in the field have the ability to export two-color tiff stacks. Would be good to add support for them.

*Note*
I have made the judgment call to map the export function to a three color tiff stack with the correct mapping, since it makes it more convenient to load into other software. Not many software packages support two color tiffs out of the box, besides, if people want the original two-color tiff, they have it already.