### PR TITLE
release: release pylake `v1.5.3`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## v1.5.3 | t.b.d.
+## v1.5.3 | 2024-10-29
 
 #### Bug fixes
 
-* Fixed a bug where an inverted force-distance [`Model`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.fitting.model.Model.html) would raise when called with a scalar value. Now it just returns the expected value.
-* Fixed a bug that would lead to a division by zero warning when performing no color adjustment on a `Scan` or `Kymo` with zero photon counts.
-* Fixed a bug resulting in an exception when trying to read the excitation powers from a confocal object using [`Kymo.red_power`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.red_power),  [`Kymo.green_power`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.green_power), [`Kymo.blue_power`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.blue_power),  [`Kymo.sted_power`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.sted_power).
+* Fixed a bug where an inverted force-distance [`Model`](https://lumicks-pylake.readthedocs.io/en/v1.5.3/_api/lumicks.pylake.fitting.model.Model.html) would raise when called with a scalar value. Now it just returns the expected value.
+* Fixed a bug that would lead to a division by zero warning when performing no color adjustment on a [`Scan`](https://lumicks-pylake.readthedocs.io/en/v1.5.3/_api/lumicks.pylake.scan.Scan.html) or [`Kymo`](https://lumicks-pylake.readthedocs.io/en/v1.5.3/_api/lumicks.pylake.kymo.Kymo.html) with zero photon counts.
+* Fixed a bug resulting in an exception when trying to read the excitation powers from a confocal object using [`Kymo.red_power`](https://lumicks-pylake.readthedocs.io/en/v1.5.3/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.red_power),  [`Kymo.green_power`](https://lumicks-pylake.readthedocs.io/en/v1.5.3/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.green_power), [`Kymo.blue_power`](https://lumicks-pylake.readthedocs.io/en/v1.5.3/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.blue_power),  [`Kymo.sted_power`](https://lumicks-pylake.readthedocs.io/en/v1.5.3/_api/lumicks.pylake.kymo.Kymo.html#lumicks.pylake.kymo.Kymo.sted_power).
 
 #### Other changes
 

--- a/lumicks/pylake/__about__.py
+++ b/lumicks/pylake/__about__.py
@@ -1,5 +1,5 @@
 __title__ = "lumicks.pylake"
-__version__ = "1.5.2"
+__version__ = "1.5.3"
 __summary__ = "Bluelake data analysis tools"
 __url__ = "https://github.com/lumicks/pylake"
 


### PR DESCRIPTION
#### Why this PR?
The main reason is to unpin `numpy` as it causes issues when installing with python `3.13`. That said, it is nice to release the bug fixes we have accrued on the release branch.