### PR TITLE
release procedure fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 * Fixed a bug where bead edge determination could fail with an unhandled exception during background estimation. This raised a `np.linalg.LinAlgError` when determining the background failed rather than the expected `RuntimeError`. In this case, a simple median is used as a fallback option.
 * Fix a bug to ensure that [`lk.GaussianMixtureModel`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.GaussianMixtureModel.html) can also be used with a single state.
 * Fixed bug that prevented opening the force distance widgets when using them with the `widget` backend on `matplotlib >= 3.9.0`.
+* Prevent near `0/0` during fitting when components of a [`DwelltimeModel`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.DwelltimeModel.html) are near zero. Note that these only occurred during the computation of the model derivatives during the fitting procedure and should not impact the model simulation itself.
 
 ## v1.5.3 | 2024-10-29
 

--- a/docs/examples/bead_coupling/coupling.rst
+++ b/docs/examples/bead_coupling/coupling.rst
@@ -293,17 +293,10 @@ Next, we define a function that calibrates all axes with both passive and active
 
 `calculate_calibrations` now returns the distances between the beads and all the calibration factors obtained with passive and active calibration.
 
-    >>> calculate_calibrations(lk.File(calibration_data[0][0]), bead_diameter=2.1, temperature=25)
-    {'dx': 22.107661709308474,
-     'dy': -0.07111526715106109,
-     'passive': {'1x': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d024aaa0>,
-      '2x': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d06df130>,
-      '1y': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d0297010>,
-      '2y': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d04992d0>},
-     'active': {'1x': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d056fe80>,
-      '2x': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d053b370>,
-      '1y': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d04992a0>,
-      '2y': <lumicks.pylake.force_calibration.power_spectrum_calibration.CalibrationResults at 0x2d049cfd0>}}
+    >>> single_distance_result = calculate_calibrations(lk.File(calibration_data[0][0]), bead_diameter=2.1, temperature=25)
+    ... single_distance_result["passive"]["1x"]
+
+.. image:: single_result.png
 
 Let's calculate calibration factors for all the data in this dataset.
 Note that this cell may take a while to execute as it is performing `240` calibrations::
@@ -347,7 +340,7 @@ Now that we have those results, let's define some functions to conveniently extr
 We can now show the effect of coupling on active calibration in practice using the analyzed data::
 
     parameters = {
-        "Rd": "Displacement sensitivity [$\mu$m/V]",
+        "Rd": r"Displacement sensitivity [$\mu$m/V]",
         "Rf": "Force sensitivity [pN/V]",
         "kappa": "Stiffness [pN/nm]",
     }
@@ -358,7 +351,7 @@ We can now show the effect of coupling on active calibration in practice using t
         dx, dy = extract_distances(experiment[0])
         plt.plot(dx, extract_parameter(experiment[0], "active", "2x", param), ".", label="active")
         plt.plot(dx, extract_parameter(experiment[0], "passive", "2x", param), "x", label="passive")
-        plt.xlabel("Bead-Bead Distance [$\mu$m]")
+        plt.xlabel(r"Bead-Bead Distance [$\mu$m]")
         plt.ylabel(param_description)
 
     plt.tight_layout()
@@ -405,7 +398,7 @@ To show how well this model fits the data, we can plot it alongside the ratio of
                 plt.plot(dx, ac / pc, f"C{trap}.")
                 plt.plot(dx_c, 1 / c, "k--")
                 plt.axvline(bead_diameter, color="lightgray", linestyle="--")
-                plt.xlabel("Bead-Bead Distance [$\mu$m]")
+                plt.xlabel(r"Bead-Bead Distance [$\mu$m]")
                 plt.ylabel("$R_{d, ac} / R_{d, passive}$")
                 plt.title(f"Displacement sensitivity ratio {axis} AC/PC")
 
