### PR TITLE
kymo: add `plot_with_channels`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 #### New features
 
+* Added [`Kymo.plot_with_channels()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.plot_with_channels) for plotting a kymograph with corresponding channel data. For more information, please refer to the [kymograph tutorial](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/kymographs.html#correlating-with-channel-data).
 * Added support for loading two-color `TIF` files with [`ImageStack`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack).
 * Made ([`CalibrationResults`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html#calibrationresults)) callable to evaluate the fitted model power spectral density at the specified frequencies.
 * Added `fitted_params` field to ([`CalibrationResults`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html#calibrationresults)) for convenience.

--- a/docs/tutorial/figures/kymographs/kymo_plot_with_channels.png
+++ b/docs/tutorial/figures/kymographs/kymo_plot_with_channels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16657780db4b05a01c17e2fcd7b889838d03517ca332688009ebd5b5bbe36332
+size 129560

--- a/docs/tutorial/figures/kymographs/kymo_plot_with_channels_customized.png
+++ b/docs/tutorial/figures/kymographs/kymo_plot_with_channels_customized.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75243ec5948af4468c332c5ad3ee7af5708b2f9e2f977978f40956cfc8b510b3
+size 164493

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -278,6 +278,24 @@ We achieved this by passing `np.sum` to the `reduce` parameter of :func:`~lumick
 This results in summing the photon counts rather than taking their average.
 The argument `title_vertical=True` places the channel names along the y-axis instead of the axis title allowing a slightly more compact plot.
 
+Note that the plot can be further customized by specifying custom `labels`, `colors` and a `scale_bar`::
+
+    kymo.plot_with_channels(
+        [
+            file.force1x.downsampled_by(100),
+            file["Photon count"]["Green"].downsampled_over(kymo.line_timestamp_ranges(), reduce=np.sum),
+        ],
+        "rgb",
+        adjustment=lk.ColorAdjustment(5, 98, "percentile"),
+        aspect_ratio=0.2,
+        title_vertical=True,
+        scale_bar=lk.ScaleBar(10.0, 5.0),
+        colors=[[1.0, 0.2, 0.5], "green"],
+        labels=["My force", "My photons"],
+    )
+
+.. image:: ./figures/kymographs/kymo_plot_with_channels_customized.png
+
 There is also a convenience function :meth:`~lumicks.pylake.kymo.Kymo.plot_with_force` to plot a kymograph along with a
 downsampled force trace::
 

--- a/docs/tutorial/kymographs.rst
+++ b/docs/tutorial/kymographs.rst
@@ -235,15 +235,15 @@ and therefore each pixel no longer has an identifiable time. For example, we can
 Additionally, a downsampled kymograph cannot be sliced (same as cropped kymographs mentioned above). Therefore you should
 first slice the kymograph and then downsample.
 
-Correlating with force
-----------------------
+Correlating with channel data
+-----------------------------
 
 We can downsample channel data according to the lines in a kymo. We can use
 :func:`~lumicks.pylake.kymo.Kymo.line_timestamp_ranges()` for this::
 
     line_timestamp_ranges = kymo.line_timestamp_ranges()
 
-This returns a list of start and stop timestamps that can be passed directly to :func:`~lumicks.pylake.channel.Slice.downsampled_to`,
+This returns a list of start and stop timestamps that can be passed directly to :func:`~lumicks.pylake.channel.Slice.downsampled_over`,
 which will then return a :class:`~lumicks.pylake.channel.Slice` with a datapoint per line::
 
     force = file.force1x
@@ -256,6 +256,27 @@ which will then return a :class:`~lumicks.pylake.channel.Slice` with a datapoint
     plt.show()
 
 .. image:: ./figures/kymographs/force_downsampled_like_kymo.png
+
+We can plot a list of (multiple) channels correlated with the kymograph using :meth:`~lumicks.pylake.kymo.Kymo.plot_with_channels`.
+For example, we can plot the kymograph with the force downsampled by a factor `100` and the photon counts downsampled over each kymograph line as follows::
+
+    kymo.plot_with_channels(
+        [
+            file.force1x.downsampled_by(100),
+            file["Photon count"]["Green"].downsampled_over(kymo.line_timestamp_ranges(), reduce=np.sum),
+        ],
+        "rgb",
+        adjustment=lk.ColorAdjustment(5, 98, "percentile"),
+        aspect_ratio=0.2,
+        title_vertical=True,
+    )
+
+.. image:: ./figures/kymographs/kymo_plot_with_channels.png
+
+Note that in this example, we also customized the method used for downsampling the photon counts.
+We achieved this by passing `np.sum` to the `reduce` parameter of :func:`~lumicks.pylake.channel.Slice.downsampled_over`.
+This results in summing the photon counts rather than taking their average.
+The argument `title_vertical=True` places the channel names along the y-axis instead of the axis title allowing a slightly more compact plot.
 
 There is also a convenience function :meth:`~lumicks.pylake.kymo.Kymo.plot_with_force` to plot a kymograph along with a
 downsampled force trace::

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_plotting.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_plotting.py
@@ -82,10 +82,21 @@ def test_plotting_with_channels(kymo_h5_file):
         kymo.plot_with_force(force_channel="2x", color_channel="red")
 
     def plot_channels():
-        kymo.plot_with_channels(force_over_kymolines, color_channel="red")
+        kymo.plot_with_channels(
+            force_over_kymolines,
+            color_channel="red",
+            labels="single",
+            colors=[0, 0, 1],
+            scale_bar=lk.ScaleBar(5.0, 5.0),
+        )
 
     def plot_with_multiple_channels():
-        kymo.plot_with_channels([force_over_kymolines, force_over_kymolines], color_channel="red")
+        kymo.plot_with_channels(
+            [force_over_kymolines, force_over_kymolines],
+            color_channel="red",
+            labels=["f2x", "f2x"],
+            colors=["red", [1.0, 0.0, 0.1]],
+        )
 
     for plot_func in (plot_with_force, plot_channels, plot_with_multiple_channels):
         plot_func()
@@ -103,12 +114,43 @@ def test_plotting_with_channels_no_downsampling(kymo_h5_file):
     kymo = f.kymos["tester"]
     kymo.plot_with_channels(f.force2x, color_channel="red")
     plot_line = plt.gca().lines[0].get_ydata()
-    np.testing.assert_allclose(plot_line, f.force2x.data)
+    np.testing.assert_allclose(plot_line, f.force2x[kymo.start : kymo.stop + 1].data)
 
     linetime = kymo.line_time_seconds
     ranges = np.vstack(kymo.line_timestamp_ranges())[:, 0]
     ranges_sec = (ranges - ranges[0]) * 1e-9
     np.testing.assert_allclose(plt.xlim(), [-(linetime / 2), ranges_sec[-1] + (linetime / 2)])
+
+
+def test_plotting_labels(kymo_h5_file):
+    f = lk.File.from_h5py(kymo_h5_file)
+    kymo = f.kymos["tester"]
+
+    def check_axes(labels, titles):
+        axes = plt.gcf().get_axes()
+        for label, title, ax in zip(labels, titles, axes[1:]):
+            assert ax.get_title() == title
+            assert ax.get_ylabel() == label
+
+    kymo.plot_with_channels(f.force2x, color_channel="red")
+    check_axes(["Force (pN)"], ["Force HF/Force 2x"])
+
+    kymo.plot_with_channels(f.force2x, color_channel="red", labels="force")
+    check_axes(["force"], ["Force HF/Force 2x"])
+
+    kymo.plot_with_channels(f.force2x, color_channel="red", labels="force", title_vertical=True)
+    check_axes(["force"], [""])
+
+    kymo.plot_with_channels(f.force2x, color_channel="red", title_vertical=True)
+    check_axes(["Force 2x\nForce (pN)"], [""])
+
+    kymo.plot_with_channels(
+        [f.force2x, f["Photon count"]["Red"]], color_channel="red", title_vertical=True
+    )
+    check_axes(["Force 2x\nForce (pN)", "Red"], [""] * 2)
+
+    kymo.plot_with_channels([f.force2x, f["Photon count"]["Red"]], color_channel="red")
+    check_axes(["Force (pN)", "y"], ["Force HF/Force 2x", "Photon count/Red"])
 
 
 def test_plotting_with_channels_bad_args(kymo_h5_file):
@@ -126,6 +168,21 @@ def test_plotting_with_channels_bad_args(kymo_h5_file):
         match="channel must be 'red', 'green', 'blue' or a combination of 'r', 'g', and/or 'b', got 'boo'.",
     ):
         kymo.plot_with_channels(f.force1x, color_channel="boo")
