### PR TITLE
docs: small style fixes

### DIFF
--- a/docs/examples/cas9_kymotracking/cas9_kymotracking.rst
+++ b/docs/examples/cas9_kymotracking/cas9_kymotracking.rst
@@ -175,7 +175,7 @@ These coordinates can be accessed with the :attr:`~lumicks.pylake.kymotracker.ky
     plt.figure(figsize=(5, 3))
     plt.plot(longest_track.seconds, longest_track.position)
     plt.xlabel('Time [s]')
-    plt.ylabel('Position [$\mu$m]')
+    plt.ylabel(r'Position [$\mu$m]')
     plt.tight_layout()
     plt.show()
 

--- a/docs/examples/cst/kinesin_closed_loop.rst
+++ b/docs/examples/cst/kinesin_closed_loop.rst
@@ -55,8 +55,8 @@ Plot it::
 
 Determine force fluctuations::
 
-    >>> print('Mean force is: '+str(np.mean(forcey_downsamp.data)) + ' pN' )
-    >>> print('Variation in the force is: '+str(np.std(forcey_downsamp.data)) + ' pN' )
+    >>> print(f"Mean force is: {np.mean(forcey_downsamp.data)} pN")
+    >>> print(f"Variation in the force is: {np.std(forcey_downsamp.data)} pN")
 
     Mean force is: 1.6587699919874592 pN
     Variation in the force is: 0.17120278599815678 pN

--- a/docs/examples/cst/kinesin_open_loop.rst
+++ b/docs/examples/cst/kinesin_open_loop.rst
@@ -69,8 +69,8 @@ Downsample the y force data::
 
 The two sampling rates are::
 
-    >>> print('Original sampling rate is ' + str(sample_rate) + ' Hz')
-    >>> print('Downsampled rate is ' + str(downsampled_rate) + ' Hz')
+    >>> print(f"Original sampling rate is {sample_rate} Hz")
+    >>> print(f"Downsampled rate is {downsampled_rate} Hz")
 
     Original sampling rate is 30000 Hz
     Downsampled rate is 100 Hz
@@ -108,8 +108,8 @@ Get stiffness from force calibration::
     
 The stiffness values are::
 
-    >>> print(ky) # this is in pN/nm
-    >>> print(kx) # this is in pN/nm
+    >>> print(ky)  # this is in pN/nm
+    >>> print(kx)  # this is in pN/nm
     0.02648593456747345
     0.019126295617530483
 

--- a/docs/theory/force_calibration/force_calibration.rst
+++ b/docs/theory/force_calibration/force_calibration.rst
@@ -76,10 +76,10 @@ We can plot this spectrum for different diffusion constants::
 
     f = np.arange(100, 23000)
     for diffusion in 10**np.arange(1, 4):
-        plt.loglog(f, diffusion / (np.pi**2 * f**2), label=f"D={diffusion} $\mu m^2/s$")
+        plt.loglog(f, diffusion / (np.pi**2 * f**2), label=fr"D={diffusion} $\mu m^2/s$")
 
     plt.xlabel("Frequency [Hz]")
-    plt.ylabel("Amplitude [$\mu m^2$/Hz]");
+    plt.ylabel(r"Amplitude [$\mu m^2$/Hz]");
     plt.legend()
 
 .. image:: figures/diffusion_spectra.png
@@ -113,10 +113,10 @@ When plotting this equation for various values of the corner frequency, we see t
     plt.subplot(1, 2, 1)
     diffusion, corner_freq = 1000, 1000
     for diffusion in 10**np.arange(1, 4):
-        plt.loglog(f, diffusion / (np.pi**2 * (f**2 + corner_freq**2)), label=f"D={diffusion} $\mu m^2/s$")
+        plt.loglog(f, diffusion / (np.pi**2 * (f**2 + corner_freq**2)), label=fr"D={diffusion} $\mu m^2/s$")
 
     plt.xlabel("Frequency [Hz]")
-    plt.ylabel("Amplitude [$\mu m^2$/Hz]");
+    plt.ylabel(r"Amplitude [$\mu m^2$/Hz]");
     plt.legend()
 
     plt.subplot(1, 2, 2)
@@ -128,7 +128,7 @@ When plotting this equation for various values of the corner frequency, we see t
         plt.axvline(corner_freq, color=line.get_color(), linestyle="--")
 
     plt.xlabel("Frequency [Hz]")
-    plt.ylabel("Amplitude [$\mu m^2$/Hz]");
+    plt.ylabel(r"Amplitude [$\mu m^2$/Hz]");
     plt.legend()
 
 .. image:: figures/lorentzians.png

--- a/docs/tutorial/fdcurves.rst
+++ b/docs/tutorial/fdcurves.rst
@@ -29,7 +29,7 @@ To visualizes an FD curve, you can use the built-in :meth:`.plot_scatter()
 An :class:`~lumicks.pylake.fdcurve.FdCurve` slices some force and distance data from the timeline data.
 You can find the range it uses for slicing in its :attr:`~lumicks.pylake.fdcurve.start` and :attr:`~lumicks.pylake.fdcurve.stop` property::
 
