### PR TITLE
zenodo: add `allow_overwrite` as parameter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.6.0 | t.b.d.
+
+#### New features
+
+* Added parameter `allow_overwrite` to [`lk.download_from_doi()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.download_from_doi.html#lumicks.pylake.download_from_doi) to allow re-downloading only those files where the checksum does not match.
+
 ## v1.5.1 | 2024-06-03
 
 * Fixed bug that prevented loading an `h5` file where only a subset of the photon channels are available. This bug was introduced in Pylake `1.4.0`.

--- a/lumicks/pylake/tests/test_file_download.py
+++ b/lumicks/pylake/tests/test_file_download.py
@@ -27,7 +27,8 @@ def test_download_record_metadata():
 
 
 @pytest.mark.preflight
-def test_download_from_doi(tmpdir_factory, capsys):
+@pytest.mark.parametrize("force_arg", [{"force_download": True}, {"allow_overwrite": True}])
+def test_download_from_doi(tmpdir_factory, capsys, force_arg):
     tmpdir = tmpdir_factory.mktemp("download_testing")
     record = download_record_metadata("4247279")
 
@@ -48,12 +49,12 @@ def test_download_from_doi(tmpdir_factory, capsys):
 
     with pytest.raises(
         RuntimeError,
-        match="Set force_download=True if you wish to overwrite the existing file on disk with the "
-        "version from Zenodo",
+        match="Set allow_overwrite=True if you wish to overwrite the existing file on disk with "
+        "the version from Zenodo",
     ):
         download_from_doi("10.5281/zenodo.4247279", tmpdir, show_progress=False)
 
-    download_from_doi("10.5281/zenodo.4247279", tmpdir, force_download=True, show_progress=False)
+    download_from_doi("10.5281/zenodo.4247279", tmpdir, **force_arg, show_progress=False)
 
     captured = capsys.readouterr()
     assert not captured.out


### PR DESCRIPTION
**Why this PR?**
Currently, when there is a hash mismatch between the file on Zenodo and the one on disk, your only recourse is to either use `force_download=True` which re-downloads all the files or delete the file manually (which can be tricky) and then rerun the function. This one adds an argument `allow_overwrite` to allow overwriting those files where there is a hash mismatch only.