### PR TITLE
Emulate numeric types for parameter classes

### DIFF
--- a/lumicks/pylake/detail/tests/test_value.py
+++ b/lumicks/pylake/detail/tests/test_value.py
@@ -1,0 +1,210 @@
+import math
+import operator
+
+import numpy as np
+import pytest
+
+from lumicks.pylake.detail.value import ValueMixin
+
+
+class Parameter(ValueMixin):
+    def __init__(self, value, description):
+        super().__init__(value)
+        self.description = description
+
+
+class BadParameter(ValueMixin):
+    def __init__(self, description):
+        self.description = description
+
+
+operators = {
+    operator.add,
+    operator.sub,
+    operator.mul,
+    operator.truediv,
+    operator.floordiv,
+    operator.mod,
+    divmod,
+    operator.pow,
+    operator.and_,
+    operator.or_,
+    operator.xor,
+}
+
+
+def test_mixin():
+    a = Parameter(2, "two")
+    a + 2
+
+    b = BadParameter("two")
+    with pytest.raises(AttributeError, match="'BadParameter' object has no attribute 'value'"):
+        b + 2
+
+
+def test_operators():
+    a = Parameter(a0 := 5, "five")
+    b = Parameter(b0 := 8, "eight")
+
+    for op in operators:
+        assert op(a0, 2) == op(a, 2)
+        assert op(2, a0) == op(2, a)
+        assert op(a0, b0) == op(a, b)
+        assert op(b0, a0) == op(b, a)
+
+
+def test_comparisons():
+    a = Parameter(5, "five")
+
+    assert a == 5
+    assert 5 == a
+
+    assert a != 4
+    assert 4 != a
+
+    assert a < 10
+    assert 10 > a
+
+    assert a > 2
+    assert 2 < a
+
+    assert a >= 5
+    assert 5 >= a
+    assert a <= 5
+    assert 5 <= a
+
+
+def test_operators_str():
+    a = Parameter(a0 := "a", "alpha")
+    b = Parameter(b0 := "b", "beta")
+
+    assert a0 + "c" == a + "c"
+    assert "c" + a0 == "c" + a
+    assert a0 + b0 == a + b
+    assert a0 * 5 == a * 5
+    assert a0 * 5 == a * Parameter(5, "five")
+    assert a0 * Parameter(5, "five") == a * 5
+
+    assert a == "a"
+
+    with pytest.raises(TypeError, match="not all arguments converted during string formatting"):
+        a % 1
+
+    assert "Hello, venus" == Parameter("Hello, %s", "fmt") % "venus"
+
+    for c in (1, "c", True):
+        for op in operators - {operator.add, operator.mul, operator.mod}:
+            with pytest.raises(TypeError):
+                op(a, c)
+
+
+def test_operators_bool():
+    a = Parameter(a0 := True, "true")
+
+    for op in operators:
+        assert op(a0, True) == op(a, True)
+        assert op(False, a0) == op(False, a)
+
+
+def test_not_implemented_operators():
+    a = Parameter(a0 := 2, "two")
+
+    for op in (operator.lshift, operator.rshift):
+        with pytest.raises(TypeError):
+            op(a, 2)
+        with pytest.raises(TypeError):
+            op(2, a)
+
+    # __matmul__ has not been specifically implemented, but it still works
+    A0 = np.array([[1, a0], [3, 4]])
+    A = np.array([[1, a], [3, 4]])
+    B0 = np.array([[11, 12], [13, 14]])
+    np.testing.assert_equal(A @ B0, A0 @ B0)
+
+    with pytest.raises(ValueError, match="matmul: Input operand 1 does not have enough dimensions"):
+        A @ 2
+
+    with pytest.raises(ValueError, match="matmul: Input operand 0 does not have enough dimensions"):
+        2 @ A
+
+    # not directly implemented but default fallback means it still works
+    assert isinstance(a, Parameter)
+    a0 += 4
+    a += 4
+    assert a0 == a
+    assert isinstance(a, int)
+
+    a = Parameter(a0 := 2, "two")
+    b = a
+    a += 4
+    assert a0 + 4 == a
+    assert a0 == b
+
+
+def test_casting():
+    a = Parameter(a0 := 2, "two")
+    assert float(a0) == float(a)
+
+    b = Parameter(b0 := 3.14, "pi")
+    assert int(b0) == int(b)
+
+    assert complex(a0) == complex(a)
+    assert complex(b0) == complex(b)
+    assert complex(a0, 2.1) == complex(a, 2.1)
+    assert complex(b0, 2.1) == complex(b, 2.1)
+
+
+def test_none():
+    a = Parameter(None, "none")
+    assert not a
+    assert a == None
+
+    with pytest.raises(AssertionError):
+        assert a is None
+
+
+def test_math():
+    a = Parameter(a0 := 2, "two")
+    assert -a0 == -a
+
+    b = Parameter(b0 := -2, "two")
+    assert +b0 == +b
+
+    assert abs(b0) == abs(b)
+
+    p = Parameter(p0 := 3.141592, "pi")
+    assert round(p0) == round(p)
+    assert round(p0, 3) == round(p, 3)
+
+    assert math.trunc(p0) == math.trunc(p)
+    assert math.floor(p0) == math.floor(p)
+    assert math.ceil(p0) == math.ceil(p)
+
+    assert max(a, b) == max(a0, b0)
+    assert min(a, b) == min(a0, b0)
+
+
+def test_numpy():
+    a = Parameter(a0 := 5, "five")
+    arr = np.arange(3) + 1
+
+    for op in operators:
+        np.testing.assert_equal(op(arr, a), op(arr, a0))
+        np.testing.assert_equal(op(a, arr), op(a0, arr))
+
+    arr = np.array([1, 2, a])
+    assert all([not isinstance(j, Parameter) for j in arr])
+    assert all([not isinstance(j, Parameter) for j in arr * a0])
+    assert all([not isinstance(j, Parameter) for j in arr * a])
+
+    np.testing.assert_allclose(a, a0)
+    np.testing.assert_almost_equal(a, a0)
+    with pytest.raises(AssertionError):
+        np.testing.assert_equal(a, a0)
+
+    assert np.sqrt(a) == np.sqrt(a0)
+    assert np.exp(a) == np.exp(a0)
+
+    # forward extra arguments to __array__()
+    b = np.asarray(a, dtype=float)
+    assert isinstance(b, np.ndarray)