-    >>> all(file.downsampled_force2[fd.start:fd.stop].data == fd.f.data)
+    >>> all(file.downsampled_force2[fd.start : fd.stop].data == fd.f.data)
     True
 
 The attribute :attr:`.fdcurves <lumicks.pylake.File.fdcurves>` is a standard Python dictionary, so we can do all the things you can do with a regular dictionary.
@@ -85,7 +85,7 @@ Plot FD curve manually::
     plt.figure()
     plt.scatter(distance.data, force.data)
     plt.ylabel("Force (pN)")
-    plt.xlabel("Distance ($\mu$m)")
+    plt.xlabel(r"Distance ($\mu$m)")
     plt.title("Manually plotted fd curve")
     plt.show()
 
@@ -130,7 +130,7 @@ and distance from such an ensemble using::
     plt.figure()
     plt.scatter(d, f, s=1)
     plt.ylabel("Force (pN)")
-    plt.xlabel("Distance $\mu$m")
+    plt.xlabel(r"Distance $\mu$m")
     plt.title("Two aligned fd curves")
     plt.show()
 

--- a/docs/tutorial/fdfitting.rst
+++ b/docs/tutorial/fdfitting.rst
@@ -56,8 +56,6 @@ We can also obtain the parameters as a list::
 
     ['DNA/Lp', 'DNA/Lc', 'DNA/St', 'kT']
 
-
-
 Simulating the model
 --------------------
 
@@ -70,7 +68,7 @@ We can simulate the model by passing a dictionary with parameters values::
     plt.figure()
     plt.plot(distance,force)
     plt.ylabel("Force [pN]")
-    plt.xlabel("Distance [$\\mu$m]")
+    plt.xlabel(r"Distance [$\mu$m]")
     plt.show()
 
 .. image:: figures/fdfitting/fdfitting_ewlc.png
@@ -202,7 +200,7 @@ initial guesses yourself.::
     plt.figure()
     fit.plot()
     plt.ylabel("Force [pN]")
-    plt.xlabel("Distance [$\\mu$m]")
+    plt.xlabel(r"Distance [$\mu$m]")
     plt.title("Before fitting")
     plt.show()
 
@@ -223,7 +221,7 @@ Plot the result of the fit::
     plt.figure()
     fit.plot()
     plt.ylabel("Force [pN]")
-    plt.xlabel("Distance [$\\mu$m]");
+    plt.xlabel(r"Distance [$\mu$m]");
     plt.title("After fitting")
     plt.show()
 
@@ -233,7 +231,7 @@ If you wish to customize the label that appears in the legend, you can pass a cu
 
     plt.figure()
     fit.plot(label="my_fit")
-    plt.xlabel("Distance [$\mu$m]")
+    plt.xlabel(r"Distance [$\mu$m]")
     plt.ylabel("Force [pN]")
     plt.show()
 
@@ -246,7 +244,7 @@ do this as follows::
     plt.figure()
     fit.plot("Control", "--", np.arange(2.0, 3.0, 0.01))
     fit.plot("RecA", "--", np.arange(2.0, 3.4, 0.01))
