### PR TITLE
fdfit: better error handling `parameter_trace()` 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 #### Improvements
 
 * Added error message when parameters are passed to [`lk.parameter_trace()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.parameter_trace.html) that do not have the required attributes. 
+* Warn when parameter estimates are hitting the fitting bounds when using [`lk.parameter_trace()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.parameter_trace.html).
 
 ## v1.4.1 | t.b.d.
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,11 @@
 * Made ([`CalibrationResults`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html#calibrationresults)) callable to evaluate the fitted model power spectral density at the specified frequencies.
 * Added `fitted_params` field to ([`CalibrationResults`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html#calibrationresults)) for convenience.
 * Added option to disable downsampling channel data to frame rates with correlated plots ([`ImageStack.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.plot_correlated), [`Scan.plot_correlated()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.Scan.html#lumicks.pylake.Scan.plot_correlated)) and exported videos ([`ImageStack.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.export_video), [`Scan.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.Scan.html#lumicks.pylake.Scan.export_video)) using `downsample_to_frames=False`.
+* Allow accessing FdFit model defaults through key access notation (i.e. `model["m/Lc"]`).
+
+#### Improvements
+
+* Added error message when parameters are passed to [`lk.parameter_trace()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.parameter_trace.html) that do not have the required attributes. 
 
 ## v1.4.1 | t.b.d.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -59,6 +59,8 @@ FD Fitting
 
     fitting.model.Model
     FdFit
+    fitting.parameters.Params
+    fitting.parameters.Parameter
 
     :template: function.rst
     parameter_trace

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -159,7 +159,7 @@ class Model:
         ----------
         independent : array_like
             Values for the independent parameter
-        params : lumicks.pylake.fitting.parameters.Params | Dict[float | Parameter]
+        params : Params | Dict[float | Parameter]
             Model parameters
         """
         independent = np.asarray(independent, dtype=np.float64)

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -158,7 +158,9 @@ class Model:
         Parameters
         ----------
         independent : array_like
-        params : lumicks.pylake.fitting.parameters.Params
+            Values for the independent parameter
+        params : lumicks.pylake.fitting.parameters.Params | Dict[float | Parameter]
+            Model parameters
         """
         independent = np.asarray(independent, dtype=np.float64)
         missing_parameters = set(self.parameter_names) - set(params.keys())
@@ -175,6 +177,9 @@ class Model:
 
     def _raw_call(self, independent, param_vector):
         return self.model_function(independent, *param_vector)
+
+    def __getitem__(self, item):
+        return self.defaults[item]
 
     def __add__(self, other):
         """
@@ -276,6 +281,7 @@ class Model:
 
     @property
     def defaults(self):
+        """Default model parameters when added to an FdFit"""
         return self._params
 
     @property

--- a/lumicks/pylake/fitting/parameters.py
+++ b/lumicks/pylake/fitting/parameters.py
@@ -210,9 +210,9 @@ class Params:
 
         Parameters
         ----------
-        params : list of str
+        params : List[str]
             parameter names
-        defaults : Parameter or None
+        defaults : List[Optional[Parameter]]
             default parameter objects
         """
         new_params = OrderedDict(

--- a/lumicks/pylake/fitting/parameters.py
+++ b/lumicks/pylake/fitting/parameters.py
@@ -90,12 +90,14 @@ class Parameter:
 
 class Params:
     """
-    Model parameters. Internally stored as a list of Parameter.
+    Model parameters.
 
     Examples
     --------
     ::
-        fit = pylake.FdFit(pylake.ewlc_odijk_distance("my_model"))
+
+        import lumicks.pylake as lk
+        fit = lk.FdFit(lk.ewlc_odijk_distance("my_model"))
 
         print(fit.params)  # Prints the model parameters
         fit["test_parameter"].value = 5  # Set parameter test_parameter to 5

--- a/lumicks/pylake/fitting/tests/test_fd_models.py
+++ b/lumicks/pylake/fitting/tests/test_fd_models.py
@@ -208,3 +208,9 @@ def test_convenience_models(convenience_model, ref_model, ref_params):
     # The convenience part is in the parameters, with the old parameters they should produce the
     # exact same as what they are supposed to be based on
     np.testing.assert_allclose(model(x, params), ref_model("m")(x, params))
+
+
+def test_model_get_item():
+    m = ewlc_odijk_force("m")
+    m["m/Lc"].value = 3.1415
+    np.testing.assert_equal(float(m.defaults["m/Lc"]), 3.1415)

--- a/lumicks/pylake/fitting/tests/test_parameter_inversion.py
+++ b/lumicks/pylake/fitting/tests/test_parameter_inversion.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 
@@ -70,3 +72,13 @@ def test_parameter_trace_invalid_args():
 
     with pytest.raises(ValueError, match="Missing parameter f/b in supplied params"):
         parameter_trace(model, {"f/a": 5}, inverted_parameter="f/a", **data)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "The argument params takes a dictionary with `Parameter` values. This can be "
+            "obtained from a fit by slicing it by a dataset (i.e. fit[dataset_handle]) or "
+            "from a model (i.e. model.defaults). See help(parameter_trace) for more information."
+        ),
+    ):
+        parameter_trace(model, {"f/a": 5, "f/b": 3}, inverted_parameter="f/a", **data)


### PR DESCRIPTION
**Why this PR?**
A few tiny fixes to reduce API friction based on a use case where we do not fit a model first.

`parameter_trace()` can be used to fit a single parameter on a per datapoint basis while keeping all others fixed. Typically, one would fit a model to _different_ data, and then use that model to compute such a parameter trace. However, there are use cases for when one just wants to do it with a set of parameters obtained earlier (or via other means).

Currently, users might attempt to pass a regular dictionary with values to `parameter_trace()` analogously to what we allow for `model.__call__()`. The error you get when you do that is not helpful, nor does the docstring indicate any way to do this.

One thing I doubted about is whether we should just fall back to the default bounds specified in the model for the parameter to be profiled if bounds are unavailable, but I decided against it, because one could start hitting those limits and users would not really understand where the limits might be coming from. I think a better approach is to point them to the correct way to obtain bounded parameters instead.

I also noticed that we don't warn when we notice that the values start hitting the bounds. I added a warning for this case, as users probably want to change their fitting limits or check their data when this happens. Unfortunately, enforcing some limits is still preferable to none, to avoid non-physical behaviour (negative contour lengths and such).

Docs build here: https://lumicks-pylake.readthedocs.io/en/fdfit_model/_api/lumicks.pylake.parameter_trace.html