### PR TITLE
dwelltime: allow parallel bootstraps

### DIFF
--- a/lumicks/pylake/population/dwelltime.py
+++ b/lumicks/pylake/population/dwelltime.py
@@ -1,6 +1,7 @@
 import warnings
 from typing import Dict, Tuple, Union
 from dataclasses import field, dataclass
+from multiprocessing import Pool
 
 import numpy as np
 import scipy
@@ -292,7 +293,7 @@ class DwelltimeBootstrap:
             )
 
     @classmethod
-    def _from_dwelltime_model(cls, optimized, iterations):
+    def _from_dwelltime_model(cls, optimized, iterations, num_processes=None):
         """Construct bootstrap distributions for parameters from an optimized
         :class:`~lumicks.pylake.DwelltimeModel`.
 
@@ -306,9 +307,27 @@ class DwelltimeBootstrap:
             optimized model results
         iterations : int
             number of iterations (random samples) to use for the bootstrap
+        num_processes : int | None
+            number of processes to use for parallelization. If `None`, no parallelization is used.
         """
-        samples = DwelltimeBootstrap._sample(optimized, iterations)
-        return cls(optimized, samples[: optimized.n_components], samples[optimized.n_components :])
+
+        def from_samples(samples):
+            return cls(
+                optimized,
+                samples[: optimized.n_components],
+                samples[optimized.n_components :],
+            )
+
+        if num_processes is None:
+            return from_samples(DwelltimeBootstrap._sample(optimized, iterations))
+
+        with Pool(num_processes) as p:
+            result = p.starmap(
+                DwelltimeBootstrap._sample,
+                [(optimized, int(np.ceil(iterations / num_processes)))] * num_processes,
+            )
+
+        return from_samples(np.hstack(result)[:, :iterations])
 
     def extend(self, iterations):
         """Extend the distribution by additional sampling iterations.
@@ -721,15 +740,19 @@ class DwelltimeModel:
         n = self.dwelltimes.size  # number of observations
         return k * np.log(n) - 2 * self.log_likelihood
 
-    def calculate_bootstrap(self, iterations=500):
+    def calculate_bootstrap(self, iterations=500, *, num_processes=None):
         """Calculate a bootstrap distribution for the model.
 
         Parameters
         ----------
         iterations : int
             Number of iterations to sample for the distribution.
+        num_processes : int | None
+            Number of processes to use for parallelization. If `None`, no parallelization is used.
         """
-        bootstrap = DwelltimeBootstrap._from_dwelltime_model(self, iterations)
+        bootstrap = DwelltimeBootstrap._from_dwelltime_model(
+            self, iterations, num_processes=num_processes
+        )
         # TODO: remove with deprecation
         self._bootstrap = bootstrap
         return bootstrap


### PR DESCRIPTION
**Why this PR?**
Bootstrapping can become prohibitively expensive for large number of samples. This adds a small API which can be used to speed things up. Considering we may want >= 2 components in models we end up ranking this is low hanging fruit for speeding things up.