-    plt.xlabel("Distance [$\mu$m]")
+    plt.xlabel(r"Distance [$\mu$m]")
     plt.ylabel("Force [pN]")
     plt.show()
 
@@ -256,7 +254,7 @@ Plot the fitted model without data::
 
     plt.figure()
     fit.plot("Control", "k--", np.arange(2.0, 4.0, 0.01), plot_data=False)
-    plt.xlabel("Distance [$\mu$m]")
+    plt.xlabel(r"Distance [$\mu$m]")
     plt.ylabel("Force [pN]")
     plt.show()
 
@@ -268,7 +266,7 @@ It is also possible to obtain simulations from the model directly, using the fit
     simulated_force = model(distance, fit["Control"])
     plt.figure()
     plt.plot(distance, simulated_force)
-    plt.xlabel("Distance [$\mu$m]")
+    plt.xlabel(r"Distance [$\mu$m]")
     plt.ylabel("Force [pN]")
     plt.show()
 
@@ -350,8 +348,8 @@ Now, we wish to allow the contour length to vary on a per data point basis. For 
     lcs = lk.parameter_trace(model, fit["Control"], "model/Lc", distance3, force3)
     plt.figure()
     plt.plot(distance3,lcs)
-    plt.xlabel("Distance [$\mu$m]")
-    plt.ylabel("Lc [$\mu$m]")
+    plt.xlabel(r"Distance [$\mu$m]")
+    plt.ylabel(r"Lc [$\mu$m]")
     plt.show()
 
 .. image:: figures/fdfitting/fdfitting_reca_parameter_trace.png
@@ -470,8 +468,8 @@ following two examples::
     >>> model = lk.ewlc_odijk_force("DNA")
     >>> fit = lk.FdFit(model)
     >>> for i, (distance, force) in enumerate(zip(distances, forces)):
-    >>>     fit.add_data(f"AdK {i}", f=force, d=distance)
-    >>>
+    ...     fit.add_data(f"AdK {i}", f=force, d=distance)
+    ...
     >>> fit.fit()
     >>> print(fit["DNA/Lc"])
     lumicks.pylake.fdfit.Parameter(value: 0.34975137317062743, lower bound: 0.00034, upper bound: inf, fixed: False)
@@ -479,9 +477,10 @@ following two examples::
 and::
 
     >>> for i, (distance, force) in enumerate(zip(distances, forces)):
-    >>>     model = lk.ewlc_odijk_force("DNA")
-    >>>     fit = lk.FdFit(model)
-    >>>     fit.add_data(f"AdK {i}", f=force, d=distance)
+    ...     model = lk.ewlc_odijk_force("DNA")
+    ...     fit = lk.FdFit(model)
+    ...     fit.add_data(f"AdK {i}", f=force, d=distance)
+    ...
     >>>
     >>> fit.fit()
     >>> print(fit["DNA/Lc"])
@@ -504,7 +503,8 @@ if the only expected difference between the experiments is the contour length, t
     >>> model = lk.ewlc_odijk_force("DNA")
     >>> fit = lk.FdFit(model)
     >>> for i, (distance, force) in enumerate(zip(distances, forces)):
-    >>>     fit.add_data(f"AdK {i}", force, distance, {"DNA/Lc": f"DNA/Lc_{i}"})
+    ...     fit.add_data(f"AdK {i}", force, distance, {"DNA/Lc": f"DNA/Lc_{i}"})
+    ...
     >>> fit.fit()
     >>> print(fit.params)
     Name           Value  Unit      Fitted      Lower bound    Upper bound
@@ -546,7 +546,7 @@ Let's plot what we have fitted so far::
     fit.fit()
     plt.figure()
     fit[model1].plot()
-    plt.xlabel("Distance [$\mu$m]")
+    plt.xlabel(r"Distance [$\mu$m]")
     plt.ylabel("Force [pN]")
     plt.show()
 
@@ -573,10 +573,10 @@ Next, we fit the data after the unfolding event. To speed up the computation, we
     >>> fit["DNA/Lp"].fixed = True
     >>> fit["DNA/St"].fixed = True
     >>>