@@ -415,7 +408,7 @@ To show how well this model fits the data, we can plot it alongside the ratio of
                 plt.plot(dx, ac / pc, f"C{trap}.")
                 plt.plot(dx_c, c, "k--")
                 plt.axvline(bead_diameter, color="lightgray", linestyle="--")
-                plt.xlabel("Bead-Bead Distance [$\mu$m]")
+                plt.xlabel(r"Bead-Bead Distance [$\mu$m]")
                 plt.ylabel("$R_{f, ac} / R_{f, passive}$")
                 plt.title(f"Force sensitivity ratio {axis} AC/PC")
 
@@ -425,8 +418,8 @@ To show how well this model fits the data, we can plot it alongside the ratio of
                 plt.plot(dx, ac / pc, f"C{trap}.", label=f"{trap}{axis}")
                 plt.plot(dx_c, c**2, "k--")
                 plt.axvline(bead_diameter, color="lightgray", linestyle="--")
-                plt.xlabel("Bead-Bead Distance [$\mu$m]")
-                plt.ylabel("$\kappa_{ac} / \kappa_{passive}$")
+                plt.xlabel(r"Bead-Bead Distance [$\mu$m]")
+                plt.ylabel(r"$\kappa_{ac} / \kappa_{passive}$")
                 plt.title(f"Stiffness sensitivity ratio {axis} AC/PC")
 
                 plt.tight_layout()
