### PR TITLE
calibration: make it easier to simulate model

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,11 @@
 
 ## v1.5.0 | t.b.d.
 
+#### New features
+
 * Added support for loading two-color `TIF` files with [`ImageStack`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack).
+* Made ([`CalibrationResults`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html#calibrationresults)) callable to evaluate the fitted model power spectral density at the specified frequencies.
+* Added `fitted_params` field to ([`CalibrationResults`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html#calibrationresults)) for convenience.
 
 ## v1.4.0 | 2024-02-28
 

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -543,15 +543,20 @@ We still have the power spectrum `ps` that was created without blocking or windo
 We will use the method :meth:`~lumicks.pylake.force_calibration.power_spectrum.PowerSpectrum.identify_peaks()` in order to do so.
 This method takes a function that accurately models the power spectrum as a function of frequency, in order to normalize it.
 It then identifies peaks based on the likelihood of encountering a peak of a certain magnitude in the resulting data set.
-If we have a "good fit", then the easiest way to get that function is to extract it from our fit parameters and the model that was used during fitting::
+If we have a "good fit", then the easiest way to get that function is to use our fitted model::
 
-    params = [v.value for k, v in fit.results.items() if k in ['fc', 'D', 'f_diode', 'alpha']]
-    model_fun = lambda f: fit.model(f, *params)
+    plt.figure()
+    frequency_range = np.arange(100, 22000)
+    # We can call the fit with a list of frequencies to evaluate the model at those frequencies.
+    # This uses the best fit parameters from fit.fitted_params.
+    plt.plot(frequency_range, fit(frequency_range))
+    plt.xscale("log")
+    plt.yscale("log")
 
 If there are no spurious peaks, then normalizing the unblocked power spectrum results in random numbers with an exponential distribution with a mean value of 1.
 The chance of encountering increasingly larger numbers decays exponentially, and this fact is used by `identify_peaks()`::
 
-    frequency_exclusions = ps.identify_peaks(model_fun, peak_cutoff=20, baseline=1)
+    frequency_exclusions = ps.identify_peaks(fit, peak_cutoff=20, baseline=1)
 
 The parameter `peak_cutoff` is taken as the minimum magnitude of any value in the normalized power spectrum in order to be concidered a peak.
 The default value is 20, and it corresponds to a chance of about 2 in a billion of a peak of magnitude 20 or larger occuring naturally in a data set.

--- a/lumicks/pylake/force_calibration/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/power_spectrum.py
@@ -123,11 +123,10 @@ class PowerSpectrum:
 
         Parameters
         ----------
-        power_spectrum : PowerSpectrum
-            The power spectrum of the Brownian motion of the bead in a trap
         model_fun : callable
             A function of one argument, frequency, that gives the theoretical power spectrum. The
-            function is used to normalize the experimental power spectrum
+            function is used to normalize the experimental power spectrum. Note that you can
+            pass an instance of `CalibrationResults`.
         peak_cutoff: float
             Indicates what value of the normalized spectrum is deemed abnormally high. Default is
             20.0, which corresponds to a chance of about 2 in 1E9 that a peak of that magnitude
@@ -188,7 +187,8 @@ class PowerSpectrum:
 
         baseline_ranges = grab_contiguous_ranges(baseline_mask)
 
-        # Find start points of baseline sections (int because derivative can be negative, and bool doesn't allow that).
+        # Find start points of baseline sections (int because derivative can be negative, and bool
+        # doesn't allow that).
         start_points = np.diff(baseline_mask, prepend=0) > 0
 
         # This allows us to look up which baseline range to grab

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -59,20 +59,33 @@ class CalibrationResults:
         Dictionary of input parameters.
     results : dict
         Dictionary of calibration results.
+    fitted_params : np.ndarray
+        Fitted parameters.
     """
 
-    def __init__(self, model, ps_model, ps_data, params, results):
+    def __init__(self, model, ps_model, ps_data, params, results, fitted_params):
         self.model = model
         self.ps_model = ps_model
         self.ps_data = ps_data
         self.params = params
         self.results = results
+        self.fitted_params = fitted_params
 
         # A few parameters have to be present for this calibration to be used.
         mandatory_params = ["kappa", "Rf"]
         for key in mandatory_params:
             if key not in results:
                 raise RuntimeError(f"Calibration did not provide calibration parameter {key}")
+
+    def __call__(self, frequency):
+        """Evaluate the spectral model for one or more frequencies
+
+        Parameters
+        ----------
+        frequency : array_like
+            One or more frequencies at which to evaluate the spectral model.
+        """
+        return self.model(frequency, *self.fitted_params)
 
     def __contains__(self, key):
         return key in self.params or key in self.results
@@ -452,4 +465,5 @@ def fit_power_spectrum(
                 "Loss function used during minimization", loss_function, ""
             ),
         },
+        fitted_params=solution_params,
     )

--- a/lumicks/pylake/force_calibration/tests/test_diode_models.py
+++ b/lumicks/pylake/force_calibration/tests/test_diode_models.py
@@ -65,6 +65,9 @@ def test_fixed_f_diode(model_params, fixed_params, free_params, reference_models
     for model in models:
         model._filter = FixedDiodeModel(**model_params)
         fit = fit_power_spectrum(power_spectrum, model=model, bias_correction=False)
+        np.testing.assert_allclose(fit(fit.ps_model.frequency), fit.ps_model.power)
+        ref_params = [fit[p].value for p in ("fc", "D", "f_diode", "alpha") if p in fit.results]
+        np.testing.assert_allclose(fit.fitted_params, ref_params)
 
         # Test good fit
         np.testing.assert_allclose(fit.results["fc"].value, 4000, 1e-6)
@@ -84,6 +87,9 @@ def test_fixed_f_diode(model_params, fixed_params, free_params, reference_models
             bad_params[key] *= 1.1
         model._filter = FixedDiodeModel(**bad_params)
         fit = fit_power_spectrum(power_spectrum, model=model, bias_correction=False)
+        np.testing.assert_allclose(fit(fit.ps_model.frequency), fit.ps_model.power)
+        ref_params = [fit[p].value for p in ("fc", "D", "f_diode", "alpha") if p in fit.results]
+        np.testing.assert_allclose(fit.fitted_params, ref_params)
         assert abs(fit.results["fc"].value - 4000) > 1.0
         assert abs(fit.results["D"].value - 1.14632) > 1e-2
 

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -260,7 +260,12 @@ def test_attributes_ps_calibration(reference_calibration_result):
 
     with pytest.raises(RuntimeError):
         psc.CalibrationResults(
-            model=None, ps_model=None, ps_data=None, params={"test": 5}, results={"test2": 5}
+            model=None,
+            ps_model=None,
+            ps_data=None,
+            params={"test": 5},
+            results={"test2": 5},
+            fitted_params=[],
         )
 
 
@@ -274,6 +279,7 @@ def test_calibration_results_params():
             "Rf": psc.CalibrationParameter("Rf", "val", 5),
             "kappa": psc.CalibrationParameter("kappa", "val", 5),
         },
+        fitted_params=[],
     )
     assert "test" in result
     assert "Rf" in result


### PR DESCRIPTION
**Why this PR?**
It's a small thing, but it can be tedious to simulate a power spectrum from a fit result (since the number of fitted parameters can vary). This PR makes that a bit more user friendly.