### PR TITLE
tracker: allow widget backend

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## v1.5.1 | 2024-06-03
 
 * Fixed bug that prevented loading an `h5` file where only a subset of the photon channels are available. This bug was introduced in Pylake `1.4.0`.
+* Fixed bug that prevented opening the kymotracking widget when using it with the `widget` backend on `matplotlib >= 3.9.0`.
 
 ## v1.5.0 | 2024-05-28
 

--- a/lumicks/pylake/nb_widgets/kymotracker_widgets.py
+++ b/lumicks/pylake/nb_widgets/kymotracker_widgets.py
@@ -418,13 +418,17 @@ class KymoWidget:
         import matplotlib.pyplot as plt
         from IPython.display import display
 
-        if not max([backend in plt.get_backend() for backend in ("nbAgg", "ipympl")]):
+        if not max(
+            # Note: Some, but not all versions of matplotlib lower the backend names. Hence, we
+            # always lower them to be on the safe side.
+            [backend in plt.get_backend().lower() for backend in ("nbagg", "ipympl", "widget")]
+        ):
             raise RuntimeError(
                 (
                     "Please enable an interactive matplotlib backend for this plot to work. In "
                     "jupyter notebook or lab you can do this by invoking either "
-                    "%matplotlib widget. Please note that you may have to restart the notebook "
-                    "kernel for this to work."
+                    "%matplotlib widget or %matplotlib ipympl. Please note that you may have to "
+                    "restart the notebook kernel for this to work."
                 )
             )
 


### PR DESCRIPTION
**Why this PR?**
The widget won't open on versions of `matplotlib` later than 3.9, since the magic `%matplotlib widget` now returns the widget name `widget` rather than `ipympl`. In addition, it seems that 3.9 [lowercases](https://github.com/matplotlib/matplotlib/pull/27948) all the backend names, but older ones didn't, so I decided to do that defensively in our check too.

I've added a second option for a magic, since in this case, if we had had this in the error message, the user would have likely found `%matplotlib ipympl` to be functional (it does work already in 3.9.0).