### PR TITLE
calibration: expose an estimate of the local drag

### DIFF
--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -250,7 +250,9 @@ To summarize, the workflow can be visualized as follows:
 
 .. note::
 
-    Note that the drag coefficient that Pylake returns always corresponds to the drag coefficient extrapolated back to its bulk value.
+    Note that the drag coefficient `gamma_ex` that Pylake returns always corresponds to the drag coefficient extrapolated back to its bulk value.
+    This ensures that drag coefficients can be compared and carried over between experiments performed at different heights.
+    The field `local_drag_coefficient` contains an estimate of the local drag coefficient (at the provided height).
 
 Axial Force
 -----------

--- a/lumicks/pylake/force_calibration/convenience.py
+++ b/lumicks/pylake/force_calibration/convenience.py
@@ -96,7 +96,10 @@ def calibrate_force(
     excluded_ranges : list of tuple of float, optional
         List of ranges to exclude specified as a list of (frequency_min, frequency_max).
     drag : float, optional
-        Overrides the drag coefficient to this particular value.
+        Overrides the drag coefficient to this particular value. Note that you want to use the
+        bulk drag coefficient for this (obtained from the field `gamma_ex`). This can be used to
+        carry over an estimate of the drag coefficient obtained using an active calibration
+        procedure.
     fixed_diode : float, optional
         Fix diode frequency to a particular frequency.
     fixed_alpha : float, optional

--- a/lumicks/pylake/force_calibration/detail/hydrodynamics.py
+++ b/lumicks/pylake/force_calibration/detail/hydrodynamics.py
@@ -62,7 +62,7 @@ def calculate_complex_drag(f, gamma0, rho_sample, bead_radius, distance_to_surfa
         Bead radius [m]
     rho_sample : float
         Sample mass density [kg/m^3]
-    distance_to_surface : float
+    distance_to_surface : float | None
         Distance from bead center to nearest surface [m]
     """
     # frequency_nu is the frequency at which the penetration depth in the liquid of the
@@ -139,7 +139,7 @@ def passive_power_spectrum_model_hydro(
         Sample mass density, in kg/m^3
     rho_bead : float
         Bead mass density, in kg/m^3
-    distance_to_surface : float
+    distance_to_surface : float | None
         Distance to nearest surface, in m
     """
     re_drag, im_drag = calculate_complex_drag(

--- a/lumicks/pylake/force_calibration/tests/conftest.py
+++ b/lumicks/pylake/force_calibration/tests/conftest.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from .data.simulate_calibration_data import generate_active_calibration_test_data
+
 
 class ReferenceModels:
     @staticmethod
@@ -67,3 +69,37 @@ def mack_parameters():
         "focal_shift": 0.921283446497108,
         "nonlinear_shift": 0.0,
     }
+
+
+@pytest.fixture(scope="session")
+def active_calibration_surface_data():
+    shared_pars = {
+        "bead_diameter": 1.03,
+        "viscosity": 1.1e-3,
+        "temperature": 25,
+        "rho_sample": 997.0,
+        "rho_bead": 1040.0,
+        "distance_to_surface": 1.03 / 2 + 500e-3,
+    }
+
+    sim_pars = {
+        "sample_rate": 78125,
+        "stiffness": 0.1,
+        "pos_response_um_volt": 0.618,
+        "driving_sinusoid": (500, 31.95633),
+        "diode": (0.4, 15000),
+    }
+
+    np.random.seed(10071985)
+    volts, stage = generate_active_calibration_test_data(
+        10, hydrodynamically_correct=True, **sim_pars, **shared_pars
+    )
+
+    active_pars = {
+        "force_voltage_data": volts,
+        "driving_data": stage,
+        "sample_rate": 78125,
+        "driving_frequency_guess": 32,
+    }
+
+    return shared_pars, sim_pars, active_pars


### PR DESCRIPTION
**Why this PR?**
It may be confusing that we calculate back our drag coefficient to bulk. The reason we do this is so that experiments can be compared and drag coefficients can be carried over from one calibration axis to the other.

However, it may not always be immediately clear how to calculate this value back to the surface-relevant value.

Since one may require the local drag coefficient for other analyses, it is a good idea to also expose a local drag coefficient.

When not using hydro, the drag coefficient we calculate _is_ the local drag.
When hydro _is_ active, then the drag coefficient we obtain with the model is the drag we would have obtained in bulk (all the height dependence is in the model). That means that we have to explicitly convert that drag coefficient to a "local" drag. For consistency, we do this with the same hydrodynamic model.