### PR TITLE
Bugfix: `load_tracks` doesn't handle basepairs well

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 #### Bug fixes
 
 * Fixed a bug where [`ForceCalibrationItem.force_sensitivity`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.calibration.ForceCalibrationItem.html#lumicks.pylake.calibration.ForceCalibrationItem.force_sensitivity) would return the signed force response rather than the unsigned force sensitivity of a Bluelake calibration. This can cause issues with the force sign when using ratios of sensitivities obtained from Bluelake or Pylake. Now Pylake and Bluelake items both return the unsigned force sensitivity.
+* Fixed a bug where [`lk.load_tracks`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.load_tracks.html#lumicks.pylake.load_tracks) incorrectly loaded the position coordinates of tracks that had been calibrated to base pairs.
 
 ## v1.6.0 | 2025-01-09
 

--- a/lumicks/pylake/kymotracker/kymotrack.py
+++ b/lumicks/pylake/kymotracker/kymotrack.py
@@ -291,7 +291,7 @@ def load_tracks(filename, kymo, channel, delimiter=";"):
             min_length = float(np.unique(min_length).squeeze())
 
         if counts is not None:
-            coord = CentroidLocalizationModel(coord * kymo.pixelsize_um, counts)
+            coord = CentroidLocalizationModel(coord * kymo.pixelsize[0], counts)
 
         return KymoTrack(time.astype(int), coord, kymo, channel, min_length)
 


### PR DESCRIPTION
**Why this PR?**
Noticed this while working on #726, `load_tracks` uses `pixelsize_um` always when loading tracks from a CSV if photon counts are present.  If there are no photon counts, it works fine. 

A better solution to this and more robust test is included in #726 but it's good to have this in the next patch release