### PR TITLE
kymo: fix bug in `Kymo.plot_with_channels()`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.6.3 | t.b.d.
+
+#### Bug fixes
+
+* Fixed a bug in `Kymo.plot_with_channels()` that would not correctly align the timeline channels in some cases. Prior to the fix, it assumed that slicing the channel with the kymograph start and stop time results in the origin being at time zero, but this may not be the case if the channel is sparsely sampled and the first point is much later (such as is the case for diagnostic channels).
+
 ## v1.6.2 | 2025-05-06
 
 #### Bug fixes

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -535,11 +535,15 @@ class Kymo(ConfocalImage):
         xlim_kymo = axes[0].get_xlim()
 
         # plot data channels
+        scan_start_ts = self.line_timestamp_ranges(include_dead_time=True)[0][0]
         for idx, (ax, channel) in enumerate(zip(axes[1:], channels)):
             plt.sca(ax)
             plot_args = kwargs if not colors else kwargs | {"color": colors[idx]}
-            # Cropping the channel to the kymograph time range leads to better axis limits
-            channel[self.start : self.stop + 1].plot(**plot_args)
+            # Cropping the channel to the kymograph time range leads to better axis limits.
+            # The kymograph defines timestamp zero at the middle of the first line.
+            channel[self.start : self.stop + 1].plot(
+                start=scan_start_ts + 1e9 * self.line_time_seconds / 2, **plot_args
+            )
             ax.set_xlim(xlim_kymo)
 
             if title_vertical:

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo.py
@@ -223,3 +223,55 @@ def test_partial_pixel():
 
     np.testing.assert_allclose(kymo_with_wave([1, 1, 1, 1, 2]).pixel_time_seconds, 5)
     np.testing.assert_allclose(kymo_with_wave([1, 1, 1, 1, 2]).line_time_seconds, 10)
+
+
+def test_kymo_line_timestamp_ranges(test_kymo):
+    ref_inc = [
+        (23125000000, 30625000000),
+        (30625000000, 38125000000),
+        (38125000000, 45625000000),
+        (45625000000, 53125000000),
+        (53125000000, 60625000000),
+        (60625000000, 68125000000),
+        (68125000000, 75625000000),
+        (75625000000, 83125000000),
+        (83125000000, 90625000000),
+        (90625000000, 98125000000),
+    ]
+
+    ref_exc = [
+        (23125000000, 24375000000),
+        (30625000000, 31875000000),
+        (38125000000, 39375000000),
+        (45625000000, 46875000000),
+        (53125000000, 54375000000),
+        (60625000000, 61875000000),
+        (68125000000, 69375000000),
+        (75625000000, 76875000000),
+        (83125000000, 84375000000),
+        (90625000000, 91875000000),
+    ]
+
+    kymo, _ = test_kymo
+    np.testing.assert_equal(kymo.line_timestamp_ranges(include_dead_time=True), ref_inc)
+    np.testing.assert_equal(kymo.line_timestamp_ranges(include_dead_time=False), ref_exc)
+    np.testing.assert_equal(kymo._first_line_start(), ref_inc[0][0])
+
+    kymo_start = kymo["10.6s":]
+    np.testing.assert_equal(kymo_start.line_timestamp_ranges(include_dead_time=True), ref_inc[1:])
+    np.testing.assert_equal(kymo_start.line_timestamp_ranges(include_dead_time=False), ref_exc[1:])
+    np.testing.assert_equal(kymo_start._first_line_start(), ref_inc[1][0])
+
+    kymo_start = kymo["10.7s":]
+    np.testing.assert_equal(kymo_start.line_timestamp_ranges(include_dead_time=True), ref_inc[2:])
+    np.testing.assert_equal(kymo_start.line_timestamp_ranges(include_dead_time=False), ref_exc[2:])
+    np.testing.assert_equal(kymo_start._first_line_start(), ref_inc[2][0])
+
+    kymo_ds = kymo.downsampled_by(7.5)
+    np.testing.assert_equal(kymo_ds._first_line_start(), ref_inc[0][0])
+
+    kymo_ds2 = kymo["5s":].downsampled_by(7.5)
+    np.testing.assert_equal(kymo_ds2._first_line_start(), ref_inc[1][0])
+
+    kymo_ds2 = kymo["10.7s":].downsampled_by(7.5)
+    np.testing.assert_equal(kymo_ds2._first_line_start(), ref_inc[2][0])

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
@@ -2,7 +2,6 @@ import itertools
 
 import numpy as np
 import pytest