--- a/lumicks/pylake/detail/value.py
+++ b/lumicks/pylake/detail/value.py
@@ -1,0 +1,173 @@
+import math
+
+import numpy as np
+
+
+class ValueMixin:
+    """Mixin class to emulate numeric types. Requires a `value` attribute on the subclass.
+
+    Follows the description for Emulating Numeric Types:
+    (https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types)
+
+    The returned type is always a primitive type, since the metadata stored in subclasses of this
+    mixin cannot be guaranteed to still be accurate after any operation on the value.
+
+    Note: cannot be used in combination with dataclass, which overrides the  `==` operator.
+
+    Operators will work for `str` and `bool` types stored in the `value` attribute;
+    however full behavior/methods for these types are not tested or guaranteed to work as expected.
+    """
+
+    def __init__(self, value):
+        self.value = value
+
+    @staticmethod
+    def extract_value(method):
+        def wrapper(self, other):
+            if isinstance(other, ValueMixin):
+                other = other.value
+
+            return method(self, other)
+
+        return wrapper
+
+    @extract_value
+    def __add__(self, other):
+        return self.value + other
+
+    @extract_value
+    def __sub__(self, other):
+        return self.value - other
+
+    @extract_value
+    def __mul__(self, other):
+        return self.value * other
+
+    @extract_value
+    def __truediv__(self, other):
+        return self.value / other
+
+    @extract_value
+    def __floordiv__(self, other):
+        return self.value // other
+
+    @extract_value
+    def __mod__(self, other):
+        return self.value % other
+
+    @extract_value
+    def __divmod__(self, other):
+        return divmod(self.value, other)
+
+    @extract_value
+    def __pow__(self, other):
+        return self.value**other
+
+    @extract_value
+    def __and__(self, other):
+        return self.value & other
+
+    @extract_value
+    def __xor__(self, other):
+        return self.value ^ other
+
+    @extract_value
+    def __or__(self, other):
+        return self.value | other
+
+    @extract_value
+    def __radd__(self, other):
+        return other + self.value
+
+    @extract_value
+    def __rsub__(self, other):
+        return other - self.value
+
+    @extract_value
+    def __rmul__(self, other):
+        return other * self.value
+
+    @extract_value
+    def __rtruediv__(self, other):
+        return other / self.value
+
+    @extract_value
+    def __rfloordiv__(self, other):
+        return other // self.value
+
+    @extract_value
+    def __rmod__(self, other):
+        return other % self.value
+
+    @extract_value
+    def __rdivmod__(self, other):
+        return divmod(other, self.value)
+
+    @extract_value
+    def __rpow__(self, other):
+        return other**self.value
+
+    @extract_value
+    def __rand__(self, other):
+        return other & self.value
+
+    @extract_value
+    def __rxor__(self, other):
+        return other ^ self.value
+
+    @extract_value
+    def __ror__(self, other):
+        return other | self.value
+
+    def __array__(self, *args, **kwargs):
+        return np.array(self.value, *args, **kwargs)
+
+    def __float__(self):
+        return float(self.value)
+
+    def __int__(self):
+        return int(self.value)
+
+    def __bool__(self):
+        return bool(self.value)
+
+    def __neg__(self):
+        return -self.value
+
+    def __pos__(self):
+        return +self.value
+
+    def __abs__(self):
+        return abs(self.value)
+
+    def __round__(self, ndigits=None):
+        return round(self.value, ndigits)
+
+    def __trunc__(self):
+        return math.trunc(self.value)
+
+    def __ceil__(self):
+        return math.ceil(self.value)
+
+    def __floor__(self):
+        return math.floor(self.value)
+
+    @extract_value
+    def __eq__(self, other):
+        return self.value == other
+
+    @extract_value
+    def __lt__(self, other):
+        return self.value < other
+
+    @extract_value
+    def __gt__(self, other):
+        return self.value > other
+
+    @extract_value
+    def __le__(self, other):
+        return self.value <= other
+
+    @extract_value
+    def __ge__(self, other):
+        return self.value >= other


### PR DESCRIPTION
**Why this PR?**

We have some parameter classes (`CalibrationParameter` and Fd-fitting `Parameter`) which hold metadata about the parameter (description, unit, etc...) along with a value. Currently, to use these types in any sort of arithmetic you have to specifically request the `value` attribute

```
result = array * parameter.value
```

Using this mixin allows for a simpler syntax while maintaining the useful metadata
```
result = array * parameter
```

This PR focuses on implementing the necessary dunder methods as described in [Emulating Numeric Types](https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types) and tests (there are a lot of possibilities here, so suggestions on extra tests or things I've missed are very welcome). Following PRs will apply this mixin to the appropriate parameter classes.