### PR TITLE
kymotrack: load photon counts from file

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,15 @@
 # Changelog
 
+## v1.5.2 | t.b.d.
+
+#### Bug fixes
+
+* Fixed bug that prevented opening the kymotracking widget when using it with the `widget` backend on `matplotlib >= 3.9.0`.
+* Fixed bug where photon counts were not being loaded from a csv file generated with the kymotracker.
+
 ## v1.5.1 | 2024-06-03
 
 * Fixed bug that prevented loading an `h5` file where only a subset of the photon channels are available. This bug was introduced in Pylake `1.4.0`.
-* Fixed bug that prevented opening the kymotracking widget when using it with the `widget` backend on `matplotlib >= 3.9.0`.
 
 ## v1.5.0 | 2024-05-28
 

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -34,6 +34,25 @@ def kymo_integration_test_data():
 
 
 @pytest.fixture
+def kymo_integration_tracks(kymo_integration_test_data):
+    track_coordinates = [
+        (np.arange(10, 20), np.full(10, 11)),
+        (np.arange(15, 25), np.full(10, 21.51)),
+    ]
+
+    tracks = KymoTrackGroup(
+        [
+            KymoTrack(
+                np.array(time_idx), np.array(position_idx), kymo_integration_test_data, "red", 0.1
+            )
+            for time_idx, position_idx in track_coordinates
+        ]
+    )
+
+    return tracks
+
+
+@pytest.fixture
 def kymo_pixel_calibrations():
     image = raw_test_data()
     background = np.random.uniform(1, 10, size=image.size).reshape(image.shape)

--- a/lumicks/pylake/kymotracker/tests/test_io.py
+++ b/lumicks/pylake/kymotracker/tests/test_io.py
@@ -1,7 +1,6 @@
 import io
 import re
 import inspect
-import contextlib
 from copy import copy
 from pathlib import Path
 
@@ -96,8 +95,9 @@ def test_kymotrackgroup_io(tmpdir_factory, dt, dx, delimiter, sampling_width, sa
         assert len([key for key in data.keys() if "counts" in key]) == 0
     else:
         count_field = [key for key in data.keys() if "counts" in key][0]
-        for track1, cnt in zip(tracks, data[count_field]):
+        for track1, imported_track, cnt in zip(tracks, imported_tracks, data[count_field]):
             np.testing.assert_allclose([sampling_outcome] * len(track1.coordinate_idx), cnt)
+            np.testing.assert_allclose(imported_track.photon_counts, cnt)
 
 
 def test_export_sources(tmpdir_factory):
@@ -128,7 +128,7 @@ def test_export_sources(tmpdir_factory):
     [[";", 0, True], [",", 0, True], [";", 1, True], [";", None, True]],
 )
 def test_roundtrip_without_file(
-    delimiter, sampling_width, correct_origin, kymo_integration_test_data
+    delimiter, sampling_width, correct_origin, kymo_integration_test_data, kymo_integration_tracks
 ):
     # Validate that this also works when providing a string handle (this is the API LV uses).
 