-    >>> fit["protein/Lp"].value = .7
-    >>> fit["protein/Lp"].lower_bound = .6
+    >>> fit["protein/Lp"].value = 0.7
+    >>> fit["protein/Lp"].lower_bound = 0.6
     >>> fit["protein/Lp"].upper_bound = 1.0
-    >>> fit["protein/Lc"].value = .025
+    >>> fit["protein/Lc"].value = 0.025
     >>>
     >>> fit.fit()
     Fit
@@ -611,7 +611,7 @@ Now we have fitted both the data before and after unfolding. The results can be 
     plt.figure()
     fit[model1].plot()
     fit[model2].plot()
-    plt.xlabel("Distance [$\mu$m]")
+    plt.xlabel(r"Distance [$\mu$m]")
     plt.ylabel("Force [pN]")
     plt.show()
 

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -245,7 +245,7 @@ Simple arithmetic operations can be performed directly on slices::
     >>> diff_force = (file.force1x - file.force2x) / 2
     <lumicks.pylake.channel.Slice at 0x2954d3016d0>
 
-    >>> force_magnitude = (file.force1x ** 2 + file.force1y ** 2) ** 0.5
+    >>> force_magnitude = (file.force1x**2 + file.force1y**2) ** 0.5
     <lumicks.pylake.channel.Slice at 0x2954d3016d0>
 
 Downsampling
@@ -329,20 +329,20 @@ We can see that the file also contains markers. These can be accessed from the m
 
 The actual markers can be obtained from the dictionary as follows::
 
-    >>> file.markers['Tether: 11']
+    >>> file.markers["Tether: 11"]
     <lumicks.pylake.marker.Marker at 0x1785ccf1990>
 
 We can find the start and stop time with ``.start`` and ``.stop``.
 
-    >>> print(file.markers['Tether: 11'].start)
+    >>> print(file.markers["Tether: 11"].start)
     1638534506519544400
 
-    >>> print(file.markers['Tether: 11'].stop)
+    >>> print(file.markers["Tether: 11"].stop)
     1638534716503544401
 
 Note that you can slice channel data directly using markers (or any other item that has a ``.start`` and ``.stop`` property)::
 
-    >>> file.force1x[file.markers['Tether: 11']]
+    >>> file.force1x[file.markers["Tether: 11"]]
     <lumicks.pylake.channel.Slice at 0x1785ccf1390>
 
 Exporting h5 files

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -301,7 +301,7 @@ If there are unexplained issues with the calibration, it is a good idea to plot 
     plt.figure()
     driving_data.plot()
     plt.xlim(0, 0.1)
-    plt.ylabel("Nanostage position ($\mu$m)")
+    plt.ylabel(r"Nanostage position ($\mu$m)")
     plt.show()
 
 .. image:: figures/force_calibration/nanostage_position.png
@@ -372,13 +372,17 @@ For convenience, assign most of the parameter to a dictionary first::
 
 Next, unpack this dictionary using the unpacking operator `**`::
 
-    >>> fit = lk.calibrate_force(**shared_parameters, active_calibration=True, distance_to_surface=distance_to_surface)
+    >>> fit = lk.calibrate_force(
+    ...     **shared_parameters, active_calibration=True, distance_to_surface=distance_to_surface
+    ... )
     >>> print(fit["kappa"].value)
     0.11662183772410809
 
 And compare this to the passive calibration result::
 
-    >>> fit = lk.calibrate_force(**shared_parameters, active_calibration=False, distance_to_surface=distance_to_surface)
+    >>> fit = lk.calibrate_force(
+    ...     **shared_parameters, active_calibration=False, distance_to_surface=distance_to_surface
+    ... )
     >>> print(fit["kappa"].value)
     0.11763849764570819
 

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -87,7 +87,7 @@ of the longest track we can do::
     plt.figure()
     plt.plot(longest_track.seconds, longest_track.position)
     plt.xlabel("Time [s]")
-    plt.ylabel("Position [$\mu$m]")
+    plt.ylabel(r"Position [$\mu$m]")
     plt.show()
 
 .. image:: figures/kymotracking/longest_track.png
