### PR TITLE
slice: ensure operators work with all scalars

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,10 @@
 * Added improved printing of calibrations performed with `Pylake`.
 * Improved error message that includes the name of the model when trying to access a model that was not added in an [`FdFit`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.FdFit.html) using angular brackets.
 
+#### Bug fixes
+
+* Ensure that operators such as (e.g. `+`, `-`, `/`) work on [`Slice`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.channel.Slice.html) with all types that are convertible to scalars. Previously these failed with zero dimensional numpy arrays and other convertible objects.
+
 ## v1.5.3 | 2024-10-29
 
 #### Bug fixes

--- a/lumicks/pylake/detail/utilities.py
+++ b/lumicks/pylake/detail/utilities.py
@@ -1,4 +1,5 @@
 import math
+import numbers
 import contextlib
 
 import numpy as np
@@ -213,3 +214,14 @@ def temp_seed(seed):
         yield
     finally:
         np.random.seed(None)
+
+
+def convert_to_scalar(value):
+    """Converts to a numeric scalar if possible, otherwise returns None"""
+    try:
+        value = np.asarray(value).item()
+    except ValueError:  # Can only convert array of size 1 to Python scalar
+        return None
+
+    if isinstance(value, numbers.Number):
+        return value

--- a/lumicks/pylake/tests/test_channels/test_arithmetic.py
+++ b/lumicks/pylake/tests/test_channels/test_arithmetic.py
@@ -1,8 +1,11 @@
+import warnings
+
 import numpy as np
 import pytest
 
 from lumicks.pylake.channel import Slice, TimeTags, Continuous, TimeSeries
 from lumicks.pylake.calibration import ForceCalibrationList
+from lumicks.pylake.detail.value import ValueMixin
 
 start = 1 + int(1e18)
 calibration = ForceCalibrationList(
@@ -64,6 +67,16 @@ def test_operations_slice(slice1, slice2):
     [
         (slice_continuous_1, 2.0),
         (slice_timeseries_1, 2.0),
+        (slice_continuous_1, 0),
+        (slice_timeseries_1, 0),
+        (slice_continuous_1, 0.0),
+        (slice_timeseries_1, 0.0),
+        (slice_continuous_1, np.array(2.0)),
+        (slice_timeseries_1, np.array(2.0)),
+        (slice_continuous_1, np.array(0)),
+        (slice_timeseries_1, np.array(0)),
+        (slice_continuous_1, ValueMixin(2.0)),
+        (slice_timeseries_1, ValueMixin(2.0)),
     ],
 )
 def test_operations_scalar(slice1, scalar):
@@ -85,7 +98,9 @@ def test_operations_scalar(slice1, scalar):
             assert not getattr(current_slice, operation)(scalar_val).calibration
 
     for operator, preserve_calibration, *_ in operators:
-        test_operator(slice1, scalar, operator, preserve_calibration)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="divide by zero encountered in divide")
+            test_operator(slice1, scalar, operator, preserve_calibration)
 
 
 slice_continuous_different_timestamps = Slice(
@@ -181,7 +196,7 @@ def test_negation(channel_slice):
 
 def test_negation_timetags_not_implemented():
     with pytest.raises(NotImplementedError):
-        negated_timetags = -timetags
+        _ = -timetags
 
 
 def test_labels_slices():


### PR DESCRIPTION
**Why this PR?**
Dividing a slice by a scalar doesn't work properly for numpy arrays and other convertible types.

The bug basically boils down to the assumption that `np.isscalar(x)` would return `False` for `np.array(1)`, which it doesn't.

Considering that we want to start using a value class for several things, I think the safest approach would be to check whether what we have is convertible to a scalar explicitly, rather than direct type checking. This way we also preserve the type of the source data, and the behavior doesn't break if more scalar-like datatypes become available.

Please think of any cases I might have missed in the tests.