### PR TITLE
Bugfix: handle tuple of excluded ranges passed in

### DIFF
--- a/lumicks/pylake/force_calibration/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/power_spectrum.py
@@ -125,7 +125,7 @@ class PowerSpectrum:
 
         ps.frequency = ps.frequency[indices]
         ps.power = ps.power[indices]
-        ps._excluded_ranges = self._excluded_ranges + excluded_ranges
+        ps._excluded_ranges = self._excluded_ranges + list(excluded_ranges)
 
         if self._variance is not None:
             ps._variance = ps._variance[indices]


### PR DESCRIPTION
Came across this as I was trying to get a handle on calibration stuff for reviewing the other PRs. In the notebook, we pass in a `tuple`, which you can't use to extend a `list` and so you get an error

```
power_spectrum = lk.calculate_power_spectrum(
    volts.data,
    sample_rate=volts.sample_rate,
    fit_range=(1e2, 23e3),
    num_points_per_block=2000,
    excluded_ranges=([19348, 19668], [24308, 24548])
)
```