### PR TITLE
plot_correlated: add option to not downsample the channel data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Added support for loading two-color `TIF` files with [`ImageStack`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack).
 * Made ([`CalibrationResults`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html#calibrationresults)) callable to evaluate the fitted model power spectral density at the specified frequencies.
 * Added `fitted_params` field to ([`CalibrationResults`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html#calibrationresults)) for convenience.
+* Added option to disable downsampling channel data to frame rates with correlated plots ([`ImageStack.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.plot_correlated), [`Scan.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.Scan.html#lumicks.pylake.Scan.plot_correlated)) and exported videos ([`ImageStack.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.export_video), [`Scan.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.Scan.html#lumicks.pylake.Scan.export_video)) using `downsample_channel=False`.
 
 ## v1.4.0 | 2024-02-28
 

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -124,6 +124,7 @@ class VideoExport:
         scale_bar=None,
         channel_slice=None,
         vertical=True,
+        downsample_channel=True,
         **kwargs,
     ):
         """Export a video
@@ -148,6 +149,8 @@ class VideoExport:
             When specified, we export a video correlated to channel data
         vertical : bool, optional
             Render with the plots vertically aligned (default: True).
+        downsample_channel : bool, optional
+            Downsample the channel data over frame timestamp ranges (default: True).
         **kwargs
             Forwarded to :func:`matplotlib.pyplot.imshow`.
 
@@ -217,6 +220,7 @@ class VideoExport:
                 channel_slice=channel_slice,
                 vertical=vertical,
                 return_frame_setter=True,
+                downsample_channel=downsample_channel,
             )
             fig = plt.gcf()  # plot_correlated makes its own plot
             fig.patch.set_alpha(1.0)  # Circumvents grainy rendering

--- a/lumicks/pylake/image_stack.py
+++ b/lumicks/pylake/image_stack.py
@@ -486,6 +486,7 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
         vertical=False,
         include_dead_time=False,
         return_frame_setter=False,
+        downsample_channel=True,
     ):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling
         function (e.g. `np.mean`) is evaluated for the time between a start and end time of a
@@ -520,6 +521,8 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
             Include dead time between frames, default: False.
         return_frame_setter : bool, optional
             Whether to return a handle that allows updating the plotted frame, default: False.
+        downsample_channel : bool, optional
+            Downsample the channel data over frame timestamp ranges (default: True).
 
         Note
         ----
@@ -554,6 +557,7 @@ class ImageStack(FrameIndex, TiffExport, VideoExport):
             figure_scale=figure_scale,
             post_update=post_update,
             vertical=vertical,
+            downsample_channel=downsample_channel,
         )
 
         if return_frame_setter:

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -296,6 +296,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         vertical=False,
         include_dead_time=False,
         return_frame_setter=False,
+        downsample_channel=True,
     ):
         """Downsample channel on a frame by frame basis and plot the results. The downsampling
         function (e.g. np.mean) is evaluated for the time between a start and end time of a frame.
@@ -331,6 +332,8 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             Include dead time between scan frames.
         return_frame_setter : bool, optional
             Whether to return a handle that allows updating the plotted frame.
+        downsample_channel : bool, optional
+            Downsample the channel data over frame timestamp ranges (default: True).
 
         Examples
         --------
@@ -369,6 +372,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             figure_scale=figure_scale,
             post_update=post_update,
             vertical=vertical,
+            downsample_channel=downsample_channel,
         )
         if return_frame_setter:
             return frame_setter


### PR DESCRIPTION
**Why this PR?**
Sometimes, you want to see things that happen within a frame. Currently, we downsample to the frame time. This PR makes this downsampling optional. This means you can just provide a slice that is downsampled the way you want it, and it'll just work.

This is especially important for `Scan` items, because they have long frame times.

This PR proposes adding a new argument for this. Which means you'd call `plot_correlated` or `export_video` with `downsample_channel=False` to get the behaviour where it doesn't downsample extra. The default is `True` for backwards compatibility; but if the old behavior is so bad that one might consider it faulty, we could consider making the default `False`.