### PR TITLE
download: allow non-url characters in filenames

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 * Added improved printing of calibrations performed with `Pylake`.
 * Added parameter `titles` to customize title of each subplot in [`Kymo.plot_with_channels()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.plot_with_channels).
 * Added [`KymoTrack.sample_from_channel()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymotracker.kymotrack.KymoTrack.html#lumicks.pylake.kymotracker.kymotrack.KymoTrack.sample_from_channel) to downsample channel data to the time points of a kymotrack.
+* Added support for file names with spaces in [`lk.download_from_doi()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.download_from_doi.html#lumicks.pylake.download_from_doi).
 
 ## v1.5.2 | 2024-07-24
 

--- a/lumicks/pylake/tests/test_file_download.py
+++ b/lumicks/pylake/tests/test_file_download.py
@@ -5,7 +5,35 @@ from lumicks.pylake.file_download import (
     get_url_from_doi,
     download_from_doi,
     download_record_metadata,
+    strip_control_characters,
 )
+
+
+@pytest.mark.parametrize(
+    "url, url_ref",
+    [
+        ("https://zenodo.org/api/records/13880274", "https://zenodo.org/api/records/13880274"),
+        ("https://zenodo.org/api/records/test?yes", "https://zenodo.org/api/records/test?yes"),
+        ("https://zenodo.org/api/test?yes no", "https://zenodo.org/api/test?yes%20no"),
+        ("https://zenodo.org/api/test?yes>no", "https://zenodo.org/api/test?yes%3Eno"),
+        (
+            "https://zenodo.org/space bar/test?yes>no",
+            "https://zenodo.org/space%20bar/test?yes%3Eno",
+        ),
+        (
+            "https://zenodo.org/api/records/13880274/files/20220203-165412 Marker 0.85_NotOscillate.h5/content",
+            "https://zenodo.org/api/records/13880274/files/20220203-165412%20Marker%200.85_NotOscillate.h5/content",
+        ),
+    ],
+)
+def test_strip_control_characters_url(url, url_ref):
+    assert strip_control_characters(url) == url_ref
+
+
+@pytest.mark.parametrize("invalid_url", ["https:://", "zenodo.org"])
+def test_invalid_url(invalid_url):
+    with pytest.raises(ValueError, match="Invalid URL provided"):
+        strip_control_characters(invalid_url)
 
 
 @pytest.mark.preflight


### PR DESCRIPTION
**Why this PR?**
We should not restrict what file names can be used in zenodo links as it will prohibit people from using this in their own notebooks.

The surface calibration data contains filenames with spaces which made me realize that we don't support non-url characters in file names.
