### PR TITLE
docs: add explicit sphinx configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,3 +10,6 @@ python:
     - method: pip
       path: .
     - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
readthedocs now [requires an explicit sphinx configuration](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/)