### PR TITLE
dwelltime: silence unnecessary warnings profiles

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 * Added improved printing of calibration items under `channel.calibration` providing a more convenient overview of the items associated with a `Slice`.
 * Added improved printing of calibrations performed with `Pylake`.
 * Improved error message that includes the name of the model when trying to access a model that was not added in an [`FdFit`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.FdFit.html) using angular brackets.
+* Allow customizing the minimum step size during step size determination for [`DwelltimeModel.profile_likelihood()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.DwelltimeModel.html#lumicks.pylake.DwelltimeModel.profile_likelihood) and choose a more sensible default. Also ensured that the warning only gets emitted at most once per direction.
 
 #### Bug fixes
 

--- a/lumicks/pylake/fitting/fit.py
+++ b/lumicks/pylake/fitting/fit.py
@@ -301,6 +301,14 @@ class Fit:
         for the profiled parameter, then fixes that parameter and re-optimizes all the other
         parameters [4]_ [5]_.
 
+        For each profile likelihood point, the profiled parameter is changed such that the fit
+        error goes up by an amount between `min_chi2_step` and `max_chi2_step`. After step size
+        determination, the step is applied and the other parameters are re-optimized.
+
+        To prevent step sizes from becoming too small, a minimal step size can be set. When the
+        step size goes below the minimum step size a warning is issued. When this happens, check
+        to verify that the profile likelihood curve is smooth.
+
         Parameters
         ----------
         parameter_name: str

--- a/lumicks/pylake/fitting/tests/test_profiles.py
+++ b/lumicks/pylake/fitting/tests/test_profiles.py
@@ -216,7 +216,7 @@ def test_bounded_valid_interval():
     fit["model/a"].value = 1
     fit.fit()
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="Warning: Step size set to minimum step size")
+        warnings.filterwarnings("ignore", message="Step size was set to minimum step size")
         warnings.filterwarnings("ignore", message="Optimization error encountered")
         profile = fit.profile_likelihood("model/a")
 

--- a/lumicks/pylake/fitting/tests/test_stepping.py
+++ b/lumicks/pylake/fitting/tests/test_stepping.py
@@ -82,7 +82,7 @@ class FlippingCost:
     ],
 )
 def test_stepper(chi2_function, start_pos, step_sign, target_step_size, target_p_trial):
-    step_size, p_trial = do_step(
+    step_size, p_trial, will_warn = do_step(
         chi2_function=chi2_function,
         step_direction_function=lambda: np.array([1, 1]),
         chi2_last=5,
@@ -94,6 +94,7 @@ def test_stepper(chi2_function, start_pos, step_sign, target_step_size, target_p
 
     assert step_size == target_step_size
     np.testing.assert_allclose(p_trial, target_p_trial)
+    assert not will_warn
 
 
 def test_minimum_step():
@@ -102,17 +103,15 @@ def test_minimum_step():
     # step size to take is 10 (see max_chi2_step_size in the cfg), this will result in the step size
     # shrinking to the minimum step size. In a non-pathological case, a smaller step size would
     # result in a smaller chi2 increase.
-    with pytest.warns(RuntimeWarning, match="Warning: Step size set to minimum step size."):
-        step_size, p_trial = do_step(
-            chi2_function=lambda x: 25,
-            step_direction_function=lambda: np.array([1, 1]),
-            chi2_last=5,
-            parameter_vector=np.array([2, 2]),
-            current_step_size=1,
-            step_sign=1,
-            step_config=cfg,
-        )
-        assert step_size == cfg.min_abs_step
-        np.testing.assert_allclose(
-            p_trial, np.array([2.0 + cfg.min_abs_step, 2.0 + cfg.min_abs_step])
-        )
+    step_size, p_trial, will_warn = do_step(
+        chi2_function=lambda x: 25,
+        step_direction_function=lambda: np.array([1, 1]),
+        chi2_last=5,
+        parameter_vector=np.array([2, 2]),
+        current_step_size=1,
+        step_sign=1,
+        step_config=cfg,
+    )
+    assert step_size == cfg.min_abs_step
+    np.testing.assert_allclose(p_trial, np.array([2.0 + cfg.min_abs_step, 2.0 + cfg.min_abs_step]))
+    assert will_warn

--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -44,6 +44,8 @@ class DwelltimeProfiles:
         *,
         alpha,
         num_steps,
+        min_step,
+        max_step,
         min_chi2_step,
         max_chi2_step,
         verbose,
@@ -60,6 +62,11 @@ class DwelltimeProfiles:
             Significance level. Confidence intervals are calculated as 100*(1-alpha)%.
         num_steps: integer
             Number of steps to take.
+        min_step : float
+            Minimum step size used in step size determination. Any step size lower will be clamped
+            to this value and a warning will be issued.
+        max_step : float
+            Maximum step size used in step size determination. Any step size larger will be clamped.
         min_chi2_step: float
             Minimal desired step in terms of chi squared change prior to re-optimization. When the
             step results in a fit change smaller than this threshold, the step-size will be
@@ -109,6 +116,8 @@ class DwelltimeProfiles:
                 num_dof=1,
                 min_chi2_step=min_chi2_step,
                 max_chi2_step=max_chi2_step,
+                min_step=min_step,
+                max_step=max_step,
                 confidence_level=1.0 - alpha,
                 bound_tolerance=1e-8,  # Needed because constraint is not always exactly fulfilled
             )
@@ -689,6 +698,8 @@ class DwelltimeModel:
         *,
         alpha=0.05,
         num_steps=150,
+        min_step=1e-7,
+        max_step=1.0,
         min_chi2_step=0.01,
         max_chi2_step=0.1,
         verbose=False,
@@ -699,6 +710,14 @@ class DwelltimeModel:
         confidence intervals. It iteratively performs a step for the profiled parameter, then
         fixes that parameter and re-optimizes all the other parameters [2]_ [3]_.
 
+        For each profile likelihood point, the profiled parameter is changed such that the fit
+        error goes up by an amount between `min_chi2_step` and `max_chi2_step`. After step size
+        determination, the step is applied and the other parameters are re-optimized.
+
+        To prevent step sizes from becoming too small, a minimal step size can be set. When the
+        step size goes below the minimum step size a warning is issued. When this happens, check
+        to verify that the profile likelihood curve is smooth.
+
         Parameters
         ----------
         alpha : float
@@ -706,6 +725,12 @@ class DwelltimeModel:
             default: 0.05
         num_steps: int
             Number of steps to take, default: 150.
+        min_step : float
+            Minimum step size used during step size determination. Any step size lower will be
+            clamped to this value and a warning will be issued. Default: 1e-7.
+        max_step : float
+            Maximum step size used during step size determination. Any step size larger will be
+            clamped to this value. Default: 1.0
         min_chi2_step: float
             Minimal desired step in terms of chi squared change prior to re-optimization. When the
             step results in a fit change smaller than this threshold, the step-size will be
@@ -731,6 +756,8 @@ class DwelltimeModel:
             self,
             alpha=alpha,
             num_steps=num_steps,
+            min_step=min_step,
+            max_step=max_step,
             min_chi2_step=min_chi2_step,
             max_chi2_step=max_chi2_step,
             verbose=verbose,


### PR DESCRIPTION
**Why this PR?**
Parameter profiles are computed by changing one parameter and re-optimizing all the others. This procedure is then repeated until we either hit a point where the fit gets significantly worse or we hit our parameter bounds.

When doing this, it is important to choose a step size of the step to make. Since the optimization part is the most expensive part, we do this adaptively _before_ optimizing. Basically we want the step to end up in some range of chi squared increase. 
We don't want it to be too large (since we don't want to end up in a different minimum). And we don't want it to be too small, because then we would take forever.

In some cases, during fd fitting, the chi squared increased so fast however that this adaptive system breaks down and we end up with step sizes that are so small that we don't move at all anymore. For this reason, we introduced a minimum step size.

In dwell time analysis however, the models are typically well behaved, and you are less likely to get an incomplete profile due to the step size collapsing (which was sometimes an issue when fitting F,d curves). Unfortunately, when this was implemented, we used the same default as for the Fd Fitter, which pushed for bigger step sizes.

Before:
![image](https://github.com/user-attachments/assets/3b57ee2e-905d-410b-9cc2-ecaec12ef4c6)

After:
<img width="616" alt="image" src="https://github.com/user-attachments/assets/9e74bd59-4538-432e-8fc6-274fb21556db">

This PR changes a few small things:
- It moves the warning a bit further upstream. Reason for this is that then we can provide the user with the parameter name, and not spam the warning many times consecutively.
- It allows users to customize the `min_step` if they do hit it, or if in some case, they need a larger one because profiles take too long to compute.
- It makes the default `min_step` for the profile lower for the dwell time model. I would argue this is a bug fix rather than a breaking change.

Note: One day I would really like to refactor this profile code a little bit, since it is pretty rough, but that seems like something for a future PR.