### PR TITLE
ci: verify before uploading, unpin setuptools

### DIFF
--- a/.github/actions/check-python-packaging/action.yml
+++ b/.github/actions/check-python-packaging/action.yml
@@ -1,0 +1,22 @@
+name: "Check Python Packaging"
+description: ""
+runs:
+  using: "composite"
+  steps:
+    - name: Install packaging dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install "setuptools>=69.3" build wheel twine
+      shell: bash
+    - name: Package pylake
+      run: |
+        python -m build
+        python -m twine check --strict dist/*
+      shell: bash
+    - name: Unpack the generated package
+      run: tar -xvzf dist/lumicks_pylake*.tar.gz
+      shell: bash
+    - name: Compare contents with the repo folder
+      run: |
+        diff -r -x __pycache__ lumicks/pylake/ lumicks_pylake-*/lumicks/pylake
+      shell: bash

--- a/.github/workflows/pylake_release.yml
+++ b/.github/workflows/pylake_release.yml
@@ -32,4 +32,5 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m build
+        python -m twine check --strict dist/*
         python -m twine upload dist/* --verbose

--- a/.github/workflows/pylake_test.yml
+++ b/.github/workflows/pylake_test.yml
@@ -43,3 +43,5 @@ jobs:
       run: |
         pip install flake8 flake8-bugbear
         flake8 .
+    - name: Check packaging
+      uses: ./.github/actions/check-python-packaging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<69.3", "wheel"]
+requires = ["setuptools>=69.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,7 +10,7 @@ authors = [
     {name = "Lumicks B.V."},
     {email = "devteam@lumicks.com"},
 ]
-readme = {file="README.md", content-type = "text/markdown"}
+readme = {file="readme.md", content-type = "text/markdown"}
 license = {file = "license.md"}
 keywords = ["optical tweezers", "kymographs", "data analysis", "lumicks"]
 classifiers=[


### PR DESCRIPTION
**Why this PR**
- The strict `twine` check verifies the build before it goes out. Previously, I missed that the `README.md` wouldn't be picked up on a case-sensitive OS such as the one we use to deploy.
- We should also unpin `setuptools` to not stick with the deprecated source distribution name (`lumicks.pylake` -> `lumicks_pylake`).
