### PR TITLE
caching: centralize caching

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * Added improved printing of calibration items under `channel.calibration` providing a more convenient overview of the items associated with a `Slice`.
 * Added improved printing of calibrations performed with `Pylake`.
 * Added parameter `titles` to customize title of each subplot in [`Kymo.plot_with_channels()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.plot_with_channels).
+* Added [`KymoTrack.sample_from_channel()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymotracker.kymotrack.KymoTrack.html#lumicks.pylake.kymotracker.kymotrack.KymoTrack.sample_from_channel) to downsample channel data to the time points of a kymotrack.
 
 ## v1.5.2 | 2024-07-24
 

--- a/docs/tutorial/figures/kymotracking/sample_from_channel.png
+++ b/docs/tutorial/figures/kymotracking/sample_from_channel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29950f8bcbcc3bdc80f26dea28a27f7b53c33d5866f47c06a9e904df142648aa
+size 31427

--- a/docs/tutorial/kymotracking.rst
+++ b/docs/tutorial/kymotracking.rst
@@ -397,6 +397,32 @@ Here `num_pixels` is the number of pixels to sum on either side of the track.
 .. note::
     For tracks obtained from tracking or :func:`~lumicks.pylake.refine_tracks_centroid`, the photon counts found in the attribute :attr:`~lumicks.pylake.kymotracker.kymotrack.KymoTrack.photon_counts` are computed by :func:`~lumicks.pylake.kymotracker.kymotrack.KymoTrack.sample_from_image` using `num_pixels=np.ceil(track_width / pixelsize) // 2` where `track_width` is the track width used for tracking or refinement.
 
+Averaging channel data over tracks
+----------------------------------
+
+It is also possible to average channel data over the track using :meth:`~lumicks.pylake.kymotracker.Kymotrack.sample_from_channel()`.
+For example, let's find out what the force was during a particular track::
+
+    force_slice = file.force1x
+    track_force = longest_track.sample_from_channel(force_slice, include_dead_time=True)
+
+When you call this function with a :class:`~lumicks.pylake.Slice`, it returns another :class:`~lumicks.pylake.Slice` with the downsampled channel data.
+What happens is that for every point on the track, the correct kymograph scan line is looked up and the channel data is averaged over the entire duration of that scan line.
+The parameter `include_dead_time` specifies whether the time it takes the mirror to return to its initial position after each scan line should be included in this average.
+For tracks which have not been refined (see :ref:`localization_refinement`) the result from this function may skip some scan lines entirely.
+
+We can plot these slices just like any other.
+Plotting this slice, we can see that the protein detaches shortly after the force drops::
+
+    plt.figure()
+    force_slice.plot(label="force (whole file)")
+    track_force.plot(start=force_slice.start, marker=".", label="force (longest track)")
+    plt.legend(loc="upper left")
+
+.. image:: figures/kymotracking/sample_from_channel.png
+
+We plotted the track here putting the time zero at the start time of the entire force plot by passing its `start` time.
+
 Plotting binding histograms
 ---------------------------
 

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numbers
 from typing import Union
+from functools import lru_cache
 
 import numpy as np
 import numpy.typing as npt
@@ -9,6 +10,40 @@ import numpy.typing as npt
 from .detail.timeindex import to_timestamp
 from .detail.utilities import downsample
 from .nb_widgets.range_selector import SliceRangeSelectorWidget
+
+
+@lru_cache(maxsize=100)
+def _get_array(cache_object):
+    return cache_object.read_array()
+
+
+class LazyCache:
+    def __init__(self, location, dset):
+        """A lazy globally cached wrapper around an object that is convertible to a numpy array"""
+        self._location = location
+        self._dset = dset
+
+    def __len__(self):
+        return len(self._dset)
+
+    def __hash__(self):
+        return hash(self._location)
+
+    @staticmethod
+    def from_h5py_dset(dset):
+        location = f"{dset.file.filename}{dset.name}"
+        return LazyCache(location, dset)
+
+    def read_array(self):
+        arr = np.asarray(self._dset)
+        arr.flags.writeable = False
+        return arr
+
+    def __eq__(self, other):
+        return self._location == other._location
+
+    def __array__(self):
+        return _get_array(self)
 
 
 class Slice:
@@ -550,7 +585,6 @@ class Continuous:
 
     def __init__(self, data, start, dt):
         self._src_data = data
-        self._cached_data = None
         self.start = start
         self.stop = start + len(data) * dt
         self.dt = dt  # ns
@@ -571,7 +605,7 @@ class Continuous:
         start = dset.attrs["Start time (ns)"]
         dt = int(1e9 / dset.attrs["Sample rate (Hz)"])  # ns
         return Slice(
-            Continuous(dset, start, dt),
+            Continuous(LazyCache.from_h5py_dset(dset), start, dt),
             labels={"title": dset.name.strip("/"), "y": y_label},
             calibration=calibration,
         )
@@ -597,9 +631,7 @@ class Continuous:
 
     @property
     def data(self) -> npt.ArrayLike:
-        if self._cached_data is None:
-            self._cached_data = np.asarray(self._src_data)
-        return self._cached_data
+        return np.asarray(self._src_data)  # Reads from cache if it exists
 
     @property
     def timestamps(self) -> npt.ArrayLike:

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -795,11 +795,25 @@ class TimeTags:
 
     def __init__(self, data, start=None, stop=None):
         self._src_data = data
-        self.start = start if start is not None else (self.data[0] if self.data.size > 0 else 0)
-        self.stop = stop if stop is not None else (self.data[-1] + 1 if self.data.size > 0 else 0)
+        self._start = start
+        self._stop = stop
 
     def __len__(self):
         return self.data.size
+
+    @property
+    def start(self):
+        return (
+            self._start if self._start is not None else (self.data[0] if self.data.size > 0 else 0)
+        )
+
+    @property
+    def stop(self):
+        return (
+            self._stop
+            if self._stop is not None
+            else (self.data[-1] + 1 if self.data.size > 0 else 0)
+        )
 
     @property
     def data(self):

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -2,29 +2,34 @@ from __future__ import annotations
 
 import numbers
 from typing import Union
-from functools import lru_cache
 
 import numpy as np
 import numpy.typing as npt
+from cachetools import LRUCache, cached
 
 from .detail.timeindex import to_timestamp
 from .detail.utilities import downsample
 from .nb_widgets.range_selector import SliceRangeSelectorWidget
 
 
-@lru_cache(maxsize=100)
+@cached(LRUCache(maxsize=1 << 30, getsizeof=lambda x: x.nbytes), info=True)  # 1 GB of cache
 def _get_array(cache_object):
     return cache_object.read_array()
 
 
 class LazyCache:
-    def __init__(self, location, dset):
+    def __init__(self, location, dset, nbytes):
         """A lazy globally cached wrapper around an object that is convertible to a numpy array"""
         self._location = location
         self._dset = dset
+        self._nbytes = nbytes
 
     def __len__(self):
         return len(self._dset)
+
+    @property
+    def nbytes(self):
+        return self._nbytes
 
     def __hash__(self):
         return hash(self._location)
@@ -35,7 +40,11 @@ class LazyCache:
         if field:
             location = f"{location}.{field}"
             dset = dset.fields(field)
-        return LazyCache(location, dset)
+            item_size = dset.read_dtype.itemsize
+        else:
+            item_size = dset.dtype.itemsize
+
+        return LazyCache(location, dset, nbytes=item_size * len(dset))
 
     def read_array(self):
         # Note, we deliberately do _not_ allow additional arguments to asarray since we would

--- a/lumicks/pylake/channel.py
+++ b/lumicks/pylake/channel.py
@@ -30,11 +30,18 @@ class LazyCache:
         return hash(self._location)
 
     @staticmethod
-    def from_h5py_dset(dset):
+    def from_h5py_dset(dset, field=None):
         location = f"{dset.file.filename}{dset.name}"
+        if field:
+            location = f"{location}.{field}"
+            dset = dset.fields(field)
         return LazyCache(location, dset)
 
     def read_array(self):
+        # Note, we deliberately do _not_ allow additional arguments to asarray since we would
+        # have to hash those with and unless necessary, they would unnecessarily increase the
+        # cache (because of sometimes defensively adding an explicit type). It's better to raise
+        # in this case and end up at this comment.
         arr = np.asarray(self._dset)
         arr.flags.writeable = False
         return arr
@@ -689,9 +696,7 @@ class TimeSeries:
             )
 
         self._src_data = data
