### PR TITLE
slice: add option to highlight time region

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 #### New features
 
+* Added option to highlight a region on a time plot using [`Slice.highlight_time_range()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.channel.Slice.html#lumicks.pylake.channel.Slice.highlight_time_range). For more information see the [`tutorial`](https://lumicks-pylake.readthedocs.io/en/latest/tutorial/file.html#highlight-time-range).
 * Added parameter `allow_overwrite` to [`lk.download_from_doi()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.download_from_doi.html#lumicks.pylake.download_from_doi) to allow re-downloading only those files where the checksum does not match.
 * Added force calibration information to channels accessed directly via the square bracket notation (e.g. `file["Force HF"]["Force 1x"].calibration`).
 * Calibration results and parameters are now accessible via properties which are listed when items are printed. See [calibration results](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html) and [calibration item](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.calibration.ForceCalibrationItem.html) API documentation for more information.

--- a/docs/tutorial/figures/file/downsampling.png
+++ b/docs/tutorial/figures/file/downsampling.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dbc2c6dd95820cfe00601cc7f55cbde43305926689ce969ac2c10d8502104a6
+size 23494

--- a/docs/tutorial/figures/file/first_plot.png
+++ b/docs/tutorial/figures/file/first_plot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69302df6069ce1b73aa23da3dd5d40b2679acffcbfe2a757db6189d6c5a0eea3
+size 24154

--- a/docs/tutorial/figures/file/full_range.png
+++ b/docs/tutorial/figures/file/full_range.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69302df6069ce1b73aa23da3dd5d40b2679acffcbfe2a757db6189d6c5a0eea3
+size 24154

--- a/docs/tutorial/figures/file/highlight_points.png
+++ b/docs/tutorial/figures/file/highlight_points.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e88d1d802d9770aadf01f014308a89d66aa1e2f6a10095818c0eb16dcc58dad0
+size 25984

--- a/docs/tutorial/figures/file/highlight_region.png
+++ b/docs/tutorial/figures/file/highlight_region.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c344f0d4ad172bc3437c68df6da390d3884f5cbbd40b5678c4a1b9f4758ed644
+size 25280

--- a/docs/tutorial/figures/file/manual_seconds.png
+++ b/docs/tutorial/figures/file/manual_seconds.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee17b2a23cd2be01b3a293f943f45108316fe5a2ed5f29899976b3c750e9ac90
+size 18856

--- a/docs/tutorial/figures/file/marker_range.png
+++ b/docs/tutorial/figures/file/marker_range.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f00a92abda93c74fffd9f7bf5e99101ca87a6e8b4240c415b18e635170107994
+size 24241

--- a/docs/tutorial/figures/file/slice.png
+++ b/docs/tutorial/figures/file/slice.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4846232e13d7a96c726c5558ea3c1411cef1522966864f60b8bc571c9780937d
+size 30278

--- a/docs/tutorial/figures/file/slice_ts.png
+++ b/docs/tutorial/figures/file/slice_ts.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95532efb80376a7664fbb7d6d1a5ffad8812c031f97e5604a04ae4c8a9f1c71d
+size 27575

--- a/docs/tutorial/figures/file/start_time.png
+++ b/docs/tutorial/figures/file/start_time.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3bc345485ca15e1d58d968e9e1a5eb621a7656c650d63fb72b02fcb643ef006
+size 20352

--- a/docs/tutorial/figures/file/timestamp_axis.png
+++ b/docs/tutorial/figures/file/timestamp_axis.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:685d5994b6ed1295295ab3d9ce93eb7c2fb1559a34032cf8184f2add08a53052
+size 20960

--- a/docs/tutorial/file.rst
+++ b/docs/tutorial/file.rst
@@ -133,6 +133,8 @@ Plotting the data can be done as follows::
     plt.savefig("force1x.png")
     plt.show()
 
+.. image:: figures/file/first_plot.png
+
 You can also access the raw data directly::
 
     f1x_data = file.force1x.data
@@ -141,6 +143,8 @@ You can also access the raw data directly::
     plt.figure()
     plt.plot(f1x_timestamps, f1x_data)
     plt.show()
+
+.. image:: figures/file/timestamp_axis.png
 
 The `timestamps` attribute returns the measurement time in nanoseconds since epoch (January 1st 1970, midnight UTC/GMT). Note that since these values are typically very large, they cannot be converted to floating point without losing precision::
 
@@ -157,6 +161,7 @@ The relative time values in seconds can also be accessed directly::
     plt.plot(f1x_seconds, f1x_data)
     plt.show()
 
+.. image:: figures/file/manual_seconds.png
 
 A full list of available channels can be found on the :class:`~lumicks.pylake.File` reference page.
 
@@ -171,6 +176,8 @@ By default, entire channels are returned from a file::
     everything.plot()
     plt.show()
 
+.. image:: figures/file/full_range.png
+
 But channels can also be sliced::
 
     # Get the data between 1 and 1.5 seconds and use the plot function in Pylake
@@ -179,6 +186,8 @@ But channels can also be sliced::
     plt.figure()
     part.plot()
     plt.show()
+
+.. image:: figures/file/slice.png
 
 ::
 
@@ -189,6 +198,8 @@ But channels can also be sliced::
     plt.figure()
     plt.plot(f1x_timestamps, f1x_data)
     plt.show()
+
+.. image:: figures/file/slice_ts.png
 
 ::
 
@@ -221,6 +232,8 @@ Plotting is typically performed with the origin of the plot set to the timestamp
     first_slice.plot()
     second_slice.plot(start=first_slice.start)  # we want to use the start of first_slice as time point "zero"
     plt.show()
+
+.. image:: figures/file/start_time.png
 
 Boolean array indexing
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -300,6 +313,8 @@ channel is sampled. For this purpose you can use `downsampled_like`::
     hf_downsampled.plot()
     plt.show()
 
+.. image:: figures/file/downsampling.png
+
 Generally, it is not possible to reconstruct the first 1-2 timepoints of the reference low frequency channel from the high frequency
 channel input. Therefore, this method returns the downsampled channel and a copy of the reference channel that is cropped such that
 both channels have exactly the same timestamps.
@@ -318,6 +333,30 @@ The actual values can be obtained from the list as follows, where the index refe
     0.0
 
 If we slice a force channel, we only obtain the calibrations relevant for the selected region.
+
+Highlighting
+------------
+
+Let's say something interesting happens in our data and we would like to mark a particular time region.
+We can use the function :meth:`~lumicks.pylake.channel.Slice.highlight_time_range` for this.
+We can highlight a range using the same syntax as slicing::
+
+    force = file.force1x
+    force.plot()
+    force.highlight_time_range(("50s", "85s"), annotation="region 2")
+
+.. image:: figures/file/highlight_region.png
+
+or just mark individual points::
+
+    force = file.force1x
+    force.plot()
+    force.highlight_time_range("50s", annotation="start 1", color="C0")
+    force.highlight_time_range("90s", annotation="start 2", color="C1")
+
+.. image:: figures/file/highlight_points.png
+
+You can even pass timeline items such as markers, but more on that in the next section.
 
 Markers
 -------
@@ -350,6 +389,13 @@ You can also slice channel data directly using markers (or any other item that h
 
     >>> file.force1x[file.markers["Tether: 11"]]
     <lumicks.pylake.channel.Slice at 0x1785ccf1390>
+
+You can visualize the region of these markers superimposed on the channel data::
+
+    file.force1x.plot()
+    file.force1x.highlight_time_range(file.markers["Tether: 11"], annotation="marker")
+
+.. image:: figures/file/marker_range.png
 
 Exporting h5 files
 ------------------

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -7,7 +7,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .detail.plotting import _annotate
-from .detail.timeindex import to_timestamp
+from .detail.timeindex import to_seconds, to_timestamp
 from .detail.utilities import downsample
 from .nb_widgets.range_selector import SliceRangeSelectorWidget
 
@@ -579,17 +579,12 @@ class Slice:
         """
         import matplotlib.pyplot as plt
 
-        def to_seconds(timestamp):
-            start_ts = self.start if start is None else start
-
-            if isinstance(timestamp, str):
-                timestamp = to_timestamp(timestamp, start_ts, self.stop)
-
-            return (timestamp - start_ts) / 1e9
+        def to_sec(timestamp):
+            return to_seconds(timestamp, self.start if start is None else start, self.stop)
 
         def get_time_range(time_item):
             try:
-                return to_seconds(time_item.start), to_seconds(time_item.stop)  # Marker-like item?
+                return to_sec(time_item.start), to_sec(time_item.stop)  # Marker-like item?
             except AttributeError:
                 pass
 
@@ -598,7 +593,7 @@ class Slice:
             # for np.isscalar, hence the check with ndim instead.
             if np.ndim(time_item) == 0:
                 try:
-                    return to_seconds(time_item), None
+                    return to_sec(time_item), None
                 except TypeError:
                     raise TypeError(
                         "Provided item must be either timestamp, two timestamps or an item with a "
@@ -606,7 +601,7 @@ class Slice:
                     )
 
             try:
-                return to_seconds(time_item[0]), to_seconds(time_item[1])
+                return to_sec(time_item[0]), to_sec(time_item[1])
             except (TypeError, IndexError):
                 raise TypeError(
                     "Provided item must be either timestamp, two timestamps or an item with a "

--- a/lumicks/pylake/detail/plotting.py
+++ b/lumicks/pylake/detail/plotting.py
@@ -70,3 +70,53 @@ def show_image(
     adjustment._update_limits(image_handle, image, channel)
 
     return image_handle
+
+
+def _annotate(start_time, annotation, annotation_direction, stop_time, **kwargs):
+    """Annotate a region or time point with some text
+
+    Parameters
+    ----------
+    start_time : float
+        Start time in seconds
+    annotation : str | None
+        String to annotate with
+    annotation_direction : "horizontal" | "vertical" | None
+        Which direction to show the text when annotating.
+    stop_time : float
+        Stop time in seconds
+    **kwargs :
+        Arguments forwarded to `matplotlib.text`.
+    """
+
+    import matplotlib.pyplot as plt
+
+    ax = plt.gca()
+    annotation_args = {
+        "va": "top",
+        "y": 0.98,
+        "s": annotation,
+        "transform": ax.get_xaxis_transform(),
+    } | kwargs
+    if not annotation_direction:
+        annotation_direction = "horizontal" if stop_time else "vertical"
+
+    match annotation_direction:
+        case "horizontal":
+            ax.text(
+                ((start_time + stop_time) / 2 if stop_time else start_time),
+                ha="center",
+                rotation=0,
+                **annotation_args,
+            )
+        case "vertical":
+            if stop_time:
+                # Prefer using the stop time, as that puts the text _inside_ the shaded area
+                ax.text(stop_time, ha="right", rotation=90, **annotation_args)
+            else:
+                ax.text(start_time, ha="right", rotation=90, **annotation_args)
+        case _:
+            raise RuntimeError(
+                'Invalid value passed for annotation_direction. Expected "horizontal" or '
+                f'"vertical", got {annotation_direction}.'
+            )

--- a/lumicks/pylake/detail/timeindex.py
+++ b/lumicks/pylake/detail/timeindex.py
@@ -77,3 +77,19 @@ def to_timestamp(value, first, after_last):
             return after_last + idx
     except TypeError:
         return value
+
+
+def to_seconds(timestamp, first, after_last):
+    """Convert `value` from either a timestamp or time string to a time in seconds.
+
+    Parameters
+    ----------
+    timestamp : int | str
+        Timestamp or time string
+    first, after_last : int
+        Nanosecond timestamps of the first and past-the-end elements of a range
+    """
+    if isinstance(timestamp, str):
+        timestamp = to_timestamp(timestamp, first, after_last)
+
+    return (timestamp - first) / 1e9

--- a/lumicks/pylake/tests/test_timeindex.py
+++ b/lumicks/pylake/tests/test_timeindex.py
@@ -1,8 +1,9 @@
 import re
 
+import numpy as np
 import pytest
 
-from lumicks.pylake.detail.timeindex import Timeindex, regex, regex_template
+from lumicks.pylake.detail.timeindex import Timeindex, regex, to_seconds, regex_template
 
 
 def test_regex_template():
@@ -65,3 +66,20 @@ def test_timeindex():
 
     with pytest.raises(TypeError):
         Timeindex(1)
+
+
+@pytest.mark.parametrize(
+    "time, ref",
+    (
+        ("1s", 1.0),
+        ("1ms", 0.001),
+        ("0.1s", 0.1),
+        ("2s", 2.0),
+        ("-1s", 9.0),
+        (1718968411999124820, 1.0),
+        (1718968412499124820, 1.5),
+        (1718968412999124820, 2.0),
+    ),
+)
+def test_to_seconds(time, ref):
+    np.testing.assert_allclose(to_seconds(time, 1718968410999124820, 1718968420999124820), ref)


### PR DESCRIPTION
**Why this PR?**
While working on the force calibration docs (not done yet), I found myself wanting to annotate some regions on a channel plot.

Instead of repeating the code in multiple notebooks / tutorials, I figured it might be a nice feature to just have in Pylake.

Docs build here: https://lumicks-pylake.readthedocs.io/en/highlight/tutorial/file.html#highlighting

```python
force.highlight_time_range(("50s", "85s"), annotation="region 2")
```
![image](https://github.com/user-attachments/assets/b73fe29f-826f-4a9f-b55d-1312cce42737)

```python
force.highlight_time_range("50s", annotation="start 1", color="C0")
force.highlight_time_range("90s", annotation="start 2", color="C1")
```
![image](https://github.com/user-attachments/assets/4c92868a-354b-4bf6-9784-f51629b61107)

```python
file.force1x.highlight_time_range(file.markers["Tether: 11"], annotation="marker")
```
![image](https://github.com/user-attachments/assets/5a1d268b-37e9-483b-9e71-3a9424bb5c48)
