### PR TITLE
calibration: force calibration API pretty printing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Added parameter `allow_overwrite` to [`lk.download_from_doi()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.download_from_doi.html#lumicks.pylake.download_from_doi) to allow re-downloading only those files where the checksum does not match.
 * Added force calibration information to channels accessed directly via the square bracket notation (e.g. `file["Force HF"]["Force 1x"].calibration`).
 * Calibration results and parameters are now accessible via properties which are listed when items are printed. See [calibration results](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html) and [calibration item](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.calibration.ForceCalibrationItem.html) API documentation for more information.
+* Added `applied_at` property to a [calibration item](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.calibration.ForceCalibrationItem.html) obtained from a force slice. This property returns the timestamp in nanoseconds at which the force calibration was applied.
 * Added improved printing of calibration items under `channel.calibration` providing a more convenient overview of the items associated with a `Slice`.
 * Added parameter `titles` to customize title of each subplot in `[`Kymo.plot_with_channels()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.plot_with_channels).
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Added parameter `allow_overwrite` to [`lk.download_from_doi()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.download_from_doi.html#lumicks.pylake.download_from_doi) to allow re-downloading only those files where the checksum does not match.
 * Added force calibration information to channels accessed directly via the square bracket notation (e.g. `file["Force HF"]["Force 1x"].calibration`).
 * Calibration results and parameters are now accessible via properties which are listed when items are printed. See [calibration results](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html) and [calibration item](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.calibration.ForceCalibrationItem.html) API documentation for more information.
+* Added improved printing of calibration items under `channel.calibration` providing a more convenient overview of the items associated with a `Slice`.
 * Added parameter `titles` to customize title of each subplot in `[`Kymo.plot_with_channels()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.plot_with_channels).
 
 ## v1.5.1 | 2024-06-03

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,8 @@
 * Calibration results and parameters are now accessible via properties which are listed when items are printed. See [calibration results](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html) and [calibration item](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.calibration.ForceCalibrationItem.html) API documentation for more information.
 * Added `applied_at` property to a [calibration item](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.calibration.ForceCalibrationItem.html) obtained from a force slice. This property returns the timestamp in nanoseconds at which the force calibration was applied.
 * Added improved printing of calibration items under `channel.calibration` providing a more convenient overview of the items associated with a `Slice`.
-* Added parameter `titles` to customize title of each subplot in `[`Kymo.plot_with_channels()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.plot_with_channels).
+* Added improved printing of calibrations performed with `Pylake`.
+* Added parameter `titles` to customize title of each subplot in [`Kymo.plot_with_channels()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.plot_with_channels).
 
 ## v1.5.1 | 2024-06-03
 

--- a/lumicks/pylake/calibration.py
+++ b/lumicks/pylake/calibration.py
@@ -28,6 +28,11 @@ class ForceCalibrationItem(UserDict, CalibrationPropertiesMixin):
             return self[bluelake_key]
 
     @property
+    def applied_at(self):
+        """Time the calibration was applied in nanoseconds since epoch"""
+        return self.data.get("Timestamp (ns)")
+
+    @property
     def _fitted_diode(self):
         """Diode parameters were fitted"""
         return "f_diode (Hz)" in self or "alpha" in self
@@ -354,8 +359,10 @@ class ForceCalibration:
         items = []
         for calibration_item in hdf5["Calibration"].values():
             if force_channel in calibration_item:
-                attrs = calibration_item[force_channel].attrs
+                attrs = dict(calibration_item[force_channel].attrs)
                 if time_field in attrs.keys():
+                    # Copy the timestamp at which the calibration was applied into the item
+                    attrs["Timestamp (ns)"] = calibration_item.attrs.get("Timestamp (ns)")
                     items.append(ForceCalibrationItem(attrs))
 
         return ForceCalibration(time_field=time_field, items=items)

--- a/lumicks/pylake/calibration.py
+++ b/lumicks/pylake/calibration.py
@@ -280,7 +280,7 @@ class ForceCalibration:
         calibration = f.force1x.calibration[1]  # Grab a calibration item for force 1x
     """
 
-    def __init__(self, time_field, items):
+    def __init__(self, time_field, items, slice_start=None, slice_stop=None):
         """Calibration item
 
         Parameters
@@ -289,9 +289,13 @@ class ForceCalibration:
             name of the field used for time
         items : list[ForceCalibrationItem]
             list of force calibration items
+        slice_start, slice_stop : int
+            Start and stop index of the slice associated with these items
         """
         self._time_field = time_field
         self._src = items
+        self._slice_start = slice_start
+        self._slice_stop = slice_stop
 
     def _with_src(self, _src):
         return ForceCalibration(self._time_field, _src)
@@ -326,6 +330,8 @@ class ForceCalibration:
         return ForceCalibration(
             self._time_field,
             _filter_calibration(self._time_field, self._src, start, stop),
+            start,
+            stop,
         )
 
     @staticmethod
@@ -365,6 +371,12 @@ class ForceCalibration:
                     f"{item.displacement_sensitivity:.2f}" if item.force_sensitivity else "N/A",
                     item.hydrodynamically_correct,
                     item.distance_to_surface is not None,
+                    bool(
+                        self._slice_start
+                        and (item.start >= self._slice_start)
+                        and self._slice_stop
+                        and (item.stop <= self._slice_stop)
+                    ),
                 )
                 for idx, item in enumerate(self._src)
             ),
@@ -377,6 +389,7 @@ class ForceCalibration:
                 "Disp. sens. (µm/V)",
                 "Hydro",
                 "Surface",
+                "Data?",
             ),
         )
 

--- a/lumicks/pylake/calibration.py
+++ b/lumicks/pylake/calibration.py
@@ -87,6 +87,9 @@ class ForceCalibrationItem(UserDict, CalibrationPropertiesMixin):
         except KeyError:
             return getattr(self, item)
 
+    def __repr__(self):
+        return self._repr_properties
+
     @_verify_full
     def _model_params(self):
         """Returns parameters with which to create an active or passive calibration model"""

--- a/lumicks/pylake/force_calibration/tests/test_active_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_active_calibration.py
@@ -97,6 +97,9 @@ def test_integration_active_calibration(
     np.testing.assert_allclose(fit["Viscosity"].value, viscosity)
     np.testing.assert_allclose(fit["num_windows"].value, 5)
 
+    assert fit.active_calibration
+    assert fit.kind == "Active"
+
     np.testing.assert_allclose(
         fit["driving_amplitude"].value, driving_sinusoid[0] * 1e-3, rtol=1e-5
     )

--- a/lumicks/pylake/force_calibration/tests/test_hydro.py
+++ b/lumicks/pylake/force_calibration/tests/test_hydro.py
@@ -380,6 +380,8 @@ def test_integration_passive_calibration_hydrodynamics(integration_test_paramete
     assert not fit.transferred_lateral_drag_coefficient  # Only relevant for axial
     assert fit.fit_range == (100, 23000)
     assert fit.excluded_ranges == []
+    assert not fit.active_calibration
+    assert fit.kind == "Passive"
 
 
 def test_integration_active_calibration_hydrodynamics_bulk(integration_test_parameters):

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -311,35 +311,34 @@ def test_repr(reference_calibration_result):
 
     assert str(ps_calibration) == dedent(
         """\
-        Name                      Description                                               Value
-        ------------------------  --------------------------------------------------------  -----------
-        Bead diameter             Bead diameter (um)                                        4.4
-        Viscosity                 Liquid viscosity (Pa*s)                                   0.001002
-        Temperature               Liquid temperature (C)                                    20
-        Distance to surface       Distance from bead center to surface (um)
-        Hydrodynamically correct  Hydrodynamically correct model used (-)                   0
-        Max iterations            Maximum number of function evaluations                    10000
-        Fit tolerance             Fitting tolerance                                         1e-07
-        Points per block          Number of points per block                                100
-        Sample rate               Sample rate (Hz)                                          78125
-        Bias correction           Perform bias correction thermal fit                       0
-        Loss function             Loss function used during minimization                    gaussian
-        Rd                        Distance response (um/V)                                  7.25366
-        kappa                     Trap stiffness (pN/nm)                                    0.171495
-        Rf                        Force response (pN/V)                                     1243.97
-        gamma_0                   Theoretical bulk drag coefficient (kg/s)                  4.1552e-08
-        err_kappa                 Stiffness Std Err (pN/V)                                  0.00841414
-        err_Rd                    Distance response Std Err (um/V)                          0.125966
-        fc                        Corner frequency (Hz)                                     656.872
-        D                         Diffusion constant (V^2/s)                                0.00185126
-        err_fc                    Corner frequency Std Err (Hz)                             32.2284
-        err_D                     Diffusion constant Std Err (V^2/s)                        6.42974e-05
-        f_diode                   Diode low-pass filtering roll-off frequency (Hz)          7936.51
-        alpha                     Diode 'relaxation factor'                                 0.500609
-        err_f_diode               Diode low-pass filtering roll-off frequency Std Err (Hz)  561.715
-        err_alpha                 Diode 'relaxation factor' Std Err                         0.0131406
-        chi_squared_per_deg       Chi squared per degree of freedom                         1.06378
-        backing                   Statistical backing (%)                                   30.5705"""
+        Property                          Description                                         Value
+        --------------------------------  --------------------------------------------------  ----------------
+        stiffness                         Trap stiffness (pN/nm)                                  0.1715
+        displacement_sensitivity          Displacement sensitivity (µm/V)                         7.2537
+        force_sensitivity                 Force sensitivity (pN/V)                             1244
+        diffusion_constant                Fitted diffusion constant (µm²/s)                       0.097405
+        corner_frequency                  Estimated corner frequency (Hz)                       656.87
+        diffusion_constant_volts          Fitted diffusion constant (V²/s)                        0.0018513
+        diode_relaxation_factor           Diode relaxation factor (-)                             0.50061
+        diode_frequency                   Diode filtering frequency (Hz).                      7936.5
+        theoretical_bulk_drag             Expected bulk drag coefficient (kg/s)                   4.1552e-08
+        backing                           Statistical backing (%)                                30.57
+        chi_squared_per_degree            Chi squared per degree of freedom                       1.0638
+        stiffness_std_err                 Stiffness error (pN/nm)                                 0.0084141
+        displacement_sensitivity_std_err  Displacement sensitivity std error (µm/V)               0.12597
+        corner_frequency_std_err          Corner frequency std error (Hz)                        32.228
+        diffusion_volts_std_err           Diffusion constant std error (V²/s)                     6.4297e-05
+        diode_relaxation_factor_std_err   Relaxation factor std error (-)                         0.013141
+        diode_frequency_std_err           Diode frequency std error (-)                         561.72
+        bead_diameter                     Bead diameter (microns)                                 4.4
+        temperature                       Temperature (C)                                        20
+        viscosity                         Viscosity of the medium (Pa s)                          0.001002
+        fitted_diode                      Diode parameters were fitted                         True
+        hydrodynamically_correct          Hydrodynamically correct model.                     False
+        fit_range                         Spectral frequency range used for calibration (Hz)  (100.0, 23000.0)
+        excluded_ranges                   Frequency exclusion ranges (Hz)                     []
+        sample_rate                       Acquisition sample rate (Hz).                       78125
+        number_of_samples                 Number of fitted samples (-).                       39063"""
     )
 
 

--- a/lumicks/pylake/tests/data/mock_file.py
+++ b/lumicks/pylake/tests/data/mock_file.py
@@ -53,7 +53,7 @@ class MockDataFile_v2(MockDataFile_v1):
     def get_file_format_version(self):
         return 2
 
-    def make_calibration_data(self, calibration_idx, group, attributes):
+    def make_calibration_data(self, calibration_idx, group, attributes, application_timestamp=None):
         if "Calibration" not in self.file:
             self.file.create_group("Calibration")
 
@@ -64,6 +64,9 @@ class MockDataFile_v2(MockDataFile_v1):
         # e.g. Force 1x, Force 1y ... etc
         if group not in self.file["Calibration"][calibration_idx]:
             self.file["Calibration"][calibration_idx].create_group(group)
+            self.file["Calibration"][calibration_idx].attrs["Timestamp (ns)"] = (
+                application_timestamp if application_timestamp else attributes["Stop time (ns)"]
+            )
 
         # Attributes
         field = self.file["Calibration"][calibration_idx][group]

--- a/lumicks/pylake/tests/test_file/conftest.py
+++ b/lumicks/pylake/tests/test_file/conftest.py
@@ -42,19 +42,35 @@ def h5_file(tmpdir_factory, request):
             "Photon Time Tags", "Red", np.arange(10, 100, step=10, dtype=np.int64)
         )
 
-        calibration_time_field = "Stop time (ns)"
-        mock_file.make_calibration_data("1", "Force 1x", {calibration_time_field: 0})
-        mock_file.make_calibration_data("2", "Force 1x", {calibration_time_field: 1})
-        mock_file.make_calibration_data("3", "Force 1x", {calibration_time_field: 10})
-        mock_file.make_calibration_data("4", "Force 1x", {calibration_time_field: 100})
-        mock_file.make_calibration_data("1", "Force 1y", {calibration_time_field: 0})
-        mock_file.make_calibration_data("2", "Force 1y", {calibration_time_field: 1})
-        mock_file.make_calibration_data("3", "Force 1y", {calibration_time_field: 10})
-        mock_file.make_calibration_data("4", "Force 1y", {calibration_time_field: 100})
-        mock_file.make_calibration_data("1", "Force 1z", {calibration_time_field: 0})
-        mock_file.make_calibration_data("2", "Force 1z", {calibration_time_field: 1})
-        mock_file.make_calibration_data("3", "Force 1z", {calibration_time_field: 10})
-        mock_file.make_calibration_data("4", "Force 1z", {calibration_time_field: 100})
+        def generate_attributes(stop_time, custom_fields=None):
+            return {
+                "Kind": "Full calibration",
+                "Start time (ns)": stop_time - 5,
+                "Stop time (ns)": stop_time,
+                "kappa (pN/nm)": 1.05,
+                "Response (pN/V)": 504.43,
+                "Rd (um/V)": 4.57,
+            } | (custom_fields if custom_fields else {})
+
+        mock_file.make_calibration_data(
+            "1", "Force 1x", {"Start time (ns)": -1, "Stop time (ns)": 0}
+        )
+        mock_file.make_calibration_data(
+            "2", "Force 1x", generate_attributes(1, {"Bead center height (um)": 5})
+        )
+        mock_file.make_calibration_data(
+            "2", "Force 1x", generate_attributes(3, {"Kind": "Reset offset"})
+        )
+        mock_file.make_calibration_data("3", "Force 1x", generate_attributes(10))
+        mock_file.make_calibration_data("4", "Force 1x", generate_attributes(100))
+        mock_file.make_calibration_data("1", "Force 1y", generate_attributes(0))
+        mock_file.make_calibration_data("2", "Force 1y", generate_attributes(1))
+        mock_file.make_calibration_data("3", "Force 1y", generate_attributes(10))
+        mock_file.make_calibration_data("4", "Force 1y", generate_attributes(100))
+        mock_file.make_calibration_data("1", "Force 1z", generate_attributes(0))
+        mock_file.make_calibration_data("2", "Force 1z", generate_attributes(1))
+        mock_file.make_calibration_data("3", "Force 1z", generate_attributes(10))
+        mock_file.make_calibration_data("4", "Force 1z", generate_attributes(100))
 
         mock_file.make_marker("test_marker", {"Start time (ns)": 100, "Stop time (ns)": 200})
         mock_file.make_marker("test_marker2", {"Start time (ns)": 200, "Stop time (ns)": 300})
@@ -88,10 +104,10 @@ def h5_file(tmpdir_factory, request):
         force_data = np.hstack((np.ones(37) * 30, np.ones(33) * 10))
         force_start = np.int64(ds.attrs["Start time (ns)"] - (freq * 5))  # before infowave
         mock_file.make_continuous_channel("Force HF", "Force 2x", force_start, freq, force_data)
-        mock_file.make_calibration_data("1", "Force 2x", {calibration_time_field: 0})
-        mock_file.make_calibration_data("2", "Force 2x", {calibration_time_field: 1})
-        mock_file.make_calibration_data("3", "Force 2x", {calibration_time_field: 10})
-        mock_file.make_calibration_data("4", "Force 2x", {calibration_time_field: 100})
+        mock_file.make_calibration_data("1", "Force 2x", generate_attributes(0))
+        mock_file.make_calibration_data("2", "Force 2x", generate_attributes(1))
+        mock_file.make_calibration_data("3", "Force 2x", generate_attributes(10))
+        mock_file.make_calibration_data("4", "Force 2x", generate_attributes(100))
 
         # Single frame image
         json = generate_scan_json(

--- a/lumicks/pylake/tests/test_file/test_calibration_item.py
+++ b/lumicks/pylake/tests/test_file/test_calibration_item.py
@@ -49,6 +49,7 @@ ref_passive_fixed_diode_with_height = {
     "gamma_0 (kg/s)": 8.388052385084746e-09,
     "kappa (pN/nm)": 0.2421057076519628,
     "Bead center height (um)": 1.0,
+    "Timestamp (ns)": 1696171386701856700,
 }
 
 
@@ -168,6 +169,7 @@ def test_passive_item(compare_to_reference_dict, reference_data, calibration_dat
     assert item.diffusion_volts_std_err == ref_passive_fixed_diode_with_height["err_D (V^2/s)"]
     assert not item.diode_frequency_std_err
     assert not item.diode_relaxation_factor_std_err
+    assert item.applied_at is 1696171386701856700
 
     compare_to_reference_dict(item.power_spectrum_params(), test_name="power")
     compare_to_reference_dict(item._model_params(), test_name="model")

--- a/lumicks/pylake/tests/test_file/test_file.py
+++ b/lumicks/pylake/tests/test_file/test_file.py
@@ -75,6 +75,23 @@ def test_redirect_list(h5_file):
         assert f["Point Scan"]["PointScan1"].start == np.int64(20e9)
 
 
+def test_calibration_str(h5_file):
+    f = pylake.File.from_h5py(h5_file)
+    if f.format_version == 2:
+        print("")
+        print(str(f.force1x.calibration))
+        assert str(f.force1x.calibration) == dedent(
+            (
+                """\
+                  Index  Kind                 Stiffness (pN/nm)    Force sens. (pN/V)    Disp. sens. (µm/V)    Hydro    Surface
+                -------  -------------------  -------------------  --------------------  --------------------  -------  ---------
+                      0  Unknown              N/A                  N/A                   N/A                   False    False
+                      1  Reset offset         1.05                 504.43                4.57                  False    True
+                      2  Passive calibration  1.05                 504.43                4.57                  False    False"""
+            )
+        )
+
+
 def test_repr_and_str(h5_file):
     f = pylake.File.from_h5py(h5_file)
 

--- a/lumicks/pylake/tests/test_file/test_file.py
+++ b/lumicks/pylake/tests/test_file/test_file.py
@@ -83,11 +83,11 @@ def test_calibration_str(h5_file):
         assert str(f.force1x.calibration) == dedent(
             (
                 """\
-                  Index  Kind                 Stiffness (pN/nm)    Force sens. (pN/V)    Disp. sens. (µm/V)    Hydro    Surface
-                -------  -------------------  -------------------  --------------------  --------------------  -------  ---------
-                      0  Unknown              N/A                  N/A                   N/A                   False    False
-                      1  Reset offset         1.05                 504.43                4.57                  False    True
-                      2  Passive calibration  1.05                 504.43                4.57                  False    False"""
+                  Index  Kind                 Stiffness (pN/nm)    Force sens. (pN/V)    Disp. sens. (µm/V)    Hydro    Surface    Data?
+                -------  -------------------  -------------------  --------------------  --------------------  -------  ---------  -------
+                      0  Unknown              N/A                  N/A                   N/A                   False    False      False
+                      1  Reset offset         1.05                 504.43                4.57                  False    True       False
+                      2  Passive calibration  1.05                 504.43                4.57                  False    False      True"""
             )
         )
 

--- a/lumicks/pylake/tests/test_file/test_file_items.py
+++ b/lumicks/pylake/tests/test_file/test_file_items.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from lumicks import pylake
+from lumicks.pylake.calibration import ForceCalibration
 
 from ..data.mock_json import force_feedback_dict
 
@@ -32,9 +33,9 @@ def test_channels(h5_file):
 def test_calibration(h5_file):
     f = pylake.File.from_h5py(h5_file)
 
-    assert type(f.force1x.calibration) is list
-    assert type(f.downsampled_force1.calibration) is list
-    assert type(f.downsampled_force1x.calibration) is list
+    assert type(f.force1x.calibration) is ForceCalibration or list
+    assert type(f.downsampled_force1.calibration) is ForceCalibration or list
+    assert type(f.downsampled_force1x.calibration) is ForceCalibration or list
 
     if f.format_version == 1:
         # v1 version doesn't include calibration data field
@@ -45,10 +46,10 @@ def test_calibration(h5_file):
         assert len(f["Force LF"]["Force 1x"].calibration) == 0
 
     if f.format_version == 2:
-        assert len(f.force1x.calibration) == 2
+        assert len(f.force1x.calibration) == 3
         assert len(f.downsampled_force1.calibration) == 0
         assert len(f.downsampled_force1x.calibration) == 1
-        assert len(f["Force HF"]["Force 1x"].calibration) == 2
+        assert len(f["Force HF"]["Force 1x"].calibration) == 3
         assert len(f["Force LF"]["Force 1x"].calibration) == 1
 
         assert f["Force HF"]["Force 1x"].calibration == f.force1x.calibration

--- a/lumicks/pylake/tests/test_file/test_file_items.py
+++ b/lumicks/pylake/tests/test_file/test_file_items.py
@@ -54,6 +54,7 @@ def test_calibration(h5_file):
 
         assert f["Force HF"]["Force 1x"].calibration == f.force1x.calibration
         assert f["Force HF"]["Force 2x"].calibration == f.force2x.calibration
+        assert f.force1x.calibration[2].applied_at == 10
 
 
 def test_marker(h5_file):


### PR DESCRIPTION
**Why this PR?**
Given that we now have actual properties defining the physical properties of each force calibration result, it's time to actually present these to the user.

In the updated API, the html and string representation of a calibration item give you a short summary of what's in there. Note the last column, which indicates whether the `Slice` you got this calibration item from actually contains the data you would need to recalibrate. I hope this will make it more clear when a sufficient amount of data was exported.

<img width="781" alt="image" src="https://github.com/lumicks/pylake/assets/19836026/c7fe1a3b-f36f-496d-8314-7f92e6858f1b">

Access to the items is still by indexing them. And this now lists a table of properties.

<img width="681" alt="image" src="https://github.com/lumicks/pylake/assets/19836026/33f9c2a9-0cfa-4075-9a93-f22dc81a08ff">

**What to look out for?**
Technically, this PR is breaking, because we used to return a raw `list` of force calirations from `.calibration`. A regular list has some more operations defined than the one added here, but I would argue that many of those didn't really make sense for what we were going for. 

In the new setup, the calibrations are always packaged with sufficient metadata to construct the visual table. Also, in the new setup, we don't allow adding items (so we can be confident we are only dealing with force calibration items).

You can however still cast it down to a regular `list()` if you really want to. We could add a new property (`calibrations`?) and deprecate `.calibration` to not be breaking, but I wonder if the removal of things that weren't really intended as valid use cases warrants this additional friction of changing the property name for users.

**Note**
If we decide to go with this approach, I will open a last one in this series that updates the documentation, but I'm holding off on that since this will involve making many screenshots, and it does not seem like a good use of time to finalize all that before deciding on the final API.