@@ -137,43 +137,67 @@ def test_roundtrip_without_file(
 
     # This helps us ensure that if we get additional arguments to this function, we don't forget to
     # add them to the parametrization here.
-    assert set(get_args(KymoTrackGroup.save)[2:]) == set(get_args(test_roundtrip_without_file)[:-1])
-
-    track_coordinates = [
-        ((1, 2, 3), (2, 3, 4)),
-        ((2, 3, 4), (3, 4, 5)),
-        ((3, 4, 5), (4, 5, 6)),
-        ((4, 5, 6), (5, 6, 7)),
-    ]
-
-    tracks = KymoTrackGroup(
-        [
-            KymoTrack(
-                np.array(time_idx), np.array(position_idx), kymo_integration_test_data, "red", 0.1
-            )
-            for time_idx, position_idx in track_coordinates
-        ]
-    )
+    assert set(get_args(KymoTrackGroup.save)[2:]) == set(get_args(test_roundtrip_without_file)[:-2])
 
     with io.StringIO() as s:
-        tracks.save(
+        kymo_integration_tracks.save(
             s, delimiter=delimiter, sampling_width=sampling_width, correct_origin=correct_origin
         )
         string_representation = s.getvalue()
 
     with io.StringIO(string_representation) as s:
         read_tracks = import_kymotrackgroup_from_csv(
-            s, kymo_integration_test_data, "green", delimiter=delimiter
+            s, kymo_integration_test_data, "red", delimiter=delimiter
         )
 
-    compare_kymotrack_group(tracks, read_tracks)
+    compare_kymotrack_group(kymo_integration_tracks, read_tracks)
+
+
+def test_photon_count_validation(kymo_integration_test_data, kymo_integration_tracks):
+    with io.StringIO() as s:
+        kymo_integration_tracks.save(s, sampling_width=0, correct_origin=False)
+        biased_tracks = s.getvalue()
+
+    with io.StringIO() as s:
+        kymo_integration_tracks.save(s, sampling_width=0, correct_origin=True)
+        good_tracks = s.getvalue()
+
+    with pytest.warns(
+        RuntimeWarning,
+        match="origin of a pixel to be at the edge rather than the center of the pixel",
+    ):
+        _ = import_kymotrackgroup_from_csv(
+            io.StringIO(biased_tracks), kymo_integration_test_data, "red"
+        )
+
+    # We can also fail by having the wrong kymo
+    with pytest.warns(
+        RuntimeWarning,
+        match="loaded kymo or channel doesn't match the one used to create this file",
+    ):
+        _ = import_kymotrackgroup_from_csv(
+            io.StringIO(good_tracks), kymo_integration_test_data, "green"
+        )
+
+    # Or by having the wrong one where it actually completely fails to sample. This tests whether
+    # the exception inside import_kymotrackgroup_from_csv is correctly caught and handled
+    with pytest.warns(
+        RuntimeWarning,
+        match="loaded kymo or channel doesn't match the one used to create this file",
+    ):
+        _ = import_kymotrackgroup_from_csv(
+            io.StringIO(good_tracks), kymo_integration_test_data[:"1s"], "red"
+        )
+
+    # Control for good tracks
+    import_kymotrackgroup_from_csv(io.StringIO(good_tracks), kymo_integration_test_data, "red")
 
 
 @pytest.mark.parametrize(
     "version, read_with_version",
     [[0, False], [1, False], [2, True], [3, True], [4, True]],
 )
-def test_csv_version(version, read_with_version):
+def test_csv_version(version, read_with_version, recwarn):
     # Test that header is parsed properly on CSV import
     # Version 2 has 2 header lines, <2 only has 1 header line
 
@@ -198,14 +222,15 @@ def test_csv_version(version, read_with_version):
     )
 
     testfile = Path(__file__).parent / f"./data/tracks_v{version}.csv"
-    with pytest.warns(
-        RuntimeWarning,
-        match=(
-            "This CSV file is from a version in which the minimum observable track duration "
-            "was incorrectly rounded to an integer."
-        ),
-    ) if version == 3 else contextlib.nullcontext():
-        imported_tracks = import_kymotrackgroup_from_csv(testfile, kymo, "red", delimiter=";")
+    imported_tracks = import_kymotrackgroup_from_csv(testfile, kymo, "red", delimiter=";")
+
+    match version:
+        case 3:
+            assert "minimum observable track duration" in str(recwarn[0].message)
+        case 4:
+            assert "loaded kymo or channel doesn't match the one used to create this file" in str(
+                recwarn[0].message
+            )
 
     data, pylake_version, csv_version = _read_txt(testfile, ";")
 
@@ -229,7 +254,12 @@ def test_bad_csv(filename, blank_kymo):
 def test_min_obs_csv_regression(tmpdir_factory, blank_kymo):
     """This tests a regression where saving a freshly imported older file does not function"""
     testfile = Path(__file__).parent / f"./data/tracks_v0.csv"
-    imported_tracks = import_kymotrackgroup_from_csv(testfile, blank_kymo, "red", delimiter=";")
+    with pytest.warns(
+        RuntimeWarning,
+        match="loaded kymo or channel doesn't match the one used to create this file",
+    ):
+        imported_tracks = import_kymotrackgroup_from_csv(testfile, blank_kymo, "red", delimiter=";")
+
     out_file = f"{tmpdir_factory.mktemp('pylake')}/no_min_lengths.csv"
 
     err_msg = "Loaded tracks have no minimum length metadata defined"


### PR DESCRIPTION
**Why this PR?**
This makes sure the `photon_counts` field is populated when loading a file and issues a warning if something unexpected happens.

Edit: Doh! When merging the last bugfix, I made changes back in time in the changelog. I just fixed that in this PR.