### PR TITLE
scan: allow loading truncated scans

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## v1.5.2 | t.b.d.
 
+#### Improvements
+
+* Added a fallback which allows loading scans or kymographs that have truncated photon count channels.
+
 #### Bug fixes
 
 * Fixed bug that prevented opening the kymotracking widget when using it with the `widget` backend on `matplotlib >= 3.9.0`.

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -849,6 +849,14 @@ class Empty:
     def timestamps(self) -> npt.ArrayLike:
         return np.empty(0)
 
+    @property
+    def start(self):
+        return None
+
+    @property
+    def stop(self):
+        return None
+
 
 empty_slice = Slice(Empty())
 


### PR DESCRIPTION
**Why this PR?**
It seems that in some rare conditions, we see some truncated confocal kymos. While we should solve this upstream, the fact that these were generated means that we should likely provide a fallback option for opening them.