### PR TITLE
confocal: fix bug with empty power channels

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Fixed a bug where an inverted force-distance [`Model`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.fitting.model.Model.html) would raise when called with a scalar value. Now it just returns the expected value.
 * Fixed a bug that would lead to a division by zero warning when performing no color adjustment on a `Scan` or `Kymo` with zero photon counts.
+* Fixed a bug resulting in an exception when trying to read the excitation powers from a confocal object using [`Kymo.red_power`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.red_power),  [`Kymo.green_power`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.green_power), [`Kymo.blue_power`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.blue_power),  [`Kymo.sted_power`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.sted_power).
 
 ## v1.5.2 | 2024-07-24
 

--- a/lumicks/pylake/detail/mixin.py
+++ b/lumicks/pylake/detail/mixin.py
@@ -1,4 +1,5 @@
 """Mixin class which add properties for predefined channels"""
+
 from ..channel import Slice, empty_slice
 
 
@@ -205,22 +206,29 @@ class ExcitationLaserPower:
 
     def _get_laser_power(self, name):
         power_data = self.file["Confocal diagnostics"][f"Excitation Laser {name}"]
-        # fetch the timestamp of the last datapoint before the beginning of the item
-        start_time = power_data[: self.start].timestamps[-1]
+
+        # fetch the timestamp of the last datapoint before the beginning of this item
+        start_time = (
+            before_item.timestamps[-1] if (before_item := power_data[: self.start]) else self.start
+        )
         return power_data[start_time : self.stop]
 
     @property
     def red_power(self) -> Slice:
+        """Red excitation laser power"""
         return _try_get_or_empty(self._get_laser_power, "Red")
 
     @property
     def green_power(self) -> Slice:
+        """Green excitation laser power"""
         return _try_get_or_empty(self._get_laser_power, "Green")
 
     @property
     def blue_power(self) -> Slice:
+        """Blue excitation laser power"""
         return _try_get_or_empty(self._get_laser_power, "Blue")
 
     @property
     def sted_power(self) -> Slice:
+        """STED laser power"""
         return _try_get_or_empty(self._get_laser_power, "Sted")

--- a/lumicks/pylake/tests/test_file/conftest.py
+++ b/lumicks/pylake/tests/test_file/conftest.py
@@ -70,6 +70,31 @@ def h5_file(tmpdir_factory, request):
 
         json_kymo = generate_scan_json([{"axis": 0, "num of pixels": 5, "pixel size (nm)": 10.0}])
 
+        # Points before and during the kymograph item
+        mock_file.make_timeseries_channel(
+            "Confocal diagnostics",
+            "Excitation Laser Red",
+            [
+                (np.int64(10e9), 5),
+                (np.int64(15e9), 10),
+                (np.int64(20e9), 15),
+                (np.int64(25e9), 20),
+            ],
+        )
+
+        # Only points during
+        mock_file.make_timeseries_channel(
+            "Confocal diagnostics",
+            "Excitation Laser Green",
+            [
+                (np.int64(20e9), 15),
+                (np.int64(25e9), 20),
+            ],
+        )
+
+        # Empty
+        mock_file.make_timeseries_channel("Confocal diagnostics", "Excitation Laser Blue", [])
+
         # Generate lines at 1 Hz
         freq = 1e9 / 16
         mock_file.make_continuous_channel("Photon count", "Red", np.int64(20e9), freq, counts)

--- a/lumicks/pylake/tests/test_file/test_file.py
+++ b/lumicks/pylake/tests/test_file/test_file.py
@@ -131,6 +131,16 @@ def test_repr_and_str(h5_file):
             - File format version: 2
             - GUID: invalid
 
+            Confocal diagnostics:
+              Excitation Laser Blue:
+              - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
+              - Size: 0
+              Excitation Laser Green:
+              - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
+              - Size: 2
+              Excitation Laser Red:
+              - Data type: [('Timestamp', '<i8'), ('Value', '<f8')]
+              - Size: 4
             Force HF:
               Force 1x:
               - Data type: float64

--- a/lumicks/pylake/tests/test_file/test_file_items.py
+++ b/lumicks/pylake/tests/test_file/test_file_items.py
@@ -107,6 +107,13 @@ def test_kymos(h5_file):
             np.transpose([[2, 0, 0, 0, 2], [0, 0, 0, 0, 0], [1, 0, 0, 0, 1], [0, 1, 1, 1, 0]]),
         )
 
+        np.testing.assert_allclose(kymo.red_power.timestamps, [np.int64(15e9), np.int64(20e9)])
+        np.testing.assert_allclose(kymo.red_power.data, [10, 15])
+        np.testing.assert_allclose(kymo.green_power.timestamps, [np.int64(20e9)])
+        np.testing.assert_allclose(kymo.green_power.data, [15])
+        np.testing.assert_allclose(kymo.blue_power.timestamps, [])
+        np.testing.assert_allclose(kymo.blue_power.data, [])
+
 
 def test_notes(h5_file):
     f = pylake.File.from_h5py(h5_file)


### PR DESCRIPTION
**Why this PR?**
If the confocal diagnostics channel has no points before the item, these properties raise, while they should just return either an empty slice (if there is really no data) or a slice with the data that is still present.