### PR TITLE
power_spectrum: two tiny improvements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 * Added [`PowerSpectrum.compress()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum.PowerSpectrum.html#lumicks.pylake.force_calibration.power_spectrum.PowerSpectrum.compress#) to discard high frequency spectral data for a downsampled spectrum to conserve memory.
 
+#### Improvements
+
+* Force `num_points_per_block` to be integer when down-sampling a [`PowerSpectrum`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum.PowerSpectrum.html).
+
 ## v1.6.0 | t.b.d.
 
 #### New features

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.6.1 | t.b.d.
+
+#### New features
+
+* Added [`PowerSpectrum.compress()`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.force_calibration.power_spectrum.PowerSpectrum.html#lumicks.pylake.force_calibration.power_spectrum.PowerSpectrum.compress#) to discard high frequency spectral data for a downsampled spectrum to conserve memory.
+
 ## v1.6.0 | t.b.d.
 
 #### New features

--- a/lumicks/pylake/force_calibration/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/power_spectrum.py
@@ -264,6 +264,11 @@ class PowerSpectrum:
             (Deprecated) Function to use for down-sampling the data. Only `np.mean` will be
             supported going forward.
         """
+        if int(factor) != factor:
+            raise NotImplementedError("Only integer downsampling factors are supported")
+        else:
+            factor = int(factor)
+
         if reduce != np.mean:
             warnings.warn(
                 DeprecationWarning(
@@ -271,6 +276,7 @@ class PowerSpectrum:
                     "removed in a future version of Pylake"
                 )
             )
+
             return PowerSpectrum(
                 downsample(self.frequency, factor, reduce),
                 downsample(self.power, factor, reduce),

--- a/lumicks/pylake/force_calibration/power_spectrum.py
+++ b/lumicks/pylake/force_calibration/power_spectrum.py
@@ -361,7 +361,11 @@ class PowerSpectrum:
 
         if self._num_points_per_block != 1:
             raise ValueError(
-                "identify_peaks only works if the power spectrum is not blocked / averaged"
+                "identify_peaks requires the raw non-averaged data to be available. Power spectra "
+                "that have been obtained either by windowing, or by compressing a blocked power "
+                "spectrum (by invoking `.compress()` on it) cannot be used with this function. For "
+                "the latter case, create the PowerSpectrum object anew with the original data and"
+                "do not call `.compress()` on it."
             )
 
         if peak_cutoff <= baseline:
@@ -452,6 +456,25 @@ class PowerSpectrum:
             num_points_per_block=num_points_per_block,
             total_samples_used=self.total_samples_used,
             variance=variance,
+        )
+
+    def compress(self):
+        """Returns a compressed power spectrum by downsampling the internal data
+
+        By default, when calling `PowerSpectrum.downsampled_by(100)`, the raw data is kept at
+        the full frequency resolution internally. When calling compress, this data is discarded
+        and only the downsampled variant is kept. This saves memory, but doesn't allow calling
+        methods which depend on the data not being downsampled (such as identify_peaks) from being
+        called."""
+        return PowerSpectrum(
+            self.frequency,
+            self.power,
+            self.sample_rate,
+            self.total_duration,
+            self.unit,
+            num_points_per_block=self.num_points_per_block,
+            total_samples_used=self.total_samples_used,
+            variance=self._variance,
         )
 
     def plot(self, *, show_excluded=False, **kwargs):

--- a/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
+++ b/lumicks/pylake/force_calibration/tests/test_power_spectrum.py
@@ -390,3 +390,15 @@ def test_compress():
     assert compressed._num_points_per_block == 100
     np.testing.assert_allclose(ps_downsampled.frequency, ps_downsampled.frequency)
     np.testing.assert_allclose(compressed.power, ps_downsampled.power)
+
+
+def test_integer_num_points_per_block():
+    ps = PowerSpectrum(np.arange(500), np.arange(500), 78125, total_duration=1)
+    ps_ds = ps.downsampled_by(10.0)
+    ps_ds_int = ps.downsampled_by(10)
+    np.testing.assert_allclose(ps_ds.power, ps_ds_int.power)
+
+    with pytest.raises(
+        NotImplementedError, match="Only integer downsampling factors are supported"
+    ):
+        ps.downsampled_by(10.00001)


### PR DESCRIPTION
**Why this PR?**
These are two small improvements to `PowerSpectrum` that would make it a lot more convenient for me to use.

- `.compress()` is needed as in simulation studies, the spectra can become prohibitively memory consuming.
- The integer cast is simply convenience. I did consider explicitly adding `int | float` as an allowed parameter, but I felt that would signal the wrong intent. Also, raising for a `float` that is losslessly convertible to an `int` would be irritating as one frequently unpacks dictionaries coming from a bluelake dictionary (which are floats).