### PR TITLE
dwelltime: add standard errors based on hessian approximation

### DIFF
--- a/lumicks/pylake/fitting/parameters.py
+++ b/lumicks/pylake/fitting/parameters.py
@@ -43,6 +43,7 @@ class Parameter:
         fixed=False,
         shared=False,
         unit=None,
+        stderr=None,
     ):
         """Model parameter
 
@@ -90,7 +91,7 @@ class Parameter:
         from the data. See also: :meth:`~lumicks.pylake.FdFit.profile_likelihood()`.
         """
 
-        self.stderr = None
+        self.stderr = stderr
         """Standard error of this parameter.
 
         Standard errors are calculated after fitting the model. These asymptotic errors are based

--- a/lumicks/pylake/fitting/profile_likelihood.py
+++ b/lumicks/pylake/fitting/profile_likelihood.py
@@ -639,7 +639,7 @@ class ProfileLikelihood1D:
     def p(self):
         return self.parameters[:, self.profile_info.profiled_parameter_index]
 
-    def plot(self, *, significance_level=None, **kwargs):
+    def plot(self, *, significance_level=None, std_err=None, **kwargs):
         """Plot profile likelihood
 
         Parameters
@@ -647,8 +647,18 @@ class ProfileLikelihood1D:
         significance_level : float, optional
             Desired significance level  (resulting in a 100 * (1 - alpha)% confidence interval) to
             plot. Default is the significance level specified when the profile was generated.
+        std_err : float | None
+            If provided, also make a quadratic plot based on a standard error.
         """
         import matplotlib.pyplot as plt
+
+        if std_err:
+            x = np.arange(-3 * std_err, 3 * std_err, 0.1 * std_err)
+            plt.plot(
+                self.p[np.argmin(self.chi2)] + x,
+                self.profile_info.minimum_chi2 + x**2 / (2 * std_err**2),
+                "k--",
+            )
 
         dash_length = 5
         plt.plot(self.p, self.chi2, **kwargs)

--- a/lumicks/pylake/kymotracker/tests/test_kymotrack.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrack.py
@@ -173,7 +173,7 @@ def test_kymotrackgroup_remove(blank_kymo, remove, remaining):
     tracks = KymoTrackGroup(src_tracks)
     for track in remove:
         tracks.remove(src_tracks[track])
-    for track, should_be_present in zip(src_tracks, remaining):
+    for track in src_tracks:
         if remaining:
             assert track in tracks
         else:
@@ -300,9 +300,10 @@ def test_kymotrack_merge():
     time_idx = ([1, 2, 3, 4, 5], [6, 7, 8], [6, 7, 8], [1, 2, 3])
     pos_idx = ([1, 1, 1, 3, 3], [4, 4, 4], [9, 9, 9], [10, 10, 10])
 
-    make_tracks = lambda: KymoTrackGroup(
-        [KymoTrack(t, p, kymo, "green", 0) for t, p in zip(time_idx, pos_idx)]
-    )
+    def make_tracks():
+        return KymoTrackGroup(
+            [KymoTrack(t, p, kymo, "green", 0) for t, p in zip(time_idx, pos_idx)]
+        )
 
     # connect first two
     tracks = make_tracks()
@@ -873,6 +874,7 @@ def test_fit_binding_times_nonzero(blank_kymo, blank_kymo_track_args):
         np.testing.assert_equal(dwelltime_model.dwelltimes, [4, 4, 4, 4])
         np.testing.assert_equal(dwelltime_model._observation_limits[0], 4)
         np.testing.assert_allclose(dwelltime_model.lifetimes[0], [0.4])
+        np.testing.assert_allclose(dwelltime_model._err_lifetimes[0], 0.199994, rtol=1e-5)
 
 
 def test_fit_binding_times_empty():
@@ -1174,10 +1176,11 @@ def test_kymotrack_group_diffusion_filter():
 
     good_tracks = KymoTrackGroup([track for j, track in enumerate(tracks) if j in (0, 3, 4)])
 
-    warning_string = lambda n_discarded: (
-        f"{n_discarded} tracks were shorter than the specified min_length "
-        "and discarded from the analysis."
-    )
+    def warning_string(n_discarded):
+        return (
+            f"{n_discarded} tracks were shorter than the specified min_length and discarded "
+            f"from the analysis."
+        )
 
     # test algorithms with default min_length
     with pytest.warns(RuntimeWarning, match=warning_string(3)):


### PR DESCRIPTION
**Why this PR?**
For some purposes, we need a quantity that calculates an approximate standard error rapidly.
Asymptotics are useful especially when the problem is well constrained (lots of data and a well-suited model).

<img width="619" alt="image" src="https://github.com/user-attachments/assets/f753e0e5-f2c7-4d0f-be27-26771569845e">

_2-component fit based on 100 dwells. Profile likelihood compared to asymptotic intervals. Confidence intervals would be given by the locations where the curves meet the threshold (dashed horizontal line)._

<img width="628" alt="image" src="https://github.com/user-attachments/assets/384ac0d9-45a6-4b51-9939-ae336511ebdb">

_2-component fit based on 1000 dwells. Profile likelihood compared to asymptotic intervals. Confidence intervals would be given by the locations where the curves meet the threshold (dashed horizontal line). Note how for lots of data, these two approaches produce almost identical results._

I have added the ability to plot them alongside the profiles, as it can be instructive to see how these type of errors compare. I think in the future, it would also be useful to explore this on the FdFitting side as well.

Small note on the implementation:

It is important to consider the constraint on the amplitudes when doing this uncertainty analysis. Without it, you get huge confidence intervals for alpha (since the problem is underdertermined). There are two ways of doing this. One you add entries to the Hessian corresponding to the constraint or you transform the derivatives into a subspace that fulfills the constraint, invert there and convert back. I chose the latter, since otherwise, we would have to choose how heavily we set this constraint constant. In the plot below you can see what varying the constraint does. You can basically see it converge to the solution we have now.

<img width="588" alt="image" src="https://github.com/user-attachments/assets/877eedb0-3cfa-4c2e-8066-abcd479eb6dd">

_Comparing the current approach (dash-dot) with an approach where we take into account the effect of the constraint by adding values to components of the Hessian manually. Note how the approaches agree for large values of C._

The risk with the constant based one is that if you choose the constant too large, it blows up (see figure below), whereas if you choose it too small you don't take the constraint into account sufficiently.

<img width="586" alt="image" src="https://github.com/user-attachments/assets/c0d2be8e-8db9-4b07-9c57-105fa42fb8aa">

_Comparing the current approach (dash-dot) with an approach where we take into account the effect of the constraint by adding values to components of the Hessian manually. Note how excessively large values result in numerical problems._

Considering @rpauszek  is working on the dwell time documentation at the moment, I have deferred writing documentation for this specifically at this time.