### PR TITLE
calibration: ensure `force_sensitivity` omits sign

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.6.1 | t.b.d.
+
+#### Bug fixes
+
+* Fixed a bug where [`ForceCalibrationItem.force_sensitivity`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.calibration.ForceCalibrationItem.html#lumicks.pylake.calibration.ForceCalibrationItem.force_sensitivity) would return the signed force response rather than the unsigned force sensitivity of a Bluelake calibration. This can cause issues with the force sign when using ratios of sensitivities obtained from Bluelake or Pylake. Now Pylake and Bluelake items both return the unsigned force sensitivity.
+
 ## v1.6.0 | 2025-01-09
 
 #### New features

--- a/lumicks/pylake/force_calibration/detail/calibration_properties.py
+++ b/lumicks/pylake/force_calibration/detail/calibration_properties.py
@@ -145,7 +145,9 @@ class CalibrationPropertiesMixin:
         To recalibrate force channels, simply multiply them by the ratio of force sensitivities of
         the old and new calibration.
         """
-        return self._get_parameter("Rf", "Response (pN/V)")
+        # We use the response in the Bluelake case, since it is always available. The force
+        # sensitivity is not available for reset calibration to unity items for instance.
+        return abs(self._get_parameter("Rf", "Response (pN/V)"))
 
     @property
     def displacement_sensitivity(self):

--- a/lumicks/pylake/force_calibration/tests/test_calibration_item.py
+++ b/lumicks/pylake/force_calibration/tests/test_calibration_item.py
@@ -1,5 +1,6 @@
 import pickle
 
+import numpy as np
 import pytest
 
 from lumicks.pylake.calibration import ForceCalibrationList
@@ -148,7 +149,9 @@ def test_passive_item(compare_to_reference_dict, reference_data, calibration_dat
     assert item.start == 1696171376701856700
     assert item.stop == 1696171386701856700
     assert item.stiffness is ref_passive_fixed_diode_with_height["kappa (pN/nm)"]
-    assert item.force_sensitivity is ref_passive_fixed_diode_with_height["Rf (pN/V)"]
+    np.testing.assert_equal(
+        item.force_sensitivity, ref_passive_fixed_diode_with_height["Rf (pN/V)"]
+    )
     assert item.displacement_sensitivity is ref_passive_fixed_diode_with_height["Rd (um/V)"]
 
     assert item.corner_frequency == item["fc (Hz)"]
@@ -200,7 +203,7 @@ def test_active_item_fixed_diode(compare_to_reference_dict, calibration_data):
     assert item.start == 1713785826919398000
     assert item.stop == 1713785836900152600
     assert item.stiffness is ref_active["kappa (pN/nm)"]
-    assert item.force_sensitivity is ref_active["Rf (pN/V)"]
+    np.testing.assert_equal(item.force_sensitivity, ref_active["Rf (pN/V)"])
     assert item.displacement_sensitivity is ref_active["Rd (um/V)"]
     assert item.offset == ref_active["Offset (pN)"]
 
@@ -235,7 +238,7 @@ def test_axial_fast_sensor(compare_to_reference_dict, calibration_data):
     assert not item.active_calibration
     assert item.fast_sensor
     assert item.stiffness is ref_axial["kappa (pN/nm)"]
-    assert item.force_sensitivity is ref_axial["Rf (pN/V)"]
+    np.testing.assert_equal(item.force_sensitivity, ref_axial["Rf (pN/V)"])
     assert item.displacement_sensitivity is ref_axial["Rd (um/V)"]
     assert item.offset == ref_axial["Offset (pN)"]
 


### PR DESCRIPTION
**Why this PR?**
The force sensitivity should correspond to `Rf` rather than the full response and should omit the sign. The reason for this is that we typically recalibrate using a ratio of sensitivities. We can do this since Bluelake is already always using the correct sign for the force data.

This helps keep things simple for users as the alternative would require users to either manually change the sign at the end, or the sign information would have to be propagated through the calibration models when recalibrating (which leads to an extra class parameter when initializing those).

Since some calibration items do not provide a value for `Rf`, I deferred to using the `Response (pN/V)` instead as it is always available. Unfortunately, I overlooked that the response can be negative and a bug snuck in where the response was used without taking the absolute value. This PR fixes that issue.