@@ -461,7 +454,7 @@ Some remaining variability is expected as the bead radius (which is subject to v
                 pc = extract_parameter(exp, "passive", f"{trap}{axis}", "Rd")
                 plt.plot(dx, ac * c / pc, f"C{trap}.")
                 plt.axvline(bead_diameter, color="lightgray", linestyle="--")
-                plt.xlabel("Bead-Bead Distance [$\mu$m]")
+                plt.xlabel(r"Bead-Bead Distance [$\mu$m]")
                 plt.ylabel("$R_{d, ac} / R_{d, passive}$")
                 plt.title(f"Displacement sensitivity ratio {axis} AC/PC")
 
@@ -470,7 +463,7 @@ Some remaining variability is expected as the bead radius (which is subject to v
                 pc = extract_parameter(exp, "passive", f"{trap}{axis}", "Rf")
                 plt.plot(dx, ac / c / pc, f"C{trap}.")
                 plt.axvline(bead_diameter, color="lightgray", linestyle="--")
-                plt.xlabel("Bead-Bead Distance [$\mu$m]")
+                plt.xlabel(r"Bead-Bead Distance [$\mu$m]")
                 plt.ylabel("$R_{f, ac} / R_{f, passive}$")
                 plt.title(f"Force sensitivity ratio {axis} AC/PC")
 
@@ -479,8 +472,8 @@ Some remaining variability is expected as the bead radius (which is subject to v
                 pc = extract_parameter(exp, "passive", f"{trap}{axis}", "kappa")
                 plt.plot(dx, ac / c**2 / pc, f"C{trap}.", label=f"{trap}{axis}")
                 plt.axvline(bead_diameter, color="lightgray", linestyle="--")
-                plt.xlabel("Bead-Bead Distance [$\mu$m]")
-                plt.ylabel("$\kappa_{ac} / \kappa_{passive}$")
+                plt.xlabel(r"Bead-Bead Distance [$\mu$m]")
+                plt.ylabel(r"$\kappa_{ac} / \kappa_{passive}$")
                 plt.title(f"Stiffness sensitivity ratio {axis} AC/PC")
 
                 plt.tight_layout()

--- a/docs/examples/bead_coupling/single_result.png
+++ b/docs/examples/bead_coupling/single_result.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb9258a870dba63509a76438bd85754f40c5d9ae0829da607c673d898a767092
+size 336009

--- a/docs/examples/binding_lifetime/binding_lifetime.rst
+++ b/docs/examples/binding_lifetime/binding_lifetime.rst
@@ -11,7 +11,7 @@ Binding lifetime analysis
 Determine the binding lifetime from a kymograph
 -----------------------------------------------
 
-In this Notebook, we will determine the binding lifetime of a fluorescently labeled protein binding to DNA. The binding lifetime is also referred to as the binding duration 
+In this Notebook, we will determine the binding lifetime of a fluorescently labeled protein binding to DNA. The binding lifetime is also referred to as the binding duration
 and relates to the off rate as :math:`k_{off}` = 1/binding lifetime.
 
 First, we will track the binding events. Then we collect the binding durations and use maximum likelihood fitting to fit an exponential function to the data.
@@ -33,7 +33,7 @@ Load the first file and plot the kymograph::
 
     file1 = lk.File("test_data/kymo1.h5")
     _, kymo1 = file1.kymos.popitem()
-    
+
     plt.figure()
     kymo1.plot("g", aspect = 5, adjustment=lk.ColorAdjustment([0], [5]))
 
@@ -43,7 +43,7 @@ Load and plot the second kymograph::
 
     file2 = lk.File("test_data/kymo2.h5")
     _, kymo2 = file2.kymos.popitem()
-    
+
     plt.figure()
     kymo2.plot("g", aspect = 5, adjustment=lk.ColorAdjustment([0], [5]))
 
@@ -100,7 +100,7 @@ The (loaded) tracks can be plotted on top of the original kymograph to visualize
 .. image:: tracks1.png
 
 Note that two tracks at t=0 were manually removed, because the starting points of these tracks are not visible. This means that we cannot determine the duration of these tracks.
-The length of each track corresponds to the duration of a binding event. As can be seen from the above image, there is a large variation in track lengths. 
+The length of each track corresponds to the duration of a binding event. As can be seen from the above image, there is a large variation in track lengths.
 By collecting all these track durations into a 'binding lifetime distribution', we can analyze the binding lifetime in more detail.
 
 Combine tracks
@@ -139,14 +139,14 @@ Fit a single exponential to the dwell times and plot the result::
 The fitted lifetime :math:`\tau = 4` seconds.
 
 The parameter `n_components` indicates the number of exponential time scales in the fit, as further explained below.
-The parameters `observed_minimum` and `discrete_model` are further explained in :ref:`dwelltime_analysis`. 
+The parameters `observed_minimum` and `discrete_model` are further explained in :ref:`dwelltime_analysis`.
 
 Double exponential fit
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Sometimes, the distribution can best be fit by multiple exponential time scales. 
-These exponential time scales reveal something about the underlying mechanism of binding. 
-For example, the protein of interest binds with higher affinity to the target site, while it binds more transiently to off-target sites. 
+Sometimes, the distribution can best be fit by multiple exponential time scales.
+These exponential time scales reveal something about the underlying mechanism of binding.
+For example, the protein of interest binds with higher affinity to the target site, while it binds more transiently to off-target sites.
 Such behavior has been observed for various proteins such as Cas9 [1]_.
 
 In binding lifetime analysis, it is therefore important to test which number of exponentials optimally fits the data.
@@ -167,10 +167,10 @@ Fit a double exponential distribution to the binding lifetimes by setting `n_com
 .. _double_exponential_fit:
 .. image:: double_exponential_fit.png
 
-The component :math:`a_1=0.94` with lifetime :math:`\tau_1 = 3.2` seconds, while component :math:`a_2=0.06` with lifetime :math:`\tau_2 = 24` seconds.
+The component :math:`a_1=0.94` with lifetime :math:`\tau_1 = 3` seconds, while component :math:`a_2=0.059` with lifetime :math:`\tau_2 = 18` seconds.
 
 Next we have to select which is the optimal model: 1 or 2 exponential time scales.
-There are various methods for model selection. We will discuss 3 of them below. 
+There are various methods for model selection. We will discuss 3 of them below.
 
 Confidence intervals and model comparison
 -----------------------------------------
@@ -190,7 +190,7 @@ The :ref:`pop_confidence_intervals`, can be used to judge how precisely we can e
 .. image:: profile1.png
 
 The parameter to be fitted is given on the x-axis of the plots and the optimal value is where the curve is at its minimum.
-The lower the :math:`\chi^2` value at the minimum, the better the fit. 
+The lower the :math:`\chi^2` value at the minimum, the better the fit.
 The point where the profile crosses the dashed horizontal line is an indication for the 95% confidence interval.
 
 The profile likelihood for the single exponent looks parabolic and is almost symmetric, which indicates that the estimate of the lifetime is precise.
@@ -206,7 +206,7 @@ The likelihood profile for the double exponential fit::
 
 .. image:: profile2.png
 
-For the double exopnential fit, the profiles look more skewed. The values of :math:`\chi^2` at the minimum are lower, which indicates a better fit. 
+For the double exopnential fit, the profiles look more skewed. The values of :math:`\chi^2` at the minimum are lower, which indicates a better fit.
 However, the binding lifetime labeled 'lifetime 1' never crosses the horizontal line, which indicates that it does not really have an upper bound; this parameter can not be optimized for this data set.
 When looking at the likelihood profiles, the single exponential fit is optimal.
 
@@ -216,7 +216,7 @@ Bootstrapping
 Bootstrapping can be used to select the most suitable model and is a good method for determining the confidence intervals for the fitted parameters.
 During bootstrapping, a random sample is taken from the original dataset and fitted. The fitted parameters are gathered in the bootstrapping distribution.
 In the example below, we perform 10000 iterations, which means that 10000 times we take a sample from the data and fit the sample with a single exponential distribution.
-The resulting 10000 binding lifetimes are plotted in the histogram. 
+The resulting 10000 binding lifetimes are plotted in the histogram.
 
 Compute and plot the bootstrapping the distribution for the single exponential fit. This will take a while...::
 
@@ -239,7 +239,7 @@ Compute and plot the bootstrapping the distribution for the double exponential f
 
 .. image:: bootstrap2.png
 
-The bootstrapping distribution for the double exponential fit is sometimes bimodal and the component :math:`a_2` has a peak close to zero. 
+The bootstrapping distribution for the double exponential fit is sometimes bimodal and the component :math:`a_2` has a peak close to zero.
 This indicates that for many of the bootstrap samples, the fraction associated with the second lifetime was really small and that the parameters of this second lifetime cannot be estimated reliably from the data.
 
 According to the bootstrapping distributions, the single exponential fit is better suitable for the data.
@@ -247,7 +247,7 @@ According to the bootstrapping distributions, the single exponential fit is bett
 Bayesian Information Criterion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Typically adding more parameters (components) to a model, will make the fit better. However, having too many parameters can lead to overfitting. 
+Typically adding more parameters (components) to a model, will make the fit better. However, having too many parameters can lead to overfitting.
 The Bayesian information Criterion (BIC) quantifies the quality of the fit by looking at the value of the likelihood function and penalizes the addition of parameters.
 
 The BIC for the single and double exponential fit are respectively given by::
@@ -267,20 +267,20 @@ We fitted a single exponential and double exponential to the distribution of bin
 The likelihood profile and bootstrapping indicated that when using a two-component model, we cannot reliably estimate the second lifetime nor the fraction of events that have this lifetime associated with them.
 The BIC indicated that a double exponential is more suitable, but the difference between the small and large model is not very large.
 
-Looking at Figure with the :ref:`double exponential fit <double_exponential_fit>`, there are only a few data points larger than 20 seconds that support the second exponential time scale. 
+Looking at Figure with the :ref:`double exponential fit <double_exponential_fit>`, there are only a few data points larger than 20 seconds that support the second exponential time scale.
 Therefore, the data set is likely too small to support a second exponential time scale. (Fitting two exponentials without overfitting, typically requires a few hundred data points.)
 
-With the current dataset, we conclude that the most suitable model is a single exponential as it gives us the most precise estimates. The fitted lifetime is :math:`\tau = 4` seconds with a 95% confidence interval of (3,5.2) seconds as determined by bootstrapping. 
+With the current dataset, we conclude that the most suitable model is a single exponential as it gives us the most precise estimates. The fitted lifetime is :math:`\tau = 4` seconds with a 95% confidence interval of (3,5.2) seconds as determined by bootstrapping.
 However, given that we do see a hint that there may be a second lifetime involved, it would be worthwhile to gather more data in this case.
 
 Splitting tracks by position
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When the target sites of the protein are known, the binding lifetimes can also be split by position and analyzed separately [1]_.
-For example, to select all tracks from `kymo1_selection` that have an average position larger than 8 micron, type:: 
-    
+For example, to select all tracks from `kymo1_selection` that have an average position larger than 8 micron, type::
+
     track_selection = tracks1[[np.mean(track.position) > 8 for track in tracks1]]
-    
+
 Similarly, we can have a two-sided interval. For example, tracks with a position between 5.5 and 6.2 micron can be obtained by::
 
     track_selection = tracks1[[5.5 < np.mean(track.position) < 6.2 for track in tracks1]]

--- a/docs/examples/binding_lifetime/bootstrap1.png
+++ b/docs/examples/binding_lifetime/bootstrap1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd60f12846a668b1893785a2cda92e68bd49c2486c972bc1bd27d29ec8487b0d
-size 17498
+oid sha256:a4a970e6331dd22e6e2298e4eaf977660ff42689de50ad359199c7d543cda7ec
+size 16970

--- a/docs/examples/binding_lifetime/bootstrap2.png
+++ b/docs/examples/binding_lifetime/bootstrap2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ef9c38adc65fd79e6f3a15c62588bb967579fe4a68714a262432b923d66e42c1
-size 35945
+oid sha256:98bb304d5c6e542a391cd87e7afee77c8b24f6d6b6b183ee02963e62f5254182
+size 35692

--- a/docs/examples/binding_lifetime/double_exponential_fit.png
+++ b/docs/examples/binding_lifetime/double_exponential_fit.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:568444fd1fe5e234e90cf0790d0a04ae8a168d9c092f6ca08a15d90922ff7b6b
-size 31942
+oid sha256:302b44513531bbbb21c00fb2bb8f43a72b29f5d751be40a017b7bafad43fd04b
+size 32622

--- a/docs/examples/binding_lifetime/exponential_fit.png
+++ b/docs/examples/binding_lifetime/exponential_fit.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36c7827b0f088411662e64d7a3de90d2e0ba8fa494993897ad15a98951acbad8
-size 26649
+oid sha256:37db486169f592c0248d6b1eec440443e483e37ebe3e73eee071f16da1c20cea
+size 26535

--- a/docs/run_notebooks.py
+++ b/docs/run_notebooks.py
@@ -117,6 +117,7 @@ def run_notebooks(include_list, reset_cache, only_copy):
     exclude_list = [
         "nbwidgets",  # Exclude the notebook widgets since those require interaction
         "cas9_kymotracking",
+        "binding_lifetime",
     ]
     base_dir = pathlib.Path(__file__).parent.parent.resolve()
     nb_test_dir = base_dir / "nb_test"

--- a/docs/theory/force_calibration/active.rst
+++ b/docs/theory/force_calibration/active.rst
@@ -3,6 +3,10 @@
 Active Calibration
 ------------------
 
+.. only:: html
+
+    :nbexport:`Download this page as a Jupyter notebook <self>`
+
 For certain applications, passive force calibration, as described above, is not sufficiently accurate.
 Using active calibration, the accuracy of the calibration can be improved.
 The reason for this is that active calibration uses fewer assumptions than passive calibration.

--- a/docs/theory/force_calibration/figures/diffusion_spectra.png
+++ b/docs/theory/force_calibration/figures/diffusion_spectra.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85fdadde8210629315e951c145291e37b3b54741e5751f97f81b146a4b85ebdd
-size 201014
+oid sha256:1a771bbef0d28786f8ce33400b8ebe378954e2e4b90a6cb7dfc12699dceb940f
+size 38577

--- a/docs/theory/force_calibration/figures/hydro_fast.png
+++ b/docs/theory/force_calibration/figures/hydro_fast.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35cd996d7220906950b9c6bf8e3fd2cbbf7fbd0cae256dc2347dd61bff7ec04d
-size 63964
+oid sha256:45a64c7c72ff837919125ae2802a800bd92c29291381d192ed8a6e36a7f22071
+size 63981

--- a/docs/theory/force_calibration/figures/lorentzians.png
+++ b/docs/theory/force_calibration/figures/lorentzians.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63b914b7e8d6e2af3d2a2f1b07fcff4e70c0c23a9c2c6f83c6d36176fe4926aa
-size 270559
+oid sha256:1c5e0217c15f8f436ba94712aee956d9fd3755e5fce5e4df5cbf22943668cd54
+size 55809

--- a/docs/theory/force_calibration/passive.rst
+++ b/docs/theory/force_calibration/passive.rst
@@ -1,6 +1,10 @@
 Passive calibration
 -------------------
 
+.. only:: html
+
+    :nbexport:`Download this page as a Jupyter notebook <self>`
+
 Passive calibration is also often referred to as thermal calibration and involves calibration without
 moving the trap or stage. In passive calibration, the Brownian motion of the bead in the trap is
 analyzed in order to find calibration factors for both the positional detection as well as the force.

--- a/docs/tutorial/figures/population_dynamics/discrete_pop.png
+++ b/docs/tutorial/figures/population_dynamics/discrete_pop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c731f102cc0d2f3de7774165b38a87f50e941b04962edbabd326b4d7f49ad00
-size 25081
+oid sha256:f5bfb8eab4218aaac492088d8707261a5815f89ad8479b11277b679e2af31283
+size 25936

--- a/docs/tutorial/force_calibration/active_calibration.rst
+++ b/docs/tutorial/force_calibration/active_calibration.rst
@@ -103,7 +103,7 @@ Let's compare the active calibration result to passive calibration::
     ...     num_points_per_block=200
     ... )
     >>> print(passive_fit.stiffness)
-    0.11763849764570819
+    0.11751264110743381
 
 This value is quite close to that obtained with active calibration above.
 
@@ -120,7 +120,7 @@ calculated from the physical input parameters)::
     ...     num_points_per_block=200
     ... )
     >>> print(passive_fit.stiffness)
-    0.08616565751377737
+    0.0860734724588009
 
 .. _bead_bead_tutorial:
 

--- a/docs/tutorial/force_calibration/force_calibration.rst
+++ b/docs/tutorial/force_calibration/force_calibration.rst
@@ -141,6 +141,7 @@ Below is an example of a bad fit due to a noise floor.
 Note how the spectrum flattens out at high frequencies and the model is unable to capture this.
 
 .. image:: figures/bad_fit_noise_floor.png
+  :nbattach:
 
 **As a rule of thumb, an upper bound of approximately four times the corner frequency is usually a safe margin.**
 The fitting bounds can be specified by providing a `fit_range` to any of the calibration functions.

--- a/docs/tutorial/population_dynamics.rst
+++ b/docs/tutorial/population_dynamics.rst
@@ -171,7 +171,7 @@ We can get some information about the training process from the :attr:`~lumicks.
 property::
 
     >>> print(hmm.fit_info)
-    HmmFitInfo(converged=True, n_iter=5, bic=1589.2881620885353, aic=1550.067858853102, log_likelihood=-768.033929426551)
+    PopulationFitInfo(converged=True, n_iter=5, bic=1589.2881620885353, aic=1550.067858853102, log_likelihood=-768.033929426551)
 
 Just as with the GMM we trained earlier, we can visually inspect the quality of the fitted
 model. First, let's look at the probability distribution of the observed data::

--- a/docs/whatsnew/1.6.0/1_6_0.rst
+++ b/docs/whatsnew/1.6.0/1_6_0.rst
@@ -5,14 +5,24 @@ Pylake 1.6.0
 
 Here is a sneak preview of features that will likely be in Pylake `v1.6.0`.
 
+New example notebooks
+---------------------
+
+Three new notebooks were added to the documentation, with examples of full analysis workflows:
+:doc:`Binding lifetime analysis</examples/binding_lifetime/binding_lifetime>`,
+:doc:`hairpin fitting</examples/hairpin_fitting/hairpin_unfolding>` and
+:doc:`phase separation</examples/droplet_fusion/droplet_fusion>`.
+
+.. figure:: new_examples.png
+
 Bead-bead coupling correction
 -----------------------------
-
-.. figure:: correction_factor_whatsnew.png
 
 When performing active calibration with two beads coupling effects can bias the estimated calibration parameters (force and displacement sensitivity, and the stiffness).
 In Pylake 1.6.0, we include a model to account for bead-bead coupling between two beads in bulk.
 See :ref:`theory<bead_bead_theory>` and :ref:`tutorial<bead_bead_tutorial>` and the :doc:`example</examples/bead_coupling/coupling>` for more information.
+
+.. figure:: correction_factor_whatsnew.png
 
 Force calibration
 -----------------

--- a/docs/whatsnew/1.6.0/new_examples.png
+++ b/docs/whatsnew/1.6.0/new_examples.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ceb5100e6968e711bbc9b23abb94ae2bcd26414b672f963329f6f943bff3b57b
+size 81485


### PR DESCRIPTION
**Why this PR?**
I had hoped this would be the release PR already, but it turns out we need a few more small fixes before we can release.

1. It seems we haven't run the notebooks in a while, and some of the figures/numbers went out of date. The figures in the theory section were updated since they didn't take into account this [PR](https://github.com/lumicks/pylake/pull/613/files) yet. Some power spectral plots were updated, since they didn't take into account that we explicitly show the cuts now. Finally, [when it was first introduced](https://github.com/lumicks/pylake/pull/541/files#diff-2c94bbb8cdc4e7320db76b6434fff877418be37b52edc9c9b14a09fd86d7c5e7), the discrete dwell time plot did not enforce specifying a minimum observation time. Now it does, (as it should) by default, but the plot was never updated! The other things are tiny fixups that hopefully speak for themselves.

2. One of the figures in the binding lifetime notebook was incorrect (namely the one for the double exponential fit).

3. I noticed that our example notebook shows a bunch of warnings when doing the bootstrap. These came from 0/0s in the numerical gradient. We can rephrase this gradient to avoid this problem.

4. I noticed that in some pathological cases, the numerical derivative of the Jacobian that we calculate for the standard deviation could fail. Reason being that during numerical differentiation we could exceed 1 for an amplitude meaning that the sum constraint is by definition violated. I have also loosened the tolerances on the tests for clearly overparametrized models (as their uncertainties are not as well defined and depend on numerics). I deliberately added such a case to the tests.

Finally, I have added a what's new entry to highlight some of the nice examples @aafkevandenberg has been contributing!

Highly recommend going commit by commit. Plan is to squash commit 2 into 3 (right now it is separate in case you wish to test that the test indeed hits that corner case).

Note tests are failing because of brittle test (fix in [718](https://github.com/lumicks/pylake/pull/718)).

Docs build [here](https://lumicks-pylake.readthedocs.io/en/final_prep/whatsnew/1.6.0/1_6_0.html).