+
+    for channels, labels, colors in (
+        (f.force1x, ["too", "many"], None),
+        ([f.force1x], ["too", "many"], None),
+        ([f.force1x, f.force1x], ["too_few_labels"], None),
+        ([f.force1x, f.force1x], ["too", "many", "labels"], None),
+        ([f.force1x, f.force1x], None, ["Red", "g", "b"]),
+        ([f.force1x, f.force1x], None, ["Red"]),
+        ([f.force1x, f.force1x], None, [0, 1, 0]),  # Valid single color that is still a list!
+    ):
+        with pytest.raises(
+            ValueError,
+            match="needs to have the same length as the number of channels",
+        ):
+            kymo.plot_with_channels(channels, color_channel="rgb", labels=labels, colors=colors)
 
 
 def test_regression_plot_with_force(kymo_h5_file):


### PR DESCRIPTION
**Why this PR?**
It would be nice to just plot any channel data alongside kymos and to have control over how these get downsampled.

With this new call (`kymo.plot_with_channels()`), you can make plots like the following with a single call:

<img width="579" alt="image" src="https://github.com/lumicks/pylake/assets/19836026/3edcf511-efa5-465c-a424-363b93967380">

and

![image](https://github.com/lumicks/pylake/assets/19836026/3b4a51db-1c85-4363-bf6f-69279f0aa15d)

Note that since not all our channels have y-label metadata (most do not), the y-labels are customizable (by passing a list of labels).

Docs [here](https://lumicks-pylake.readthedocs.io/en/plot_with_channel/tutorial/kymographs.html#correlating-with-channel-data) and [here](https://lumicks-pylake.readthedocs.io/en/plot_with_channel/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.plot_with_channels).

I figured that since we are generalizing this behavior and making it more composable, users may also want to be able to plot more than one correlated channel at once. To reduce friction, the function accepts both a single slice or multiple.