### PR TITLE
confocal: add api for getting axis info

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.8.0 | t.b.d.
+
+* Added confocal API endpoints [`axis_units`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.scan.Scan.html#lumicks.pylake.scan.Scan.axis_units), [`axis_names`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.scan.Scan.html#lumicks.pylake.scan.Scan.axis_names), [`axis_labels`](https://lumicks-pylake.readthedocs.io/en/latest/_api/lumicks.pylake.scan.Scan.html#lumicks.pylake.scan.Scan.axis_labels) to get the units, names and labels of the axes of a confocal scan in human-readable form.
+
 ## v1.7.0 | t.b.d.
 
 #### New features

--- a/lumicks/pylake/detail/pixel_calibration.py
+++ b/lumicks/pylake/detail/pixel_calibration.py
@@ -1,0 +1,66 @@
+from enum import Enum
+from collections import namedtuple
+from dataclasses import dataclass
+
+import numpy as np
+
+UnitInfo = namedtuple("UnitInfo", ["name", "label"])
+
+
+class PositionUnit(Enum):
+    um = UnitInfo(name="um", label=r"μm")
+    kbp = UnitInfo(name="kbp", label="kbp")
+    pixel = UnitInfo(name="pixel", label="pixels")
+    au = UnitInfo(name="au", label="au")
+
+    def __str__(self):
+        return self.value.name
+
+    def __hash__(self):
+        return hash(self.value)
+
+    @property
+    def label(self):
+        return self.value.label
+
+    def get_diffusion_labels(self) -> dict:
+        return {
+            "unit": f"{self}^2 / s",
+            "_unit_label": f"{self.label}²/s",
+        }
+
+    def get_squared_labels(self) -> dict:
+        return {
+            "unit": f"{self}^2",
+            "_unit_label": f"{self.label}²",
+        }
+
+
+@dataclass(frozen=True)
+class PositionCalibration:
+    unit: PositionUnit = PositionUnit.pixel
+    scale: float = 1.0
+    origin: float = 0.0
+
+    def __post_init__(self):
+        if not isinstance(self.unit, PositionUnit):
+            raise TypeError("`unit` must be a PositionUnit instance")
+
+    def from_pixels(self, pixels):
+        """Convert coordinates from pixel values to calibrated values"""
+        return self.scale * (np.array(pixels) - self.origin)
+
+    def to_pixels(self, calibrated):
+        """Convert coordinates from calibrated values to pixel values"""
+        return np.array(calibrated) / self.scale + self.origin
+
+    @property
+    def pixelsize(self):
+        return np.abs(self.scale)
+
+    def downsample(self, factor):
+        return (
+            self
+            if self.unit == PositionUnit.pixel
+            else PositionCalibration(self.unit, self.scale * factor)
+        )

--- a/lumicks/pylake/kymo.py
+++ b/lumicks/pylake/kymo.py
@@ -1,8 +1,5 @@
 import warnings
 from copy import copy
-from enum import Enum
-from collections import namedtuple
-from dataclasses import dataclass
 
 import numpy as np
 
@@ -20,6 +17,7 @@ from .detail.plotting import get_axes, show_image
 from .detail.timeindex import to_timestamp
 from .detail.utilities import method_cache
 from .detail.bead_cropping import find_beads_template, find_beads_brightness
+from .detail.pixel_calibration import PositionUnit, PositionCalibration
 
 
 def _default_line_time_factory(self: "Kymo"):
@@ -1113,68 +1111,6 @@ class EmptyKymo(Kymo):
 
     def __bool__(self):
         return False
-
-
-UnitInfo = namedtuple("UnitInfo", ["name", "label"])
-
-
-class PositionUnit(Enum):
-    um = UnitInfo(name="um", label=r"μm")
-    kbp = UnitInfo(name="kbp", label="kbp")
-    pixel = UnitInfo(name="pixel", label="pixels")
-    au = UnitInfo(name="au", label="au")
-
-    def __str__(self):
-        return self.value.name
-
-    def __hash__(self):
-        return hash(self.value)
-
-    @property
-    def label(self):
-        return self.value.label
-
-    def get_diffusion_labels(self) -> dict:
-        return {
-            "unit": f"{self}^2 / s",
-            "_unit_label": f"{self.label}²/s",
-        }
-
-    def get_squared_labels(self) -> dict:
-        return {
-            "unit": f"{self}^2",
-            "_unit_label": f"{self.label}²",
-        }
-
-
-@dataclass(frozen=True)
-class PositionCalibration:
-    unit: PositionUnit = PositionUnit.pixel
-    scale: float = 1.0
-    origin: float = 0.0
-
-    def __post_init__(self):
-        if not isinstance(self.unit, PositionUnit):
-            raise TypeError("`unit` must be a PositionUnit instance")
-
-    def from_pixels(self, pixels):
-        """Convert coordinates from pixel values to calibrated values"""
-        return self.scale * (np.array(pixels) - self.origin)
-
-    def to_pixels(self, calibrated):
-        """Convert coordinates from calibrated values to pixel values"""
-        return np.array(calibrated) / self.scale + self.origin
-
-    @property
-    def pixelsize(self):
-        return np.abs(self.scale)
-
-    def downsample(self, factor):
-        return (
-            self
-            if self.unit == PositionUnit.pixel
-            else PositionCalibration(self.unit, self.scale * factor)
-        )
 
 
 def _kymo_from_array(

--- a/lumicks/pylake/kymotracker/detail/msd_estimation.py
+++ b/lumicks/pylake/kymotracker/detail/msd_estimation.py
@@ -5,7 +5,7 @@ from dataclasses import field, dataclass
 import numpy as np
 import numpy.typing as npt
 
-from ...kymo import PositionUnit
+from ...detail.pixel_calibration import PositionUnit
 
 
 @dataclass(frozen=True)

--- a/lumicks/pylake/kymotracker/kymotracker.py
+++ b/lumicks/pylake/kymotracker/kymotracker.py
@@ -3,12 +3,12 @@ from itertools import chain
 
 import numpy as np
 
-from ..kymo import PositionUnit
 from .kymotrack import KymoTrack, KymoTrackGroup
 from .detail.peakfinding import find_kymograph_peaks, refine_peak_based_on_moment
 from .detail.gaussian_mle import gaussian_mle_1d, overlapping_pixels
 from .detail.trace_line_2d import detect_lines, points_to_line_segments
 from .detail.scoring_functions import kymo_score
+from ..detail.pixel_calibration import PositionUnit
 from .detail.localization_models import GaussianLocalizationModel
 
 __all__ = [

--- a/lumicks/pylake/scan.py
+++ b/lumicks/pylake/scan.py
@@ -419,6 +419,16 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         else:
             return data
 
+    @property
+    def axis_names(self):
+        """Return axis labels of the scan in the order of the reconstruction shape."""
+        return tuple(ax.axis_label.lower() for ax in self._metadata.ordered_axes)
+
+    @property
+    def axis_units(self):
+        """Return axis units of the scan in the order of the reconstruction shape."""
+        return tuple(self._calibration.unit.label for _ in self._metadata.ordered_axes)
+
     def plot(
         self,
         channel="rgb",
@@ -469,7 +479,7 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
         if show_axes is False:
             axes.set_axis_off()
 
-        positional_unit = r"μm"
+        positional_unit = self._calibration.unit.label
         if scale_bar and not image_handle:
             scale_bar._attach_scale_bar(axes, 1.0, 1.0, positional_unit, positional_unit)
 
@@ -492,9 +502,8 @@ class Scan(ConfocalImage, VideoExport, FrameIndex):
             axes=axes,
             **{**default_kwargs, **kwargs},
         )
-        scan_axes = self._metadata.ordered_axes
-        axes.set_xlabel(rf"{scan_axes[0].axis_label.lower()} ({positional_unit})")
-        axes.set_ylabel(rf"{scan_axes[1].axis_label.lower()} ({positional_unit})")
+        axes.set_xlabel(self.axis_labels[0])
+        axes.set_ylabel(self.axis_labels[1])
         if show_title:
             axes.set_title(make_image_title(self, frame))
 

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_from_array.py
@@ -3,7 +3,8 @@ import itertools
 import numpy as np
 import pytest
 
-from lumicks.pylake.kymo import PositionUnit, _kymo_from_array
+from lumicks.pylake.kymo import _kymo_from_array
+from lumicks.pylake.detail.pixel_calibration import PositionUnit
 
 timestamp_err_msg = (
     "Per-pixel timestamps are not implemented. "

--- a/lumicks/pylake/tests/test_imaging_confocal/test_kymo_transforms.py
+++ b/lumicks/pylake/tests/test_imaging_confocal/test_kymo_transforms.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from lumicks.pylake.kymo import PositionUnit, PositionCalibration
+from lumicks.pylake.detail.pixel_calibration import PositionUnit, PositionCalibration
 
 
 def test_calibrate_to_kbp(test_kymo):


### PR DESCRIPTION
**Why this PR?**
Provides a public endpoint as requested in https://github.com/lumicks/pylake/issues/751.

Also looked into making the spatial calibration code a bit more homogeneous between `Scan` and `Kymo` and moved the calibration into its own file which helps keep the `Kymo` file manageable in size.