### PR TITLE
calibration: Explicitly check if `CalibrationItem.stop is None`...

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.7.1 | tbd
+
+#### Bug fixes
+
+- Fixed a bug that could affect calibrations returned by [Slice.calibration](https://lumicks-pylake.readthedocs.io/en/v1.7.0/_api/lumicks.pylake.channel.Slice.html#lumicks.pylake.channel.Slice.calibration) with a stop time of `0` (01/01/1970). This bug could affect mocked force and calibration data, but it should not affect real data.
+
 ## v1.7.0 | 2025-07-29
 
 #### New features

--- a/lumicks/pylake/calibration.py
+++ b/lumicks/pylake/calibration.py
@@ -12,7 +12,8 @@ def _filter_calibration(items, start, stop):
         return []
 
     def timestamp(x):
-        return x.stop if x.stop else x.applied_at  # Pylake items do not have a start and stop (yet)
+        # Pylake items do not have a start and stop (yet)
+        return x.stop if x.stop is not None else x.applied_at
 
     items = sorted(items, key=timestamp)
 


### PR DESCRIPTION
during filtering of calibrations with `ForceCalibrationList.filter_calibration`.

Issue: If a force channel calibration has a stop time value of 0 ns, it is filtered out. While this is unlikely to happen with real-world data, it could lead to falsely filtered calibrations with mocked data files.

Solution: Explicitly check for the existence (`not None`) and not just the truth value of the stop time.