### PR TITLE
fdfitter: fix inversion for the scalar case

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.5.3 | t.b.d.
+
+#### Bug fixes
+
+* Fixed a bug where an inverted force-distance [`Model`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.fitting.model.Model.html) would raise when called with a scalar value. Now it just returns the expected value.
+
 ## v1.5.2 | 2024-07-24
 
 #### Improvements

--- a/lumicks/pylake/fitting/detail/derivative_manipulation.py
+++ b/lumicks/pylake/fitting/detail/derivative_manipulation.py
@@ -42,7 +42,10 @@ def inversion_functions(model_function, f_min, f_max, derivative_function, tol):
         return single_estimate.x[0]
 
     def manual_inversion(distances, initial_guess):
-        """Invert the dependent and independent variable for a list"""
+        """Invert the dependent and independent variable"""
+        if distances.ndim == 0:
+            return fit_single(distances, initial_guess)
+
         return np.array([fit_single(distance, initial_guess) for distance in distances])
 
     return manual_inversion, fit_single

--- a/lumicks/pylake/fitting/model.py
+++ b/lumicks/pylake/fitting/model.py
@@ -161,10 +161,25 @@ class Model:
             Values for the independent parameter
         params : Params | Dict[float | Parameter]
             Model parameters
+
+        Raises
+        ------
+        ValueError
+            if values for the independent variable are provided that are not a scalar or one
+            dimensional array or list.
+        KeyError
+            if some model parameters required for simulation are missing from the supplied
+            params dictionary.
         """
         independent = np.asarray(independent, dtype=np.float64)
-        missing_parameters = set(self.parameter_names) - set(params.keys())
-        if missing_parameters:
+
+        if independent.ndim > 1:
+            raise TypeError(
+                "Only 0- or 1-dimensional arrays are supported for the independent variable, "
+                f"got {independent.ndim}"
+            )
+
+        if missing_parameters := set(self.parameter_names) - set(params.keys()):
             raise KeyError(
                 f"The following missing parameters must be specified to simulate the "
                 f"model: {missing_parameters}."

--- a/lumicks/pylake/fitting/tests/test_model_sim.py
+++ b/lumicks/pylake/fitting/tests/test_model_sim.py
@@ -41,8 +41,11 @@ def test_model_calls():
     def model_function(x, b, c, d):
         return b + c * x + d * x * x
 
+    def model_derivative(x, b, c, d):
+        return c + 2 * d * x
+
     t = np.array([1.0, 2.0, 3.0])
-    model = Model("m", model_function)
+    model = Model("m", model_function, derivative=model_derivative)
     y_ref = model._raw_call(t, [2.0, 3.0, 4.0])
 
     np.testing.assert_allclose(
@@ -60,12 +63,23 @@ def test_model_calls():
         y_ref,
     )
 
-    np.testing.assert_allclose(
-        model(t, Params(**{"m/d": Parameter(4), "m/c": Parameter(3), "m/b": Parameter(2)})), y_ref
-    )
+    params = Params(**{"m/d": Parameter(4), "m/c": Parameter(3), "m/b": Parameter(2)})
+    np.testing.assert_allclose(model(t, params), y_ref)
+    np.testing.assert_allclose(model(t[0], params), y_ref[0])
+    np.testing.assert_allclose(model.invert()(y_ref, params), t)
+    np.testing.assert_allclose(model.invert()(y_ref[0], params), t[0])
 
-    with pytest.raises(KeyError):
+    with pytest.raises(
+        KeyError,
+        match=r"The following missing parameters must be specified to simulate the model: {'m/c'}",
+    ):
         np.testing.assert_allclose(
             model(t, Params(**{"m/a": Parameter(1), "m/b": Parameter(2), "m/d": Parameter(4)})),
             y_ref,
         )
+
+    with pytest.raises(
+        TypeError,
+        match="Only 0- or 1-dimensional arrays are supported for the independent variable, got 2",
+    ):
+        model(np.array([[1, 2], [3, 4]]), params)


### PR DESCRIPTION
**Why this PR?**
Noticed something odd in external code using the call operator on an inverted model (wrapping the independent variable in a list only to immediately extract it again after the call).

Turns out, calling the model with a scalar returns an error instead of working properly. Not ideal, so let's fix it.