### PR TITLE
testing: add small script to test notebooks we ship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 venv/
 docs/changelog.md
 docs/_api/
+nb_test/
 
 __pycache__/
 *.py[cod]

--- a/docs/run_notebooks.py
+++ b/docs/run_notebooks.py
@@ -1,11 +1,12 @@
 import io
 import os
-import sys
+import json
+import time
 import pathlib
+import argparse
 import warnings
 import traceback
-from json import load
-from contextlib import redirect_stderr, redirect_stdout, contextmanager
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -25,7 +26,7 @@ def execute_notebook(nb_test_dir, filename):
     os.environ["JUPYTER_PLATFORM_DIRS"] = "1"
 
     with open(filename) as fp:
-        nb = load(fp)
+        nb = json.load(fp)
 
     mpl.use("agg")  # Use a non-interactive backend
 
@@ -39,7 +40,60 @@ def execute_notebook(nb_test_dir, filename):
                     plt.close("all")
 
 
-def run_notebooks(include_list):
+def read_report(filename):
+    """Reads a dictionary from a file"""
+    if not filename.is_file():
+        return {}
+
+    try:
+        with open(filename, "r") as f:
+            return json.load(f)
+    except json.decoder.JSONDecodeError:
+        return {}
+
+
+def process_notebook(notebook, report, nb_test_dir):
+    """Process a single notebook and return a report on it
+
+    Parameters
+    ----------
+    notebook : pathlib.Path
+        Filename of a notebook
+    report : dict
+        Dictionary with notebook results
+    nb_test_dir : pathlib.Path
+        Path to the testing directory.
+    """
+    finished_success = report.get("result", "") == "success"
+
+    if finished_success:
+        print(f"Skipping notebook: {notebook} (already successful)")
+    else:
+        print(f"Testing notebook: {notebook}")
+
+        try:
+            tic = time.time()
+            execute_notebook(nb_test_dir, notebook)
+            report["time"] = f"{time.time() - tic:.2f}"
+        except Exception as e:
+            print("\nAn exception was raised:\n")
+            print(f"   {e}\n")
+            print(traceback.format_exc())
+
+            report["result"] = str(e)
+        else:
+            report["result"] = "success"
+
+    return report
+
+
+def run_notebooks(include_list, reset_cache):
+    """Run all notebooks
+
+    Parameters
+    ----------
+    include_list : List[str]
+    """
     exclude_list = [
         "nbwidgets",  # Exclude the notebook widgets since those require interaction
         "cas9_kymotracking",
@@ -48,6 +102,9 @@ def run_notebooks(include_list):
     base_dir = pathlib.Path(__file__).parent.parent.resolve()
     nb_test_dir = base_dir / "nb_test"
     os.makedirs(nb_test_dir, exist_ok=True)
+
+    report_file = nb_test_dir / "test_report.txt"
+
     print(f"Output folder: {nb_test_dir}")
     notebook_folder = base_dir / "build" / "html" / "nbexport"
 
@@ -70,27 +127,62 @@ def run_notebooks(include_list):
         "ignore",
         message="Maximum iterations reached! Reverting to two-point OLS.",  # kymotracking
     )
+    warnings.filterwarnings(
+        "ignore",
+        message="Polyfit may be poorly conditioned",  # piezotracking
+    )
 
-    for root, _, files in os.walk(notebook_folder):
-        root = pathlib.Path(root)
-        notebooks = [f for f in files if pathlib.Path(f).suffix == ".ipynb"]
+    data = {} if reset_cache else read_report(report_file)
 
-        for nb_file in notebooks:
-            notebook = root / pathlib.Path(nb_file)
+    try:
+        for root, _, files in os.walk(notebook_folder):
+            root = pathlib.Path(root)
+            notebooks = [f for f in files if pathlib.Path(f).suffix == ".ipynb"]
 
-            excluded = any(ex in str(notebook) for ex in exclude_list)
-            included = not include_list or any(inc in str(notebook) for inc in include_list)
+            for nb_file in notebooks:
+                notebook = root / nb_file
 
-            if not excluded and included:
-                print(f"Testing notebook: {notebook}")
+                excluded = any(ex in str(notebook) for ex in exclude_list)
+                included = not include_list or any(inc in str(notebook) for inc in include_list)
 
-                try:
-                    execute_notebook(nb_test_dir, notebook)
-                except Exception as e:
-                    print("\nAn exception was raised:\n")
-                    print(f"   {str(e)}\n")
-                    print(traceback.format_exc())
+                report = data[nb_file] if nb_file in data else {}
+                if not excluded and included:
+                    process_notebook(notebook, report, nb_test_dir)
+
+                data[nb_file] = report
+    finally:
+        with open(report_file, "w") as f:
+            json.dump(data, f, indent=4)
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        prog="run_notebooks",
+        description="Runs python notebooks from the docs. Considering these notebooks take a while "
+        "to run, this script maintains a list of notebooks already run. To rerun all notebooks, "
+        "specify the commandline option --reset.",
+    )
+    parser.add_argument(
+        "-n",
+        "--notebooks",
+        required=False,
+        default=[],
+        nargs="+",
+        help="Run these notebooks specifically (ignored whether they have already been run)",
+    )
+    parser.add_argument(
+        "-r",
+        "--reset",
+        default=False,
+        required=False,
+        nargs="?",
+        const=True,
+        help="Reset list of processed notebooks before starting",
+    )
+
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
-    run_notebooks(sys.argv[1:])
+    options = parse_arguments()
+    run_notebooks(options.notebooks, options.reset)

