### PR TITLE
channel: support recalibrating force data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.6.1 | t.b.d.
+## v1.7.0 | t.b.d.
 
 #### New features
 

--- a/docs/tutorial/force_calibration/calibration_items.rst
+++ b/docs/tutorial/force_calibration/calibration_items.rst
@@ -160,11 +160,9 @@ We can also see that the residual now should less systematic deviation::
 
 .. image:: figures/residual_better.png
 
-Now that we have our new calibration item, we can recalibrate a slice of force data.
-To do so, take the slice and multiply it by the ratio of the old and new calibration factors::
+Now that we have our new calibration item, we can recalibrate a slice of force data::
 
-    correction_factor = recalibrated_hyco.force_sensitivity / old_calibration.force_sensitivity
-    recalibrated_force1x = force1x_slice * correction_factor
+    recalibrated_force1x = force1x_slice.recalibrate_force(recalibrated_hyco)
 
     plt.figure()
     force1x_slice.plot()

--- a/lumicks/pylake/calibration.py
+++ b/lumicks/pylake/calibration.py
@@ -5,13 +5,13 @@ from tabulate import tabulate
 from lumicks.pylake.force_calibration.calibration_item import ForceCalibrationItem
 
 
-def _filter_calibration(time_field, items, start, stop):
+def _filter_calibration(items, start, stop):
     """filter calibration data based on time stamp range [ns]"""
     if len(items) == 0:
         return []
 
     def timestamp(x):
-        return x[time_field]
+        return x.stop if x.stop else x.applied_at  # Pylake items do not have a start and stop (yet)
 
     items = sorted(items, key=timestamp)
 
@@ -38,25 +38,22 @@ class ForceCalibrationList:
         calibration = f.force1x.calibration[1]  # Grab a calibration item for force 1x
     """
 
-    def __init__(self, time_field, items, slice_start=None, slice_stop=None):
+    def __init__(self, items, slice_start=None, slice_stop=None):
         """Calibration item
 
         Parameters
         ----------
-        time_field : string
-            name of the field used for time
         items : list[ForceCalibrationItem]
             list of force calibration items
         slice_start, slice_stop : int
             Start and stop index of the slice associated with these items
         """
-        self._time_field = time_field
         self._src = items
         self._slice_start = slice_start
         self._slice_stop = slice_stop
 
     def _with_src(self, _src):
-        return ForceCalibrationList(self._time_field, _src)
+        return ForceCalibrationList(_src)
 
     def __getitem__(self, item):
         if isinstance(item, slice):
@@ -86,14 +83,13 @@ class ForceCalibrationList:
         stop  : int
             time stamp at stop [ns]"""
         return ForceCalibrationList(
-            self._time_field,
-            _filter_calibration(self._time_field, self._src, start, stop),
+            _filter_calibration(self._src, start, stop),
             start,
             stop,
         )
 
     @staticmethod
-    def from_field(hdf5, force_channel, time_field="Stop time (ns)") -> "ForceCalibrationList":
+    def from_field(hdf5, force_channel) -> "ForceCalibrationList":
         """Fetch force calibration data from the HDF5 file
 
         Parameters
@@ -102,23 +98,25 @@ class ForceCalibrationList:
             A Bluelake HDF5 file.
         force_channel : str
             Calibration field to access (e.g. "Force 1x").
-        time_field : str
-            Attribute which holds the timestamp of the item (e.g. "Stop time (ns)").
         """
 
         if "Calibration" not in hdf5.keys():
-            return ForceCalibrationList(time_field=time_field, items=[])
+            return ForceCalibrationList(items=[])
 
-        items = []
-        for calibration_item in hdf5["Calibration"].values():
-            if force_channel in calibration_item:
-                attrs = dict(calibration_item[force_channel].attrs)
-                if time_field in attrs.keys():
-                    # Copy the timestamp at which the calibration was applied into the item
-                    attrs["Timestamp (ns)"] = calibration_item.attrs.get("Timestamp (ns)")
-                    items.append(ForceCalibrationItem(attrs))
+        return ForceCalibrationList._from_items(
+            items=[
+                ForceCalibrationItem(
+                    dict(calibration_item[force_channel].attrs)
+                    | {"Timestamp (ns)": calibration_item.attrs.get("Timestamp (ns)")}
+                )
+                for calibration_item in hdf5["Calibration"].values()
+                if force_channel in calibration_item
+            ]
+        )
 
