### PR TITLE
calibration: private api for exclusion/fit ranges

### DIFF
--- a/lumicks/pylake/force_calibration/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/power_spectrum.py
@@ -52,6 +52,8 @@ class PowerSpectrum:
             )
 
         self.unit = unit
+        self._excluded_ranges = []
+
         data = data - np.mean(data)
 
         # Calculate power spectrum for slices of data.
@@ -74,6 +76,7 @@ class PowerSpectrum:
         self.frequency = np.fft.rfftfreq(num_points_per_window, 1.0 / sample_rate)
         scaling_factor = (2.0 / sample_rate) / num_points_per_window
         self.power = scaling_factor * squared_fft
+        self._fit_range = (self.frequency.min(), self.frequency.max())
 
         # Store a variance for temporally blocked power spectra
         self._variance = (
@@ -122,6 +125,7 @@ class PowerSpectrum:
 
         ps.frequency = ps.frequency[indices]
         ps.power = ps.power[indices]
+        ps._excluded_ranges = self._excluded_ranges + excluded_ranges
 
         if self._variance is not None:
             ps._variance = ps._variance[indices]
@@ -233,6 +237,11 @@ class PowerSpectrum:
         mask = (self.frequency > frequency_min) & (self.frequency <= frequency_max)
         ir.frequency = self.frequency[mask]
         ir.power = self.power[mask]
+
+        ir._fit_range = (
+            max(self._fit_range[0], frequency_min),
+            min(self._fit_range[1], frequency_max),
+        )
 
         if self._variance is not None:
             ir._variance = self._variance[mask]

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -93,6 +93,16 @@ class CalibrationResults:
     def __getitem__(self, item):
         return self.params[item] if item in self.params else self.results[item]
 
+    @property
+    def _fit_range(self):
+        """Fitted range"""
+        return self.ps_data._fit_range
+
+    @property
+    def _excluded_ranges(self):
+        """Frequency exclusion ranges"""
+        return self.ps_data._excluded_ranges
+
     def plot(self):
         """Plot the fitted spectrum"""
         import matplotlib.pyplot as plt

--- a/lumicks/pylake/force_calibration/tests/test_hydro.py
+++ b/lumicks/pylake/force_calibration/tests/test_hydro.py
@@ -357,6 +357,9 @@ def test_integration_passive_calibration_hydrodynamics(integration_test_paramete
     for key, value in expected_results.items():
         np.testing.assert_allclose(fit.results[key].value, value, err_msg=key)
 
+    assert fit._fit_range == (1e2, 23e3)
+    assert fit._excluded_ranges == []
+
 
 def test_integration_active_calibration_hydrodynamics_bulk(integration_test_parameters):
     shared_pars, simulation_pars = integration_test_parameters
@@ -371,7 +374,9 @@ def test_integration_active_calibration_hydrodynamics_bulk(integration_test_para
         sample_rate=simulation_pars["sample_rate"],
         driving_frequency_guess=33,
     )
-    power_spectrum = calculate_power_spectrum(volts, simulation_pars["sample_rate"])
+    power_spectrum = calculate_power_spectrum(
+        volts, simulation_pars["sample_rate"], excluded_ranges=[(20, 40)]
+    )
     fit = fit_power_spectrum(power_spectrum, model, bias_correction=False)
 
     expected_params = {
@@ -411,6 +416,8 @@ def test_integration_active_calibration_hydrodynamics_bulk(integration_test_para
 
     for key, value in expected_results.items():
         np.testing.assert_allclose(fit.results[key].value, value, err_msg=key)
+
+    assert fit._excluded_ranges == [(20, 40)]
 
 
 def test_distance_to_surface_input(integration_test_parameters):


### PR DESCRIPTION
**Why this PR?**
In an effort to make Pylake calibration results more similar to Bluelake calibration results, this adds both fit range and exclusion ranges to the `CalibrationResults`.

Note that it is private in this PR, because the next PR will add a layer on top that unifies the properties for both classes (`CalibrationResults` and `ForceCalibrationItem`).