-        self._cached_data = None
         self._src_timestamps = timestamps
-        self._cached_timestamps = None
 
     def __len__(self):
         return len(self._src_data)
@@ -706,32 +711,8 @@ class TimeSeries:
 
     @staticmethod
     def from_dataset(dset, y_label="y", calibration=None) -> Slice:
-        class LazyLoadedCompoundField:
-            """Wrapper to enable lazy loading of HDF5 compound datasets
-
-            Notes
-            -----
-            We only need to support the methods `__array__()` and `__len__()`, as we only access
-            `LazyLoadedCompoundField` via the properties `TimeSeries.data`, `timestamps` and the
-            method `__len__()`.
-
-            `LazyLoadCompoundField` might be replaced with `dset.fields(fieldname)` if and when the
-            returned `FieldsWrapper` object provides an `__array__()` method itself"""
-
-            def __init__(self, dset, fieldname):
-                self._dset = dset
-                self._fieldname = fieldname
-
-            def __array__(self):
-                """Get the data of the field as an array"""
-                return self._dset[self._fieldname]
-
-            def __len__(self):
-                """Get the length of the underlying dataset"""
-                return len(self._dset)
-
-        data = LazyLoadedCompoundField(dset, "Value")
-        timestamps = LazyLoadedCompoundField(dset, "Timestamp")
+        data = LazyCache.from_h5py_dset(dset, field="Value")
+        timestamps = LazyCache.from_h5py_dset(dset, field="Timestamp")
         return Slice(
             TimeSeries(data, timestamps),
             labels={"title": dset.name.strip("/"), "y": y_label},
@@ -760,15 +741,11 @@ class TimeSeries:
 
     @property
     def data(self) -> npt.ArrayLike:
-        if self._cached_data is None:
-            self._cached_data = np.asarray(self._src_data)
-        return self._cached_data
+        return np.asarray(self._src_data)
 
     @property
     def timestamps(self) -> npt.ArrayLike:
-        if self._cached_timestamps is None:
-            self._cached_timestamps = np.asarray(self._src_timestamps)
-        return self._cached_timestamps
+        return np.asarray(self._src_timestamps)
 
     @property
     def start(self):
@@ -817,12 +794,16 @@ class TimeTags:
     """
 
     def __init__(self, data, start=None, stop=None):
-        self.data = np.asarray(data, dtype=np.int64)
+        self._src_data = data
         self.start = start if start is not None else (self.data[0] if self.data.size > 0 else 0)
         self.stop = stop if stop is not None else (self.data[-1] + 1 if self.data.size > 0 else 0)
 
     def __len__(self):
         return self.data.size
+
+    @property
+    def data(self):
+        return np.asarray(self._src_data)
 
     def _with_data(self, data):
         raise NotImplementedError("Time tags do not currently support this operation")
@@ -832,7 +813,10 @@ class TimeTags:
 
     @staticmethod
     def from_dataset(dset, y_label="y"):
-        return Slice(TimeTags(dset))
+        return Slice(
+            TimeTags(LazyCache.from_h5py_dset(dset)),
+            labels={"title": dset.name.strip("/"), "y": y_label},
+        )
 
     def to_dataset(self, parent, name, **kwargs):
         """Save this to an h5 dataset

--- a/lumicks/pylake/file.py
+++ b/lumicks/pylake/file.py
@@ -1,3 +1,4 @@
+import pathlib
 import warnings
 from typing import Dict
 
@@ -50,7 +51,7 @@ class File(Group, Force, DownsampledFD, BaselineCorrectedForce, PhotonCounts, Ph
     def __init__(self, filename, *, rgb_to_detectors=None):
         import h5py
 
-        super().__init__(h5py.File(filename, "r"), lk_file=self)
+        super().__init__(h5py.File(pathlib.Path(filename).absolute(), "r"), lk_file=self)
         self._check_file_format()
         self._rgb_to_detectors = self._get_detector_mapping(rgb_to_detectors)
 

--- a/lumicks/pylake/kymotracker/tests/test_image_sampling.py
+++ b/lumicks/pylake/kymotracker/tests/test_image_sampling.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 
 from lumicks.pylake.kymo import _kymo_from_array
+from lumicks.pylake.channel import Slice, Continuous
+from lumicks.pylake.detail.imaging_mixins import _FIRST_TIMESTAMP
 from lumicks.pylake.kymotracker.kymotrack import KymoTrack
 from lumicks.pylake.kymotracker.kymotracker import track_greedy
 from lumicks.pylake.tests.data.mock_confocal import generate_kymo
@@ -114,3 +116,50 @@ def test_origin_warning_sample_from_image():
         ),
     ):
         tracks[0].sample_from_image(0)
