### PR TITLE
tests: fix test for tracking `ImageStack`-based `Kymo`

### DIFF
--- a/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
+++ b/lumicks/pylake/tests/test_imaging_camera/test_image_stack.py
@@ -1205,7 +1205,7 @@ def test_integration_test_to_kymo(
         (tether_start * pixelsize, 10 * pixelsize), (26 * pixelsize, 10 * pixelsize)
     )
     kymo = with_tether.to_kymo(half_window=half_window, reduce=np.sum)
-    lines = track_greedy(kymo, "red", pixel_threshold=3)
+    lines = track_greedy(kymo, "red", pixel_threshold=4)
     np.testing.assert_allclose(
         lines[0].position, [(position - tether_start) * pixelsize] * num_images
     )


### PR DESCRIPTION
*Why this PR?*
Unfortunately, one of our tests is broken.

The test in question tests whether a `Kymo` coming from an `ImageStack` can be tracked successfully.

`track_greedy` raises when the threshold is equal or smaller than the minimum pixel value.

The minimum pixel value of the `Kymo` exported from the `ImageStack` here is `3`. That means this test can randomly fail during tracking, depending on whether the floating point pixel value (after filtering) is slightly above or below this critical value.

It seems that numerically, we typically ended up with `2.9999999999999996` for the minimum pixel value. Meaning the threshold would be above.