### PR TITLE
deps: allow `numpy>=2`, add `python==3.13` to ci

### DIFF
--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@
 * Fixed a bug that would lead to a division by zero warning when performing no color adjustment on a `Scan` or `Kymo` with zero photon counts.
 * Fixed a bug resulting in an exception when trying to read the excitation powers from a confocal object using [`Kymo.red_power`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.red_power),  [`Kymo.green_power`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.green_power), [`Kymo.blue_power`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.blue_power),  [`Kymo.sted_power`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.sted_power).
 
+#### Other changes
+
+* Added support for python `3.13`. Removed upper bound on `numpy` version.
+
 ## v1.5.2 | 2024-07-24
 
 #### Improvements

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -296,7 +296,7 @@ In China, the installation instructions as presented above can be slow. The foll
 First, follow the first 3 steps of the installation instructions at the top of this page.
 Next, create a new environment::
 
-    conda create -n pylake conda=23.7.2
+    conda create -n pylake
 
 Activate the environment as follows::
 
@@ -309,7 +309,7 @@ Install pip in the activated environment by invoking::
 
 Then install Pylake and Jupyter Notebook as follows::
 
-    pip install -i https://pypi.tuna.tsinghua.edu.cn/simple lumicks.pylake[notebook]
+    pip install -i https://pypi.tuna.tsinghua.edu.cn/simple "lumicks.pylake[notebook]"
 
 Next, you can start Jupyter Notebook by typing::
 

--- a/docs/tutorial/force_calibration.rst
+++ b/docs/tutorial/force_calibration.rst
@@ -79,7 +79,7 @@ Next we'll decalibrate the force data back to the original voltage measured by t
 
     def decalibrate(force_slice):
         offset = force_slice.calibration[0]["Offset (pN)"]
-        response = force_slice.calibration[0]["Rf (pN/V)"]
+        response = force_slice.calibration[0]["Response (pN/V)"]
         return (force_slice - offset) / response
 
     volts = decalibrate(force_slice)

--- a/lumicks/pylake/force_calibration/power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/power_spectrum_calibration.py
@@ -286,8 +286,8 @@ def _fit_power_spectra(
         solution_params_scaled = np.abs(minimize_result.x)
         solution_params = scaled_model.scale_params(solution_params_scaled)
 
-        # Return NaN for perr, as scipy.optimize.minimize does not return the covariance matrix
-        perr = np.NaN * np.ones_like(solution_params)
+        # Return nan for perr, as scipy.optimize.minimize does not return the covariance matrix
+        perr = np.nan * np.ones_like(solution_params)
 
     chi_squared = np.sum(((1 / model(frequencies, *solution_params) - 1 / powers) / sigma) ** 2)
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -1606,7 +1606,7 @@ class KymoTrackGroup:
                     ]
                 )
             )
-            if np.all(min_observation_time) is None:
+            if None in np.asarray(min_observation_time):
                 raise RuntimeError(
                     "Minimum observation time unavailable in KymoTrackGroup (tracking was "
                     "performed prior to version `1.2.0`). The minimum observable time will be "

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=[
         "pytest>=3.5",
         "h5py>=3.4, <4",
-        "numpy>=1.24, <2",  # 1.24 is needed for dtype in vstack/hstack (Dec 18th, 2022)
+        "numpy>=1.24",
         "scipy>=1.9, <2",  # 1.9.0 needed for lazy imports (July 29th, 2022)
         "matplotlib>=3.8",
         "tifffile>=2022.7.28",


### PR DESCRIPTION
**Why this PR?**
We need to remove the `numpy` upper bound. When people install via pip, they will get `python` `3.13`. `numpy` is not going to release wheels for `1.24.x`for `3.13` and up. This means that people who made an environment with `python` `3.13` will end up in the situation where installing numpy will result in an attempt to compile it on their system (which often fails on windows).

I had a quick look and it seems that the only change that impacted us was the removal of `np.NaN` and the fact that `np.all([None, 5])` returns `None` for `numpy<2` and `False` for `numpy>=2`.

I piggybacked two tiny fixes to the documentation on this PR.
1. `Rf` is not present in items where the calibration was reset to unity, hence we want to use `Response (pN/V)` instead so people don't run into errors when trying to use this code for other situations.
2. Drop conda pin for instructions for China.