### PR TITLE
video export: fix two bugs in video export

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,11 +17,10 @@
 * Warn when parameter estimates are hitting the fitting bounds when using [`lk.parameter_trace()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.parameter_trace.html).
 * Added `err_kappa` and `err_Rd` to force calibration results. These contain error estimates for the calibration constants propagated from the fitting errors.
 
-## v1.4.1 | t.b.d.
-
 #### Bug fixes
 
 * Fixed statistical backing returning an incorrect value.
+* Fixed bug where the `start_frame` parameter was being ignored when exporting a movie with [`ImageStack.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.ImageStack.html#lumicks.pylake.ImageStack.export_video) and [`Scan.export_video()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.scan.Scan.html#lumicks.pylake.scan.Scan.export_video). This bug was introduced in Pylake `v1.3.0`.
 
 ## v1.4.0 | 2024-02-28
 

--- a/lumicks/pylake/detail/imaging_mixins.py
+++ b/lumicks/pylake/detail/imaging_mixins.py
@@ -136,9 +136,9 @@ class VideoExport:
         file_name : str
             File name to export to.
         start_frame : int
-            First frame in exported video.
+            First frame in exported video (starts at zero).
         stop_frame : int
-            Last frame in exported video.
+            Stop frame in exported video. Note that this frame is no longer included.
         fps : int
             Frame rate.
         adjustment : lk.ColorAdjustment
@@ -209,8 +209,8 @@ class VideoExport:
         else:
             raise RuntimeError("You need either ffmpeg or pillow installed to export videos.")
 
-        start_frame = start_frame if start_frame else 0
-        stop_frame = stop_frame if stop_frame else self.num_frames
+        start_frame = start_frame if start_frame is not None else 0
+        stop_frame = stop_frame if stop_frame is not None else self.num_frames
 
         shared_args = {"channel": channel, "adjustment": adjustment}
         if channel_slice:
@@ -226,7 +226,7 @@ class VideoExport:
             fig.patch.set_alpha(1.0)  # Circumvents grainy rendering
 
             def plot(frame):
-                set_frame(frame)
+                set_frame(frame + start_frame)
                 artists = []
                 for ax in fig.get_children():
                     artists = ax.get_children()
@@ -244,7 +244,7 @@ class VideoExport:
                 nonlocal image_handle
                 image_handle = self.plot(
                     **shared_args,
-                    frame=frame,
+                    frame=frame + start_frame,
                     image_handle=image_handle,
                     scale_bar=scale_bar,
                     **kwargs,

--- a/lumicks/pylake/nb_widgets/correlated_plot.py
+++ b/lumicks/pylake/nb_widgets/correlated_plot.py
@@ -58,6 +58,9 @@ def plot_correlated(
         else channel_slice[frame_timestamps[0][0] : frame_timestamps[-1][-1]]
     )
 
+    if len(processed_channel) < 2:
+        raise ValueError("Channel slice must contain at least two data points.")
+
     if len(processed_channel.timestamps) < len(frame_timestamps):
         warnings.warn("Only subset of time range available for selected channel")
 
@@ -79,12 +82,16 @@ def plot_correlated(
     t, y = processed_channel.seconds, processed_channel.data
 
     # We explicitly append the last frame time to make sure that it still shows up
-    last_dt = np.diff(
-        [
-            frame_range
-            for frame_range in frame_timestamps
-            if frame_range[0] >= channel_slice.start and frame_range[1] <= channel_slice.stop
-        ][-1]
+    last_dt = (
+        np.diff(
+            [
+                frame_range
+                for frame_range in frame_timestamps
+                if frame_range[0] >= channel_slice.start and frame_range[1] <= channel_slice.stop
+            ][-1]
+        )
+        if downsample_to_frames
+        else (processed_channel.timestamps[-1] - processed_channel.timestamps[-2])
     )
     t = np.hstack((t, t[-1] + last_dt * 1e-9))
     y = np.hstack((y, y[-1]))

--- a/lumicks/pylake/tests/test_imaging_confocal/test_export.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_export.py
@@ -113,8 +113,8 @@ def test_correlated_movie_export(tmpdir_factory, test_scans_multiframe, vertical
     scan.export_video(
         channel,
         f"{tmpdir}/{channel}_corr.gif",
-        start_frame=0,
-        stop_frame=0,
+        start_frame=None,
+        stop_frame=None,
         channel_slice=corr_data,
         vertical=vertical,
     )


### PR DESCRIPTION
**Why this PR?**
Working on the what's new section, I noticed two bugs in the video export functionality.

The first is that the final time step when not downsampling is too big (it takes the frame time step rather than the channel time step we should actually be using when not downsampling to frames).

Without it, you get this:
<img width="1081" alt="image" src="https://github.com/lumicks/pylake/assets/19836026/fe8d1e6b-00c9-4625-8c7e-c91eba2f7388">

This feature was never released (therefore I did not include a changelog entry).

The second bug is that the `start_frame` argument is ignored. This bug was introduced in Pylake 1.3.0 in this [PR](https://github.com/lumicks/pylake/pull/600).

Note that I am targeting `main`, since we want to release `1.5.0` soon and have no plans for `1.4.1`, but we could easily backport the `start_frame` fix if there is a need.

In both cases, I've hardened the tests to cover these specific errors.