+
+
+@pytest.mark.parametrize(
+    "time_idx, ref_dead_included, ref_dead_excluded",
+    [
+        ([0, 1, 2], [14.5, 24.5, 34.5], [12.5, 22.5, 32.5]),
+        ([0, 2], [14.5, 34.5], [12.5, 32.5]),
+        ([], [], []),
+    ],
+)
+def test_sample_from_channel(time_idx, ref_dead_included, ref_dead_excluded):
+    img = np.zeros((5, 5))
+    kymo = _kymo_from_array(
+        img,
+        "r",
+        line_time_seconds=1.0,
+        exposure_time_seconds=0.6,
+        start=_FIRST_TIMESTAMP + int(1e9),
+    )
+
+    data = Slice(Continuous(np.arange(100), start=_FIRST_TIMESTAMP, dt=int(1e8)))  # 10 Hz
+    kymotrack = KymoTrack(time_idx, time_idx, kymo, "red", 0)
+
+    sampled = kymotrack.sample_from_channel(data)
+    np.testing.assert_allclose(sampled.data, ref_dead_included)
+
+    sampled = kymotrack.sample_from_channel(data, include_dead_time=False)
+    np.testing.assert_allclose(sampled.data, ref_dead_excluded)
+
+
+def test_sample_from_channel_out_of_bounds():
+    kymo = _kymo_from_array(np.zeros((5, 5)), "r", line_time_seconds=1.0)
+    data = Slice(Continuous(np.arange(100), start=0, dt=int(1e8)))
+    kymotrack = KymoTrack([0, 6], [0, 6], kymo, "red", 0)
+
+    with pytest.raises(IndexError):
+        kymotrack.sample_from_channel(data, include_dead_time=False)
+
+
+def test_sample_from_channel_no_overlap():
+    img = np.zeros((5, 5))
+    kymo = _kymo_from_array(img, "r", start=_FIRST_TIMESTAMP, line_time_seconds=int(1e8))
+    data = Slice(Continuous(np.arange(100), start=kymo.stop + 100, dt=int(1e8)))
+    kymotrack = KymoTrack([0, 1, 2], [0, 1, 2], kymo, "red", 0)
+
+    with pytest.raises(RuntimeError, match="No overlap"):
+        _ = kymotrack.sample_from_channel(data)