-        return ForceCalibrationList(time_field=time_field, items=items)
+    @staticmethod
+    def _from_items(items: list[ForceCalibrationItem]):
+        return ForceCalibrationList(items=items)
 
     def _print_summary(self, tablefmt):
         def format_timestamp(timestamp):
@@ -139,11 +137,15 @@ class ForceCalibrationList:
                     ),
                     item.hydrodynamically_correct,
                     item.distance_to_surface is not None,
-                    bool(
-                        self._slice_start
-                        and (item.start >= self._slice_start)
-                        and self._slice_stop
-                        and (item.stop <= self._slice_stop)
+                    (
+                        bool(
+                            self._slice_start
+                            and (item.start >= self._slice_start)
+                            and self._slice_stop
+                            and (item.stop <= self._slice_stop)
+                        )
+                        if item.start and item.stop
+                        else False
                     ),
                 )
                 for idx, item in enumerate(self._src)
@@ -169,7 +171,7 @@ class ForceCalibrationList:
         return self._print_summary(tablefmt="text")
 
     @staticmethod
-    def from_dataset(hdf5, n, xy, time_field="Stop time (ns)") -> "ForceCalibrationList":
+    def from_dataset(hdf5, n, xy) -> "ForceCalibrationList":
         """Fetch the force calibration data from the HDF5 file
 
         Parameters
@@ -180,14 +182,10 @@ class ForceCalibrationList:
             Trap index.
         xy : str
             Force axis (e.g. "x").
-        time_field : str
-            Attribute which holds the timestamp of the item (e.g. "Stop time (ns)").
         """
 
         if xy:
