### PR TITLE
file: populate calibration field when accessing force via square brackets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### New features
 
 * Added parameter `allow_overwrite` to [`lk.download_from_doi()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.download_from_doi.html#lumicks.pylake.download_from_doi) to allow re-downloading only those files where the checksum does not match.
+* Added force calibration information to channels accessed directly via the square bracket notation (e.g. `file["Force HF"]["Force 1x"].calibration`).
 
 ## v1.5.1 | 2024-06-03
 

--- a/lumicks/pylake/calibration.py
+++ b/lumicks/pylake/calibration.py
@@ -47,27 +47,51 @@ class ForceCalibration:
         return _filter_calibration(self._time_field, self._items, start, stop)
 
     @staticmethod
-    def from_field(hdf5, field, time_field="Stop time (ns)") -> "ForceCalibration":
-        """Fetch force calibration data from the HDF5 file"""
+    def from_field(hdf5, force_channel, time_field="Stop time (ns)") -> "ForceCalibration":
+        """Fetch force calibration data from the HDF5 file
+
+        Parameters
+        ----------
+        hdf5 : h5py.File
+            A Bluelake HDF5 file.
+        force_channel : str
+            Calibration field to access (e.g. "Force 1x").
+        time_field : str
+            Attribute which holds the timestamp of the item (e.g. "Stop time (ns)").
+        """
 
         if "Calibration" not in hdf5.keys():
             return ForceCalibration(time_field=time_field, items=[])
 
         items = []
         for calibration_item in hdf5["Calibration"].values():
-            if field in calibration_item:
-                attrs = calibration_item[field].attrs
+            if force_channel in calibration_item:
+                attrs = calibration_item[force_channel].attrs
                 if time_field in attrs.keys():
                     items.append(dict(attrs))
 
         return ForceCalibration(time_field=time_field, items=items)
 
     @staticmethod
-    def from_dataset(hdf5, n, xy, time_field="Stop time (ns)"):
-        """Fetch the force calibration data from the HDF5 file"""
+    def from_dataset(hdf5, n, xy, time_field="Stop time (ns)") -> "ForceCalibration":
+        """Fetch the force calibration data from the HDF5 file
+
+        Parameters
+        ----------
+        hdf5 : h5py.File
+            A Bluelake HDF5 file.
+        n : int
+            Trap index.
+        xy : str
+            Force axis (e.g. "x").
+        time_field : str
+            Attribute which holds the timestamp of the item (e.g. "Stop time (ns)").
+        """
 
         if xy:
-            return ForceCalibration.from_field(hdf5, field=f"Force {n}{xy}", time_field=time_field)
+            return ForceCalibration.from_field(
+                hdf5, force_channel=f"Force {n}{xy}", time_field=time_field
+            )
         else:
             raise NotImplementedError(
                 "Calibration is currently only implemented for single axis data"

--- a/lumicks/pylake/group.py
+++ b/lumicks/pylake/group.py
@@ -1,6 +1,7 @@
 import warnings
 
 from .channel import channel_class
+from .calibration import ForceCalibration
 
 
 class Group:
@@ -30,7 +31,10 @@ class Group:
         import h5py
 
         thing = self.h5[item]
-        item_type = thing.name.split("/")[1]
+        split_name = thing.name.split("/")
+        item_type = split_name[1]
+        item_name = split_name[-1]
+
         redirect_location, redirect_class = self._lk_file.redirect_list.get(item_type, (None, None))
         if redirect_location and not redirect_class:
             warnings.warn(
@@ -47,6 +51,13 @@ class Group:
                 return redirect_class.from_dataset(thing, self._lk_file)
             else:
                 cls = channel_class(thing)
+
+                if item_type in ("Force HF", "Force LF"):
+                    return cls.from_dataset(
+                        thing,
+                        calibration=ForceCalibration.from_field(self._lk_file.h5, item_name),
+                    )
+
                 return cls.from_dataset(thing)
 
     def __iter__(self):

--- a/lumicks/pylake/tests/test_file/test_file_items.py
+++ b/lumicks/pylake/tests/test_file/test_file_items.py
@@ -41,11 +41,18 @@ def test_calibration(h5_file):
         assert len(f.force1x.calibration) == 0
         assert len(f.downsampled_force1.calibration) == 0
         assert len(f.downsampled_force1x.calibration) == 0
+        assert len(f["Force HF"]["Force 1x"].calibration) == 0
+        assert len(f["Force LF"]["Force 1x"].calibration) == 0
 
     if f.format_version == 2:
         assert len(f.force1x.calibration) == 2
         assert len(f.downsampled_force1.calibration) == 0
         assert len(f.downsampled_force1x.calibration) == 1
+        assert len(f["Force HF"]["Force 1x"].calibration) == 2
+        assert len(f["Force LF"]["Force 1x"].calibration) == 1
+
+        assert f["Force HF"]["Force 1x"].calibration == f.force1x.calibration
+        assert f["Force HF"]["Force 2x"].calibration == f.force2x.calibration
 
 
 def test_marker(h5_file):


### PR DESCRIPTION
**Why this PR?**
It's a small thing, but it is often awkward to explain the difference between

`f.force1x`, `f.downsampled_force1x` and `f["Force HF"]["Force 1x"]` and `f["Force LF"]["Force 1x"]`. The former nets you metadata, while the latter does not, even though most other channel access happens with square brackets.

This PR adds that the force metadata is available when accessing with square brackets as well.