--- a/lumicks/pylake/tests/test_channels/test_channels.py
+++ b/lumicks/pylake/tests/test_channels/test_channels.py
@@ -790,7 +790,7 @@ def test_channel_plot():
 
 def test_regression_lazy_loading(channel_h5_file):
     ch = channel.Continuous.from_dataset(channel_h5_file["Force HF"]["Force 1x"])
-    assert type(ch._src._src_data) == h5py.Dataset
+    assert isinstance(ch._src._src_data._dset, h5py.Dataset)
 
 
 @pytest.mark.parametrize(

--- a/lumicks/pylake/tests/test_file/test_caching.py
+++ b/lumicks/pylake/tests/test_file/test_caching.py
@@ -3,9 +3,16 @@ import pytest
 from lumicks import pylake
 
 
-def test_global_cache(h5_file):
+def test_global_cache_continuous(h5_file):
     # Load the file (never storing the file handle)
     f1x1 = pylake.File.from_h5py(h5_file).force1x
+    f1x2 = pylake.File.from_h5py(h5_file).force1x
+
+    # These should point to the same data
+    assert id(f1x1.data) == id(f1x2.data)
+
+    # Load the file (never storing the file handle)
+    f1x1 = pylake.File.from_h5py(h5_file)["Force HF/Force 1x"]
     f1x2 = pylake.File.from_h5py(h5_file).force1x
 
     # These should point to the same data
@@ -16,3 +23,30 @@ def test_global_cache(h5_file):
 
     file = pylake.File.from_h5py(h5_file)
     assert id(file.force1x.data) == id(file.force1x.data)
+
+
+def test_global_cache_timeseries(h5_file):
+    f1x1 = pylake.File.from_h5py(h5_file).downsampled_force1x
+    f1x2 = pylake.File.from_h5py(h5_file).downsampled_force1x
+
+    # These should point to the same data
+    assert id(f1x1.data) == id(f1x2.data)
+    assert id(f1x1.timestamps) == id(f1x2.timestamps)
+
+    with pytest.raises(ValueError, match="assignment destination is read-only"):
+        f1x1.data[5:100] = 3
+
+    with pytest.raises(ValueError, match="assignment destination is read-only"):
+        f1x1.timestamps[5:100] = 3
+
+
+def test_global_cache_timetags(h5_file):
+    if pylake.File.from_h5py(h5_file).format_version == 2:
+        tags1 = pylake.File.from_h5py(h5_file)["Photon Time Tags"]["Red"]
+        tags2 = pylake.File.from_h5py(h5_file)["Photon Time Tags"]["Red"]
+
+        # These should point to the same data
+        assert id(tags1.data) == id(tags2.data)
+
+        with pytest.raises(ValueError, match="assignment destination is read-only"):
+            tags1.data[5:100] = 3

--- a/lumicks/pylake/tests/test_file/test_caching.py
+++ b/lumicks/pylake/tests/test_file/test_caching.py
@@ -1,22 +1,20 @@
 import pytest
 
 from lumicks import pylake
+from lumicks.pylake.channel import _get_array
 
 
 def test_global_cache_continuous(h5_file):
-    # Load the file (never storing the file handle)
-    f1x1 = pylake.File.from_h5py(h5_file).force1x
-    f1x2 = pylake.File.from_h5py(h5_file).force1x
-
-    # These should point to the same data
-    assert id(f1x1.data) == id(f1x2.data)
+    _get_array.cache_clear()
 
     # Load the file (never storing the file handle)
     f1x1 = pylake.File.from_h5py(h5_file)["Force HF/Force 1x"]
     f1x2 = pylake.File.from_h5py(h5_file).force1x
+    assert _get_array.cache_info().hits == 0  # No cache used yet (lazy loading)
 
     # These should point to the same data
     assert id(f1x1.data) == id(f1x2.data)
+    assert _get_array.cache_info().hits == 1
 
     with pytest.raises(ValueError, match="assignment destination is read-only"):
         f1x1.data[5:100] = 3
@@ -26,12 +24,17 @@ def test_global_cache_continuous(h5_file):
 
 
 def test_global_cache_timeseries(h5_file):
+    _get_array.cache_clear()
+
     f1x1 = pylake.File.from_h5py(h5_file).downsampled_force1x
     f1x2 = pylake.File.from_h5py(h5_file).downsampled_force1x
+    assert _get_array.cache_info().hits == 0  # No cache used yet (lazy loading)
 
     # These should point to the same data
     assert id(f1x1.data) == id(f1x2.data)
+    assert _get_array.cache_info().hits == 1
     assert id(f1x1.timestamps) == id(f1x2.timestamps)
+    assert _get_array.cache_info().hits == 2
 
     with pytest.raises(ValueError, match="assignment destination is read-only"):
         f1x1.data[5:100] = 3
@@ -42,11 +45,15 @@ def test_global_cache_timeseries(h5_file):
 
 def test_global_cache_timetags(h5_file):
     if pylake.File.from_h5py(h5_file).format_version == 2:
+        _get_array.cache_clear()
         tags1 = pylake.File.from_h5py(h5_file)["Photon Time Tags"]["Red"]
+        assert _get_array.cache_info().hits == 3  # start and stop pull the data every time
         tags2 = pylake.File.from_h5py(h5_file)["Photon Time Tags"]["Red"]
+        assert _get_array.cache_info().hits == 6
 
         # These should point to the same data
         assert id(tags1.data) == id(tags2.data)
+        assert _get_array.cache_info().hits == 1
 
         with pytest.raises(ValueError, match="assignment destination is read-only"):
             tags1.data[5:100] = 3

--- a/lumicks/pylake/tests/test_file/test_caching.py
+++ b/lumicks/pylake/tests/test_file/test_caching.py
@@ -15,6 +15,7 @@ def test_global_cache_continuous(h5_file):
     # These should point to the same data
     assert id(f1x1.data) == id(f1x2.data)
     assert _get_array.cache_info().hits == 1
+    assert _get_array.cache_info().currsize == 40
 
     with pytest.raises(ValueError, match="assignment destination is read-only"):
         f1x1.data[5:100] = 3
@@ -33,8 +34,10 @@ def test_global_cache_timeseries(h5_file):
     # These should point to the same data
     assert id(f1x1.data) == id(f1x2.data)
     assert _get_array.cache_info().hits == 1
+    assert _get_array.cache_info().currsize == 16
     assert id(f1x1.timestamps) == id(f1x2.timestamps)
     assert _get_array.cache_info().hits == 2
+    assert _get_array.cache_info().currsize == 32
 
     with pytest.raises(ValueError, match="assignment destination is read-only"):
         f1x1.data[5:100] = 3
@@ -53,6 +56,7 @@ def test_global_cache_timetags(h5_file):
         # These should point to the same data
         assert id(tags1.data) == id(tags2.data)
         assert _get_array.cache_info().hits == 1
+        assert _get_array.cache_info().currsize == 72
 
         with pytest.raises(ValueError, match="assignment destination is read-only"):
             tags1.data[5:100] = 3

--- a/lumicks/pylake/tests/test_file/test_caching.py
+++ b/lumicks/pylake/tests/test_file/test_caching.py
@@ -1,0 +1,18 @@
+import pytest
+
+from lumicks import pylake
+
+
+def test_global_cache(h5_file):
+    # Load the file (never storing the file handle)
+    f1x1 = pylake.File.from_h5py(h5_file).force1x
+    f1x2 = pylake.File.from_h5py(h5_file).force1x
+
+    # These should point to the same data
+    assert id(f1x1.data) == id(f1x2.data)
+
+    with pytest.raises(ValueError, match="assignment destination is read-only"):
+        f1x1.data[5:100] = 3
+
+    file = pylake.File.from_h5py(h5_file)
+    assert id(file.force1x.data) == id(file.force1x.data)

--- a/lumicks/pylake/tests/test_file/test_caching.py
+++ b/lumicks/pylake/tests/test_file/test_caching.py
@@ -47,9 +47,8 @@ def test_global_cache_timetags(h5_file):
     if pylake.File.from_h5py(h5_file).format_version == 2:
         _get_array.cache_clear()
         tags1 = pylake.File.from_h5py(h5_file)["Photon Time Tags"]["Red"]
-        assert _get_array.cache_info().hits == 3  # start and stop pull the data every time
         tags2 = pylake.File.from_h5py(h5_file)["Photon Time Tags"]["Red"]
-        assert _get_array.cache_info().hits == 6
+        assert _get_array.cache_info().hits == 0
 
         # These should point to the same data
         assert id(tags1.data) == id(tags2.data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers=[
 ]
 dependencies = [
     "pytest>=3.5",
-    "h5py>=3.4, <4",
+    "h5py>=3.8, <4",  # Minimum bound needed for using __array__ on Dataset.fields()
     "numpy>=1.24, <2",  # 1.24 is needed for dtype in vstack/hstack (Dec 18th, 2022)
     "scipy>=1.9, <2",  # 1.9.0 needed for lazy imports (July 29th, 2022)
     "matplotlib>=3.8",


### PR DESCRIPTION
## Why this PR?

### 1. Allows us to monitor memory consumption of all the caches.

By centralizing the channel caching, we can monitor the memory consumption by the caches. In certain cases, because we now store caches uniquely by location (rather than independently in every single channel object), it can lead to less memory consumption than before.

### 2. It fixes subtle sources of bugs

We can also enforce that the slices are read only resulting. This prevents the following source of "bugs":

```python
ch1 = file["Force HF"]["Force 1x"]
ch2 = file["Force HF"]["Force 1x"]

ch1.data[0:100] = 0
print(ch2.data)  # Shows zeroes for the ones we overwrote in channel 1.
```
And instead prompts the user to explicitly make a copy if they want to change the data. We already do this for certain arrays coming from confocal objects.

```python
ch1 = file["Force HF"]["Force 1x"]
ch2 = file["Force HF"]["Force 1x"]
ch1.data[0:100] = 0  # ValueError: assignment destination is read-only

copy = ch1.data.copy()  # Explicit copy!
copy[0:100] = 0
print(ch2.data)  # Data in ch1 was not modified
```

Note that in-place operations on slices are still fine though (which is nice, because those are often used in de/recalibrating). For example::

```python
ch1 = file.force1x
ch2 = file.force1x

assert id(ch1.data) == id(ch2.data)
ch1 /= 5

assert id(ch1.data) != id(ch2.data)
np.testing.assert_allclose(ch1.data * 5, ch2.data)
```

### 3. It makes certain access patterns much more performant

Currently doing something like:
```python
file = lk.File("file.h5")
for t in tracked_lines:
    track_force = t.sample_from_channel(file.force1x, include_dead_time=True)
```
Is horrendously slow clocking in at `42 +- 5` seconds for a small `30` second kymograph with `50` tracks. This reduces to `1.6 +- 0.1` seconds with the new cache. The following would have also worked to fix the problem without the cache:

```python
file = lk.File("file.h5")
ch = file.force1x
for t in tracked_lines:
    track_force = t.sample_from_channel(ch, include_dead_time=True)
```

But would require additional user training and doesn't have the benefit of allowing us to monitor how much data is going into these caches going forward.

## Open questions

### 1. Small versus big slices

While doing this, I noticed that for `Continuous` slices, we always read the whole slice even if we take only a small segment. Note that this was also the case before the caching was introduced (bug?).

At first, this seemed wasteful, so I set up the cache to allow slicing first and then grab the data (including start index and stop index in the location), but when you take many small slices, the performance is frequently far worse than reading the big slice as a whole at once. As a result, the case discussed above with the tracks still took 23 seconds.

One possible improvement to the cache system could be to include a start and stop index in the location again for continuous channels. Then keep track of how frequently a slice of a continuous channel with a particular path is accessed and if that exceeds some threshold assume that the user will be taking more chunks, dump the small chunks and load the whole slice instead. Then in the cache grabber, we could always check if the parent location (the one without additional indexing) is already present, and slice from that if present.

Right now, from my testing so far, this additional complexity does not seem worth it though. Most `h5` files contain one or two items and generally, you look at the whole thing before you start interacting with sub-slices. The only iffy part would be if a single slice would exceed the memory capacity. But right now, you also have no way of loading those without going through the raw `h5` structure.

### 2. What is a good default cache size?

I currently hardcoded 1 GB, but I suspect this should depend on the user system somehow? I think making it proportional to a size in bytes makes more sense than number of items however. Especially considering how much the items can vary in size.

### 3. API

Do we want to expose an API for users to set cache size or disable it entirely?

### Some final notes

1. When reading data from `TimeTag` channels, we actually read the data 3 times already even when we don't want to access it at all 4 by the time we actually read it. Note that we can fix this without having to resort to a global cache however.

2. The default functools lru cache is great, but items can have pretty different sizes, so. I think it's better to go with one where you can set a custom `size_of`.

3. Considering that disallowing data modification is a breaking change, I would propose we iterate on this a bit now, and roll this out when `2.0` rolls around. Thoughts?