-import matplotlib.pyplot as plt
 
 from lumicks.pylake.kymo import _kymo_from_array
 
@@ -54,6 +53,7 @@ def test_from_array(test_kymo, crop):
         kymo.line_timestamp_ranges(include_dead_time=True),
         arr_kymo.line_timestamp_ranges(include_dead_time=True),
     )
+    np.testing.assert_equal(kymo._first_line_start(), kymo.line_timestamp_ranges()[0][0])
 
     np.testing.assert_equal(kymo.pixelsize_um, arr_kymo.pixelsize_um)
     np.testing.assert_equal(kymo.pixelsize, arr_kymo.pixelsize)
@@ -190,19 +190,19 @@ def test_color_format(test_kymo):
     with pytest.raises(
         ValueError, match="Invalid color format 'rgp'. Only 'r', 'g', and 'b' are valid components."
     ):
-        arr_kymo = make_kymo_from_array(kymo, image, "rgp")
+        make_kymo_from_array(kymo, image, "rgp")
 
     with pytest.raises(
         ValueError, match="Color format 'r' specifies 1 channel for a 3 channel image."
     ):
-        arr_kymo = make_kymo_from_array(kymo, image, "r")
+        make_kymo_from_array(kymo, image, "r")
 
     with pytest.raises(
         ValueError, match="Color format 'rb' specifies 2 channels for a 3 channel image."
     ):
-        arr_kymo = make_kymo_from_array(kymo, image, "rb")
+        make_kymo_from_array(kymo, image, "rb")
 
     with pytest.raises(
         ValueError, match="Color format 'rgb' specifies 3 channels for a 2 channel image."
     ):
-        arr_kymo = make_kymo_from_array(kymo, image[:, :, :2], "rgb")
+        make_kymo_from_array(kymo, image[:, :, :2], "rgb")


### PR DESCRIPTION
**Why this PR?**
It seems that we did not consider the start time of the `kymo` versus the `timestamp` of the first data point when implementing `Kymo.plot_with_channels()`.

Considering that `line_timestamp_ranges()` typically does a lot more than we need (we only need the very first timestamp), I also added a small method to shortcut this calculation. The difference in performance is about 9x for a typical kymograph.

<img width="585" alt="image" src="https://github.com/user-attachments/assets/ce6d0cc4-3db9-4f84-a627-8ae3db16a47f" />

```python
f = lk.File("kymo.h5")
kymo = f.kymos["test_kymo"]

kymo.plot_with_channels(
    [f["Photon count"]["Red"].downsampled_by(100),
     f["Photon count"]["Red"].downsampled_over(kymo.line_timestamp_ranges())],
    adjustment=lk.ColorAdjustment([0, 0, 0], [95, 100, 100], "percentile"),
    titles=("Kymograph", "Downsampled 100", "Downsampled kymo")
)

plt.gcf().axes[0].get_images()[0].set_interpolation('none')
for i, ax in enumerate(plt.gcf().axes):
    ax.axvline(13.61, color="w", linewidth=2, alpha=0.5)
    ax.axvline(13.61, color="k", linewidth=1, alpha=0.5)

    ax.axvline(49.6, color="w", linewidth=2, alpha=0.5)
    ax.axvline(49.6, color="k", linewidth=1, alpha=0.5)
    ax.set_aspect("auto")

plt.xlim([49, 50])
plt.tight_layout()
```

Without:
<img width="633" alt="image" src="https://github.com/user-attachments/assets/ad31823c-9b00-4f8e-b21d-311baf6fc7bf" />

With:
<img width="619" alt="image" src="https://github.com/user-attachments/assets/7fda114c-3798-4406-8dca-ad559948c683" />