-            return ForceCalibrationList.from_field(
-                hdf5, force_channel=f"Force {n}{xy}", time_field=time_field
-            )
+            return ForceCalibrationList.from_field(hdf5, force_channel=f"Force {n}{xy}")
         else:
             raise NotImplementedError(
                 "Calibration is currently only implemented for single axis data"

--- a/lumicks/pylake/conftest.py
+++ b/lumicks/pylake/conftest.py
@@ -2,6 +2,7 @@ import json
 import hashlib
 import warnings
 import importlib
+import contextlib
 
 import numpy as np
 import pytest
@@ -68,6 +69,27 @@ def report_line():
         atexit.register(report)
 
     return reporter
+
+
+@pytest.fixture()
+def mock_datetime(monkeypatch):
+    class FakeDateTime:
+        @classmethod
+        def fromtimestamp(cls, timestamp, *args, **kwargs):
+            """Inject a timezone"""
+            return FakeDateTime()
+
+        def strftime(self, str_format):
+            return str_format
+
+    @contextlib.contextmanager
+    def fake_datetime(function_location):
+        # Representation of time is timezone and locale dependent, hence we monkeypatch it
+        with monkeypatch.context() as m:
+            m.setattr(function_location, FakeDateTime)
+            yield m
+
+    return fake_datetime
 
 
 @pytest.fixture(autouse=True)

--- a/lumicks/pylake/force_calibration/calibration_item.py
+++ b/lumicks/pylake/force_calibration/calibration_item.py
@@ -187,8 +187,7 @@ class ForceCalibrationItem(UserDict, CalibrationPropertiesMixin):
             less_blocking.plot()
 
             # Recalibrate the force channels
-            rf_ratio = less_blocking.force_sensitivity / previous_calibration.force_sensitivity
-            recalibrated_force1x = f.force1x * rf_ratio
+            recalibrated_force1x = f.force1x.recalibrate_force(less_blocking)
         """
         return (
             self.power_spectrum_params()

--- a/lumicks/pylake/force_calibration/calibration_item.py
+++ b/lumicks/pylake/force_calibration/calibration_item.py
@@ -1,4 +1,5 @@
 import re
+import copy
 from functools import wraps
 from collections import UserDict
 
@@ -27,11 +28,6 @@ class ForceCalibrationItem(UserDict, CalibrationPropertiesMixin):
         """Grab a parameter"""
         if bluelake_key in self:
             return self[bluelake_key]
-
-    @property
-    def applied_at(self):
-        """Time the calibration was applied in nanoseconds since epoch"""
-        return self.data.get("Timestamp (ns)")
 
     @property
     def _fitted_diode(self):
@@ -225,6 +221,13 @@ class ForceCalibrationItem(UserDict, CalibrationPropertiesMixin):
                 self.data["Fit range (max.) (Hz)"],
             )
 
+    def _with_timestamp(self, applied_timestamp):
+        """Return a copy of this item with a timestamp of when it was applied"""
+        item = copy.copy(self)
+        item.data = copy.deepcopy(self.data)
+        item.data["Timestamp (ns)"] = applied_timestamp
+        return item
+
     @property
     def sample_rate(self):
         """Returns the data sample rate"""
@@ -241,28 +244,3 @@ class ForceCalibrationItem(UserDict, CalibrationPropertiesMixin):
         """Number of points per block used for spectral down-sampling"""
         if "Points per block" in self.data:
             return int(self.data["Points per block"])  # BL returns float which API doesn't accept
-
-    @property
-    def start(self):
-        """Starting timestamp of this calibration
-
-        Examples
-        --------
-        ::
-
-            import lumicks.pylake as lk
-
-            f = lk.File("file.h5")
-            item = f.force1x.calibration[1]  # Grab a calibration item for force 1x
-
-            # Slice the data corresponding to this item
-            calibration_data = f.force1x[item.start : item.stop]
-
-            # or alternatively:
-            calibration_data = f.force1x[item]
-        """
-        return self.data.get("Start time (ns)")
-
-    @property
-    def stop(self):
-        return self.data.get("Stop time (ns)")

--- a/lumicks/pylake/force_calibration/calibration_results.py
+++ b/lumicks/pylake/force_calibration/calibration_results.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy as np
 
 from lumicks.pylake.force_calibration.detail.calibration_properties import (
@@ -47,6 +49,17 @@ class CalibrationResults(CalibrationPropertiesMixin):
             One or more frequencies at which to evaluate the spectral model.
         """
         return self.model(frequency, *self.fitted_params)
+
+    def _with_timestamp(self, applied_timestamp):
+        """Return a copy of this item with a timestamp of when it was applied"""
+        from lumicks.pylake.force_calibration.power_spectrum_calibration import CalibrationParameter
+
+        item = copy.copy(self)
+        item.params = copy.deepcopy(self.params)
+        item.params["Timestamp"] = CalibrationParameter(
+            "Timestamp when item was applied", applied_timestamp, "nanoseconds"
+        )
+        return item
 
     def __contains__(self, key):
         return key in self.params or key in self.results

--- a/lumicks/pylake/force_calibration/detail/calibration_properties.py
+++ b/lumicks/pylake/force_calibration/detail/calibration_properties.py
@@ -581,3 +581,34 @@ class CalibrationPropertiesMixin:
             return "Active" if self.active_calibration else "Passive"
         else:
             return kind if kind is not None else "Unknown"
+
+    @property
+    def applied_at(self):
+        """Time the calibration was applied in nanoseconds since epoch"""
+        return self._get_parameter("Timestamp", "Timestamp (ns)")
+
+    @property
+    def start(self):
+        """Starting timestamp of this calibration
+
+        Examples
+        --------
+        ::
+
+            import lumicks.pylake as lk
+
+            f = lk.File("file.h5")
+            item = f.force1x.calibration[1]  # Grab a calibration item for force 1x
+
+            # Slice the data corresponding to this item
+            calibration_data = f.force1x[item.start : item.stop]
+
+            # or alternatively:
+            calibration_data = f.force1x[item]
+        """
+        return self._get_parameter("Start time", "Start time (ns)")
+
+    @property
+    def stop(self):
+        """Stop time stored in the calibration item"""
+        return self._get_parameter("Stop time", "Stop time (ns)")

--- a/lumicks/pylake/force_calibration/tests/test_calibration_item.py
+++ b/lumicks/pylake/force_calibration/tests/test_calibration_item.py
@@ -191,6 +191,9 @@ def test_passive_item(compare_to_reference_dict, reference_data, calibration_dat
         test_name="text_representations_passive",
     )
 
+    new_item = item._with_timestamp(1696171386701856701)
+    assert new_item.applied_at == 1696171386701856701
+
 
 def test_active_item_fixed_diode(compare_to_reference_dict, calibration_data):
     item = ForceCalibrationItem(ref_active)
@@ -310,12 +313,10 @@ def test_force_calibration_handling():
         create_item(11, 12),
         create_item(15, 25),
     ]
