### PR TITLE
ci: make sure we used fixed seed in fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 venv/
 docs/changelog.md
 docs/_api/
+nb_test/
 
 __pycache__/
 *.py[cod]

--- a/lumicks/pylake/kymotracker/tests/conftest.py
+++ b/lumicks/pylake/kymotracker/tests/conftest.py
@@ -55,7 +55,8 @@ def kymo_integration_tracks(kymo_integration_test_data):
 @pytest.fixture
 def kymo_pixel_calibrations():
     image = raw_test_data()
-    background = np.random.uniform(1, 10, size=image.size).reshape(image.shape)
+    rng = np.random.default_rng(533017)
+    background = rng.uniform(1, 10, size=image.size).reshape(image.shape).astype(int)
 
     kymo_um = generate_kymo(
         "test",

--- a/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
+++ b/lumicks/pylake/kymotracker/tests/test_kymotrackgroup_sources.py
@@ -8,7 +8,7 @@ from lumicks.pylake.kymotracker.kymotrack import *
 
 @pytest.fixture(scope="module")
 def kymos():
-    image = np.random.poisson(10, size=(10, 10, 3))
+    image = np.random.default_rng(1337).poisson(10, size=(10, 10, 3))
 
     def make_kymo(line_time_seconds, pixel_size_um):
         return _kymo_from_array(

--- a/lumicks/pylake/kymotracker/tests/test_refinement.py
+++ b/lumicks/pylake/kymotracker/tests/test_refinement.py
@@ -244,13 +244,14 @@ def test_no_swap_gaussian_refinement():
     swapping Gaussians around (making the localization jump between tracks), we enforce that
     they stay within limits dictated by their order."""
 
+    rng = np.random.default_rng(31415)
+
     def gen_gaussians(locs):
         x = np.arange(0, 20, 1)
-        return np.random.poisson(
+        return rng.poisson(
             200 * np.sum(np.vstack([scipy.stats.norm.pdf(x, loc=loc) for loc in locs]), axis=0) + 10
         )
 
-    np.random.seed(31415)
     locations = (5, 9, 12, 16)
     kymo = _kymo_from_array(
         np.vstack((gen_gaussians(locations[:-1]), gen_gaussians(locations))).T,

--- a/lumicks/pylake/tests/test_imaging_confocal/conftest.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/conftest.py
@@ -26,7 +26,7 @@ channel_map = {"r": 0, "g": 1, "b": 2}
 @pytest.fixture(scope="module")
 def test_kymo():
     # RGB Kymo with infowave as expected from BL
-    image = np.random.poisson(5, size=(5, 10, 3))
+    image = np.random.default_rng(42).poisson(5, size=(5, 10, 3))
 
     kymo, ref = generate_kymo_with_ref(
         "tester",
@@ -43,7 +43,7 @@ def test_kymo():
 
 @pytest.fixture(scope="module")
 def truncated_kymo():
-    image = np.random.poisson(5, size=(5, 4, 3))
+    image = np.random.default_rng(42).poisson(5, size=(5, 4, 3))
 
     kymo, ref = generate_kymo_with_ref(
         "truncated",
@@ -231,7 +231,8 @@ def kymo_h5_file(tmpdir_factory, test_kymo):
 @pytest.fixture(scope="module")
 def test_point_scan():
     n_samples = 90
-    data = {c: np.random.poisson(15, n_samples) for c in ("red", "green", "blue")}
+    rng = np.random.default_rng(42)
+    data = {c: rng.poisson(15, n_samples) for c in ("red", "green", "blue")}
 
     mock_file, metadata, stop = MockConfocalFile.from_streams(
         start,
@@ -258,7 +259,7 @@ def test_point_scan():
 
 @pytest.fixture(scope="module")
 def test_scans():
-    image = np.random.poisson(5, size=(4, 5, 3))
+    image = np.random.default_rng(42).poisson(5, size=(4, 5, 3))
     return {
         (name := f"fast {axes[0]} slow {axes[1]}"): generate_scan_with_ref(
             name,
@@ -277,7 +278,7 @@ def test_scans():
 
 @pytest.fixture(scope="module")
 def test_scans_multiframe():
-    image = np.random.poisson(5, size=(10, 4, 5, 3))
+    image = np.random.default_rng(42).poisson(5, size=(10, 4, 5, 3))
     return {
         (name := f"fast {axes[0]} slow {axes[1]} multiframe"): generate_scan_with_ref(
             name,
@@ -297,9 +298,10 @@ def test_scans_multiframe():
 @pytest.fixture(scope="module")
 def test_scan_missing_channels():
     empty = Slice(Continuous([], start=start, dt=dt))
+    rng = np.random.default_rng(42)
 
     def make_data(*missing_channels):
-        image = np.random.poisson(5, size=(4, 5, 3))
+        image = rng.poisson(5, size=(4, 5, 3))
         for channel in missing_channels:
             image[:, :, channel_map[channel[0]]] = 0
 
@@ -325,7 +327,7 @@ def test_scan_missing_channels():
 
 @pytest.fixture(scope="module")
 def test_scan_truncated():
-    image = np.random.poisson(5, size=(2, 4, 5, 3))
+    image = np.random.default_rng(42).poisson(5, size=(2, 4, 5, 3))
     scan, ref = generate_scan_with_ref(
         "truncated",
         image,
@@ -343,7 +345,7 @@ def test_scan_truncated():
 
 @pytest.fixture(scope="module")
 def test_scan_sted_bug():
-    image = np.random.poisson(5, size=(2, 4, 5, 3))
+    image = np.random.default_rng(42).poisson(5, size=(2, 4, 5, 3))
     scan, ref = generate_scan_with_ref(
         "sted bug",
         image,
@@ -370,7 +372,7 @@ def test_scan_slicing():
 
     scan, ref = generate_scan_with_ref(
         "slicing",
-        np.random.poisson(5, size=(10, 2, 2, 3)),
+        np.random.default_rng(42).poisson(5, size=(10, 2, 2, 3)),
         pixel_sizes_nm=[50, 50],
         axes=[1, 0],
         start=start - line_padding * dt,


### PR DESCRIPTION
**Why this PR?**
I notice some of our tests fail in some rare cases. I verified that these were false positives and they were related to the rng involved in making the fixture. This PR makes sure that all the fixtures are using a fixed seed.

Note that in the first commit I added a folder to the gitignore list, this is since on `main` we ignore a big `nb_test` folder that is used for semi-automatically testing notebooks that I would not like to have to stash or drop when rebasing every time. I intend to squash this to one commit.