### PR TITLE
tools: small fix to `run_notebooks`

### DIFF
--- a/docs/run_notebooks.py
+++ b/docs/run_notebooks.py
@@ -106,12 +106,13 @@ def run_notebooks(include_list, reset_cache, only_copy):
     ]
     base_dir = pathlib.Path(__file__).parent.parent.resolve()
     nb_test_dir = base_dir / "nb_test"
+    nb_source_folder_name = "nbexport"
     os.makedirs(nb_test_dir, exist_ok=True)
 
     report_file = nb_test_dir / "test_report.txt"
 
     print(f"Output folder: {nb_test_dir}")
-    notebook_folder = base_dir / "build" / "html" / "nbexport"
+    notebook_folder = base_dir / "build" / "html" / nb_source_folder_name
 
     if not notebook_folder.exists():
         raise FileNotFoundError(
@@ -147,19 +148,21 @@ def run_notebooks(include_list, reset_cache, only_copy):
 
             for nb_file in notebooks:
                 notebook = pathlib.Path(root) / nb_file
+                start_point = notebook.parts.index(nb_source_folder_name)
+                notebook_name = "-".join(notebook.parts[start_point + 1 :])
 
                 if only_copy:
-                    copyfile(notebook, base_dir / nb_test_dir / notebook.name)
+                    copyfile(notebook, base_dir / nb_test_dir / notebook_name)
                     continue
 
                 excluded = any(ex in str(notebook) for ex in exclude_list)
                 included = not include_list or any(inc in str(notebook) for inc in include_list)
 
-                report = data[nb_file] if nb_file in data else {}
+                report = data[notebook_name] if notebook_name in data else {}
                 if not excluded and included:
                     process_notebook(notebook, report, nb_test_dir)
 
-                data[nb_file] = report
+                data[notebook_name] = report
     finally:
         with open(report_file, "w") as f:
             json.dump(data, f, indent=4)

--- a/docs/run_notebooks.py
+++ b/docs/run_notebooks.py
@@ -53,7 +53,7 @@ def read_report(filename):
         return {}
 
 
-def process_notebook(notebook, report, nb_test_dir):
+def process_notebook(notebook, report, nb_test_dir, force_run):
     """Process a single notebook and return a report on it
 
     Parameters
@@ -64,10 +64,12 @@ def process_notebook(notebook, report, nb_test_dir):
         Dictionary with notebook results
     nb_test_dir : pathlib.Path
         Path to the testing directory.
+    force_run : bool
+        Force this one to re-run.
     """
     finished_success = report.get("result", "") == "success"
 
-    if finished_success:
+    if finished_success and not force_run:
         print(f"Skipping notebook: {notebook} (already successful)")
     else:
         print(f"Testing notebook: {notebook}")
@@ -156,11 +158,12 @@ def run_notebooks(include_list, reset_cache, only_copy):
                     continue
 
                 excluded = any(ex in str(notebook) for ex in exclude_list)
-                included = not include_list or any(inc in str(notebook) for inc in include_list)
+                force_included = any(inc in str(notebook) for inc in include_list)
+                included = not include_list or force_included
 
                 report = data[notebook_name] if notebook_name in data else {}
                 if not excluded and included:
-                    process_notebook(notebook, report, nb_test_dir)
+                    process_notebook(notebook, report, nb_test_dir, force_included)
 
                 data[notebook_name] = report
     finally:


### PR DESCRIPTION
**Why this PR?**
I didn't realize this, but we use the same filenames quite frequently. This silently makes the checker skip these files. This commit fixes that by encoding the relevant part of the path in the name used in both the report and the target filename in case of a `--copy`.

I also added two quality of life features.
- If you run this script with `-n specific_notebook.ipynb`, it force runs it (despite it having passed before).
- It now checks a hash whether a notebook changed, and if it did, it will rerun it even if the last run was a success (this should have probably been the behavior initially).