-    items = ForceCalibrationList("Stop time (ns)", fcs)
-    same_items = ForceCalibrationList("Stop time (ns)", fcs2)
-    different_item = ForceCalibrationList(
-        "Stop time (ns)", fcs2[:-1] + [create_item(15, 25, extra=5)]
-    )
-    shorter_list = ForceCalibrationList("Stop time (ns)", fcs[:-1])
+    items = ForceCalibrationList(fcs)
+    same_items = ForceCalibrationList(fcs2)
+    different_item = ForceCalibrationList(fcs2[:-1] + [create_item(15, 25, extra=5)])
+    shorter_list = ForceCalibrationList(fcs[:-1])
 
     assert len(items) == 3
     assert items == same_items

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum_calibration.py
@@ -224,6 +224,13 @@ def test_bad_fit(reference_calibration_result):
     assert ps_calibration["backing"].value > bad_calibration["backing"].value
 
 
+def test_applied_at(reference_calibration_result):
+    calibration = reference_calibration_result[0]
+    assert calibration.applied_at is None
+    new_calibration = calibration._with_timestamp(1696171386701856701)
+    assert new_calibration.applied_at == 1696171386701856701
+
+
 def test_actual_spectrum(reference_calibration_result):
     ps_calibration, model, reference_spectrum = reference_calibration_result
 

--- a/lumicks/pylake/piezo_tracking/piezo_tracking.py
+++ b/lumicks/pylake/piezo_tracking/piezo_tracking.py
@@ -141,7 +141,7 @@ class PiezoTrackingCalibration:
 
         trap_trap_dist = self.trap_calibration(trap_position)
         bead_displacements = 1e-3 * sum(
-            sign * force / force.calibration[0]["kappa (pN/nm)"]
+            sign * force / force.calibration[0].stiffness
             for force, sign in zip((force1, force2), self._signs)
         )
 

--- a/lumicks/pylake/tests/test_channels/test_arithmetic.py
+++ b/lumicks/pylake/tests/test_channels/test_arithmetic.py
@@ -4,12 +4,12 @@ import numpy as np
 import pytest
 
 from lumicks.pylake.channel import Slice, TimeTags, Continuous, TimeSeries
-from lumicks.pylake.calibration import ForceCalibrationList
+from lumicks.pylake.calibration import ForceCalibrationItem, ForceCalibrationList
 from lumicks.pylake.detail.value import ValueMixin
 
 start = 1 + int(1e18)
