### PR TITLE
release: release Pylake v1.5.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.5.1 | t.b.d.
+## v1.5.1 | 2024-06-03
 
 * Fixed bug that prevented loading an `h5` file where only a subset of the photon channels are available. This bug was introduced in Pylake `1.4.0`.
 

--- a/lumicks/pylake/__about__.py
+++ b/lumicks/pylake/__about__.py
@@ -1,5 +1,5 @@
 __title__ = "lumicks.pylake"
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 __summary__ = "Bluelake data analysis tools"
 __url__ = "https://github.com/lumicks/pylake"
 


### PR DESCRIPTION
**Why this PR?**
We currently have a bug on the latest release that prevents people from opening files with a subset of photon channels.

Would be nice to quickly release a hotfix for this.