@@ -593,7 +593,7 @@ MSDs for individual tracks are available through :meth:`~lumicks.pylake.kymotrac
 
 which returns a tuple of lags and MSD estimates. If we only wish MSDs up to a certain lag, we can provide a `max_lag` argument::
 
-    >>> tracks[0].msd(max_lag = 5)
+    >>> tracks[0].msd(max_lag=5)
     (array([0.16, 0.32, 0.48, 0.64, 0.8 ]), array([ 3.63439512,  6.13181603,  9.08823918, 11.43574189, 12.61152129]))
 
 If it is safe to assume that all particles exhibit the same diffusive motion, one can calculate the ensemble and time-averaged MSD for an entire group of tracks using the method :meth:`~lumicks.pylake.kymotracker.kymotrack.KymoTrackGroup.ensemble_msd`::
@@ -726,7 +726,7 @@ We'll demonstrate this functionality using multiple sections on a single :class:
 The API for the different methods is identical, requiring no changes to your downstream analysis compared to the case of tracks from a single kymograph.
 For instance, one can compute the binding lifetime with::
 
-    multi_dwell = multiple_groups.fit_binding_times(n_components=2)
+    multi_dwell = multiple_groups.fit_binding_times(n_components=2, observed_minimum=False, discrete_model=True)
     print(multi_dwell.lifetimes)  # list of bound lifetimes
     print(multi_dwell.amplitudes)  # list of fractional amplitudes for each component
 

--- a/docs/tutorial/nbwidgets.rst
+++ b/docs/tutorial/nbwidgets.rst
@@ -95,7 +95,7 @@ These timestamps can directly be used to extract the relevant data::
             fdcurves["40"].f[t_start:t_stop].data,
             s=2,  # Use a smaller marker size
         )
-        plt.xlabel("Distance [$\mu$m]")
+        plt.xlabel(r"Distance [$\mu$m]")
         plt.ylabel("Force [pN]")
 
     plt.tight_layout()

--- a/docs/tutorial/piezotracking.rst
+++ b/docs/tutorial/piezotracking.rst
@@ -166,7 +166,7 @@ Which we can then plot::
 
     plt.figure()
     plt.scatter(tether_length.data, force_data.data, s=1)
-    plt.xlabel('Distance [$\mu$m]')
+    plt.xlabel(r'Distance [$\mu$m]')
     plt.ylabel('Force [pN]')
     plt.show()
 
@@ -177,7 +177,7 @@ We can compare this to the camera-based distance and raw force curve and see a c
     plt.figure()
     plt.scatter(tether_length.data, force_data.data, s=1, label="corrected")
     plt.scatter(pulling_curve.distance1.data, - (pulling_curve.downsampled_force2x.data - f2_offset), s=1, label="raw")
-    plt.xlabel('Distance [$\mu$m]')
+    plt.xlabel(r'Distance [$\mu$m]')
     plt.ylabel('Force [pN]')
     plt.legend()
     plt.show()

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -198,7 +198,7 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
             + "".join(
                 (
                     print_force(field)
-                    for field in [f"force{channel+1}{axis}" for channel in rng for axis in axes]
+                    for field in [f"force{channel + 1}{axis}" for channel in rng for axis in axes]
                 )
             )
             + "\n"
@@ -206,7 +206,7 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
                 (
                     print_force(field)
                     for field in [
-                        f"downsampled_force{channel+1}{axis}" for channel in rng for axis in axes
+                        f"downsampled_force{channel + 1}{axis}" for channel in rng for axis in axes
                     ]
                 )
             )

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -447,7 +447,7 @@ class DwelltimeBootstrap:
 
             label = "a" if key == "amplitude" else r"\tau"
             unit = "" if key == "amplitude" else "sec"
-            prefix = rf"${label}_{component+1}$" if use_index else rf"${label}$"
+            prefix = rf"${label}_{component + 1}$" if use_index else rf"${label}$"
             plt.title(f"{prefix} = {mean:0.2g} ({lower:0.2g}, {upper:0.2g}) {unit}")
 
         if self.n_components == 1:


### PR DESCRIPTION
**Why this PR?**
Our example/tutorial notebooks were producing some warnings because of characters not being escaped, and we had some other small formatting issues. This PR fixes those. Some of these were found with [blackdoc](https://github.com/keewis/blackdoc).