-calibration = ForceCalibrationList(
-    "Stop time (ns)", [{"Stop time (ns)": start, "kappa (pN/nm)": 0.45}]
+calibration = ForceCalibrationList._from_items(
+    [ForceCalibrationItem({"Stop time (ns)": start, "kappa (pN/nm)": 0.45})]
 )
 time_series = np.array([1, 2, 3, 4, 5], dtype=np.int64) + int(1e18)
 slice_continuous_1 = Slice(Continuous([1, 2, 3, 4, 5], start=start, dt=1), calibration=calibration)

--- a/lumicks/pylake/tests/test_channels/test_channels.py
+++ b/lumicks/pylake/tests/test_channels/test_channels.py
@@ -9,7 +9,7 @@ import matplotlib as mpl
 
 from lumicks.pylake import channel
 from lumicks.pylake.low_level import make_continuous_slice
-from lumicks.pylake.calibration import ForceCalibrationList
+from lumicks.pylake.calibration import ForceCalibrationItem, ForceCalibrationList
 
 
 def with_offset(t, start_time=1592916040906356300):
@@ -18,16 +18,15 @@ def with_offset(t, start_time=1592916040906356300):
 
 def test_calibration_timeseries_channels():
     time_field = "Stop time (ns)"
-    mock_calibration = ForceCalibrationList(
-        time_field=time_field,
+    mock_calibration = ForceCalibrationList._from_items(
         items=[
-            {"Calibration Data": 50, time_field: 50},
-            {"Calibration Data": 20, time_field: 20},
-            {"Calibration Data": 30, time_field: 30},
-            {"Calibration Data": 40, time_field: 40},
-            {"Calibration Data": 80, time_field: 80},
-            {"Calibration Data": 90, time_field: 90},
-            {"Calibration Data": 120, time_field: 120},
+            ForceCalibrationItem({"Calibration Data": 50, time_field: 50}),
+            ForceCalibrationItem({"Calibration Data": 20, time_field: 20}),
+            ForceCalibrationItem({"Calibration Data": 30, time_field: 30}),
+            ForceCalibrationItem({"Calibration Data": 40, time_field: 40}),
+            ForceCalibrationItem({"Calibration Data": 80, time_field: 80}),
+            ForceCalibrationItem({"Calibration Data": 90, time_field: 90}),
+            ForceCalibrationItem({"Calibration Data": 120, time_field: 120}),
         ],
     )
 
@@ -72,16 +71,15 @@ def test_calibration_timeseries_channels():
 
 def test_calibration_continuous_channels():
     time_field = "Stop time (ns)"
-    mock_calibration = ForceCalibrationList(
-        time_field=time_field,
+    mock_calibration = ForceCalibrationList._from_items(
         items=[
-            {"Calibration Data": 50, time_field: 50},
-            {"Calibration Data": 20, time_field: 20},
-            {"Calibration Data": 30, time_field: 30},
-            {"Calibration Data": 40, time_field: 40},
-            {"Calibration Data": 80, time_field: 80},
-            {"Calibration Data": 90, time_field: 90},
-            {"Calibration Data": 120, time_field: 120},
+            ForceCalibrationItem({"Calibration Data": 50, time_field: 50}),
+            ForceCalibrationItem({"Calibration Data": 20, time_field: 20}),
+            ForceCalibrationItem({"Calibration Data": 30, time_field: 30}),
+            ForceCalibrationItem({"Calibration Data": 40, time_field: 40}),
+            ForceCalibrationItem({"Calibration Data": 80, time_field: 80}),
+            ForceCalibrationItem({"Calibration Data": 90, time_field: 90}),
+            ForceCalibrationItem({"Calibration Data": 120, time_field: 120}),
         ],
     )
 
@@ -263,8 +261,8 @@ def test_timeseries_indexing():
 
 def test_timeseries_mask():
     """Test masking operation"""
-    calibration = ForceCalibrationList(
-        "Stop time (ns)", [{"Stop time (ns)": 1, "kappa (pN/nm)": 0.45}]
+    calibration = ForceCalibrationList._from_items(
+        [ForceCalibrationItem({"Stop time (ns)": 1, "kappa (pN/nm)": 0.45})]
     )
     s = channel.Slice(
         channel.TimeSeries([14, 15, 16, 17], [4, 5, 6, 7]),
@@ -341,8 +339,8 @@ def test_continuous_indexing():
 
 def test_continuous_mask():
     """Test masking operation"""
-    calibration = ForceCalibrationList(
-        "Stop time (ns)", [{"Stop time (ns)": 1, "kappa (pN/nm)": 0.45}]
+    calibration = ForceCalibrationList._from_items(
+        [ForceCalibrationItem({"Stop time (ns)": 1, "kappa (pN/nm)": 0.45})]
     )
     s = channel.Slice(
         channel.Continuous([14, 15, 16, 17], 4, 1),

--- a/lumicks/pylake/tests/test_channels/test_channels.py
+++ b/lumicks/pylake/tests/test_channels/test_channels.py
@@ -1,4 +1,5 @@
 import re
+import textwrap
 from collections import namedtuple
 from dataclasses import dataclass
 
@@ -10,6 +11,7 @@ import matplotlib as mpl
 from lumicks.pylake import channel
 from lumicks.pylake.low_level import make_continuous_slice
 from lumicks.pylake.calibration import ForceCalibrationItem, ForceCalibrationList
+from lumicks.pylake.force_calibration import power_spectrum_calibration as psc
 
 
 def with_offset(t, start_time=1592916040906356300):
@@ -1006,3 +1008,89 @@ def test_low_level_construction():
     slc = make_continuous_slice(data, start, int(1e9 / 78125), name="hi", y_label="there")
     assert slc.labels["title"] == "hi"
     assert slc.labels["y"] == "there"
+
+
+def test_recalibrate_force_wrong_number_of_calibrations():
+    cc = channel.Slice(
+        channel.Continuous(np.arange(100), int(with_offset(40)), 10),
+        calibration=ForceCalibrationList([]),
+    )
+    with pytest.raises(RuntimeError, match="Slice does not contain any calibration items"):
+        cc.recalibrate_force(None)
+
+
+def make_calibration_item(response, applied_at):
+    return ForceCalibrationItem(
+        {
+            "Calibration Data": 50,
+            "Stop time (ns)": with_offset(50),
+            "Timestamp (ns)": with_offset(applied_at),
+            "Response (pN/V)": response,
+        }
+    )
+
+
+def make_calibration_result(calibration_factor):
+    return psc.CalibrationResults(
+        model=None,
+        ps_model=None,
+        ps_data=None,
+        params={},
+        results={
+            "Rf": psc.CalibrationParameter("Rf", calibration_factor, "val"),
+            "kappa": psc.CalibrationParameter("kappa", 5, "val"),
+        },
+        fitted_params=[],
+    )
+
+
+def test_recalibrate_force(mock_datetime):
+    slc = channel.Slice(
+        channel.Continuous(np.arange(100), with_offset(40), 10),
+        calibration=ForceCalibrationList._from_items([make_calibration_item(10, 40)]),
+    )
+
+    slc_recalibrated = slc.recalibrate_force(make_calibration_result(5))
+    np.testing.assert_allclose(slc.data, np.arange(100))
+    np.testing.assert_allclose(slc_recalibrated.data, np.arange(100) * 0.5)
+    assert slc.calibration[0].force_sensitivity == 10
+    assert slc_recalibrated.calibration[0].force_sensitivity == 5
+
+    with mock_datetime("lumicks.pylake.calibration.datetime.datetime"):
+        assert str(slc_recalibrated.calibration) == textwrap.dedent(
+            """\
+              #  Applied at    Kind       Stiffness (pN/nm)    Force sens. (pN/V)  Disp. sens. (µm/V)    Hydro    Surface    Data?
+            ---  ------------  -------  -------------------  --------------------  --------------------  -------  ---------  -------
+              0  %x %X         Unknown                    5                     5  N/A                   False    False      False"""
+        )
+    slc_recalibrated.calibration._repr_html_()
+
+    slc_recalibrate_twice = slc.recalibrate_force(make_calibration_result(10))
+    np.testing.assert_allclose(slc_recalibrated.data, np.arange(100) * 0.5)
+    np.testing.assert_allclose(slc_recalibrate_twice.data, np.arange(100))
+    assert slc_recalibrated.calibration[0].force_sensitivity == 5
+    assert slc_recalibrate_twice.calibration[0].force_sensitivity == 10
+
+
+@pytest.mark.parametrize(
+    "items, ref_forces",
+    [
+        (((10, 40), (20, 60), (40, 80)), [10, 10, 5, 5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5]),
+        (((10, 40), (40, 60), (40, 80)), [10, 10, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5]),
+        (((10, 40), (20, 60)), [10, 10, 5, 5, 5, 5, 5, 5, 5, 5]),
+        (((10, 40), (20, 61)), [10, 10, 10, 5, 5, 5, 5, 5, 5, 5]),
+        (((10, 40), (20, 50000)), [10, 10, 10, 10, 10, 10, 10, 10, 10, 10]),
+        # If there is no calibration at the start, we cannot meaningfully decalibrate, so we
+        # emit np.nan
+        ([(20, 60)], [np.nan, np.nan, 5, 5, 5, 5, 5, 5, 5, 5]),
+    ],
+)
+def test_recalibrate_force_multi(items, ref_forces):
+    slc = channel.Slice(
+        channel.Continuous(np.full(10, 10), with_offset(40), 10),
+        calibration=ForceCalibrationList._from_items(
+            [make_calibration_item(response, applied_at) for response, applied_at in items]
+        ),
+    )
+    slc_recal = slc.recalibrate_force(make_calibration_result(10))
+    np.testing.assert_equal(slc_recal.data, np.array(ref_forces))

--- a/lumicks/pylake/tests/test_file/test_file.py
+++ b/lumicks/pylake/tests/test_file/test_file.py
@@ -75,25 +75,10 @@ def test_redirect_list(h5_file):
         assert f["Point Scan"]["PointScan1"].start == np.int64(20e9)
 
 
-def test_calibration_str(h5_file, monkeypatch):
-    # Representation of time is timezone and locale dependent, hence we monkeypatch it
-    class FakeDateTime:
-        @classmethod
-        def fromtimestamp(cls, timestamp, *args, **kwargs):
-            """Inject a timezone"""
-            return FakeDateTime()
-
-        def strftime(self, str_format):
-            return str_format
-
+def test_calibration_str(h5_file, mock_datetime):
     f = pylake.File.from_h5py(h5_file)
     if f.format_version == 2:
-        with monkeypatch.context() as m:
-            m.setattr(
-                "lumicks.pylake.calibration.datetime.datetime",
-                FakeDateTime,
-            )
-
+        with mock_datetime("lumicks.pylake.calibration.datetime.datetime"):
             assert str(f.force1x.calibration) == dedent(
                 (
                     """\


### PR DESCRIPTION
**Why this PR?**
It is good to be able to recalibrate your force data.

By providing an API to do this, you basically end up with a force slice that can be treated as any other force slice (with a calibration item attached that conforms to a common API).

For instance, a recalibrated force slice can now directly be fed to the piezo tracking API (which reads from the calibration item).

Prior to implementing the new functionality, I removed some old cruftiness from the API that didn't really gel well with the new API. I left this as a separate commit.

Usage example:
```python
  import lumicks.pylake as lk
  f = lk.File("passive_calibration.h5")
  calibration = f.force1x.calibration[1]  # Grab a calibration item for force 1x

  # Slice the data corresponding to the calibration we want to reproduce.
  calib_slice = f.force1x[calibration]

  # De-calibrate to volts using the calibration that was active before this slice.
  previous_calibration = calib_slice.calibration[0]
  calib_slice = calib_slice / previous_calibration.force_sensitivity
  calibration_params = previous_calibration.calibration_params()
  new_calibration = lk.calibrate_force(calib_slice.data, **calibration_params)
  new_calibration.plot()

  # Make a new calibration, but change the amount of blocking
  less_blocking_params = calibration_params | {"num_points_per_block": 200}
  less_blocking = lk.calibrate_force(calib_slice.data, **less_blocking_params)
  less_blocking.plot()

  # Recalibrate the force channels
  recalibrated_force1x = f.force1x.recalibrate_force(less_blocking)
```