--- a/docs/run_notebooks.py
+++ b/docs/run_notebooks.py
@@ -1,0 +1,96 @@
+import io
+import os
+import sys
+import pathlib
+import warnings
+import traceback
+from json import load
+from contextlib import redirect_stderr, redirect_stdout, contextmanager
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+
+@contextmanager
+def with_cwd(directory):
+    old_directory = os.getcwd()
+    os.chdir(directory)
+    try:
+        yield
+    finally:
+        os.chdir(old_directory)
+
+
+def execute_notebook(nb_test_dir, filename):
+    os.environ["JUPYTER_PLATFORM_DIRS"] = "1"
+
+    with open(filename) as fp:
+        nb = load(fp)
+
+    mpl.use("agg")  # Use a non-interactive backend
+
+    with with_cwd(nb_test_dir):
+        notebook_state = {}
+        for cell in nb["cells"]:
+            if cell["cell_type"] == "code":
+                source = "".join(line for line in cell["source"] if not line.startswith("%"))
+                with redirect_stdout(io.StringIO()) as _, redirect_stderr(io.StringIO()) as _:
+                    exec(source, notebook_state, notebook_state)
+                    plt.close("all")
+
+
+def run_notebooks(include_list):
+    exclude_list = [
+        "nbwidgets",  # Exclude the notebook widgets since those require interaction
+        "cas9_kymotracking",
+        "checkpoints",  # Don't want any checkpoint files in here
+    ]
+    base_dir = pathlib.Path(__file__).parent.parent.resolve()
+    nb_test_dir = base_dir / "nb_test"
+    os.makedirs(nb_test_dir, exist_ok=True)
+    print(f"Output folder: {nb_test_dir}")
+    notebook_folder = base_dir / "build" / "html" / "nbexport"
+
+    if not notebook_folder.exists():
+        raise FileNotFoundError(
+            f"Could not find notebook folder at {notebook_folder}. Are you on the root pylake "
+            f"folder and did you compile the docs? Please see docs/readme.md for instructions on "
+            f"how to compile the docs."
+        )
+
+    warnings.filterwarnings("error")  # Treat warnings as errors
+    warnings.filterwarnings(
+        "ignore", message="FigureCanvasAgg is non-interactive, and thus cannot be shown"
+    )  # we know
+    warnings.filterwarnings(
+        "ignore",
+        message="Warning: Step size set to minimum step size.",  # fd-fitting
+    )
+    warnings.filterwarnings(
+        "ignore",
+        message="Maximum iterations reached! Reverting to two-point OLS.",  # kymotracking
+    )
+
+    for root, _, files in os.walk(notebook_folder):
+        root = pathlib.Path(root)
+        notebooks = [f for f in files if pathlib.Path(f).suffix == ".ipynb"]
+
+        for nb_file in notebooks:
+            notebook = root / pathlib.Path(nb_file)
+
+            excluded = any(ex in str(notebook) for ex in exclude_list)
+            included = not include_list or any(inc in str(notebook) for inc in include_list)
+
+            if not excluded and included:
+                print(f"Testing notebook: {notebook}")
+
+                try:
+                    execute_notebook(nb_test_dir, notebook)
+                except Exception as e:
+                    print("\nAn exception was raised:\n")
+                    print(f"   {str(e)}\n")
+                    print(traceback.format_exc())
+
+
+if __name__ == "__main__":
+    run_notebooks(sys.argv[1:])

--- a/release.md
+++ b/release.md
@@ -19,6 +19,8 @@ Within the Pylake repo dir:
   - `git diff v<previous_release_version_number> setup.py` to check changed dependencies.
   - Check availability of package versions on [anaconda](https://anaconda.org/) in the channel `anaconda` and `conda-forge`.
 - Run `pytest` with `pytest --runpreflight --runslow ./lumicks/pylake` and verify that all tests pass (none may be skipped).
+- Build the docs (see `docs/readme.md`) and verify that they build without warnings.
+- Run the notebook testing script with `python docs/run_notebooks.py --reset`. The reset flag removes the cached results. If a notebook runs into an error, you fix it, rebuild the docs and then you can rerun the script without `--reset` to run only those that failed previously.
 - Push to origin, create a PR targeting the `release/X.Y` branch, wait until all checks have passed and merge.
 
 ## Releasing


### PR DESCRIPTION
**Why this PR?**
This is a little Friday afternoon project. It's happened more than once that notebooks we ship broke or used deprecated API. Considering how our collection of notebooks is growing (and expected to grow further), I think we need some sort of semi-automated solution to catch these problems. I did have a quick look at [galata](https://github.com/jupyterlab/jupyterlab/tree/main/galata), but I feel that for what we are doing here it is overkill for now.

Running this little script before release should prevent that.

Basically, you just run it from the command line _after_ building the docs:

`python docs/run_notebooks.py --reset`

It caches which notebooks already passed, so rerunning it without `reset` only reruns the needed ones.

`python docs/run_notebooks.py`

Finally, if you do find issues, you can copy the current versions of the notebooks in the built docs folder such that you can debug them where the files are:

`python docs/run_notebooks.py --copy`

Do note that it fetches the notebooks from the built docs folder and expects them to be built in the usual folder (`build/html`).

**Why did you not makes this part of CI testing?**
It is much too slow to put on `ci` (and pulls in far too much data). I think it makes much more sense to just run these integration tests once manually prior to each release we do.

Considering it downloads a whole bunch of files from Zenodo (and the total size is bulky), I would recommend just keeping the folder it makes around. It is on the ignore list, so it shouldn't be a problem.

Note:  While doing this, I noticed some of the notebooks did not ship with the data, so I will be opening a [second PR](https://github.com/lumicks/pylake/pull/671) where I fix them up.