### PR TITLE
PowerSpectrum: improve diagnostic value power spectrum api

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,8 @@
 * Added parameter `titles` to customize title of each subplot in [`Kymo.plot_with_channels()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.plot_with_channels).
 * Added [`KymoTrack.sample_from_channel()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymotracker.kymotrack.KymoTrack.html#lumicks.pylake.kymotracker.kymotrack.KymoTrack.sample_from_channel) to downsample channel data to the time points of a kymotrack.
 * Added support for file names with spaces in [`lk.download_from_doi()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.download_from_doi.html#lumicks.pylake.download_from_doi).
+* Show the ranges that were excluded from a power spectrum or calibration fit by passing `show_excluded=True` to [`PowerSpectrum.plot()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum.PowerSpectrum.html#lumicks.pylake.force_calibration.power_spectrum.PowerSpectrum.plot) or [`CalibrationResults.plot()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html#lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.plot).
+* Plot the active calibration peak for a calibration result using `show_active_peak=True` with [`CalibrationResults.plot()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.html#lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults.plot).
 
 #### Improvements
 

--- a/lumicks/pylake/force_calibration/calibration_results.py
+++ b/lumicks/pylake/force_calibration/calibration_results.py
@@ -91,12 +91,36 @@ class CalibrationResults(CalibrationPropertiesMixin):
         """Number of fitted samples (-)."""
         return self.ps_data.total_sampled_used
 
-    def plot(self):
-        """Plot the fitted spectrum"""
+    def plot(self, show_excluded=False, show_active_peak=False):
+        """Plot the fitted spectrum
+
+        Parameters
+        ----------
+        show_excluded : bool
+            Show fitting regions excluded from the fit
+        show_active_peak : bool
+            Show active calibration peak when available
+
+        Raises
+        ------
+        ValueError
+            If specifying `show_active_peak=True` for a passive calibration.
+        """
         import matplotlib.pyplot as plt
 
-        self.ps_data.plot(label="Data")
+        if show_active_peak and not hasattr(self.model, "output_power"):
+            raise ValueError(
+                "Requested to plot an active calibration peak while this is not an active "
+                "calibration. Please specify `show_active_peak=False` when plotting passive"
+                "calibration results."
+            )
+
+        self.ps_data.plot(label="Data", show_excluded=show_excluded)
         self.ps_model.plot(label="Model")
+
+        if show_active_peak:
+            self.model.output_power.ps.plot(label="Active peak")
+
         plt.legend()
 
     def plot_spectrum_residual(self):

--- a/lumicks/pylake/force_calibration/detail/driving_input.py
+++ b/lumicks/pylake/force_calibration/detail/driving_input.py
@@ -145,7 +145,7 @@ def estimate_driving_input_parameters(
 class DrivenPower:
     def __init__(self, psd_data, sample_rate, driving_frequency, num_windows, freq_window=50.0):
         """This class is used to determine power in the driven peak."""
-        self.ps = PowerSpectrum(
+        self.ps = PowerSpectrum.from_data(
             psd_data, sample_rate, window_seconds=num_windows / driving_frequency
         ).in_range(max(1.0, driving_frequency - freq_window), driving_frequency + freq_window)
 

--- a/lumicks/pylake/force_calibration/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/power_spectrum.py
@@ -61,7 +61,7 @@ class PowerSpectrum:
 
         self.total_samples_used = total_samples_used
         self._raw_variance = variance
-        self._src_num_points_per_block = num_points_per_block
+        self._num_points_per_block = num_points_per_block
 
         self._downsampling_factor = 1
         self._fit_range = (
@@ -72,7 +72,7 @@ class PowerSpectrum:
 
     @property
     def num_points_per_block(self) -> int:
-        return self._src_num_points_per_block * self._downsampling_factor
+        return self._num_points_per_block * self._downsampling_factor
 
     @staticmethod
     def from_data(data, sample_rate, unit="V", window_seconds=None) -> "PowerSpectrum":
@@ -149,7 +149,7 @@ class PowerSpectrum:
         """Returns the frequency bin width of the spectrum"""
         return self.sample_rate / self.total_samples_used * self.num_points_per_block
 
-    def _apply_transforms(self, data, with_exclusions=True) -> np.ndarray:
+    def _apply_transforms(self, data, with_exclusions=True, downsample_data=True) -> np.ndarray:
         """Apply transformations to the raw spectral data
 
         Prior to plotting, specific sections of the spectrum are typically excluded and the data
@@ -162,11 +162,17 @@ class PowerSpectrum:
         with_exclusions : np.ndarray
             Whether to apply the frequency exclusion ranges (these carve out noise peaks and
             the active calibration peak).
+        downsample_data : bool
+            Should the data be down-sampled?
         """
         fit_range = (self._frequency > self._fit_range[0]) & (self._frequency <= self._fit_range[1])
 
         if not with_exclusions:
-            return downsample(data[fit_range], self._downsampling_factor, np.mean)
+            return (
+                downsample(data[fit_range], self._downsampling_factor, np.mean)
+                if downsample_data
+                else data[fit_range]
+            )
 
         exclusion_mask = np.logical_and.reduce(
             [
@@ -175,7 +181,9 @@ class PowerSpectrum:
             ]
         )
 
-        return downsample(data[exclusion_mask & fit_range], self._downsampling_factor, np.mean)
+        data = data[exclusion_mask & fit_range]
+
+        return downsample(data, self._downsampling_factor, np.mean) if downsample_data else data
 
     @property
     def frequency(self) -> np.ndarray:
@@ -311,7 +319,7 @@ class PowerSpectrum:
             ranges[:, 1] -= 1
             return ranges
 
-        if self.num_points_per_block != 1:
+        if self._num_points_per_block != 1:
             raise ValueError(
                 "identify_peaks only works if the power spectrum is not blocked / averaged"
             )
@@ -322,8 +330,11 @@ class PowerSpectrum:
         if baseline < 0:
             raise ValueError("baseline cannot be negative")
 
+        power = self._apply_transforms(self._power, downsample_data=False)
+        frequency = self._apply_transforms(self._frequency, downsample_data=False)
+
         # Normalize the spectrum
-        flattened_spectrum = self._power / model_fun(self._frequency)
+        flattened_spectrum = power / model_fun(frequency)
 
         baseline_mask = (flattened_spectrum >= baseline).astype("int")
         peak_mask = (flattened_spectrum > peak_cutoff).astype("int")
@@ -350,8 +361,8 @@ class PowerSpectrum:
         # Only report unique ones
         exclusion_ranges = baseline_ranges[np.unique(exclusion_baseline_indices)]
         # Convert the indices to frequencies
-        df = self.frequency[1] - self.frequency[0]
-        return_val = [(self.frequency[x[0]], self.frequency[x[1]] + df) for x in exclusion_ranges]
+        df = frequency[1] - frequency[0]
+        return_val = [(frequency[x[0]], frequency[x[1]] + df) for x in exclusion_ranges]
         return return_val
 
     def in_range(self, frequency_min, frequency_max) -> "PowerSpectrum":

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -77,7 +77,7 @@ def calculate_power_spectrum(
     if not isinstance(data, np.ndarray) or (data.ndim != 1):
         raise TypeError('Argument "data" must be a numpy vector')
 
-    power_spectrum = PowerSpectrum(data, sample_rate)
+    power_spectrum = PowerSpectrum.from_data(data, sample_rate)
     power_spectrum = power_spectrum.in_range(*fit_range)._exclude_range(excluded_ranges)
     power_spectrum = power_spectrum.downsampled_by(num_points_per_block)
 

--- a/lumicks/pylake/force_calibration/tests/test_power_model.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_model.py
@@ -50,14 +50,14 @@ def test_spectrum_parameter_scaling(reference_models):
 @pytest.mark.parametrize(
     "corner_frequency,diffusion_constant,num_samples,sigma_fc,sigma_diffusion",
     [
-        [1000, 1e-9, 30000, 21.113382377506746, 1.1763968470146817e-11],
-        [1500, 1.2e-9, 50000, 28.054469036154266, 1.5342555193009045e-11],
-        [1500, 1.2e-9, 10000, 28.068761746382837, 1.5365711725327977e-11],
-        [1500, 1.2e-9, 10000, 28.068761746382837, 1.5365711725327977e-11],
-        [1500, 1.2e-9, 10000, 28.068761746382837, 1.5365711725327977e-11],
-        [1500, 1.2e-9, 10000, 28.068761746382837, 1.5365711725327977e-11],
-        [1000, 1e-9, 30000, 21.113382377506746, 1.1763968470146817e-11],
-        [1000, 1e-9, 30000, 21.113382377506746, 1.1763968470146817e-11],
+        [1000, 1e-9, 30000, 21.255492602472234, 1.1778290972794654e-11],
+        [1500, 1.2e-9, 50000, 28.18419978206862, 1.536264614183137e-11],
+        [1500, 1.2e-9, 10000, 28.184199782068603, 1.5362646141831333e-11],
+        [1500, 1.2e-9, 10000, 28.184199782068603, 1.5362646141831333e-11],
+        [1500, 1.2e-9, 10000, 28.184199782068603, 1.5362646141831333e-11],
+        [1500, 1.2e-9, 10000, 28.184199782068603, 1.5362646141831333e-11],
+        [1000, 1e-9, 30000, 21.255492602472234, 1.1778290972794654e-11],
+        [1000, 1e-9, 30000, 21.255492602472234, 1.1778290972794654e-11],
     ],
 )
 def test_fit_analytic(
@@ -69,12 +69,11 @@ def test_fit_analytic(
     data = np.fft.irfft(np.sqrt(np.abs(power_spectrum) * 0.5), norm="forward")
 
     num_points_per_block = 20
-    fit_range = (0, 15000)
-    ps = PowerSpectrum(data, sample_rate=len(data))
-    ps = ps.in_range(*fit_range)
+    ps = PowerSpectrum.from_data(data, sample_rate=len(data))
+    ps = ps.in_range(1e1, 1e4)
     ps = ps.downsampled_by(num_points_per_block)
 
-    fit = fit_analytical_lorentzian(ps.in_range(1e1, 1e4))
+    fit = fit_analytical_lorentzian(ps)
 
     np.testing.assert_allclose(fit.fc, corner_frequency, rtol=1e-5)
     np.testing.assert_allclose(fit.D, diffusion_constant, rtol=1e-5, atol=0)
@@ -83,9 +82,12 @@ def test_fit_analytic(
 
 
 def test_analytic_corner_case():
-    ps = PowerSpectrum([1, 2, 3], 78125)
-    ps.frequency = np.array([178.63690424, 335.92231409, 493.20772395, 650.4931338, 807.77854365])
-    ps.power = np.array([0.00029835, 0.00027251, 0.00027432, 0.00028302, 0.00029127])
+    ps = PowerSpectrum(
+        np.array([178.63690424, 335.92231409, 493.20772395, 650.4931338, 807.77854365]),
+        np.array([0.00029835, 0.00027251, 0.00027432, 0.00028302, 0.00029127]),
+        sample_rate=78125,
+        total_duration=1.0,
+    )
     fit = fit_analytical_lorentzian(ps)
     assert fit.D > 0
 
@@ -99,13 +101,13 @@ def test_analytic_low_frequency(reference_models):
     data = power_model_to_time_series(
         78125, 78125, lambda f: reference_models.lorentzian(f, 35, 0.33)
     )
-    ps = PowerSpectrum(data, sample_rate=78125).in_range(1e2, 1e4)
+    ps = PowerSpectrum.from_data(data, sample_rate=78125).in_range(1e2, 1e4)
     fit = fit_analytical_lorentzian(ps)
     np.testing.assert_allclose(fit.fc, 0.5 * ps.frequency[0])
 
 
 def test_fit_analytic_curve():
-    ps = PowerSpectrum([3, 3, 4, 5, 1, 3, 2, 4, 5, 2], 100)
+    ps = PowerSpectrum.from_data([3, 3, 4, 5, 1, 3, 2, 4, 5, 2], 100)
     ref = [0.079276, 0.077842, 0.073833, 0.067997, 0.061221, 0.054269]
     fit = fit_analytical_lorentzian(ps)
     np.testing.assert_allclose(fit.ps_fit.frequency, np.arange(0, 60, 10))

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
@@ -263,6 +263,12 @@ def test_plot():
     ps.plot()
 
 
+def test_show_excluded():
+    ps = PowerSpectrum.from_data(np.sin(2.0 * np.pi * 100 / 78125 * np.arange(100)), 78125)
+    ps_excl = ps._exclude_range([(500, 1000)])
+    ps_excl.plot(show_excluded=True)
+
+
 def test_replace_spectrum():
     power_spectrum = PowerSpectrum.from_data(np.arange(10), 5)
     replaced = power_spectrum.with_spectrum(np.arange(6))

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
@@ -9,7 +9,7 @@ def test_power_spectrum_bad_shape():
         ValueError,
         match=r"Only 1D arrays of data are supported. You provided a 2D array of shape \(10, 2\)",
     ):
-        _ = PowerSpectrum(np.ones((10, 2)), 1, window_seconds=1)
+        _ = PowerSpectrum.from_data(np.ones((10, 2)), 1, window_seconds=1)
 
 
 def test_power_spectrum_variance():
@@ -17,7 +17,9 @@ def test_power_spectrum_variance():
     sigma, sample_rate = 40, 100
 
     np.random.seed(90083773)
-    ps = PowerSpectrum(sigma * np.random.normal(size=(1000000)), sample_rate, window_seconds=1)
+    ps = PowerSpectrum.from_data(
+        sigma * np.random.normal(size=(1000000)), sample_rate, window_seconds=1
+    )
     avg_variance = np.mean(ps._variance[1:-1])  # First and last bin have twice the variance
 
     # scaling_factor = (2.0 / sample_rate)
@@ -34,14 +36,14 @@ def test_power_spectrum_variance():
     np.testing.assert_equal(ps._exclude_range([[10, 25]])._variance, ps._variance[mask])
 
     # A single window won't give us a variance
-    ps = PowerSpectrum(
+    ps = PowerSpectrum.from_data(
         sigma * np.random.normal(size=(2 * sample_rate - 1)), sample_rate, window_seconds=1
     )
     assert ps._variance is None
     assert ps.in_range(10, 15)._variance is None
 
     # Two windows will (though it will likely not be a great estimate)
-    ps = PowerSpectrum(
+    ps = PowerSpectrum.from_data(
         sigma * np.random.normal(size=(2 * sample_rate)), sample_rate, window_seconds=1
     )
     assert np.all(ps._variance)
@@ -59,7 +61,7 @@ def test_power_spectrum_variance():
 def test_power_spectrum_attrs(frequency, num_data, sample_rate):
     """Testing the attributes of power spectra"""
     data = np.sin(2.0 * np.pi * frequency / sample_rate * np.arange(num_data))
-    power_spectrum = PowerSpectrum(data, sample_rate)
+    power_spectrum = PowerSpectrum.from_data(data, sample_rate)
 
     df = sample_rate / num_data
     frequency_axis = np.arange(0, 0.5 * sample_rate + 1, df)
@@ -82,6 +84,9 @@ def test_power_spectrum_attrs(frequency, num_data, sample_rate):
     np.testing.assert_allclose(power_spectrum.frequency_bin_width, sample_rate / num_data)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Providing other reduction functions than `np.mean` is deprecated*"
+)
 @pytest.mark.parametrize(
     "frequency, num_data, sample_rate, num_blocks, f_blocked, p_blocked",
     [
@@ -98,28 +103,35 @@ def test_power_spectrum_blocking(
     frequency, num_data, sample_rate, num_blocks, f_blocked, p_blocked
 ):
     """Functional test whether the results of blocking the power spectrum are correct"""
-    data = np.sin(2.0 * np.pi * frequency / sample_rate * np.arange(num_data)) / np.sqrt(2)
-    power_spectrum = PowerSpectrum(data, sample_rate)
 
-    downsampling_factor = len(power_spectrum.frequency) // num_blocks
-    blocked = power_spectrum.downsampled_by(downsampling_factor)
-    np.testing.assert_allclose(blocked.frequency, f_blocked)
-    np.testing.assert_allclose(blocked.power, p_blocked, atol=1e-16)
-    np.testing.assert_allclose(blocked.num_samples(), len(f_blocked))
-    np.testing.assert_allclose(len(power_spectrum.power), num_data // 2 + 1)
-    np.testing.assert_allclose(
-        blocked.num_points_per_block, np.floor(len(power_spectrum.power) / num_blocks)
-    )
-    np.testing.assert_allclose(
-        blocked.frequency_bin_width, blocked.frequency[1] - blocked.frequency[0]
-    )
+    def custom_reduce(x, *args, **kwargs):
+        return np.mean(x, *args, **kwargs)
 
-    # Downsample again and make sure the num_points_per_block is correct
-    dual_blocked = blocked.downsampled_by(2)
-    np.testing.assert_allclose(dual_blocked.num_points_per_block, blocked.num_points_per_block * 2)
-    np.testing.assert_allclose(
-        dual_blocked.frequency_bin_width, dual_blocked.frequency[1] - dual_blocked.frequency[0]
-    )
+    for reduce in (np.mean, custom_reduce):
+        data = np.sin(2.0 * np.pi * frequency / sample_rate * np.arange(num_data)) / np.sqrt(2)
+        power_spectrum = PowerSpectrum.from_data(data, sample_rate)
+
+        downsampling_factor = len(power_spectrum.frequency) // num_blocks
+        blocked = power_spectrum.downsampled_by(downsampling_factor, reduce=reduce)
+        np.testing.assert_allclose(blocked.frequency, f_blocked)
+        np.testing.assert_allclose(blocked.power, p_blocked, atol=1e-16)
+        np.testing.assert_allclose(blocked.num_samples(), len(f_blocked))
+        np.testing.assert_allclose(len(power_spectrum.power), num_data // 2 + 1)
+        np.testing.assert_allclose(
+            blocked.num_points_per_block, np.floor(len(power_spectrum.power) / num_blocks)
+        )
+        np.testing.assert_allclose(
+            blocked.frequency_bin_width, blocked.frequency[1] - blocked.frequency[0]
+        )
+
+        # Downsample again and make sure the num_points_per_block is correct
+        dual_blocked = blocked.downsampled_by(2, reduce=reduce)
+        np.testing.assert_allclose(
+            dual_blocked.num_points_per_block, blocked.num_points_per_block * 2
+        )
+        np.testing.assert_allclose(
+            dual_blocked.frequency_bin_width, dual_blocked.frequency[1] - dual_blocked.frequency[0]
+        )
 
 
 @pytest.mark.parametrize(
@@ -141,7 +153,9 @@ def test_windowing_sine_wave(amp, frequency, data_duration, sample_rate, multipl
     )
 
     window_duration = multiple / frequency
-    power_spectrum_windowed = PowerSpectrum(data, sample_rate, window_seconds=window_duration)
+    power_spectrum_windowed = PowerSpectrum.from_data(
+        data, sample_rate, window_seconds=window_duration
+    )
 
     # Windowing with the correct window size makes the full power end up in a single bin (this is
     # the property we're after).
@@ -161,7 +175,7 @@ def test_windowing_sine_wave(amp, frequency, data_duration, sample_rate, multipl
 
     # When we don't use windowing, we leak when the driving frequency is not an exact multiple of
     # the sampling rate.
-    power_spectrum = PowerSpectrum(data, sample_rate)
+    power_spectrum = PowerSpectrum.from_data(data, sample_rate)
     low_power = np.max(power_spectrum.power) * (
         power_spectrum.frequency[1] - power_spectrum.frequency[0]
     )
@@ -175,10 +189,12 @@ def test_windowing_sine_wave(amp, frequency, data_duration, sample_rate, multipl
 def test_windowing_too_long_duration():
     sample_rate = 78125
     data = np.sin(2.0 * np.pi * 36.33 / sample_rate * np.arange(2 * sample_rate))
-    ref_power_spectrum = PowerSpectrum(data, sample_rate)
+    ref_power_spectrum = PowerSpectrum.from_data(data, sample_rate)
 
     with pytest.warns(RuntimeWarning):
-        power_spectrum_windowed = PowerSpectrum(data, sample_rate, window_seconds=50000000)
+        power_spectrum_windowed = PowerSpectrum.from_data(
+            data, sample_rate, window_seconds=50000000
+        )
 
     assert power_spectrum_windowed.num_points_per_block == 1
     np.testing.assert_allclose(ref_power_spectrum.frequency, power_spectrum_windowed.frequency)
@@ -191,7 +207,7 @@ def test_windowing_too_long_duration():
 
 def test_windowing_negative_duration():
     with pytest.raises(ValueError):
-        PowerSpectrum([], 78125, window_seconds=-1)
+        PowerSpectrum.from_data([], 78125, window_seconds=-1)
 
 
 @pytest.mark.parametrize(
@@ -207,8 +223,8 @@ def test_windowing_negative_duration():
 )
 def test_in_range(frequency, num_data, sample_rate, num_blocks, f_min, f_max):
     data = np.sin(2.0 * np.pi * frequency / sample_rate * np.arange(num_data))
-    power_spectrum = PowerSpectrum(data, sample_rate)
-    assert power_spectrum._fit_range == (0, sample_rate / 2)
+    power_spectrum = PowerSpectrum.from_data(data, sample_rate)
+    np.testing.assert_allclose(power_spectrum._fit_range, (0, sample_rate / 2), atol=1e-12)
 
     power_subset = power_spectrum.in_range(f_min, f_max)
     assert id(power_subset) != id(power_spectrum)
@@ -221,15 +237,17 @@ def test_in_range(frequency, num_data, sample_rate, num_blocks, f_min, f_max):
     np.testing.assert_allclose(power_subset.power, power_spectrum.power[mask], atol=1e-16)
     np.testing.assert_allclose(power_spectrum.total_duration, power_subset.total_duration)
     np.testing.assert_allclose(power_spectrum.sample_rate, power_subset.sample_rate)
-    assert power_subset._fit_range == (f_min, min(sample_rate / 2, f_max))
+    np.testing.assert_allclose(power_subset._fit_range, (f_min, min(sample_rate / 2, f_max)))
 
 
 def test_in_range_twice():
     sample_rate, num_data = 2000, 1000
     data = np.sin(2.0 * np.pi * 10 / sample_rate * np.arange(num_data))
-    power_spectrum = PowerSpectrum(data, sample_rate)
-    assert power_spectrum._fit_range == (0, sample_rate / 2)
-    assert power_spectrum.frequency[-1] == power_spectrum._fit_range[-1]
+    power_spectrum = PowerSpectrum.from_data(data, sample_rate)
+    np.testing.assert_allclose(power_spectrum._fit_range, (0, sample_rate / 2), atol=1e-12)
+    np.testing.assert_allclose(
+        power_spectrum.frequency[-1], power_spectrum._fit_range[-1], atol=1e-12
+    )
     subset = power_spectrum.in_range(100, 500)
     assert subset._fit_range == (100, 500)
     subset2 = subset.in_range(50, 800)
@@ -239,21 +257,21 @@ def test_in_range_twice():
 
 
 def test_plot():
-    ps = PowerSpectrum(np.sin(2.0 * np.pi * 100 / 78125 * np.arange(100)), 78125)
+    ps = PowerSpectrum.from_data(np.sin(2.0 * np.pi * 100 / 78125 * np.arange(100)), 78125)
     ps.plot()
     ps = ps.downsampled_by(2)
     ps.plot()
 
 
 def test_replace_spectrum():
-    power_spectrum = PowerSpectrum(np.arange(10), 5)
+    power_spectrum = PowerSpectrum.from_data(np.arange(10), 5)
     replaced = power_spectrum.with_spectrum(np.arange(6))
 
     np.testing.assert_allclose(power_spectrum.frequency, replaced.frequency)
     np.testing.assert_allclose(replaced.power, np.arange(6), atol=1e-16)
     np.testing.assert_allclose(replaced.num_points_per_block, 1)
     np.testing.assert_allclose(replaced.sample_rate, power_spectrum.sample_rate)
-    np.testing.assert_allclose(replaced.total_duration, power_spectrum.total_duration)
+    assert replaced.total_duration == 2
 
     with pytest.raises(ValueError, match="New power spectral density vector has incorrect length"):
         power_spectrum.with_spectrum(np.arange(7))
@@ -272,10 +290,15 @@ def test_replace_spectrum():
     ],
 )
 def test_exclusions(exclusion_ranges, result_frequency, result_power):
-    ps = PowerSpectrum([1], 78125, unit="V")
-    ps.frequency = np.arange(1, 12, 2)
-    ps.power = np.arange(10, 120, 20)
-    ps._variance = None
+    ps = PowerSpectrum(
+        np.arange(1, 12, 2),
+        np.arange(10, 120, 20),
+        sample_rate=78125,
+        unit="V",
+        total_duration=1000,
+        total_samples_used=1000,
+    )
+    ps._raw_variance = None
     excluded_range = ps._exclude_range(exclusion_ranges)
     np.testing.assert_allclose(excluded_range.frequency, result_frequency)
     np.testing.assert_allclose(excluded_range.power, result_power)
@@ -289,9 +312,11 @@ def test_exclusions(exclusion_ranges, result_frequency, result_power):
 
 
 def test_identify_peaks_args():
-    power_spectrum = PowerSpectrum([1], 5)
-    power_spectrum.frequency = np.arange(10)
-    power_spectrum.power = np.ones_like(power_spectrum.frequency)
+    frequency = np.arange(10)
+    power_spectrum = PowerSpectrum(
+        frequency, np.ones_like(frequency), sample_rate=78125, total_duration=1
+    )
+
     with pytest.raises(ValueError, match="baseline cannot be negative"):
         power_spectrum.identify_peaks(lambda f: np.ones_like(f), baseline=-1.0)
 
@@ -324,8 +349,6 @@ def test_identify_peaks_args():
     ],
 )
 def test_identify_peaks(power, result_frequency):
-    power_spectrum = PowerSpectrum([1], 5)
-    power_spectrum.frequency = np.arange(10)
-    power_spectrum.power = power
+    power_spectrum = PowerSpectrum(np.arange(10), power, sample_rate=78125, total_duration=1.0)
 
     assert power_spectrum.identify_peaks(lambda f: np.ones_like(f)) == result_frequency

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -266,6 +266,16 @@ def test_actual_spectrum(reference_calibration_result):
 def test_result_plot(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
     ps_calibration.plot()
+    ps_calibration.plot(show_excluded=True)
+
+
+def test_result_plot_active_fail(reference_calibration_result):
+    ps_calibration, model, reference_spectrum = reference_calibration_result
+    with pytest.raises(
+        ValueError,
+        match="Requested to plot an active calibration peak while this is not an active calibration",
+    ):
+        ps_calibration.plot(show_active_peak=True)
 
 
 def test_result_plot_residual(reference_calibration_result):

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -182,14 +182,14 @@ def test_no_data_in_range():
     model = PassiveCalibrationModel(1, temperature=20, viscosity=0.0004)
 
     # Here the range slices off all the data and we are left with an empty spectrum
-    power_spectrum = psc.PowerSpectrum(np.arange(100), sample_rate=100).in_range(47, 100)
+    power_spectrum = psc.PowerSpectrum.from_data(np.arange(100), sample_rate=100).in_range(47, 100)
 
     with pytest.raises(RuntimeError):
         psc.fit_power_spectrum(power_spectrum, model=model)
 
     # Check whether a failure to get a sufficient number of points in the analytical fit is
     # detected.
-    power_spectrum = psc.PowerSpectrum(np.arange(100), sample_rate=1e-3)
+    power_spectrum = psc.PowerSpectrum.from_data(np.arange(100), sample_rate=1e-3)
 
     with pytest.raises(RuntimeError):
         psc.fit_power_spectrum(power_spectrum, model=model)
@@ -268,7 +268,7 @@ def test_result_plot(reference_calibration_result):
     ps_calibration.plot()
 
 
-def test_result_plot(reference_calibration_result):
+def test_result_plot_residual(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
     ps_calibration.plot_spectrum_residual()
 


### PR DESCRIPTION
### Why this PR?
- A simpler constructor will allow easier construction of a `PowerSpectrum`. The benefits of this may not be evident in this PR, but a followup one will have pathological spectra constructed directly rather than ifft'ing the spectrum only to immediately fft it again.
- Keeping track of the uncut data will allow us to plot what we excluded.
- Keeping track of the high frequency data and performing the downsampling and exclusion/fit ranges lazily will allow us to do multiple analyses without the requirement to always recompute the expensive part (the FFT) or keep two separate power spectra around. It also means that we will be getting the full spectrum in the calibration routine, which will allow us to apply some improvements going forward.
- Plotting the driving peak for an active calibration result gives a feel for how far above the noise floor it sits.

<img width="598" alt="image" src="https://github.com/user-attachments/assets/6d388ed0-34dd-484a-84ca-0e9c71454bf2">

### Tradeoffs

#### Increased size
Keeping the high frequency spectrum around does come at a cost, namely the increased memory footprint. For a typical calibration (100 kHz sample rate) this is about 4 MB worth of data per axis for passive, 8 for active.

#### Downsampling and frequency exclusion ranges
There is one annoying issue with showing the frequency exclusion ranges. Exclusion ranges are applied _prior_ to downsampling, which means that downsampling can subsequently pull a point outside the exclusion ranges into it. This is not really a bug, as this allows us to make cuts smaller than the blocking size, but it can look weird.

<img width="592" alt="image" src="https://github.com/user-attachments/assets/9c0218dc-ae07-4329-a3ff-142a2bd73693">