### PR TITLE
calibration: expose all relevant calibration parameters as properties

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Added parameter `allow_overwrite` to [`lk.download_from_doi()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.download_from_doi.html#lumicks.pylake.download_from_doi) to allow re-downloading only those files where the checksum does not match.
 * Added force calibration information to channels accessed directly via the square bracket notation (e.g. `file["Force HF"]["Force 1x"].calibration`).
+* Calibration results and parameters are now accessible via properties which are listed when items are printed. See [calibration results](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html) and [calibration item](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.calibration.ForceCalibrationItem.html) API documentation for more information.
 * Added parameter `titles` to customize title of each subplot in `[`Kymo.plot_with_channels()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.plot_with_channels).
 
 ## v1.5.1 | 2024-06-03

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,6 +12,7 @@ If you are just looking to get started, read the :doc:`/tutorial/index` first.
 
     File
     channel.Slice
+    calibration.ForceCalibrationItem
     fdcurve.FdCurve
     fdensemble.FdEnsemble
     kymo.Kymo

--- a/lumicks/pylake/force_calibration/calibration_models.py
+++ b/lumicks/pylake/force_calibration/calibration_models.py
@@ -587,6 +587,9 @@ class PassiveCalibrationModel:
             "Distance to surface": CalibrationParameter(
                 "Distance from bead center to surface", self.distance_to_surface, "um"
             ),
+            "Hydrodynamically correct": CalibrationParameter(
+                "Hydrodynamically correct model used", self.hydrodynamically_correct, "-"
+            ),
             **hydrodynamic_parameters,
         }
 

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -44,12 +44,435 @@ from lumicks.pylake.force_calibration.detail.power_models import (
 CalibrationParameter = namedtuple("CalibrationParameter", ["description", "value", "unit"])
 
 
-class CalibrationResults:
+class CalibrationPropertiesMixin:
+    def _get_parameter(self, pylake_key, bluelake_key):
+        raise NotImplementedError
+
+    @property
+    def stiffness(self):
+        """Trap stiffness (pN/nm)
+
+        The trap stiffness gives a measure for how much force is required to displace the bead
+        from the center of the optical trap. In passive calibration, this factor depends
+        on a theoretical drag coefficient which is determined from the fluid viscosity, bead
+        diameter and distance to the surface.
+
+        In active calibration fewer assumptions are required to calculate the trap stiffness and
+        the drag coefficient is inferred from the measurement data."""
+        return self._get_parameter("kappa", "kappa (pN/nm)")
+
+    @property
+    def force_sensitivity(self):
+        """Force sensitivity (pN/V)
+
+        The force sensitivity provides the calibration factor for converting sensor readouts from
+        voltages to forces. It is given by the product of the displacement sensitivity and
+        trap stiffness.
+
+        To recalibrate force channels, simply multiply them by the ratio of force sensitivities of
+        the old and new calibration.
+        """
+        return self._get_parameter("Rf", "Response (pN/V)")
+
+    @property
+    def displacement_sensitivity(self):
+        """Displacement sensitivity (µm/V)
+
+        The displacement sensitivity corresponds to the conversion factor from raw sensor voltages
+        to the bead displacement from the trap center.
+
+        In passive calibration, it is calculated from the ratio of the expected diffusion
+        constant (in µm²/s) to the diffusion constant quantified from the power spectral fit
+        (in V²/s). The former depends on the drag coefficient which in turn is linearly dependent
+        on the viscosity and bead diameter, as well as non-linearly dependent on the distance
+        from the flow-cell surface.
+
+        In active calibration with a nano-stage, the displacement sensitivity is determined by
+        applying a known displacement to the fluid in the flow-cell. Using parameters from the
+        passive fit, we can calculate an expected motion of the bead in response to this fluid
+        motion. The driving peak can be observed on the position sensitive detector (in Volts),
+        while we know its motion in (microns). The advantage of active calibration is that it does
+        not rely as strongly on a theoretical drag coefficient and is therefore less sensitivity to
+        the input parameters viscosity, bead diameter and distance to the surface.
+
+        To recalibrate distance channels, simply multiply them by the ratio of displacement
+        sensitivities of the old and new calibration.
+        """
+        return self._get_parameter("Rd", "Rd (um/V)")
+
+    @property
+    def measured_drag_coefficient(self):
+        """Measured bulk drag coefficient (kg/s)
+
+        .. note::
+
+            This parameter is only available when using active calibration.
+
+            For surface calibrations where the distance to the surface was provided, this
+            represents the bulk value as the model is used to calculate it back to what the
+            drag would have been in bulk.
+        """
+        return self._get_parameter("gamma_ex", "gamma_ex (kg/s)")
+
+    @property
+    def corner_frequency(self):
+        """Estimated corner frequency (Hz)
+
+        .. note::
+
+            When the hydrodynamically correct model is used and a height is provided, this returns
+            the value in bulk. When this model is used, the height dependence due to the change in
+            drag coefficient is captured by the model. In this case, any remaining
+            height-dependent variation is due to optical aberrations.
+
+            When using the simpler model or when not providing the height, the estimated corner
+            frequency will depend on the distance to the surface resulting in a lower corner
+            frequency near the surface.
+        """
+        return self._get_parameter("fc", "fc (Hz)")
+
+    @property
+    def theoretical_bulk_drag(self):
+        r"""Expected bulk drag coefficient (kg/s)
+
+        The expected drag coefficient in bulk for a spherical particle is given by:
+
+        .. math::
+
+            \gamma = 3 \pi \eta d
+
+        Where :math:`d` represents the bead diameter, :math:`\eta` the liquid viscosity and
+        :math:`T` the temperature.
+        """
+        return self._get_parameter("gamma_0", "gamma_0 (kg/s)")
+
+    @property
+    def diffusion_constant_volts(self):
+        """Fitted diffusion constant (V²/s)
+
+        .. note::
+
+            When the hydrodynamically correct model is used and a height is provided, this returns
+            the value in bulk. When this model is used, the height dependence due to the change in
+            drag coefficient is captured by the model.
+
+            When using the simpler model or when not providing the height, the estimated diffusion
+            constant will depend on the distance to the surface resulting in a lower diffusion
+            constant near the surface.
+        """
+        return self._get_parameter("D", "D (V^2/s)")
+
+    @property
+    def diffusion_constant(self):
+        """Fitted diffusion constant (µm²/s)
+
+        .. note::
+
+            When the hydrodynamically correct model is used and a height is provided, this returns
+            the value in bulk. When this model is used, the height dependence due to the change in
+            drag coefficient is captured by the model.
+
+            When using the simpler model or when not providing the height, the estimated diffusion
+            constant will depend on the distance to the surface resulting in a lower diffusion
+            constant near the surface.
+        """
+        if self.diffusion_constant_volts and self.displacement_sensitivity:
+            return self.diffusion_constant_volts * self.displacement_sensitivity**2
+
+    @property
+    def diode_relaxation_factor(self):
+        """Diode relaxation factor (-)
+
+        The measured voltage (and thus the shape of the power spectrum) is determined by the
+        Brownian motion of the bead within the trap as well as the response of the PSD to the
+        incident light.
+
+        For "fast" sensors, this second contribution is negligible at the frequencies typically
+        fitted, while "standard" sensors exhibit a characteristic filtering where the PSD becomes
+        less sensitive to changes in signal at high frequencies. This filtering effect is
+        characterized by a constant that reflects the fraction of light that is transmitted
+        instantaneously (the diode relaxation factor) and a corner frequency (diode_frequency).
+
+        A relaxation factor of 1.0 results in no filtering. This property will return `None` for
+        fast sensors (where the diode model is not taken into account).
+
+        .. note::
+
+            Some systems have characterized diodes. In these systems, this is not a fitted but
+            fixed value. Please refer to the property `fitted_diode` to determine whether the diode
+            frequency was fixed (pre-characterized) or fitted.
+        """
+        if alpha := self._get_parameter("alpha", "alpha"):
+            return alpha  # Fitted diode
+
+        return self._get_parameter("alpha", "Diode alpha")
+
+    @property
+    def diode_frequency(self):
+        """Diode filtering frequency (Hz).
+
+        The measured voltage (and thus the shape of the power spectrum) is determined by the
+        Brownian motion of the bead within the trap as well as the response of the PSD to the
+        incident light.
+
+        For "fast" sensors, this second contribution is negligible at the frequencies typically
+        fitted, while "standard" sensors exhibit a characteristic filtering where the PSD becomes
+        less sensitive to changes in signal at high frequencies. This filtering effect is
+        characterized by a constant that reflects the fraction of light that is transmitted
+        instantaneously (the diode relaxation factor) and a corner frequency (diode_frequency).
+
+        .. note::
+
+            Some systems have characterized diodes. In these systems, this is not a fitted but
+            fixed value. Please refer to the property `fitted_diode` to determine whether the diode
+            frequency was fixed (pre-characterized) or fitted.
+        """
+        if f_diode := self._get_parameter("f_diode", "f_diode (Hz)"):
+            return f_diode
+
+        return self._get_parameter("f_diode", "Diode frequency (Hz)")  # Fixed diode
+
+    @property
+    def hydrodynamically_correct(self):
+        """Hydrodynamically correct model.
+
+        Force calibration involves fitting a model to the power spectrum of the calibration data.
+
+        This power spectrum has a Lorentian shape when the viscous drag force is proportional
+        to the bead velocity. This is true when the velocity field is stationary around the bead.
+        This model is only appropriate at low frequencies or when using small beads.
+
+        For larger beads, inertial effects start to play a role and the viscous force depends on
+        the frequency of the motion and the second derivative of the bead position. These effects
+        originate from waves generated by the interaction of the bead with the fluid, which in turn
+        interact with the bead again. The hydrodynamically correct model takes these effects into
+        account providing a more accurate description of the data especially for larger beads an
+        at high frequencies."""
+        return bool(
+            self._get_parameter("Hydrodynamically correct", "Hydrodynamic correction enabled")
+        )
+
+    @property
+    def fast_sensor(self):
+        """Fast sensor
+
+        Some force sensors include a parasitic filtering effect. When this flag is set to `False`,
+        the model includes such a parasitic filtering effect. When this flag is `True`, no such
+        effect is included in the model. This flag should only be used for fast sensors (sensors
+        where the sensor does not exhibit a frequency dependent attenuation over the measured
+        bandwidth)."""
+        return not self.diode_frequency
+
+    @property
+    def bead_diameter(self):
+        """Bead diameter (microns)"""
+        return self._get_parameter("Bead diameter", "Bead diameter (um)")
+
+    @property
+    def viscosity(self):
+        """Viscosity of the medium (Pa s)"""
+        return self._get_parameter("Viscosity", "Viscosity (Pa*s)")
+
+    @property
+    def temperature(self):
+        """Temperature (C)"""
+        return self._get_parameter("Temperature", "Temperature (C)")
+
+    @property
+    def distance_to_surface(self):
+        """Distance from bead center to surface (µm)"""
+        return self._get_parameter("Distance to surface", "Bead center height (um)")
+
+    @property
+    def rho_sample(self):
+        """Density of the medium (kg/m³).
+
+        .. note::
+
+            This parameter only affects hydrodynamically correct fits."""
+        return self._get_parameter("Sample density", "Fluid density (Kg/m3)")
+
+    @property
+    def rho_bead(self):
+        """Density of the bead (kg/m³).
+
+        .. note::
+
+            This parameter only affects hydrodynamically correct fits."""
+        return self._get_parameter("Bead density", "Bead density (Kg/m3)")
+
+    @property
+    def backing(self):
+        """Statistical backing (%)
+
+        The support or backing is the probability that a repetition of the measurement that
+        produced the data we fitted to will, after fitting, produce residuals whose squared sum is
+        greater than the one we initially obtained. More informally, it represents the probability
+        that a fit error at least this large should occur by chance.
+        """
+        return self._get_parameter("backing", "backing (%)")
+
+    @property
+    def stiffness_std_err(self):
+        """Stiffness error (pN/nm)
+
+        Obtained through Gaussian error propagation. See :attr:`stiffness` for more information."""
+        # Note: Isn't exported by BL yet
+        return self._get_parameter("err_kappa", "err_kappa (pN/nm)")
+
+    @property
+    def displacement_sensitivity_std_err(self):
+        """Displacement sensitivity std error (µm/V)
+
+        Obtained through Gaussian error propagation. See :attr:`displacement_sensitivity` for more
+        information."""
+        # Note: Isn't exported by BL yet
+        return self._get_parameter("err_Rd", "err_Rd (um/V)")
+
+    @property
+    def corner_frequency_std_err(self):
+        """Corner frequency std error (Hz)
+
+        Asymptotic standard error of the fit. See :attr:`corner_frequency` for more information
+        on this parameter."""
+        return self._get_parameter("err_fc", "err_fc (Hz)")
+
+    @property
+    def diffusion_volts_std_err(self):
+        """Diffusion constant std error (V²/s)
+
+        Asymptotic standard error of the fit. See :attr:`diffusion_volts` for more information on
+        this parameter."""
+        return self._get_parameter("err_D", "err_D (V^2/s)")
+
+    @property
+    def diode_relaxation_factor_std_err(self):
+        """Relaxation factor std error (-)
+
+        Asymptotic standard error of the fit. See :attr:`diode_relaxation_factor` for more
+        information on this parameter."""
+        return self._get_parameter("err_alpha", "err_alpha")
+
+    @property
+    def diode_frequency_std_err(self):
+        """Diode frequency std error (-)
+
+        Asymptotic standard error of the fit. See :attr:`diode_frequency` for more information
+        on this parameter."""
+        return self._get_parameter("err_f_diode", "err_f_diode (Hz)")
+
+    @property
+    def chi_squared_per_degree(self):
+        """Chi squared per degree of freedom
+
+        This quantity is given by the sum of squares divided by the number of degrees of freedom
+        and should be close to unity for a good fit."""
+        return self._get_parameter("chi_squared_per_deg", "chi_squared_per_deg")
+
+    @property
+    def driving_frequency_guess(self):
+        """Driving frequency guess (Hz)
+
+        The force calibration procedure requires an initial guess of the frequency driving the
+        active calibration procedure. This frequency is typically the requested driving frequency
+        of the nano-stage. This initial estimate is refined using power spectral estimation.
+        See :attr:`driving_frequency` for the achieved driving frequency.
+        """
+        return self._get_parameter("Driving frequency (guess)", "Driving data frequency (Hz)")
+
+    @property
+    def transferred_lateral_drag_coefficient(self):
+        """Drag coefficient from lateral calibration
+
+        When performing axial calibration, one can specify a known bulk drag coefficient obtained
+        with active calibration and use that to calibrate the trap. This coefficient is then
+        subsequently corrected for surface effects by applying Brenner's law and used in
+        passive calibration."""
+        return self._get_parameter("gamma_ex_lateral", "gamma_ex_lateral (kg/s)")
+
+    @property
+    def driving_amplitude(self):
+        """Quantified driving amplitude (µm)
+
+        This property corresponds to the driving amplitude quantified from the position signal
+        measuring the stage or trap motion."""
+        return self._get_parameter("driving_amplitude", "driving_amplitude (um)")
+
+    @property
+    def driving_frequency(self):
+        """Quantified frequency (Hz)
+
+        This property corresponds to the driving frequency quantified from the position signal
+        measuring the stage or trap motion."""
+        return self._get_parameter("driving_frequency", "driving_frequency (Hz)")
+
+    @property
+    def driving_power(self):
+        """Driving power at the position sensitive detector (V²)
+
+        This property corresponds to the driving power measured at the force detector (in Volts).
+        The estimated :attr:`driving_frequency` is used to window the calibration data such that
+        the driving peak ends up on exactly one frequency bin which can then subsequently be
+        quantified. After quantification of the peak magnitude, the thermal background is
+        subtracted to obtain the driving power.
+        """
+        # Note: Isn't exported by BL yet
+        return self._get_parameter("driving_power", "driving_power (V^2)")
+
+    @property
+    def fitted_diode(self):
+        """Diode parameters were fitted
+
+        The measured voltage (and thus the shape of the power spectrum) is determined by the
+        Brownian motion of the bead within the trap as well as the response of the PSD to the
+        incident light.
+
+        For "fast" sensors, this second contribution is negligible at the frequencies typically
+        fitted, while "standard" sensors exhibit a characteristic filtering where the PSD becomes
+        less sensitive to changes in signal at high frequencies. This filtering effect is
+        characterized by a constant that reflects the fraction of light that is transmitted
+        instantaneously (the diode relaxation factor) and a corner frequency (diode_frequency).
+
+        Some systems have characterized diodes. In these systems, this is not a fitted but
+        fixed value. This property is `False` for calibrations where the diode frequency and
+        relaxation factor were fixed (pre-characterized)."""
+        return self._fitted_diode
+
+    @property
+    def fit_range(self):
+        """Spectral frequency range used for calibration (Hz)"""
+        return self._fit_range
+
+    @property
+    def excluded_ranges(self):
+        """Frequency exclusion ranges (Hz)
+
+        When fitting power spectra, specific frequency intervals of the spectrum can be ignored to
+        exclude noise peaks. This property returns a list of these intervals in Hertz."""
+        return self._excluded_ranges
+
+    @property
+    def sample_rate(self):
+        """Acquisition sample rate (Hz)."""
+        raise NotImplementedError("This property is not defined for this item")
+
+    @property
+    def number_of_samples(self):
+        """Number of fitted samples (-)."""
+        raise NotImplementedError("This property is not defined for this item")
+
+    @property
+    def offset(self):
+        """Force offset (pN)"""
+        return self._get_parameter("NA", "Offset")
+
+
+class CalibrationResults(CalibrationPropertiesMixin):
     """Power spectrum calibration results.
 
     Attributes
     ----------
-    model : lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationModel
+    model : PassiveCalibrationModel | ActiveCalibrationModel
         Model used for calibration.
     ps_model : PowerSpectrum
         Power spectrum of the fitted model.
@@ -102,6 +525,35 @@ class CalibrationResults:
     def _excluded_ranges(self):
         """Frequency exclusion ranges"""
         return self.ps_data._excluded_ranges
+
+    def _get_parameter(self, pylake_key, _):
+        """Grab a parameter"""
+        if pylake_key in self:
+            return self[pylake_key].value
+
+    @property
+    def kind(self):
+        """Type of calibration performed"""
+        return (
+            "active calibration"
+            if self.model.__class__.__name__ == "ActiveCalibrationModel"
+            else "passive calibration"
+        )
+
+    @property
+    def _fitted_diode(self):
+        """Diode parameters were fitted"""
+        return "f_diode" in self.results or "alpha" in self.results
+
+    @property
+    def sample_rate(self):
+        """Acquisition sample rate (Hz)."""
+        return self.ps_data.sample_rate
+
+    @property
+    def number_of_samples(self):
+        """Number of fitted samples (-)."""
+        return self.ps_data.total_sampled_used
 
     def plot(self):
         """Plot the fitted spectrum"""
@@ -157,21 +609,6 @@ class CalibrationResults:
 
     def __str__(self) -> str:
         return self._print_data()
-
-    @property
-    def stiffness(self):
-        """Stiffness in pN/nm"""
-        return self.results["kappa"].value
-
-    @property
-    def force_sensitivity(self):
-        """Force sensitivity in pN/V"""
-        return self.results["Rf"].value
-
-    @property
-    def displacement_sensitivity(self):
-        """Displacement sensitivity in um/V"""
-        return self.results["Rd"].value
 
 
 def calculate_power_spectrum(

--- a/lumicks/pylake/force_calibration/tests/test_active_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_active_calibration.py
@@ -82,6 +82,11 @@ def test_integration_active_calibration(
         rtol=1e-9,
     )
     np.testing.assert_allclose(fit["gamma_ex"].value, drag_coeff_calc * 1e12, rtol=1e-9)
+    np.testing.assert_allclose(fit.measured_drag_coefficient, fit["gamma_ex"].value)
+    np.testing.assert_allclose(fit.driving_frequency_guess, fit.model.driving_frequency_guess)
+    np.testing.assert_allclose(fit.driving_amplitude, fit["driving_amplitude"].value)
+    np.testing.assert_allclose(fit.driving_frequency, fit["driving_frequency"].value)
+    np.testing.assert_allclose(fit.driving_power, fit["driving_power"].value)
     np.testing.assert_allclose(
         fit["local_drag_coefficient"].value, drag_coeff_calc * 1e12, rtol=1e-9
     )

--- a/lumicks/pylake/force_calibration/tests/test_axial.py
+++ b/lumicks/pylake/force_calibration/tests/test_axial.py
@@ -106,3 +106,6 @@ def test_axial_calibration(reference_models, hydro):
         axial_fit["gamma_ex_lateral"].description
         == "Bulk drag coefficient from lateral calibration"
     )
+    np.testing.assert_allclose(
+        axial_fit.transferred_lateral_drag_coefficient, axial_fit["gamma_ex_lateral"].value
+    )

--- a/lumicks/pylake/force_calibration/tests/test_diode_models.py
+++ b/lumicks/pylake/force_calibration/tests/test_diode_models.py
@@ -40,6 +40,10 @@ def test_fit_fixed_pars(reference_models):
         np.testing.assert_allclose(fit.results["D"].value, 1.14632, 1e-6)
         assert "f_diode" not in fit.results
         assert "alpha" not in fit.results
+        assert not fit.fitted_diode
+        assert fit.fast_sensor
+        assert not fit.diode_frequency
+        assert not fit.diode_relaxation_factor
 
 
 def test_underfit_fast_sensor(reference_models):
@@ -80,6 +84,12 @@ def test_fixed_f_diode(model_params, fixed_params, free_params, reference_models
             np.testing.assert_allclose(fit.params[key].value, value, 1e-6)
         for key in fixed_params.keys():
             assert key not in fit.results
+
+        # Verify properties
+        assert fit.fitted_diode == ("alpha" in free_params or "f_diode" in free_params)
+        assert not fit.fast_sensor
+        np.testing.assert_allclose(fit.diode_frequency, 14000, rtol=1e-6)
+        np.testing.assert_allclose(fit.diode_relaxation_factor, 0.4, rtol=1e-6)
 
         # Fix to the wrong value (this should mess up the fit)
         bad_params = deepcopy(model_params)

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -111,6 +111,13 @@ def test_good_fit_integration(
     np.testing.assert_allclose(ps_calibration["alpha"].value, alpha, rtol=1e-4)
     np.testing.assert_allclose(ps_calibration["f_diode"].value, f_diode, rtol=1e-4)
 
+    np.testing.assert_allclose(ps_calibration["fc"].value, ps_calibration.corner_frequency)
+    np.testing.assert_allclose(ps_calibration["D"].value, ps_calibration.diffusion_constant_volts)
+    np.testing.assert_allclose(
+        ps_calibration["D"].value * ps_calibration["Rd"].value * ps_calibration["Rd"].value,
+        ps_calibration.diffusion_constant,
+    )
+
     gamma = sphere_friction_coefficient(viscosity, bead_diameter * 1e-6)
     kappa_true = 2.0 * np.pi * gamma * corner_frequency * 1e3
     boltzmann_temperature = sp.constants.k * sp.constants.convert_temperature(temperature, "C", "K")
@@ -124,6 +131,7 @@ def test_good_fit_integration(
     np.testing.assert_equal(ps_calibration.stiffness, ps_calibration["kappa"].value)
     np.testing.assert_equal(ps_calibration.displacement_sensitivity, ps_calibration["Rd"].value)
     np.testing.assert_equal(ps_calibration.force_sensitivity, ps_calibration["Rf"].value)
+    assert not ps_calibration.measured_drag_coefficient
 
     if loss_function == "gaussian":
         compare_to_reference_dict(
@@ -300,36 +308,38 @@ def test_calibration_results_params():
 
 def test_repr(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
+
     assert str(ps_calibration) == dedent(
         """\
-        Name                 Description                                               Value
-        -------------------  --------------------------------------------------------  -----------
-        Bead diameter        Bead diameter (um)                                        4.4
-        Viscosity            Liquid viscosity (Pa*s)                                   0.001002
-        Temperature          Liquid temperature (C)                                    20
-        Distance to surface  Distance from bead center to surface (um)
-        Max iterations       Maximum number of function evaluations                    10000
-        Fit tolerance        Fitting tolerance                                         1e-07
-        Points per block     Number of points per block                                100
-        Sample rate          Sample rate (Hz)                                          78125
-        Bias correction      Perform bias correction thermal fit                       0
-        Loss function        Loss function used during minimization                    gaussian
-        Rd                   Distance response (um/V)                                  7.25366
-        kappa                Trap stiffness (pN/nm)                                    0.171495
-        Rf                   Force response (pN/V)                                     1243.97
-        gamma_0              Theoretical bulk drag coefficient (kg/s)                  4.1552e-08
-        err_kappa            Stiffness Std Err (pN/V)                                  0.00841414
-        err_Rd               Distance response Std Err (um/V)                          0.125966
-        fc                   Corner frequency (Hz)                                     656.872
-        D                    Diffusion constant (V^2/s)                                0.00185126
-        err_fc               Corner frequency Std Err (Hz)                             32.2284
-        err_D                Diffusion constant Std Err (V^2/s)                        6.42974e-05
-        f_diode              Diode low-pass filtering roll-off frequency (Hz)          7936.51
-        alpha                Diode 'relaxation factor'                                 0.500609
-        err_f_diode          Diode low-pass filtering roll-off frequency Std Err (Hz)  561.715
-        err_alpha            Diode 'relaxation factor' Std Err                         0.0131406
-        chi_squared_per_deg  Chi squared per degree of freedom                         1.06378
-        backing              Statistical backing (%)                                   30.5705"""
+        Name                      Description                                               Value
+        ------------------------  --------------------------------------------------------  -----------
+        Bead diameter             Bead diameter (um)                                        4.4
+        Viscosity                 Liquid viscosity (Pa*s)                                   0.001002
+        Temperature               Liquid temperature (C)                                    20
+        Distance to surface       Distance from bead center to surface (um)
+        Hydrodynamically correct  Hydrodynamically correct model used (-)                   0
+        Max iterations            Maximum number of function evaluations                    10000
+        Fit tolerance             Fitting tolerance                                         1e-07
+        Points per block          Number of points per block                                100
+        Sample rate               Sample rate (Hz)                                          78125
+        Bias correction           Perform bias correction thermal fit                       0
+        Loss function             Loss function used during minimization                    gaussian
+        Rd                        Distance response (um/V)                                  7.25366
+        kappa                     Trap stiffness (pN/nm)                                    0.171495
+        Rf                        Force response (pN/V)                                     1243.97
+        gamma_0                   Theoretical bulk drag coefficient (kg/s)                  4.1552e-08
+        err_kappa                 Stiffness Std Err (pN/V)                                  0.00841414
+        err_Rd                    Distance response Std Err (um/V)                          0.125966
+        fc                        Corner frequency (Hz)                                     656.872
+        D                         Diffusion constant (V^2/s)                                0.00185126
+        err_fc                    Corner frequency Std Err (Hz)                             32.2284
+        err_D                     Diffusion constant Std Err (V^2/s)                        6.42974e-05
+        f_diode                   Diode low-pass filtering roll-off frequency (Hz)          7936.51
+        alpha                     Diode 'relaxation factor'                                 0.500609
+        err_f_diode               Diode low-pass filtering roll-off frequency Std Err (Hz)  561.715
+        err_alpha                 Diode 'relaxation factor' Std Err                         0.0131406
+        chi_squared_per_deg       Chi squared per degree of freedom                         1.06378
+        backing                   Statistical backing (%)                                   30.5705"""
     )
 
 


### PR DESCRIPTION
**Why this PR?**
It's about time we defined a unified calibration API that exposes (but also documents) all the relevant properties.

This PR adds almost all of the plumbing.

Previously, we always exposed the raw dictionary data for calibration items. This has lead to subtle differences between calibration items coming from Bluelake and ones performed by Pylake. In addition, many of the names of these dictionaries can be sort of cryptic if you are not intimately familiar with force calibration.

This commit adds an actual calibration API with properties that have human readable names for all the important parameters and results. In addition to that, there are extensive doc-strings now that describe what each parameter means. To make sure the items do not go out of sync again (and keep docstrings on both sides the same), the properties are defined in a mixin.

The dictionary key access is kept around for people that just want to directly interact with the raw data, but we could consider deprecating direct access once we hop to a next major version (although I don't really see a need to yet).

You can find the docs build [here](https://lumicks-pylake.readthedocs.io/en/all_the_properties/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html).